### PR TITLE
Added Grid Lines for the Role, Property, State, and Tabindex Attributes Tables

### DIFF
--- a/examples/css/core.css
+++ b/examples/css/core.css
@@ -42,7 +42,8 @@ table.attributes tbody th:first-child {
 
 table.attributes tbody th:first-child + td,
 table.attributes tbody th:nth-child(2) {
-  border-right: 2px solid;
+  border-right: 1px solid silver;
   border-top: 1px solid silver;
   padding-right: 1em;
 }
+

--- a/examples/css/core.css
+++ b/examples/css/core.css
@@ -35,15 +35,18 @@ pre code:not(.hljs),
   box-shadow: inset 0 -1px 0 #bbb
 }
 
-/* Align border for */
-table.attributes tbody th:first-child {
-  border-right: 0;
-}
 
-table.attributes tbody th:first-child + td,
-table.attributes tbody th:nth-child(2) {
+table.attributes tbody th,
+table.attributes tbody td {
   border-right: 1px solid silver;
   border-top: 1px solid silver;
   padding-right: 1em;
 }
+
+table.data  tbody th:first-child,
+	table.index tbody th:first-child  {
+		border-right: 1px solid silver;
+		border-top: 1px solid silver;
+		padding-right: 1em;
+	}
 


### PR DESCRIPTION
In the example documents added grid lines for the Role, Property, State, and Tabindex Attributes Tables