### PR TITLE
Clarify role names in § 3.1.6.1

### DIFF
--- a/aria-practices.html
+++ b/aria-practices.html
@@ -3198,7 +3198,7 @@ function detectHiContrast() {
 <p>
 It is essential that application vendors maintain a valid format for
 <a href="#aria-valuenow" class="property-reference">aria-valuenow</a>, and aria-valuenow should
-accurately represent the value of the widget.The value must be within range of <a href="#aria-valuemax" class="property-reference">aria-valuemin</a> and <a href="#aria-valuemin" class="property-reference">aria-valuemin</a>, where the value of aria-valuemin is less than or equal to the value of aria-valuemax, throughout the life cycle of your widget. If aria-valuemin is not less than or equal to the value of aria-valuemax, or if the aria-valuemax is indeterminate, this creates an error condition that will be handled by
+accurately represent the value of the widget.The value must be within range of <a href="#aria-valuemax" class="property-reference">aria-valuemax</a> and <a href="#aria-valuemin" class="property-reference">aria-valuemin</a>, where the value of aria-valuemin is less than or equal to the value of aria-valuemax, throughout the life cycle of your widget. If aria-valuemin is not less than or equal to the value of aria-valuemax, or if the aria-valuemax is indeterminate, this creates an error condition that will be handled by
 the assistive technology, resulting in undesirable results. Should an alternative text
   equivalent be needed to properly represent the aria-valuenow, such as a day
   of the week, then you should accompany the aria-valuenow with an appropriate


### PR DESCRIPTION
Paragraph previously duplicated reference to `aria-valuemin` where `aria-valuemax` was intended.