### PR TITLE
[Accordion] Fix CSS bugs in MS Edge

### DIFF
--- a/examples/accordion/accordion.html
+++ b/examples/accordion/accordion.html
@@ -53,7 +53,7 @@
         <dl id="accordionGroup" role="presentation" class="Accordion">
           <dt role="heading" aria-level="3">
             <button aria-expanded="true" class="Accordion-trigger"
-              aria-controls="sect1" id="accordion1id"
+              aria-controls="sect1" id="accordion1id" type="button"
             >
               <span class="Accordion-title">Personal Information</span><span class="Accordion-icon"></span>
             </button>
@@ -95,14 +95,14 @@
           </dd>
           <dt role="heading" aria-level="3">
             <button aria-expanded="false" class="Accordion-trigger"
-              aria-controls="sect2" id="accordion2id"
+              aria-controls="sect2" id="accordion2id" type="button"
             >
               <span class="Accordion-title">Billing Address</span><span class="Accordion-icon"></span>
             </button>
           </dt>
           <dd id="sect2" role="region" aria-labelledby="accordion2id" class="Accordion-panel" hidden>
             <div>
-              <fieldset class="billing flex">
+              <fieldset>
                 <p>
                   <label for="b-add1">Address 1:</label>
                   <input type="text" name="b-add1" id="b-add1" />
@@ -128,7 +128,7 @@
           </dd>
           <dt role="heading" aria-level="3">
             <button aria-expanded="false" class="Accordion-trigger"
-              aria-controls="sect3" id="accordion3id"
+              aria-controls="sect3" id="accordion3id" type="button"
             >
               <span class="Accordion-title">Shipping Address</span><span class="Accordion-icon"></span>
             </button>

--- a/examples/accordion/css/accordion.css
+++ b/examples/accordion/css/accordion.css
@@ -32,6 +32,7 @@
 }
 
 .Accordion-title {
+  display: block; /* For Edge bug https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/8295099/ */
   pointer-events: none;
 }
 
@@ -59,6 +60,11 @@
 .Accordion-panel {
     margin: 0;
     padding: 1em 1.5em;
+}
+
+/* For Edge bug https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/4806035/ */
+.Accordion-panel[hidden] {
+  display: none;
 }
 
 fieldset {


### PR DESCRIPTION
Based on a [comment](https://github.com/w3c/aria-practices/issues/401#issuecomment-338934277) by @finalborgo I have fixed 2 CSS bugs for MS Edge.

The first is an issue with using `pointer-events: none` on non-block level elements will still allow interaction. See MS Edge defect [8295099](https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/8295099/).

The second, Edge has an issue with using the `hidden` attribute. See MS Edge defect [4806035](https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/4806035/)

Those are really sad bugs IMO. I can understand why this project doesn't necessarily support Edge. Thankfully, there were simple CSS workarounds.

Lastly, just to be complete, I added `type="button" to all the accordion trigger buttons, as a best practice and to prevent any unintentional form submission.