### PR TITLE
Do not focus on menu buttons on page load

### DIFF
--- a/examples/grid/js/menuButton.js
+++ b/examples/grid/js/menuButton.js
@@ -393,7 +393,7 @@ aria.widget.MenuButton.prototype.initMenuButton = function () {
     }
   }
 
-  this.closeMenu();
+  this.closeMenu(false, false);
 
   var self = this;
 


### PR DESCRIPTION
Fixed menu buttons on data grid example page so that they do not autofocus on page load