### PR TITLE
Fixed some behavior bugs and added documentation for aria-disabled on font smaller and larger; also fixed the aria-expanded bug with link menubar and second level popups

### DIFF
--- a/examples/menubar/menubar-1/js/PopupMenuLinks.js
+++ b/examples/menubar/menubar-1/js/PopupMenuLinks.js
@@ -241,7 +241,7 @@ PopupMenu.prototype.open = function () {
     this.domNode.style.zIndex = 100;
   }
 
-  this.controller.domNode.setAttribute('aria-expanded', 'true');
+  this.domNode.setAttribute('aria-expanded', 'true');
 
 };
 
@@ -256,6 +256,6 @@ PopupMenu.prototype.close = function (force) {
   if (force || (!this.hasFocus && !this.hasHover && !controllerHasHover)) {
     this.domNode.style.display = 'none';
     this.domNode.style.zIndex = 0;
-    this.controller.domNode.setAttribute('aria-expanded', 'false');
+    this.domNode.setAttribute('aria-expanded', 'false');
   }
 };

--- a/examples/menubar/menubar-2/js/PopupMenuAction.js
+++ b/examples/menubar/menubar-2/js/PopupMenuAction.js
@@ -142,6 +142,22 @@ PopupMenuAction.prototype.updateMenuStates = function () {
     }
   }
 
+  // Update the radio buttons for font, in case they were updated using the larger 
+  // smaller font menu items
+
+  var rbs = this.domNode.querySelectorAll('[role=menuitemradio]');
+
+  for (var i = 0; i < rbs.length; i++) {
+    var rb = rbs[i];
+    
+    if(this.actionManager.fontSize === rb.textContent.toLowerCase()) {
+      rb.setAttribute('aria-checked', 'true');
+    } 
+    else {
+      rb.setAttribute('aria-checked', 'false');          
+    }  
+  }
+  
 };
 
 /* EVENT HANDLERS */

--- a/examples/menubar/menubar-2/js/PopupMenuAction.js
+++ b/examples/menubar/menubar-2/js/PopupMenuAction.js
@@ -149,15 +149,15 @@ PopupMenuAction.prototype.updateMenuStates = function () {
 
   for (var i = 0; i < rbs.length; i++) {
     var rb = rbs[i];
-    
-    if(this.actionManager.fontSize === rb.textContent.toLowerCase()) {
+
+    if (this.actionManager.fontSize === rb.textContent.toLowerCase()) {
       rb.setAttribute('aria-checked', 'true');
-    } 
+    }
     else {
-      rb.setAttribute('aria-checked', 'false');          
-    }  
+      rb.setAttribute('aria-checked', 'false');
+    }
   }
-  
+
 };
 
 /* EVENT HANDLERS */

