### PR TITLE
Fix issue 486: Update mixed state on change

### DIFF
--- a/examples/checkbox/checkbox-2/js/checkboxMixed.js
+++ b/examples/checkbox/checkbox-2/js/checkboxMixed.js
@@ -67,7 +67,14 @@ CheckboxMixed.prototype.updateCheckboxMixed = function () {
     }
     else {
       this.domNode.setAttribute('aria-checked', 'mixed');
+      this.updateControlledStates();
     }
+  }
+};
+
+CheckboxMixed.prototype.updateControlledStates = function () {
+  for (var i = 0; i < this.controlledCheckboxes.length; i++) {
+    this.controlledCheckboxes[i].lastState = this.controlledCheckboxes[i].isChecked();
   }
 };
 


### PR DESCRIPTION
Fix issue #486.

The selected state of each individual checkbox was only recorded on click of that individual checkbox. In order to properly track the state of all the checkboxes a routine is added to update the state of all controlled checkboxes when the master is set to mixed state, which happens every time a change occurs in the controlled checkboxes.

I would have preferred a cleaner approach where the controller stored the mixed states, but did not want to be too destructive with my changes.

cc: @mcking65 