### PR TITLE
Define a shell script to generate new examples.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,16 +15,16 @@ future ARIA features we need to implement.
 * To keep code in this repository consistent; editors should use a text editor
 that supports [EditorConfig](http://editorconfig.org/).
 
-## Code examples
+### Writing code examples
 
 - Choose a pattern from the
   [Design Patterns Status](https://github.com/w3c/aria-practices/wiki/Design-Patterns-Status)
   document that is missing a code example.
 - Via the command line, run:
 
-      $ bin/generate <name>
+        $ bin/generate <name>
 
-  Where `<name>` is the camel-cased name of the design pattern example. This
+  Where `<name>` is the dasherized name of the design pattern example. This
   creates a new example directory and file with the same name, based on a
   template.
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,22 @@ future ARIA features we need to implement.
 * To keep code in this repository consistent; editors should use a text editor
 that supports [EditorConfig](http://editorconfig.org/).
 
+## Code examples
+
+- Choose a pattern from the
+  [Design Patterns Status](https://github.com/w3c/aria-practices/wiki/Design-Patterns-Status)
+  document that is missing a code example.
+- Via the command line, run:
+
+      $ bin/generate <name>
+
+  Where `<name>` is the camel-cased name of the design pattern example. This
+  creates a new example directory and file with the same name, based on a
+  template.
+
+- Edit the new html file with an example corresponding to the description in
+  `aria-practices.html`
+
 ### Editorial documentation
 
 General documentation for editing ARIA deliverables is available in the 

--- a/bin/generate
+++ b/bin/generate
@@ -1,0 +1,12 @@
+#!/usr/bin/env sh
+
+set -e
+
+example_name="$@"
+
+# Create a directory for the example name.
+mkdir -p examples/"$example_name"
+
+# Copy the template to the new example file.
+cp examples/coding-template/template3.html \
+  examples/"$example_name"/"$example_name".html


### PR DESCRIPTION
- Use this script from the command line to copy the template.
- This can get more sophisticated over time, or replaced with a more
  robust template generator. For now, it captures in code what would
  otherwise be undocumented or documented poorly in the README.

## Example usage

```
aria-practices % ls examples
alert           button          checkbox        coding-template css      js              link            radio           slider
aria-practices % bin/generate date-picker
aria-practices % head -10 examples/date-picker/date-picker.html
<!DOCTYPE html>
<html lang="en">
<head>
  <meta charset="utf-8" />
  <title>ARIA Example: Pattern Name: Coding Example Name</title>
  <meta name="generator" content="BBEdit 10.5" />
  <link href="../css/core.css" rel="stylesheet">
  <link href="../css/table.css" rel="stylesheet">
  <link href="css/codingtemplate.css" rel="stylesheet">
</head>
```