### PR TITLE
Menu Design Pattern: Document Optional Behaviors for Space and Up Arrow

### DIFF
--- a/aria-practices.html
+++ b/aria-practices.html
@@ -1340,8 +1340,8 @@ For additional guidance, see <a href="#kbd_selection_follows_focus">Deciding Whe
           </li>
           <li><kbd>Space</kbd>:
             <ul>
-              <li>When focus is on a <code>menuitemcheckbox</code>, changes the state without closing the menu.</li>
-              <li>When focus is on a <code>menuitemradio</code> that is not checked, without closing the menu, checks the focused <code>menuitemradio</code> and unchecks any other checked <code>menuitemradio</code> element in the same group.</li>
+              <li>(Optional): When focus is on a <code>menuitemcheckbox</code>, changes the state without closing the menu.</li>
+              <li>(Optional): When focus is on a <code>menuitemradio</code> that is not checked, without closing the menu, checks the focused <code>menuitemradio</code> and unchecks any other checked <code>menuitemradio</code> element in the same group.</li>
               <li>(Optional): When focus is on a <code>menuitem</code> that has a submenu, opens the submenu and places focus on its first item.</li>
               <li>(Optional): When focus is on a <code>menuitem</code> that does not have a submenu, activates the <code>menuitem</code> and closes the menu.</li>
             </ul>
@@ -1355,7 +1355,7 @@ For additional guidance, see <a href="#kbd_selection_follows_focus">Deciding Whe
           <li><kbd>Up Arrow</kbd>:
             <ul>
             <li>When focus is in a <code>menu</code>, moves focus to the previous item, optionally wrapping from the first to the last.</li>
-            <li>When focus is in a <code>menubar</code>, does nothing.</li>
+            <li>(Optional): When focus is on a <code>menuitem</code> in a <code>menubar</code>, opens its submenu and places focus on the last item in the submenu.</li>
             </ul>
           </li>
           <li><kbd>Right Arrow</kbd>:


### PR DESCRIPTION
For issue #336, modified keyboard interaction subsection of menu or menubar design pattern section in aria-practices.html:
1. Mark space bar toggle of menuitemcheckbox as optional.
2. Mark space bar toggle of menuitemradio as optional.
3. Add optional up arrow behavior for menuitem elements in a menubar. (Note, this behavior is implemented in the examples).