--- a/examples/menubar/menubar-2/js/PopupMenuItemAction.js
+++ b/examples/menubar/menubar-2/js/PopupMenuItemAction.js
@@ -76,6 +76,23 @@ MenuItem.prototype.activateMenuitem = function (node) {
 
   if (role === 'menuitem') {
     this.menu.actionManager.setOption(option, value);
+
+    if (option === 'font-smaller' || option === 'font-larger') {
+
+      var rbs = node.parentNode.querySelectorAll('[role=menuitemradio]');
+
+      for (var i = 0; i < rbs.length; i++) {
+        var rb = rbs[i];
+        
+        if(this.menu.actionManager.fontSize === rb.textContent.toLowerCase()) {
+          rb.setAttribute('aria-checked', 'true');
+        } 
+        else {
+          rb.setAttribute('aria-checked', 'false');          
+        }  
+      }
+    }
+
   }
   else {
     if (role === 'menuitemcheckbox') {

--- a/examples/menubar/menubar-2/js/PopupMenuItemAction.js
+++ b/examples/menubar/menubar-2/js/PopupMenuItemAction.js
@@ -76,23 +76,6 @@ MenuItem.prototype.activateMenuitem = function (node) {
 
   if (role === 'menuitem') {
     this.menu.actionManager.setOption(option, value);
-
-    if (option === 'font-smaller' || option === 'font-larger') {
-
-      var rbs = node.parentNode.querySelectorAll('[role=menuitemradio]');
-
-      for (var i = 0; i < rbs.length; i++) {
-        var rb = rbs[i];
-        
-        if(this.menu.actionManager.fontSize === rb.textContent.toLowerCase()) {
-          rb.setAttribute('aria-checked', 'true');
-        } 
-        else {
-          rb.setAttribute('aria-checked', 'false');          
-        }  
-      }
-    }
-
   }
   else {
     if (role === 'menuitemcheckbox') {

--- a/examples/menubar/menubar-2/js/styleManager.js
+++ b/examples/menubar/menubar-2/js/styleManager.js
@@ -51,7 +51,7 @@ StyleManager.prototype.setItalic = function (flag) {
     this.node.style.fontStyle = 'italic';
   }
   else {
-    this.node.style.fontStyle = 'none';
+    this.node.style.fontStyle = 'normal';
   }
 };
 

--- a/examples/menubar/menubar-2/menubar-2.html
+++ b/examples/menubar/menubar-2/menubar-2.html
@@ -90,8 +90,8 @@
         <li role="menuitem" aria-haspopup="true" aria-expanded="false">
           <span>Size</span>
           <ul role="menu" aria-label="Size" >
-            <li role="menuitem" rel="font-smaller">Smaller</li>
-            <li role="menuitem" rel="font-larger">Larger</li>
+            <li role="menuitem" rel="font-smaller" aria-disabled="false">Smaller</li>
+            <li role="menuitem" rel="font-larger"  aria-disabled="false">Larger</li>
             <li role="separator"></li>
             <li>
               <ul role="group" rel="font-size" aria-label="Font Sizes">
@@ -366,7 +366,10 @@
               <code>li</code>
             </td>
             <td>
-              Identifies the element as a menu item within the menubar.
+              <ul>
+                <li>Identifies the element as a menu item within the menubar.</li>
+                <li>Accessible name comes from the text content.</li>
+              </ul>  
             </td>
           </tr>
           <tr>
@@ -497,7 +500,10 @@
             <code>li</code>
           </td>
           <td>
-            Identifies the element as an item in the submenu.
+            <ul>
+              <li>Identifies the element as an item in the submenu.</li>
+              <li>Accessible name comes from the text content.</li>
+            </ul>
           </td>
         </tr>
         <tr>
@@ -513,6 +519,30 @@
           </td>
         </tr>
         <tr>
+          <td></td>
+          <th scope="row">
+            <code>aria-disabled=&quot;false&quot;</code>
+          </th>
+          <td>
+            <code>li</code>
+          </td>
+          <td>
+            Used on the font size "Smaller" and "Larger" options to indicate they are active.
+          </td>
+        </tr>
+        <tr>
+          <td></td>
+          <th scope="row">
+            <code>aria-disabled=&quot;true&quot;</code>
+          </th>
+          <td>
+            <code>li</code>
+          </td>
+          <td>
+            Used on the font size "Smaller" and "Larger" options to indicate one of the options is <strong>not</strong> active because the largest or smallest font has been selected.
+          </td>
+        </tr>
+        <tr>
           <th scope="row">
             <code>menuitemcheckbox</code>
           </th>
@@ -521,7 +551,10 @@
             <code>li</code>
           </td>
           <td>
-            Identifies the element as a <code>menuitemcheckbox</code>.
+            <ul>
+              <li>Identifies the element as a <code>menuitemcheckbox</code>.</li>
+              <li>Accessible name comes from the text content.</li>
+            </ul>  
           </td>
         </tr>
         <tr>
@@ -609,6 +642,9 @@
               <li>
                 When all items in a submenu are members of the same radio group,
                 the group is defined by the <code>menu</code> element; a <code>group</code> element is not necessary.
+              </li>
+              <li>
+                Accessible name comes from the text content.
               </li>
             </ul>
           </td>


### PR DESCRIPTION
fixed bugs in:
1. Italic style menu button did not toggle off italics and now it does
2. Activating the font larger or smaller menu item was not updating the list of menubuttonradio items for font size and now there are updated
3. Updated documentation to include information about the use of aria-disabled for the font smaller and larger options