### PR TITLE
Update pattern status link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ that supports [EditorConfig](http://editorconfig.org/).
 ### Writing code examples
 
 - Choose a pattern from the
-  [Design Patterns Status](https://github.com/w3c/aria-practices/wiki/Design-Patterns-Status)
+  [Design Patterns Development Status](https://github.com/w3c/aria-practices/wiki/Design-Patterns-Development-Status)
   document that is missing a code example.
 - Via the command line, run:
 


### PR DESCRIPTION
The wiki's Design Pattern Status page [was renamed earlier this year](https://github.com/w3c/aria-practices/wiki/_compare/31351016c6648aab547a44c308af902abb370126...470bff08a79cdc691539174fbcee2cd62e14f9db).
This PR updates the README's link to that wiki page.