### PR TITLE
removed from Javascript setting a tabindex=0

### DIFF
--- a/examples/disclosure/js/disclosureButton.js
+++ b/examples/disclosure/js/disclosureButton.js
@@ -26,7 +26,6 @@ var ButtonExpand = function (domNode) {
 
 ButtonExpand.prototype.init = function () {
 
-  this.domNode.tabIndex = 0;
   this.controlledNode = false;
 
   var id = this.domNode.getAttribute('aria-controls');


### PR DESCRIPTION
I fixed a bug of the Javascript adding a tabindex=0, this is not needed since the button is already part of the tab order of the page