### PR TITLE
Remove example 4, add clearer focus outline

### DIFF
--- a/examples/link/css/link.css
+++ b/examples/link/css/link.css
@@ -1,34 +1,22 @@
-[role="link"]
-{
-    color: #009;
-    background: transparent;
-    text-decoration: underline;
-    border: thin solid transparent;
+[role="link"] {
+  color: #009;
+  background: transparent;
+  text-decoration: underline;
 }
 
-[role="link"]:hover, [role="link"]:focus, [role="link"]:active
-{
-    color:#000;
-    border-color: #fc0;
-    cursor: pointer;
+[role="link"]:hover,
+[role="link"]:focus,
+[role="link"]:hover::before,
+[role="link"]:focus::before {
+  color:#000;
+  cursor: pointer;
+  outline: .2em solid hsl(219, 63%, 44%);
+  outline-offset: .2em;
 }
 
-[role="link"].link3:before {
+[role="link"].link3::before {
   display: block;
   content: url('../images/w3c-logo.png');
   width:153px;
-  height:104px; 
-}
-
-[role="link"].link4 {
-  display: block;
-  background-repeat: no-repeat;
-  background-image: url('../images/w3c-logo.png');
-  width:153px;
-  height:104px; 
-}
-
-td div {
-  margin-bottom: 0.25em;
-  font-weight: bold;
+  height:104px;
 }

--- a/examples/link/link.html
+++ b/examples/link/link.html
@@ -22,7 +22,7 @@
     <a href="https://github.com/w3c/aria-practices/issues/228">issue 228.</a>
   </p>
   <p>
-    The examples below demonstrate four variations of the
+    The examples below demonstrate three variations of the
     <a href="../../#link">design pattern for link</a>.
      The link pattern is used when it is necessary for elements other than the HTML <code>a</code> element to have link behaviors.
   </p>
@@ -160,7 +160,7 @@
           <th scope="row"><code>aria-label</code></th>
           <td><code>span</code></td>
           <td>
-            Examples 3: Defines the accessible name of the link.
+            Example 3: Defines the accessible name of the link.
         </tr>
       </tbody>
     </table>

--- a/examples/link/link.html
+++ b/examples/link/link.html
@@ -15,14 +15,14 @@
 <script src="js/link.js" type="text/javascript"></script>
 </head>
 <body>
-  <main> 
+  <main>
   <h1>Link Examples</h1>
   <p>
-    <strong>NOTE:</strong> provide feedback on this example page in 
+    <strong>NOTE:</strong> provide feedback on this example page in
     <a href="https://github.com/w3c/aria-practices/issues/228">issue 228.</a>
   </p>
   <p>
-    The examples below demonstrate four variations of the 
+    The examples below demonstrate four variations of the
     <a href="../../#link">design pattern for link</a>.
      The link pattern is used when it is necessary for elements other than the HTML <code>a</code> element to have link behaviors.
   </p>
@@ -50,7 +50,7 @@
             <code>span</code> element with text content.
           </th>
           <td id="ex1">
-            <span 
+            <span
                 tabindex="0"
                 role="link"
                 onclick="goToLink(event, 'http://www.w3.org/')"
@@ -67,12 +67,12 @@
             <code>img</code> element with <code>alt</code> attribute.
           </td>
           <td id="ex2">
-            <img 
+            <img
               tabindex="0"
               role="link"
               onclick="goToLink(event, 'http://www.w3.org/')"
               onKeyDown="goToLink(event, 'http://www.w3.org/')"
-              src="images/w3c-logo.png" 
+              src="images/w3c-logo.png"
               alt="W3C Website">
           </td>
         </tr>
@@ -84,32 +84,13 @@
             CSS <code>:before</code> content property on a <code>span</code> element.
           </td>
           <td id="ex3">
-            <span 
+            <span
               tabindex="0"
               role="link"
               class="link3"
               onclick="goToLink(event, 'http://www.w3.org/TR/wai-aria-practices/')"
               onKeyDown="goToLink(event, 'http://www.w3.org/TR/wai-aria-practices/')"
-              aria-label="W3C website">
-            </span>
-          </td>
-        </tr>
-        <tr>
-          <th>
-            4
-          </th>
-          <td>
-            CSS background image on a <code>span</code> element.
-          </td>
-          <td id="ex4">
-            <span 
-              tabindex="0"
-              role="link"
-              class="link4"
-              onclick="goToLink(event, 'http://www.w3.org/TR/wai-aria-practices/')"
-              onKeyDown="goToLink(event, 'http://www.w3.org/TR/wai-aria-practices/')"
-              aria-label="W3C website">
-            </span>
+              aria-label="W3C website"></span>
           </td>
         </tr>
       </tbody>
@@ -155,7 +136,7 @@
           <td><code>span</code><br><code>img</code></td>
           <td>
             <ul>
-            <li>Examples 1, 3, and 4: Identifies the <code>span</code> element as a <code>link</code>.</li>
+            <li>Examples 1 and 3: Identifies the <code>span</code> element as a <code>link</code>.</li>
             <li>Example 2: Identifies the <code>img</code> element as a <code>link</code>.</li>
             </ul>
           </td>
@@ -179,7 +160,7 @@
           <th scope="row"><code>aria-label</code></th>
           <td><code>span</code></td>
           <td>
-            Examples 3 and 4: Defines the accessible name of the link.
+            Examples 3: Defines the accessible name of the link.
         </tr>
       </tbody>
     </table>
@@ -213,15 +194,10 @@
     <div role="separator" id="sc3_start_sep" aria-labelledby="sc3_start_sep sc3_label" aria-label="Start of"></div>
     <div id="sc3"></div>
     <div role="separator" id="sc3_end_sep" aria-labelledby="sc3_end_sep sc3_label" aria-label="End of"></div>
-    <h3 id="sc4_label">Link 4</h3>
-    <div role="separator" id="sc4_start_sep" aria-labelledby="sc4_start_sep sc4_label" aria-label="Start of"></div>
-    <div id="sc4"></div>
-    <div role="separator" id="sc4_end_sep" aria-labelledby="sc4_end_sep sc4_label" aria-label="End of"></div>
     <script>
       sourceCode.add('sc1', 'ex1');
       sourceCode.add('sc2', 'ex2');
       sourceCode.add('sc3', 'ex3');
-      sourceCode.add('sc4', 'ex4');
       sourceCode.make();
     </script>
   </section>


### PR DESCRIPTION
Fixes issue described in https://github.com/w3c/aria-practices/issues/228#issuecomment-278679852.

Tested in: 

- Safari 10 on macOS 10.12
- Edge on Windows 10
- IE 11 on Windows 10
- Firefox 50 on Windows 10

All tests on Windows include a check in High Contrast mode.