### PR TITLE
Relicense

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,22 @@
+Contributions to this repository are intended to become part of Recommendation-track documents governed by the
+[W3C Patent Policy](https://www.w3.org/Consortium/Patent-Policy-20040205/) and
+[Software and Document License](https://www.w3.org/Consortium/Legal/copyright-software). To make substantive contributions to specifications, you must either participate
+in the relevant W3C Working Group or make a non-member patent licensing commitment.
+
+If you are not the sole contributor to a contribution (pull request), please identify all 
+contributors in the pull request comment.
+
+To add a contributor (other than yourself, that's automatic), mark them one per line as follows:
+
+```
++@github_username
+```
+
+If you added a contributor by mistake, you can remove them in a comment with:
+
+```
+-@github_username
+```
+
+If you are making a pull request on behalf of someone else but you had no part in designing the 
+feature, you can remove yourself with the above syntax.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,6 @@
-Contributions to this repository are intended to become part of Recommendation-track documents governed by the
-[W3C Patent Policy](https://www.w3.org/Consortium/Patent-Policy-20040205/) and
-[Software and Document License](https://www.w3.org/Consortium/Legal/copyright-software). To make substantive contributions to specifications, you must either participate
-in the relevant W3C Working Group or make a non-member patent licensing commitment.
+Contributions to this repository are intended to become part of Technical Reports governed by the
+[Software and Document License](https://www.w3.org/Consortium/Legal/copyright-software). To make substantive contributions to documents, you must either participate
+in the relevant W3C Working Group or transfer copyright to W3C.
 
 If you are not the sole contributor to a contribution (pull request), please identify all 
 contributors in the pull request comment.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,4 @@
+All documents in this Repository are licensed by contributors
+under the 
+[W3C Software and Document License](https://www.w3.org/Consortium/Legal/copyright-software).
+

--- a/respec-config.js
+++ b/respec-config.js
@@ -11,6 +11,7 @@ var respecConfig = {
   // publishDate: "2013-08-22",
   noRecTrack: true,
   diffTool: 'http://www.aptest.com/standards/htmldiff/htmldiff.pl',
+  license: "w3c-software-doc",
 
   // The specifications short name, as in http://www.w3.org/TR/short-name/
   shortName: 'wai-aria-practices-1.1',


### PR DESCRIPTION
It came to my attention that W3C GitHub repos are supposed to contain license information (another undocumented thing). This was in context of a question about which license specs should have. The ARIA specs are currently under the W3C Document License (the respec default, and also the only one recognized by PubRules), but my recollection is the group wanted Practices to be under the Software and Document License to allow code snippets to be reused. This pull request makes that happen, submitted as a pull request to enable review and discussion. It will probably cause headaches at publication time, but it's better to swith to the license we intended then to forget about it again.