### PR TITLE
Navigation Menubar Example: Remove second example with dynamically added ARIA attributes

### DIFF
--- a/examples/menubar/menubar-1/js/MenubarItemLinks.js
+++ b/examples/menubar/menubar-1/js/MenubarItemLinks.js
@@ -64,14 +64,6 @@ var MenubarItem = function (domNode, menuObj) {
 MenubarItem.prototype.init = function () {
   this.domNode.tabIndex = -1;
 
-  this.domNode.setAttribute('role', 'menuitem');
-  this.domNode.setAttribute('aria-haspopup', 'true');
-  this.domNode.setAttribute('aria-expanded', 'false');
-
-  if (this.domNode.parentNode.tagName === 'LI') {
-    this.domNode.parentNode.setAttribute('role', 'none');
-  }
-
   this.domNode.addEventListener('keydown', this.handleKeydown.bind(this));
   this.domNode.addEventListener('click', this.handleClick.bind(this));
   this.domNode.addEventListener('focus', this.handleFocus.bind(this));

--- a/examples/menubar/menubar-1/js/MenubarLinks.js
+++ b/examples/menubar/menubar-1/js/MenubarLinks.js
@@ -68,7 +68,6 @@ var Menubar = function (domNode) {
 Menubar.prototype.init = function () {
   var menubarItem, childElement, menuElement, textContent, numItems;
 
-  this.domNode.setAttribute('role', 'menubar');
 
   // Traverse the element children of menubarNode: configure each with
   // menuitem role behavior and store reference in menuitems array.

--- a/examples/menubar/menubar-1/js/PopupMenuItemLinks.js
+++ b/examples/menubar/menubar-1/js/PopupMenuItemLinks.js
@@ -54,14 +54,6 @@ var MenuItem = function (domNode, menuObj) {
 MenuItem.prototype.init = function () {
   this.domNode.tabIndex = -1;
 
-  if (!this.domNode.getAttribute('role')) {
-    this.domNode.setAttribute('role', 'menuitem');
-  }
-
-  if (this.domNode.parentNode.tagName === 'LI') {
-    this.domNode.parentNode.setAttribute('role', 'none');
-  }
-
   this.domNode.addEventListener('keydown', this.handleKeydown.bind(this));
   this.domNode.addEventListener('click', this.handleClick.bind(this));
   this.domNode.addEventListener('focus', this.handleFocus.bind(this));

--- a/examples/menubar/menubar-1/js/PopupMenuLinks.js
+++ b/examples/menubar/menubar-1/js/PopupMenuLinks.js
@@ -86,14 +86,8 @@ PopupMenu.prototype.init = function () {
   var childElement, menuElement, menuItem, textContent, numItems, label;
 
   // Configure the domNode itself
-  this.domNode.tabIndex = -1;
 
   this.domNode.setAttribute('role', 'menu');
-
-  if (!this.domNode.getAttribute('aria-labelledby') && !this.domNode.getAttribute('aria-label') && !this.domNode.getAttribute('title')) {
-    label = this.controller.domNode.innerHTML;
-    this.domNode.setAttribute('aria-label', label);
-  }
 
   this.domNode.addEventListener('mouseover', this.handleMouseover.bind(this));
   this.domNode.addEventListener('mouseout', this.handleMouseout.bind(this));

--- a/examples/menubar/menubar-1/js/PopupMenuLinks.js
+++ b/examples/menubar/menubar-1/js/PopupMenuLinks.js
@@ -87,8 +87,6 @@ PopupMenu.prototype.init = function () {
 
   // Configure the domNode itself
 
-  this.domNode.setAttribute('role', 'menu');
-
   this.domNode.addEventListener('mouseover', this.handleMouseover.bind(this));
   this.domNode.addEventListener('mouseout', this.handleMouseout.bind(this));
 

--- a/examples/menubar/menubar-1/menubar-1.html
+++ b/examples/menubar/menubar-1/menubar-1.html
@@ -27,126 +27,124 @@
     <a href="https://github.com/w3c/aria-practices/issues/410">issue 410.</a>
   </p>
   <p>
-    The following two implementations of the
+    The following implementation of the
     <a href="../../../#menu">design pattern for menubar</a>
-    demonstrate a menubar that presents site navigation menus. 
-    Each item in the menubars represents a section of a web site for a mythical university and opens a submenu containing menu items that link to pages within that section. 
-    The two examples are functionally equivalent but differ in how they are coded; see notes that follow each example.
+    demonstrates a menubar that provides site navigation menus. 
+    Each item in the menubar represents a section of a web site for a mythical university and opens a submenu containing menu items that link to pages within that section. 
   </p>
   <p>Similar examples include: </p>
   <ul>
     <li><a href="../menubar-2/menubar-2.html">Editor Menubar Example</a>: Example of a menubar that presents text styling actions similar to an editor application.</li>
   </ul>
   <section id="code-ex-1">
-    <h2>Examples</h2>
-    <section>
-      <h3 id="ex1_label">Example 1: Menubar With ARIA Markup in the HTML Source</h3>
-      <div role="separator" id="ex1_start_sep" aria-labelledby="ex1_start_sep ex1_label" aria-label="Start of"></div>
-      <div id="ex1">
-        <ul id="menubar1" role="menubar" aria-label="Mythical University Menu 1" >
-          <li>
-            <a role="menuitem" aria-haspopup="true" aria-expanded="false" href="#">About</a>
-            <ul role="menu" aria-label="About">
-              <li role="none">
-                <a role="menuitem" href="mb-about.html#overview">Overview</a>
-              </li>
-              <li role="none">
-                <a role="menuitem" href="mb-about.html#admin">Administration</a>
-              </li>
-              <li role="none">
-                <a id="menubar113" role="menuitem" href="#" aria-haspopup="true" aria-expanded="false">Facts</a>
-                <ul role="menu"  aria-label="Facts">
-                  <li role="none">
-                    <a role="menuitem" href="mb-about.html#facts">History</a>
-                  </li>
-                  <li role="none">
-                    <a role="menuitem" href="mb-about.html#facts">Current Statistics</a>
-                  </li>
-                  <li role="none">
-                    <a role="menuitem" href="mb-about.html#facts">Awards</a>
-                  </li>  
-                </ul>
-              </li>
-              <li>
-                <a role="menuitem" href="#" aria-haspopup="true" aria-expanded="false">Campus Tours</a>
-                <ul role="menu"  aria-label="Campus Tours">
-                  <li role="none">
-                    <a role="menuitem" href="mb-about.html#tours">For prospective students</a>
-                  </li>
-                  <li role="none">
-                    <a role="menuitem" href="mb-about.html#tours">For alumni</a>
-                  </li>
-                  <li role="none">
-                    <a role="menuitem" href="mb-about.html#tours">For visitors</a>
-                  </li>  
-                </ul>
-              </li>
-            </ul>
-          </li>
-          <li>
-            <a role="menuitem" aria-haspopup="true" aria-expanded="false" href="#">Admissions</a>
-            <ul role="menu"  aria-label="Admissions">
-              <li role="none">
-                <a role="menuitem" href="mb-admissions.html#apply">Apply</a>
-              </li>
-              <li role="none">
-                <a role="menuitem" href="mb-admissions.html#tuition">Tuition</a>
-              </li>
-              <li role="none">
-                <a role="menuitem" href="mb-admissions.html#signup">Sign Up</a>
-              </li>
-              <li role="separator"></li>
-              <li role="none">
-                <a role="menuitem" href="mb-admissions.html#visit">Visit</a>
-              </li>
-              <li role="none">
-                <a role="menuitem" href="mb-admissions.html#photo">Photo Tour</a>
-              </li>
-              <li role="none">
-                <a role="menuitem" href="mb-admissions.html#connect">Connect</a>
-              </li>
-            </ul>
-          </li>
-          <li>
-            <a role="menuitem" aria-haspopup="true" aria-expanded="false" href="#">Academics</a>
-            <ul role="menu"  aria-label="Academics">
-              <li role="none">
-                <a role="menuitem" href="mb-academics.html#colleges">Colleges &amp; Schools</a>
-              </li>
-              <li role="none">
-                <a role="menuitem" href="mb-academics.html#programs">Programs of Study</a>
-              </li>
-              <li role="none">
-                <a role="menuitem" href="mb-academics.html#honors">Honors Programs</a>
-              </li>
-              <li role="none">
-                <a role="menuitem" href="mb-academics.html#online">Online Courses</a>
-              </li>
-              <li role="separator"></li>
-              <li role="none">
-                <a role="menuitem" href="mb-academics.html#explorer">Course Explorer</a>
-              </li>
-              <li role="none">
-                <a role="menuitem" href="mb-academics.html#register">Register for Class</a>
-              </li>
-              <li role="none">
-                <a role="menuitem" href="mb-academics.html#academic">Academic Calendar</a>
-              </li>
-              <li role="none">
-                <a role="menuitem" href="mb-academics.html#tanscripts">Transscripts</a>
-              </li>
-            </ul>
-          </li>
-        </ul>
+    <h2 id="ex_label">Example</h2>
+    <div role="separator" id="ex_start_sep" aria-labelledby="ex_start_sep ex_label" aria-label="Start of"></div>
+    <div id="ex1">
+      <ul id="menubar1" role="menubar" aria-label="Mythical University Menu 1">
+        <li>
+          <a role="menuitem" aria-haspopup="true" aria-expanded="false" href="#">About</a>
+          <ul role="menu" aria-label="About">
+            <li role="none">
+              <a role="menuitem" href="mb-about.html#overview">Overview</a>
+            </li>
+            <li role="none">
+              <a role="menuitem" href="mb-about.html#admin">Administration</a>
+            </li>
+            <li role="none">
+              <a id="menubar113" role="menuitem" href="#" aria-haspopup="true" aria-expanded="false">Facts</a>
+              <ul role="menu" aria-label="Facts">
+                <li role="none">
+                  <a role="menuitem" href="mb-about.html#facts">History</a>
+                </li>
+                <li role="none">
+                  <a role="menuitem" href="mb-about.html#facts">Current Statistics</a>
+                </li>
+                <li role="none">
+                  <a role="menuitem" href="mb-about.html#facts">Awards</a>
+                </li>
+              </ul>
+            </li>
+            <li>
+              <a role="menuitem" href="#" aria-haspopup="true" aria-expanded="false">Campus
+                Tours</a>
+              <ul role="menu" aria-label="Campus Tours">
+                <li role="none">
+                  <a role="menuitem" href="mb-about.html#tours">For prospective students</a>
+                </li>
+                <li role="none">
+                  <a role="menuitem" href="mb-about.html#tours">For alumni</a>
+                </li>
+                <li role="none">
+                  <a role="menuitem" href="mb-about.html#tours">For visitors</a>
+                </li>
+              </ul>
+            </li>
+          </ul>
+        </li>
+        <li>
+          <a role="menuitem" aria-haspopup="true" aria-expanded="false" href="#">Admissions</a>
+          <ul role="menu" aria-label="Admissions">
+            <li role="none">
+              <a role="menuitem" href="mb-admissions.html#apply">Apply</a>
+            </li>
+            <li role="none">
+              <a role="menuitem" href="mb-admissions.html#tuition">Tuition</a>
+            </li>
+            <li role="none">
+              <a role="menuitem" href="mb-admissions.html#signup">Sign Up</a>
+            </li>
+            <li role="separator"></li>
+            <li role="none">
+              <a role="menuitem" href="mb-admissions.html#visit">Visit</a>
+            </li>
+            <li role="none">
+              <a role="menuitem" href="mb-admissions.html#photo">Photo Tour</a>
+            </li>
+            <li role="none">
+              <a role="menuitem" href="mb-admissions.html#connect">Connect</a>
+            </li>
+          </ul>
+        </li>
+        <li>
+          <a role="menuitem" aria-haspopup="true" aria-expanded="false" href="#">Academics</a>
+          <ul role="menu" aria-label="Academics">
+            <li role="none">
+              <a role="menuitem" href="mb-academics.html#colleges">Colleges &amp; Schools</a>
+            </li>
+            <li role="none">
+              <a role="menuitem" href="mb-academics.html#programs">Programs of Study</a>
+            </li>
+            <li role="none">
+              <a role="menuitem" href="mb-academics.html#honors">Honors Programs</a>
+            </li>
+            <li role="none">
+              <a role="menuitem" href="mb-academics.html#online">Online Courses</a>
+            </li>
+            <li role="separator"></li>
+            <li role="none">
+              <a role="menuitem" href="mb-academics.html#explorer">Course Explorer</a>
+            </li>
+            <li role="none">
+              <a role="menuitem" href="mb-academics.html#register">Register for Class</a>
+            </li>
+            <li role="none">
+              <a role="menuitem" href="mb-academics.html#academic">Academic Calendar</a>
+            </li>
+            <li role="none">
+              <a role="menuitem" href="mb-academics.html#tanscripts">Transscripts</a>
+            </li>
+          </ul>
+        </li>
+      </ul>
 
-        <script type="text/javascript">
-          var menubar = new Menubar(document.getElementById('menubar1'));
-          menubar.init();
-        </script>
+      <script type="text/javascript">
+              var menubar = new Menubar(document.getElementById('menubar1'));
+              menubar.init();
+            </script>
 
-      </div>
-    </section>  
-   </section>
+    </div>
+    <div role="separator" id="ex_end_sep" aria-labelledby="ex_end_sep ex_label" aria-label="End of"></div>
+  </section>
 
   <section>
     <h2>Accessibility Features</h2>
@@ -617,11 +615,10 @@
   </section>
 
   <section>
-    <h2>HTML Source Code</h2>
-
-    <div id="sc1_start_sep" role="separator" aria-labelledby="sc1_start_sep sc1_label" aria-label="Start of HTML for" ></div>
+    <h2 id="sc_label">HTML Source Code</h2>
+    <div id="sc1_start_sep" role="separator" aria-labelledby="sc1_start_sep sc_label" aria-label="Start of "></div>
     <pre><code id="sc1"></code></pre>
-    <div id="sc1_end_sep" role="separator" aria-labelledby="sc1_end_sep sc1_label" aria-label="End of HTML for" ></div>
+    <div id="sc1_end_sep" role="separator" aria-labelledby="sc1_end_sep sc_label" aria-label="End of "></div>
     <script>
             sourceCode.add('sc1', 'ex1')
             </script>

--- a/examples/menubar/menubar-1/menubar-1.html
+++ b/examples/menubar/menubar-1/menubar-1.html
@@ -46,7 +46,7 @@
         <ul id="menubar1" role="menubar" aria-label="Mythical University Menu 1" >
           <li>
             <a role="menuitem" aria-haspopup="true" aria-expanded="false" href="#">About</a>
-            <ul role="menu">
+            <ul role="menu" aria-label="About">
               <li role="none">
                 <a role="menuitem" href="mb-about.html#overview">Overview</a>
               </li>
@@ -54,10 +54,8 @@
                 <a role="menuitem" href="mb-about.html#admin">Administration</a>
               </li>
               <li role="none">
-                <a id="menubar113" role="menuitem" href="#" aria-haspopup="true" aria-expanded="false">
-                  Facts
-                </a>
-                <ul role="menu">
+                <a id="menubar113" role="menuitem" href="#" aria-haspopup="true" aria-expanded="false">Facts</a>
+                <ul role="menu"  aria-label="Facts">
                   <li role="none">
                     <a role="menuitem" href="mb-about.html#facts">History</a>
                   </li>
@@ -70,9 +68,8 @@
                 </ul>
               </li>
               <li>
-                <a role="menuitem" href="#" aria-haspopup="true" aria-expanded="false">Campus
-                  Tours</a>
-                <ul role="menu">
+                <a role="menuitem" href="#" aria-haspopup="true" aria-expanded="false">Campus Tours</a>
+                <ul role="menu"  aria-label="Campus Tours">
                   <li role="none">
                     <a role="menuitem" href="mb-about.html#tours">For prospective students</a>
                   </li>
@@ -88,7 +85,7 @@
           </li>
           <li>
             <a role="menuitem" aria-haspopup="true" aria-expanded="false" href="#">Admissions</a>
-            <ul role="menu">
+            <ul role="menu"  aria-label="Admissions">
               <li role="none">
                 <a role="menuitem" href="mb-admissions.html#apply">Apply</a>
               </li>
@@ -112,7 +109,7 @@
           </li>
           <li>
             <a role="menuitem" aria-haspopup="true" aria-expanded="false" href="#">Academics</a>
-            <ul role="menu">
+            <ul role="menu"  aria-label="Academics">
               <li role="none">
                 <a role="menuitem" href="mb-academics.html#colleges">Colleges &amp; Schools</a>
               </li>
@@ -147,97 +144,9 @@
           menubar.init();
         </script>
 
-
       </div>
-      <div role="separator" id="ex1_end_sep" aria-labelledby="ex1_end_sep ex1_label" aria-label="End of"></div>
-      <h4>Notes</h4>
-      <p>This implementation includes the ARIA roles and properties in the HTML to make it easy to see how they are used.</p>
-    </section>
-    <section>
-      <h3 id="ex2_label">Example 2: ARIA markup added dynamically</h3>
-      <div role="separator" id="ex2_start_sep" aria-labelledby="ex2_start_sep ex2_label" aria-label="Start of"></div>
-      <div id="ex2">
-        <ul id="menubar2" aria-label="Mythical University Menu 2">
-          <li>
-            <a href="#">Research</a>
-            <ul>
-              <li>
-                <a href="mb-research.html#res-news">Research News</a>
-              </li>
-              <li>
-                <a href="mb-research.html#res-centers">Reseach Centers</a>
-              </li>
-              <li>
-                <a href="mb-research.html#res-find">Find an Expert</a>
-              </li>
-              <li>
-                <a href="mb-research.html#res-park">Research Park</a>
-              </li>
-              <li>
-                <a href="mb-research.html#res-comm">Technology Commercialization</a>
-              </li>
-            </ul>
-          </li>
-          <li>
-            <a href="#">Outreach</a>
-            <ul>
-              <li>
-                <a href="mb-outreach.html#comm-engage">Community Engagement</a>
-              </li>
-              <li>
-                <a href="mb-outreach.html#copr-rel">Corporate Relations</a>
-              </li>
-              <li>
-                <a href="mb-outreach.html#extension">Extension</a>
-              </li>
-              <li>
-                <a href="mb-outreach.html#outreach-events">Outreach Events</a>
-              </li>
-            </ul>
-          </li>
-          <li>
-            <a href="#">Arts and Culture</a>
-            <ul>
-              <li>
-                <a href="mb-arts.html#fas">College of Fine and Applied Arts</a>
-              </li>
-              <li>
-                <a href="mb-arts.html#las">College of Liberal Arts and Sciences</a>
-              </li>
-              <li role="separator"></li>
-              <li>
-                <a href="mb-arts.html#cultural-center">Cultural Center</a>
-              </li>
-              <li>
-                <a href="mb-arts.html#perfoming-arts">Performing Arts</a>
-              </li>
-              <li>
-                <a href="mb-arts.html#art-museum">Art Museum</a>
-              </li>
-              <li>
-                <a href="mb-arts.html#history-museum">History Museum</a>
-              </li>
-              <li>
-                <a href="mb-arts.html#union">Student Union</a>
-              </li>
-            </ul>
-          </li>
-        </ul>
-
-          <script type="text/javascript">
-            var menubar = new Menubar(document.getElementById('menubar2'));
-            menubar.init();
-          </script>
-
-      </div>
-      <div role="separator" id="ex2_end_sep" aria-labelledby="ex2_end_sep ex2_label" aria-label="End of"></div>
-      <h4>Notes</h4>
-      <ol>
-        <li>In this implementation, ARIA roles and properties are added by the scripts based on the HTML structure.</li>
-        <li>This approach may be helpful when applying the menubar pattern to existing content.</li>
-      </ol>
-    </section>
-  </section>
+    </section>  
+   </section>
 
   <section>
     <h2>Accessibility Features</h2>
@@ -593,6 +502,25 @@
           <td>Identifies the element as a menu container for a set of menu items.</td>
         </tr>
         <tr>
+          <td></td>
+          <th>
+            <code>aria-label=&quot;<em>string</em>&quot;
+            </code>
+          </th>
+          <td>
+            <code>ul</code>
+          </td>
+          <td>
+            <ul>
+              <li>
+                Defines an acessible name for the <code>menu</code>.
+              </li>
+              <li>Helps assistive technology users understand the purpose of the menu and
+                distinguish it from any other menu or similar elements (e.g. menubar) on the page.</li>
+            </ul>
+          </td>
+        </tr>
+        <tr>
           <th>
             <code>menuitem</code>
           </th>
@@ -690,20 +618,14 @@
 
   <section>
     <h2>HTML Source Code</h2>
-    <h3 id="sc1_label">Example 1: Menubar With ARIA Markup in the HTML Source</h3>
+
     <div id="sc1_start_sep" role="separator" aria-labelledby="sc1_start_sep sc1_label" aria-label="Start of HTML for" ></div>
     <pre><code id="sc1"></code></pre>
     <div id="sc1_end_sep" role="separator" aria-labelledby="sc1_end_sep sc1_label" aria-label="End of HTML for" ></div>
     <script>
             sourceCode.add('sc1', 'ex1')
             </script>
-    <h3 id="sc2_label">Example 2: ARIA markup added dynamically</h3>
-    <div id="sc2_start_sep" role="separator" aria-labelledby="sc2_start_sep sc2_label" aria-label="Start of HTML for" ></div>
-    <pre><code id="sc2"></code></pre>
-    <div id="sc2_end_sep" role="separator" aria-labelledby="sc2_end_sep sc2_label" aria-label="End of HTML for" ></div>
-    <script>
-            sourceCode.add('sc2', 'ex2')
-            </script>
+
     <!--  After all source has been added, run make to do the insert.  -->
     <script>
             sourceCode.make()

--- a/examples/menubar/menubar-1/menubar-1.html
+++ b/examples/menubar/menubar-1/menubar-1.html
@@ -43,7 +43,7 @@
       <h3 id="ex1_label">Example 1: Menubar With ARIA Markup in the HTML Source</h3>
       <div role="separator" id="ex1_start_sep" aria-labelledby="ex1_start_sep ex1_label" aria-label="Start of"></div>
       <div id="ex1">
-        <ul id="menubar1" role="menubar" aria-label="Mythical University Menu 1">
+        <ul id="menubar1" role="menubar" aria-label="Mythical University Menu 1" >
           <li>
             <a role="menuitem" aria-haspopup="true" aria-expanded="false" href="#">About</a>
             <ul role="menu">
@@ -54,9 +54,9 @@
                 <a role="menuitem" href="mb-about.html#admin">Administration</a>
               </li>
               <li role="none">
-                <a id="menubar113" role="menuitem" href="#" aria-haspopup="true"
-                  aria-expanded="false"
-                >Facts</a>
+                <a id="menubar113" role="menuitem" href="#" aria-haspopup="true" aria-expanded="false">
+                  Facts
+                </a>
                 <ul role="menu">
                   <li role="none">
                     <a role="menuitem" href="mb-about.html#facts">History</a>
@@ -66,6 +66,7 @@
                   </li>
                   <li role="none">
                     <a role="menuitem" href="mb-about.html#facts">Awards</a>
+                  </li>  
                 </ul>
               </li>
               <li>
@@ -80,6 +81,7 @@
                   </li>
                   <li role="none">
                     <a role="menuitem" href="mb-about.html#tours">For visitors</a>
+                  </li>  
                 </ul>
               </li>
             </ul>
@@ -138,13 +140,14 @@
               </li>
             </ul>
           </li>
-
-          <script type="text/javascript">
-            var menubar = new Menubar(document.getElementById('menubar1'));
-            menubar.init();
-          </script>
-
         </ul>
+
+        <script type="text/javascript">
+          var menubar = new Menubar(document.getElementById('menubar1'));
+          menubar.init();
+        </script>
+
+
       </div>
       <div role="separator" id="ex1_end_sep" aria-labelledby="ex1_end_sep ex1_label" aria-label="End of"></div>
       <h4>Notes</h4>
@@ -588,22 +591,6 @@
             <code>ul</code>
           </td>
           <td>Identifies the element as a menu container for a set of menu items.</td>
-        </tr>
-        <tr>
-          <td></td>
-          <th>
-            <code>aria-label=&quot;<em>string</em>&quot;
-            </code>
-          </th>
-          <td>
-            <code>ul</code>
-          </td>
-          <td>
-            <ul>
-              <li>Defines an acessible name for the menu.</li>
-              <li>Helps assistive technology users understand the purpose of the menu.</li>
-            </ul>
-          </td>
         </tr>
         <tr>
           <th>


### PR DESCRIPTION
This bug fixes a problem in the source code view and I don't think we needed a label for the role=menu or a tabindex=-1 on the menu role