### PR TITLE
Check for this.deleteButton before trying to set an attribute

### DIFF
--- a/examples/listbox/js/listbox.js
+++ b/examples/listbox/js/listbox.js
@@ -180,11 +180,13 @@ aria.Listbox.prototype.toggleSelectItem = function (element) {
       element.getAttribute('aria-selected') === 'true' ? 'false' : 'true'
     );
 
-    if (this.listboxNode.querySelector('[aria-selected="true"]')) {
-      this.deleteButton.setAttribute('aria-disabled', 'false');
-    }
-    else {
-      this.deleteButton.setAttribute('aria-disabled', 'true');
+    if (this.deleteButton) {
+      if (this.listboxNode.querySelector('[aria-selected="true"]')) {
+        this.deleteButton.setAttribute('aria-disabled', 'false');
+      }
+      else {
+        this.deleteButton.setAttribute('aria-disabled', 'true');
+      }
     }
   }
 };


### PR DESCRIPTION
After a select item is toggled, attribute aria-disabled on this.deleteButton was always set. This results in an error if no deleteButton is set.