### PR TITLE
ARIA 1.0 Combobox Examples: Integrate 3 New Examples

### DIFF
--- a/aria-practices.html
+++ b/aria-practices.html
@@ -636,9 +636,11 @@
       <section class="notoc">
         <h4>Examples</h4>
         <ul>
-          <li><a href="examples/combobox/aria1.1pattern/listbox-combo.html">Examples of ARIA 1.1 Combobox with Listbox Popup</a>: Comboboxes that demonstrate the various forms of autocomplete behavior using a listbox popup.</li>
+          <li><a href="examples/combobox/aria1.1pattern/listbox-combo.html">Examples of ARIA 1.1 Combobox with Listbox Popup</a>: Comboboxes that demonstrate the various forms of autocomplete behavior using a listbox popup and use the ARIA 1.1 implementation pattern.</li>
           <li><a href="examples/combobox/aria1.1pattern/grid-combo.html">Example of ARIA 1.1 Combobox with Grid Popup</a>: A combobox that presents suggestions in a grid, enabling users to navigate descriptive information about each suggestion.</li>
-          <li><a href="examples/combobox/aria1.0pattern/combobox-autocomplete-list.html">ARIA 1.0 Combobox with List Autocomplete</a></li>
+          <li><a href="examples/combobox/aria1.0pattern/combobox-autocomplete-both.html">ARIA 1.0 Combobox with Both List and Inline Autocomplete</a>: A combobox that demonstrates the autocomplete behavior known as <q>list with inline autocomplete</q> and uses the ARIA 1.0 implementation pattern.</li>
+          <li><a href="examples/combobox/aria1.0pattern/combobox-autocomplete-list.html">ARIA 1.0 Combobox with List Autocomplete</a>: A combobox that demonstrates the autocomplete behavior known as <q>list with manual selection</q> and uses the ARIA 1.0 implementation pattern.</li>
+          <li><a href="examples/combobox/aria1.0pattern/combobox-autocomplete-none.html">ARIA 1.0 Combobox Without Autocomplete</a>: A combo box that demonstrates the behavior associated with <code>aria-autocomplete=none</code> and uses the ARIA 1.0 implementation pattern.</li>
         </ul>
       </section>
 

--- a/examples/combobox/aria1.0pattern/combobox-autocomplete-both.html
+++ b/examples/combobox/aria1.0pattern/combobox-autocomplete-both.html
@@ -2,409 +2,461 @@
 <html lang="en">
 <head>
 <meta charset="utf-8" />
-<title>Example of Legacy ARIA 1.0 Combobox With Both List and Inline Autocompletion | WAI-ARIA Authoring Practices 1.1</title>
+<title>Legacy ARIA 1.0 Combobox With Both List and Inline Autocomplete Example | WAI-ARIA Authoring Practices
+  1.1</title>
 
 <!--  Core js and css shared by all examples; do not modify when using this template. -->
 <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/base.css">
 <link rel="stylesheet" href="../../css/core.css">
-
 <script type="text/javascript" src="../../js/examples.js"></script>
 <script type="text/javascript" src="../../js/highlight.pack.js"></script>
 <script type="text/javascript" src="../../js/app.js"></script>
 
+<!--  js and css for this example. -->
 <link rel="stylesheet" href="css/combobox-1.0.css">
 <link rel="stylesheet" href="css/listbox.css">
-
 <script type="text/javascript" src="js/combobox-1.0-list.js"></script>
 <script type="text/javascript" src="js/listbox.js"></script>
 <script type="text/javascript" src="js/listboxOption.js"></script>
-
 </head>
 <body>
   <main>
-  <h1>Example of Legacy ARIA 1.0 Combobox With Both List and Inline Autocompletion</h1>
-  <p>
-    <strong>NOTE:</strong> This page is ready to start reviewing.
-    This work is tracked by <a href="https://github.com/w3c/aria-practices/issues/99">issue 99</a>.
-  </p>
-  <p>
-    The below example section demonstrates a <code>combobox</code> that implements the
-    <a href="../../#combobox">ARIA 1.0 design pattern for combobox.</a>
-    This example demonstrates a combobox that provides both a list and an inline of
-    autocomplete options to the user.
-    The options available in the listbox are filtered based on user input into the textbox.
-    The user can select an option from the list to set the value of the textbox or use the
-    enter key to select the autocompelete option in the textbox.
-  </p>The major design feature of the ARIA 1.0 combobox pattern is the use of
-    <code>aria-activedescendant</code> to reference options in a listbox, while keyboard
-    focus remains on the textbox.
-  <p>
-  </p>
-  <p>Similar examples include: </p>
-  <ul>
-    <li>
-      <a href="combobox-autocomplete-none.html">Combobox Without Autocomplete</a>
-      : example demonstrates the behavior associated with <code>aria-autocomplete=none</code>.
-    </li>
-    <li>
-      <a href="combobox-autocomplete-list.html">Combobox With an List Autocomplete</a>
-      : example demonstrates the behavior associated with <code>aria-autocomplete=list</code>.
-    </li>
-  </ul>
-
-  <section>
-    <h2 id="ex_label">Example</h2>
-    <div role="separator" id="ex_start_sep" aria-labelledby="ex_start_sep ex_label" aria-label="Start of"></div>
-    <div id="ex1">
-      <div class="combobox-list">
-        <label for="cb1-input">State</label>
-
-        <div class="group">
-          <input id="cb1-input" class="cb_edit" type="text"
-                 role="combobox"
-                 aria-autocomplete="both"
-                 aria-expanded="false"
-                 aria-haspopup="true"
-                 aria-owns="lb1"
-                 aria-activedescendant=""
-          />
-          <button id="cb1-button"
-                  aria-label="open button"
-                  tabindex="-1">
-            &#9661;
-          </button>
-        </div>
-
-        <ul id="lb1" role="listbox" aria-label="States">
-          <li id="lb1-al" role="option">Alabama</li>
-          <li id="lb1-ak" role="option">Alaska</li>
-          <li id="lb1-as" role="option">American Samoa</li>
-          <li id="lb1-az" role="option">Arizona</li>
-          <li id="lb1-ar" role="option">Arkansas</li>
-          <li id="lb1-ca" role="option">California</li>
-          <li id="lb1-co" role="option">Colorado</li>
-          <li id="lb1-ct" role="option">Connecticut</li>
-          <li id="lb1-de" role="option">Delaware</li>
-          <li id="lb1-dc" role="option">District of Columbia</li>
-          <li id="lb1-fl" role="option">Florida</li>
-          <li id="lb1-ga" role="option">Georgia</li>
-          <li id="lb1-gm" role="option">Guam</li>
-          <li id="lb1-hi" role="option">Hawaii</li>
-          <li id="lb1-id" role="option">Idaho</li>
-          <li id="lb1-il" role="option">Illinois</li>
-          <li id="lb1-in" role="option">Indiana</li>
-          <li id="lb1-ia" role="option">Iowa</li>
-          <li id="lb1-ks" role="option">Kansas</li>
-          <li id="lb1-ky" role="option">Kentucky</li>
-          <li id="lb1-la" role="option">Louisiana</li>
-          <li id="lb1-me" role="option">Maine</li>
-          <li id="lb1-md" role="option">Maryland</li>
-          <li id="lb1-ma" role="option">Massachusetts</li>
-          <li id="lb1-mi" role="option">Michigan</li>
-          <li id="lb1-mn" role="option">Minnesota</li>
-          <li id="lb1-ms" role="option">Mississippi</li>
-          <li id="lb1-mo" role="option">Missouri</li>
-          <li id="lb1-mn" role="option">Montana</li>
-          <li id="lb1-ne" role="option">Nebraska</li>
-          <li id="lb1-nv" role="option">Nevada</li>
-          <li id="lb1-nh" role="option">New Hampshire</li>
-          <li id="lb1-nj" role="option">New Jersey</li>
-          <li id="lb1-nm" role="option">New Mexico</li>
-          <li id="lb1-ny" role="option">New York</li>
-          <li id="lb1-nc" role="option">North Carolina</li>
-          <li id="lb1-nd" role="option">North Dakota</li>
-          <li id="lb1-nm" role="option">Northern Marianas Islands</li>
-          <li id="lb1-oh" role="option">Ohio</li>
-          <li id="lb1-ok" role="option">Oklahoma</li>
-          <li id="lb1-or" role="option">Oregon</li>
-          <li id="lb1-pa" role="option">Pennsylvania</li>
-          <li id="lb1-pr" role="option">Puerto Rico</li>
-          <li id="lb1-ri" role="option">Rhode Island</li>
-          <li id="lb1-sc" role="option">South Carolina</li>
-          <li id="lb1-sd" role="option">South Dakota</li>
-          <li id="lb1-tn" role="option">Tennessee</li>
-          <li id="lb1-tx" role="option">Texas</li>
-          <li id="lb1-ut" role="option">Utah</li>
-          <li id="lb1-ve" role="option">Vermont</li>
-          <li id="lb1-va" role="option">Virginia</li>
-          <li id="lb1-vi" role="option">Virgin Islands</li>
-          <li id="lb1-wa" role="option">Washington</li>
-          <li id="lb1-wv" role="option">West Virginia</li>
-          <li id="lb1-wi" role="option">Wisconsin</li>
-          <li id="lb1-wy" role="option">Wyoming</li>
-        </ul>
-      </div>
-    </div>
-    <div role="separator" id="ex_end_sep" aria-labelledby="ex_end_sep ex_label" aria-label="End of"></div>
-  </section>
-
-  <section>
-    <h2 id="kbd_label_textbox">Combobox Keyboard Support</h2>
-
-    <table aria-labelledby="kbd_label_textbox" class="def">
-      <thead>
-        <tr>
-          <th>Key</th>
-          <th>Function</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <th><kbd>Down Arrow</kbd></th>
-          <td>
-            <ul>
-              <li>If the listbox is <strong>closed</strong>, the listbox is opened and <code>aria-activedescendant</code> is set to reference the first option in the listbox.  </li>
-              <li>If the listbox is <strong>open</strong>, <code>aria-activedescendant</code> is updated to reference the next option in the listbox.  <br/>Note: When <code>aria-activedescendant</code> is referencing the last option the reference does not change.</li>
-              <li>If the listbox is <strong>empty</strong> (e.g. no options avaialble), <code>aria-activedescendant</code> is set to an empty string.</li>
-            </ul>
-          </td>
-        </tr>
-        <tr>
-          <th><kbd>Up Arrow</kbd></th>
-          <td>
-            <ul>
-              <li>If the listbox is <strong>closed</strong>, the listbox is opened and <code>aria-activedescendant</code> is set to reference the last option in the listbox.  </li>
-              <li>If the listbox is <strong>open</strong>, <code>aria-activedescendant</code> is updated to reference the previous option in the listbox.  <br/>Note: When <code>aria-activedescendant</code> is referencing the first option the reference does not change.</li>
-              <li>If the listbox is <strong>empty</strong> (e.g. no options avaialble), <code>aria-activedescendant</code> is set to an empty string.</li>
-            </ul>          </td>
-        </tr>
-        <tr>
-          <th><kbd>Left Arrow</kbd>,<br/><kbd>Right Arrow</kbd>,<br/><kbd>Backspace</kbd>,<br/><kbd>Printable characters</kbd></th>
-          <td>
-            <ul>
-              <li>The list of options in the listbox are updated based on the text content of the <code>combobox</code>.</li>
-              <li>The list of options are filtered based on user input before the edit cursor (e.g. <code>sectionStart</code> property of the textbox).</li>
-              <li>After the options are updated:
-                <ul>
-                  <li>If the currently referenced option <strong>remains</strong> in the list, <code>aria-activedescendant</code> will not change.</li>
-                  <li>If the currently referenced option is <strong>not</strong> a match, <code>aria-activedescendant</code> is updated to reference the first item in the new list of options.</li>
-                  <li>If there are <strong>no</strong> options available, <code>aria-activedescendant</code> is set to an empty string.</li>
-                </ul>
-              </li>
-            </ul>
-          </td>
-        </tr>
-        <tr>
-          <th><kbd>Escape</kbd></th>
-          <td>If the listbox is <strong>open</strong>, the listbox is closed and aria-activedescendant</code> is set to an empty string.</td>
-        </tr>
-      </tbody>
-    </table>
-
-  </section>
-
-  <section>
-
-    <h2 id="rps_label_combobox">Combobox Role, Property, State, and Tabindex  Attributes</h2>
-    <!--
-      Update this table to describe how roles, properties, states, and tabindex are used in this example.
-    -->
-    <table aria-labelledby="rps_label_combobox" class="data attributes">
-      <thead>
-        <tr>
-          <th scope="col">Role</th>
-          <th scope="col">Attribute</th>
-          <th scope="col">Element</th>
-          <th scope="col">Usage</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <th scope="row"><code>combobox</code></th>
-          <td><!--  Leave this cell blank in rows where a role is being described. --></td>
-          <td><code>input[type="text"]</code></td>
-          <td>
-            Identifies the <code>input[type=<q>text</q>] as a combobox option.
-          </td>
-        </tr>
-        <tr>
-          <td>
-          </td>
-          <th scope="row"><code>aria-autocomplete=<q>both</q></code></th>
-          <td><code>input[type="text"]</code></td>
-          <td>
-            <ul>
-              <li>The value of <code>both</code> identifies that the combobox will update
-                the <code>input[type=<q>text</q>]</code> value with the currently selected option
-                and the list of options will be filtered based on user input.
-              </li>
-              <li>When there is an autocomplete options, the selection range of
-                <code>input[type=<q>text</q>]</code> will be set to the end of the text being
-                used to filter the list of options and the end of the autocomplete option.
-              </li>
-          </td>
-        </tr>
-        <tr>
-          <td>
-          </td>
-          <th scope="row"><code>aria-haspopup=<q>true</q></code></th>
-          <td><code>input[type="text"]</code></td>
-          <td>
-            Identifies the <code>combobox</code> as having a popup list of options for the value of the textbox.
-          </td>
-        </tr>
-        <tr>
-          <td>
-          </td>
-          <th scope="row"><code>aria-owns=<q>#IDREF</q></code></th>
-          <td><code>input[type="text"]</code></td>
-          <td>
-            Identifies the <code>listbox</code> that is controlled by the combobox.
-          </td>
-        </tr>
-        <tr>
-          <td>
-          </td>
-          <th scope="row"><code>aria-expanded=<q>false</q></code></th>
-          <td><code>input[type="text"]</code></td>
-          <td>
-            Idenitifies the <code>listbox</code> as closed (e.g. hidden from the user).
-          </td>
-        </tr>
-        <tr>
-          <td>
-          </td>
-          <th scope="row"><code>aria-expanded=<q>true</q></code></th>
-          <td><code>input[type="text"]</code></td>
-          <td>
-            Idenitifies the <code>listbox</code> as open (e.g. visible to the user).
-          </td>
-        </tr>
-        <tr>
-          <td>
-          </td>
-          <th scope="row"><code>aria-activedescendant=<q>#IDREF</q></code></th>
-          <td><code>input[type="text"]</code></td>
-          <td>
-            References the current autocomplete <code>option</code> in the <code>listbox</code>.
-          </td>
-        </tr>
-        <tr>
-          <td>
-          </td>
-          <th scope="row"><code>aria-activedescendant=<q></q></code></th>
-          <td><code>input[type="text"]</code></td>
-          <td>
-            If no autocomplete <code>option</code> is selected or the list of <code>option</code>s is emtpy, <code>aria-activedescendant</code> is set to an empty string.</td>
-          </td>
-        </tr>
-      </tbody>
-    </table>
-
-
-    <h2 id="rps_label_listbox">Listbox Role, Property, State, and Tabindex  Attributes</h2>
-    <!--
-      Update this table to describe how roles, properties, states, and tabindex are used in this example.
-    -->
-    <table aria-labelledby="rps_label_listbox" class="data attributes">
-      <thead>
-        <tr>
-          <th scope="col">Role</th>
-          <th scope="col">Attribute</th>
-          <th scope="col">Element</th>
-          <th scope="col">Usage</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <th scope="row">
-            <code>listbox</code>
-          </th>
-          <td></td>
-          <td>
-            <code>ul</code>
-          </td>
-          <td>Identifies the <code>ul</code> element as a <code>listbox</code>.</td>
-        </tr>
-        <tr>
-          <td>
-            <code></code>
-          </td>
-          <th scope="row"><code>aria-label=<q>States</q></code></th>
-          <td>
-            <code>ul</code>
-          </td>
-          <td>
-            Provides a label for the <code>listbox</code>.
-          </td>
-        </tr>
-        <tr>
-          <th scope="row">
-            <code>option</code>
-          </th>
-          <td></td>
-          <td>
-            <code>li</code>
-          </td>
-          <td>
-            <ul>
-              <li>Identifies the <code>li</code> element as a <code>option</code> in a <cpde>listbox</cpde>.</li>
-              <li>The text content of the <code>li</code> element provides the accessible name of the <code>option</code>.</li>
-            </ul>
-          </td>
-        </tr>
-        <tr>
-          <td>
-            <code></code>
-          </td>
-          <th scope="row"><code>id=<q>ID</q></code></th>
-          <td>
-            <code>li</code>
-          </td>
-          <td>
-            Provides a unique reference for the option that is referenced by the <code>aria-activedescendant</code> attribute of the <code>combobox</code>.
-          </td>
-        </tr>
-      </tbody>
-    </table>
-  </section>
-
-  <section>
-    <h2>Javascript and CSS Source Code</h2>
-    <!--  After the js and css files are named with the name of this example, change the href and text of the following 2 links to refer to the appropriate js and css files.  -->
+    <h1>Legacy ARIA 1.0 Combobox With Both List and Inline Autocomplete Example</h1>
+    <p>
+      <strong>NOTE:</strong> This page is work in progress. Please provide feedback in
+      <a href="https://github.com/w3c/aria-practices/issues/99">issue 99.</a>
+    </p>
+    <p>
+      The below combobox for choosing the name of a US state or territory demonstrates the
+      <a href="../../../#combobox">ARIA 1.0 design pattern for combobox.</a>
+      The design pattern describes four types of autocomplete behavior.
+      This example illustrates the autocomplete behavior referred to in the pattern as list with inline completion.
+      If the user types one or more characters in the edit box and the typed characters match the beginning of the name of one or more states or territories,
+      a listbox popup appears containing the matching names, and the first match is automatically selected.
+      In addition, the portion of the selected suggestion that has not been typed by the user, a completion string, appears inline after the input cursor in the textbox.
+      The automatically selected suggestion becomes the value of the textbox when the combobox loses focus unless the user chooses a different suggestion or changes the character string in the textbox.
+      Note that this implementation enables users to input the name of a state or territory, but it does not prevent input of any other arbetrary value.
+    </p>
+    <p>Similar examples include:</p>
     <ul>
-      <li>
-        CSS:
-        <a href="css/combobox-1.0.css" type="text/css">combobox-1.0.css</a>
-      </li>
-      <li>
-        CSS:
-        <a href="css/listbox.css" type="text/css">listbox.css</a>
-      </li>
-      <li>
-        Javascript:
-        <a href="js/combobox-1.0-list.js" type="text/javascript">combobox-1.0-list.js</a>
-      </li>
-      <li>
-        Javascript:
-        <a href="js/listbox.js" type="text/javascript">listbox.js</a>
-      </li>
-      <li>
-        Javascript:
-        <a href="js/listboxOption.js" type="text/javascript">listboxOption.js</a>
-      </li>
+      <li><a href="combobox-autocomplete-list.html">ARIA 1.0 Combobox with List Autocomplete</a>: A combobox that demonstrates the autocomplete behavior known as <q>list with manual selection</q> and uses the ARIA 1.0 implementation pattern.</li>
+      <li><a href="combobox-autocomplete-none.html">ARIA 1.0 Combobox Without Autocomplete</a>: A combo box that demonstrates the behavior associated with <code>aria-autocomplete=none</code> and uses the ARIA 1.0 implementation pattern.</li>
+      <li><a href="../aria1.1pattern/listbox-combo.html">ARIA 1.1 Combobox with Listbox Popup</a>: Comboboxes that demonstrate the various forms of autocomplete behavior using a listbox popup and use the ARIA 1.1 implementation pattern.</li>
+      <li><a href="../aria1.1pattern/grid-combo.html">ARIA 1.1 Combobox with Grid Popup</a>: A combobox that presents suggestions in a grid, enabling users to navigate descriptive information about each suggestion.</li>
     </ul>
-  </section>
+    <section>
+      <h2 id="ex_label">Example</h2>
+      <div role="separator" id="ex_start_sep" aria-labelledby="ex_start_sep ex_label" aria-label="Start of"></div>
+      <div id="ex1">
+        <div class="combobox-list">
+          <label for="cb1-input">State</label>
+          <div class="group">
+            <input id="cb1-input" class="cb_edit" type="text" role="combobox" aria-autocomplete="both"
+              aria-expanded="false" aria-haspopup="true" aria-owns="lb1"
+            />
+            <button id="cb1-button" aria-label="Open" tabindex="-1">&#9661;</button>
+          </div>
+          <ul id="lb1" role="listbox" aria-label="States">
+            <li id="lb1-al" role="option">Alabama</li>
+            <li id="lb1-ak" role="option">Alaska</li>
+            <li id="lb1-as" role="option">American Samoa</li>
+            <li id="lb1-az" role="option">Arizona</li>
+            <li id="lb1-ar" role="option">Arkansas</li>
+            <li id="lb1-ca" role="option">California</li>
+            <li id="lb1-co" role="option">Colorado</li>
+            <li id="lb1-ct" role="option">Connecticut</li>
+            <li id="lb1-de" role="option">Delaware</li>
+            <li id="lb1-dc" role="option">District of Columbia</li>
+            <li id="lb1-fl" role="option">Florida</li>
+            <li id="lb1-ga" role="option">Georgia</li>
+            <li id="lb1-gm" role="option">Guam</li>
+            <li id="lb1-hi" role="option">Hawaii</li>
+            <li id="lb1-id" role="option">Idaho</li>
+            <li id="lb1-il" role="option">Illinois</li>
+            <li id="lb1-in" role="option">Indiana</li>
+            <li id="lb1-ia" role="option">Iowa</li>
+            <li id="lb1-ks" role="option">Kansas</li>
+            <li id="lb1-ky" role="option">Kentucky</li>
+            <li id="lb1-la" role="option">Louisiana</li>
+            <li id="lb1-me" role="option">Maine</li>
+            <li id="lb1-md" role="option">Maryland</li>
+            <li id="lb1-ma" role="option">Massachusetts</li>
+            <li id="lb1-mi" role="option">Michigan</li>
+            <li id="lb1-mn" role="option">Minnesota</li>
+            <li id="lb1-ms" role="option">Mississippi</li>
+            <li id="lb1-mo" role="option">Missouri</li>
+            <li id="lb1-mn" role="option">Montana</li>
+            <li id="lb1-ne" role="option">Nebraska</li>
+            <li id="lb1-nv" role="option">Nevada</li>
+            <li id="lb1-nh" role="option">New Hampshire</li>
+            <li id="lb1-nj" role="option">New Jersey</li>
+            <li id="lb1-nm" role="option">New Mexico</li>
+            <li id="lb1-ny" role="option">New York</li>
+            <li id="lb1-nc" role="option">North Carolina</li>
+            <li id="lb1-nd" role="option">North Dakota</li>
+            <li id="lb1-nm" role="option">Northern Marianas Islands</li>
+            <li id="lb1-oh" role="option">Ohio</li>
+            <li id="lb1-ok" role="option">Oklahoma</li>
+            <li id="lb1-or" role="option">Oregon</li>
+            <li id="lb1-pa" role="option">Pennsylvania</li>
+            <li id="lb1-pr" role="option">Puerto Rico</li>
+            <li id="lb1-ri" role="option">Rhode Island</li>
+            <li id="lb1-sc" role="option">South Carolina</li>
+            <li id="lb1-sd" role="option">South Dakota</li>
+            <li id="lb1-tn" role="option">Tennessee</li>
+            <li id="lb1-tx" role="option">Texas</li>
+            <li id="lb1-ut" role="option">Utah</li>
+            <li id="lb1-ve" role="option">Vermont</li>
+            <li id="lb1-va" role="option">Virginia</li>
+            <li id="lb1-vi" role="option">Virgin Islands</li>
+            <li id="lb1-wa" role="option">Washington</li>
+            <li id="lb1-wv" role="option">West Virginia</li>
+            <li id="lb1-wi" role="option">Wisconsin</li>
+            <li id="lb1-wy" role="option">Wyoming</li>
+          </ul>
+        </div>
+      </div>
+      <div role="separator" id="ex_end_sep" aria-labelledby="ex_end_sep ex_label" aria-label="End of"></div>
+    </section>
+  
+    <section>
+      <h2 id="kbd_label">Keyboard Support</h2>
+      <p>
+      The example combobox on this page implements the following keyboard interface. 
+        Other variations and options for the keyboard interface are described in the  
+        <a href="../../../#combobox_kbd_interaction">Keyboard Interaction section of the combobox design pattern.</a>
+      </p>
+      <h3 id="kbd_label_textbox">Textbox</h3>
+      <table aria-labelledby="kbd_label_textbox kbd_label" class="def">
+        <thead>
+          <tr>
+            <th>Key</th>
+            <th>Function</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th><kbd>Down Arrow</kbd></th>
+            <td>Opens the listbox and moves focus to the first suggested value.</td>
+          </tr>
+          <tr>
+            <th><kbd>Up Arrow</kbd></th>
+            <td>Opens the listbox and moves focus to the last suggested value.</td>
+          </tr>
+          <tr>
+            <th><kbd>Escape</kbd></th>
+            <td>if open, closes the listbox.</td>
+          </tr>
+          <tr>
+            <th><li>Standard single line text editing keys</th>
+            <td>
+              <ul>
+                <li>Keys used for cursor movement and text manipulation, such as <kbd>Delete</kbd> and <kbd>Shift + Right Arrow</kbd>.</li>
+                <li>As the value of the textbox changes, suggestions in the listbox change to show values that match the input; if there are no matches, the listbox is not visible.</li>
+                <li>Note: An HTML <code>input</code> with <code>type=<q>text</q></code> is used for the textbox so the browser will provide platform-specific editing keys.</li>
+              </ul>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <h3 id="kbd_label_listbox">Listbox Popup</h3>
+      <p>
+        <strong>NOTE:</strong> When visual focus is in the listbox, DOM focus remains on the textbox and the value of <code>aria-activedescendant</code> on the textbox is set to a value that refers to the listbox option that is visually indicated as focused.
+        Where the following descriptions of keyboard commands mention focus, they are referring to the visual focus indicator.
+        For more information about this focus management technique, see 
+        <a href="../../../#kbd_focus_activedescendant">Using aria-activedescendant to Manage Focus.</a>
+      </p>
+      <table aria-labelledby="kbd_label_listbox kbd_label" class="def">
+        <thead>
+          <tr>
+            <th>Key</th>
+            <th>Function</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th><kbd>Enter</kbd></th>
+            <td>
+              <ul>
+                <li>Sets the textbox value to the content of the focused option in the listbox.</li>
+                <li>Closes the listbox.</li>
+                <li>Sets focus on the textbox.</li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <th><kbd>Escape</kbd></th>
+            <td>Closes the listbox and sets focus on the textbox.</td>
+          </tr>
+          <tr>
+            <th><kbd>Down Arrow</kbd></th>
+            <td>
+              <ul>
+                <li>Moves focus to the next <code>option</code>.</li>
+                <li>If focus is on the last <code>option</code>, the focus does not move.</li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <th><kbd>Up Arrow</kbd></th>
+            <td>
+              <ul>
+                <li>Moves focus to the previous <code>option</code>.</li>
+                <li>If focus is on the first <code>option</code>, the focus does not move.</li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <th><kbd>Right Arrow</kbd></th>
+            <td>
+              <ul>
+                <li>Returns focus to the textbox without closing the listbox.</li>
+                <li>Moves the input cursor one character to the right. If the input cursor is on the right-most character, the cursor does not move.</li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <th><kbd>Left Arrow</kbd></th>
+            <td>
+              <ul>
+                <li>Returns focus to the textbox without closing the listbox.</li>
+                <li>Moves the input cursor one character to the left. If the input cursor is on the left-most character, the cursor does not move.</li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <th><kbd>Home</kbd></th>
+            <td>Moves focus to the first <code>option</code>.</td>
+          </tr>
+          <tr>
+            <th><kbd>End</kbd></th>
+            <td>Moves focus to the last <code>option</code>.</td>
+          </tr>
+          <tr>
+            <th>Printable Characters</th>
+            <td>
+              <ul>
+                <li>Returns focus to the textbox without closing the popup and types the character.</li>
+                <li>Note: the listbox content may change due to the new textbox value.</li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <th>Standard Editing Keys<br>e.g., <kbd>Delete</kbd></th>
+            <td>
+              <ul>
+                <li>Return focus to the textbox without closing the popup.</li>
+                <li>Executes the platform-specific function for the key.</li>
+                <li>Note: the listbox content may change due to the new textbox value.</li>
+              </ul>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+  
+    <section>
+      <h2 id="rps_label">Role, Property, State, and Tabindex Attributes</h2>
+      <p>
+        The example combobox on this page implements the following ARIA roles, states, and properties. 
+        Information about other ways of applying ARIA roles, states, and properties is available in the    
+        <a href="../../../#combobox_roles_states_props">Roles, States, and Properties section of the combobox design pattern.</a>
+      </p>
+      <h3 id="rps_label_textbox">Textbox</h3>
+      <table aria-labelledby="rps_label_textbox rps_label" class="data attributes">
+        <thead>
+          <tr>
+            <th scope="col">Role</th>
+            <th scope="col">Attribute</th>
+            <th scope="col">Element</th>
+            <th scope="col">Usage</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th scope="row">
+              <code>combobox</code>
+            </th>
+            <td></td>
+            <td><code>input[type="text"]</code></td>
+            <td>
+              <ul>
+                <li>Identifies the input as a combobox.</li>
+                <li>Note: The primary difference between the ARIA 1.0 pattern and the ARIA 1.1 pattern is the placement of the <code>combobox</code> role.</li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td></td>
+            <th scope="row">
+              <code>aria-autocomplete=<q>both</q></code>
+            </th>
+            <td><code>input[type="text"]</code></td>
+            <td>Indicates that the autocomplete behavior of the text input is to both show an inline completion string and suggest a list of possible values in a popup where the suggestions are related to the string that is present in the textbox.</td>
+          </tr>
+          <tr>
+            <td></td>
+            <th scope="row">
+              <code>aria-haspopup=<q>true</q></code>
+            </th>
+            <td><code>input[type="text"]</code></td>
+            <td>Indicates that the combobox can popup another element to suggest values.</td>
+          </tr>
+          <tr>
+            <td></td>
+            <th scope="row">
+              <code>aria-owns=<q>#IDREF</q></code>
+            </th>
+            <td><code>input[type="text"]</code></td>
+            <td>
+              <ul>
+                <li>Identifies the element that serves as the popup.</li>
+                <li>Note: In the ARIA 1.1 combobox pattern, the combobox uses <code>aria-controls</code> instead of <code>aria-owns</code>.</li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td></td>
+            <th scope="row">
+              <code>aria-expanded=<q>false</q></code>
+            </th>
+            <td><code>input[type="text"]</code></td>
+            <td>Indicates that the popup element <strong>is not</strong> displayed.</td>
+          </tr>
+          <tr>
+            <td></td>
+            <th scope="row">
+              <code>aria-expanded=<q>true</q></code>
+            </th>
+            <td><code>input[type="text"]</code></td>
+            <td>Indicates that the popup element <strong>is</strong> displayed.</td>
+          </tr>
+          <tr>
+            <td></td>
+            <th scope="row">
+              <code>aria-activedescendant=<q>IDREF</q></code>
+            </th>
+            <td><code>input[type="text"]</code></td>
+            <td>
+              <ul>
+                <li>When an option in the listbox is visually indicated as having keyboard focus, refers to that option.</li>
+                <li>When navigation keys, such as <kbd>Down Arrow</kbd>, are pressed, the JavaScript changes the value.</li>
+                <li>Enables assistive technologies to know which element the application regards as focused while DOM focus remains on the <code>input</code> element.</li>
+                <li>
+                  For more information about this focus management technique, see 
+                  <a href="../../../#kbd_focus_activedescendant">Using aria-activedescendant to Manage Focus.</a>
+                </li>
+              </ul>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <h3 id="rps_label_listbox">Listbox Popup</h3>
+      <table aria-labelledby="rps_label_listbox rps_label" class="data attributes">
+        <thead>
+          <tr>
+            <th scope="col">Role</th>
+            <th scope="col">Attribute</th>
+            <th scope="col">Element</th>
+            <th scope="col">Usage</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th scope="row">
+              <code>listbox</code>
+            </th>
+            <td></td>
+            <td>
+              <code>ul</code>
+            </td>
+            <td>Identifies the <code>ul</code> element as a <code>listbox</code>.</td>
+          </tr>
+          <tr>
+            <td></td>
+            <th scope="row">
+              <code>aria-label=<q>States<q></code>
+            </th>
+            <td><code>ul</code></td>
+            <td>Provides a label for the <code>listbox</code>.</td>
+          </tr>
+          <tr>
+            <th scope="row">
+              <code>option</code>
+            </th>
+            <td></td>
+            <td><code>li</code></td>
+            <td>
+              <ul>
+                <li>Identifies the element as a <code>listbox</code> <code>option</code>.</li>
+                <li>The text content of the element provides the accessible name of the <code>option</code>.</li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td></td>
+            <th scope="row">
+              <code>aria-selected=<q>true</q></code>
+            </th>
+            <td><code>li</code></td>
+            <td>
+              <ul>
+                <li>Specified on an option in the listbox when it is visually highlighted as selected.</li>
+                <li>Occurs when an option in the list is referenced by <code>aria-activedescendant</code> and when focus is in the textbox and the first option is automatically selected.</li>
+              </ul>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
 
-  <section>
-    <h2 id="sc1_label">HTML Source Code</h2>
-    <div role="separator" id="sc1_start_sep" aria-labelledby="sc1_start_sep sc1_label" aria-label="Start of"></div>
-    <pre><code id="sc1"></code></pre>
-    <div role="separator" id="sc1_end_sep" aria-labelledby="sc1_end_sep sc1_label" aria-label="End of"></div>
-    <!--
-      The following script will show the reader the HTML source for the example that is in the div with ID 'ex1'.
-      It renders the HTML in the preceding pre element with ID 'sc1'.
-      If you change the ID of either the 'ex1' div or the 'sc1' pre, be sure to update the sourceCode.add function parameters.
-      -->
-    <script>
-      sourceCode.add('sc1', 'ex1');
-      sourceCode.make();
-    </script>
-  </section>
+    <section>
+      <h2>Javascript and CSS Source Code</h2>
+      <!--  After the js and css files are named with the name of this example, change the href and text of the following 2 links to refer to the appropriate js and css files.  -->
+      <ul>
+        <li>
+          CSS:
+          <a href="css/combobox-1.0.css" type="text/css">combobox-1.0.css</a>
+        </li>
+        <li>
+          CSS:
+          <a href="css/listbox.css" type="text/css">listbox.css</a>
+        </li>
+        <li>
+          Javascript:
+          <a href="js/combobox-1.0-list.js" type="text/javascript">combobox-1.0-list.js</a>
+        </li>
+        <li>
+          Javascript:
+          <a href="js/listbox.js" type="text/javascript">listbox.js</a>
+        </li>
+        <li>
+          Javascript:
+          <a href="js/listboxOption.js" type="text/javascript">listboxOption.js</a>
+        </li>
+      </ul>
+    </section>
+
+    <section>
+      <h2 id="sc1_label">HTML Source Code</h2>
+      <div role="separator" id="sc1_start_sep" aria-labelledby="sc1_start_sep sc1_label" aria-label="Start of"></div>
+      <pre>
+        <code id="sc1"></code>
+      </pre>
+      <div role="separator" id="sc1_end_sep" aria-labelledby="sc1_end_sep sc1_label" aria-label="End of"></div>
+      <!--
+        The following script will show the reader the HTML source for the example that is in the div with ID 'ex1'.
+        It renders the HTML in the preceding pre element with ID 'sc1'.
+        If you change the ID of either the 'ex1' div or the 'sc1' pre, be sure to update the sourceCode.add function parameters.
+        -->
+      <script>
+        sourceCode.add('sc1', 'ex1');
+        sourceCode.make();
+      </script>
+    </section>
   </main>
   <nav>
-    <!--  Update the pattern_ID parameter of this link to refer to the APG design pattern section related to this example.  -->
-    <a href="../../#pattern_ID">EXAMPLE_NAME Design Pattern in WAI-ARIA Authoring Practices 1.1</a>
+    <a href="../../../#combobox">Combobox Design Pattern in WAI-ARIA Authoring Practices 1.1</a>
   </nav>
 </body>
 </html>

--- a/examples/combobox/aria1.0pattern/combobox-autocomplete-both.html
+++ b/examples/combobox/aria1.0pattern/combobox-autocomplete-both.html
@@ -7,83 +7,141 @@
 <!--  Core js and css shared by all examples; do not modify when using this template. -->
 <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/base.css">
 <link rel="stylesheet" href="../../css/core.css">
-<script src="../../js/examples.js"></script>
-<script src="../../js/highlight.pack.js"></script>
-<script src="../../js/app.js"></script>
 
-<!--  js and css for this example. -->
-<link href="css/combobox-1.0.css" rel="stylesheet">
-<script src="js/combobox-1.0.js" type="text/javascript"></script>
+<script type="text/javascript" src="../../js/examples.js"></script>
+<script type="text/javascript" src="../../js/highlight.pack.js"></script>
+<script type="text/javascript" src="../../js/app.js"></script>
+
+<link rel="stylesheet" href="css/combobox-1.0.css">
+<link rel="stylesheet" href="css/listbox.css">
+
+<script type="text/javascript" src="js/combobox-1.0-list.js"></script>
+<script type="text/javascript" src="js/listbox.js"></script>
+<script type="text/javascript" src="js/listboxOption.js"></script>
+
 </head>
 <body>
   <main>
   <h1>Example of Legacy ARIA 1.0 Combobox With Both List and Inline Autocompletion</h1>
   <p>
-    <strong>NOTE:</strong> This page is work in progress; it is not ready for review.
+    <strong>NOTE:</strong> This page is ready to start reviewing.
     This work is tracked by <a href="https://github.com/w3c/aria-practices/issues/99">issue 99</a>.
   </p>
   <p>
-    <!-- Provide an overview of the example where the first sentence provides a link to the section of aria-practices.html that describes the pattern this example implements. -->
-    Replace this paragraph with an overview of the example that is something like the following. The
-    below example section demonstrates a simple checkbox that implements the
-    <a href="../../#checkbox">design pattern for checkbox.</a>
-    This example uses ... summarize salient techniques )
+    The below example section demonstrates a <code>combobox</code> that implements the
+    <a href="../../#combobox">ARIA 1.0 design pattern for combobox.</a>
+    This example demonstrates a combobox that provides both a list and an inline of
+    autocomplete options to the user.
+    The options available in the listbox are filtered based on user input into the textbox.
+    The user can select an option from the list to set the value of the textbox or use the
+    enter key to select the autocompelete option in the textbox.
+  </p>The major design feature of the ARIA 1.0 combobox pattern is the use of
+    <code>aria-activedescendant</code> to reference options in a listbox, while keyboard
+    focus remains on the textbox.
+  <p>
   </p>
   <p>Similar examples include: </p>
   <ul>
-    <li><a href="#">example name</a>: summarize what this related example demonstrates.</li>
-    <!--  list other examples that implement the same design pattern. -->
+    <li>
+      <a href="combobox-autocomplete-none.html">Combobox Without Autocomplete</a>
+      : example demonstrates the behavior associated with <code>aria-autocomplete=none</code>.
+    </li>
+    <li>
+      <a href="combobox-autocomplete-list.html">Combobox With an List Autocomplete</a>
+      : example demonstrates the behavior associated with <code>aria-autocomplete=list</code>.
+    </li>
   </ul>
 
   <section>
     <h2 id="ex_label">Example</h2>
     <div role="separator" id="ex_start_sep" aria-labelledby="ex_start_sep ex_label" aria-label="Start of"></div>
-    <!--
-      Note the ID of the following div that contains the example HTML is used as a parameter for the sourceCode.add() function.
-      The sourceCode functions in the examples/js/examples.js render the HTML source to show it to the reader of the example page.
-      If you change the ID of this div, be sure to update the parameters of the sourceCode.add() function call, which is made following the div with id="sc1" where the HTML is render.
-      The div for the rendered HTML source is in the last section of the page.
-    -->
     <div id="ex1">
-      <!--  Replace content of this div with the example.  -->
-      <p>This is the place where the reader will experience the functioning example.</p>
-      <ul>
-        <li>The HTML in this section along with the javascript and CSS it uses demonstrate
-          the design pattern.</li>
-        <li>
-          When developing an example implementation for this guide, please follow the <a href="https://ianpouncey.github.io/code-guide/">APG example coding guidelines</a>.
-        </li>
-        <!--  Target of previous link will need to be updated when we move the guidelines into the wiki from Ian's repo.  -->
-      </ul>
+      <div class="combobox-list">
+        <label for="cb1-input">State</label>
+
+        <div class="group">
+          <input id="cb1-input" class="cb_edit" type="text"
+                 role="combobox"
+                 aria-autocomplete="both"
+                 aria-expanded="false"
+                 aria-haspopup="true"
+                 aria-owns="lb1"
+                 aria-activedescendant=""
+          />
+          <button id="cb1-button"
+                  aria-label="open button"
+                  tabindex="-1">
+            &#9661;
+          </button>
+        </div>
+
+        <ul id="lb1" role="listbox" aria-label="States">
+          <li id="lb1-al" role="option">Alabama</li>
+          <li id="lb1-ak" role="option">Alaska</li>
+          <li id="lb1-as" role="option">American Samoa</li>
+          <li id="lb1-az" role="option">Arizona</li>
+          <li id="lb1-ar" role="option">Arkansas</li>
+          <li id="lb1-ca" role="option">California</li>
+          <li id="lb1-co" role="option">Colorado</li>
+          <li id="lb1-ct" role="option">Connecticut</li>
+          <li id="lb1-de" role="option">Delaware</li>
+          <li id="lb1-dc" role="option">District of Columbia</li>
+          <li id="lb1-fl" role="option">Florida</li>
+          <li id="lb1-ga" role="option">Georgia</li>
+          <li id="lb1-gm" role="option">Guam</li>
+          <li id="lb1-hi" role="option">Hawaii</li>
+          <li id="lb1-id" role="option">Idaho</li>
+          <li id="lb1-il" role="option">Illinois</li>
+          <li id="lb1-in" role="option">Indiana</li>
+          <li id="lb1-ia" role="option">Iowa</li>
+          <li id="lb1-ks" role="option">Kansas</li>
+          <li id="lb1-ky" role="option">Kentucky</li>
+          <li id="lb1-la" role="option">Louisiana</li>
+          <li id="lb1-me" role="option">Maine</li>
+          <li id="lb1-md" role="option">Maryland</li>
+          <li id="lb1-ma" role="option">Massachusetts</li>
+          <li id="lb1-mi" role="option">Michigan</li>
+          <li id="lb1-mn" role="option">Minnesota</li>
+          <li id="lb1-ms" role="option">Mississippi</li>
+          <li id="lb1-mo" role="option">Missouri</li>
+          <li id="lb1-mn" role="option">Montana</li>
+          <li id="lb1-ne" role="option">Nebraska</li>
+          <li id="lb1-nv" role="option">Nevada</li>
+          <li id="lb1-nh" role="option">New Hampshire</li>
+          <li id="lb1-nj" role="option">New Jersey</li>
+          <li id="lb1-nm" role="option">New Mexico</li>
+          <li id="lb1-ny" role="option">New York</li>
+          <li id="lb1-nc" role="option">North Carolina</li>
+          <li id="lb1-nd" role="option">North Dakota</li>
+          <li id="lb1-nm" role="option">Northern Marianas Islands</li>
+          <li id="lb1-oh" role="option">Ohio</li>
+          <li id="lb1-ok" role="option">Oklahoma</li>
+          <li id="lb1-or" role="option">Oregon</li>
+          <li id="lb1-pa" role="option">Pennsylvania</li>
+          <li id="lb1-pr" role="option">Puerto Rico</li>
+          <li id="lb1-ri" role="option">Rhode Island</li>
+          <li id="lb1-sc" role="option">South Carolina</li>
+          <li id="lb1-sd" role="option">South Dakota</li>
+          <li id="lb1-tn" role="option">Tennessee</li>
+          <li id="lb1-tx" role="option">Texas</li>
+          <li id="lb1-ut" role="option">Utah</li>
+          <li id="lb1-ve" role="option">Vermont</li>
+          <li id="lb1-va" role="option">Virginia</li>
+          <li id="lb1-vi" role="option">Virgin Islands</li>
+          <li id="lb1-wa" role="option">Washington</li>
+          <li id="lb1-wv" role="option">West Virginia</li>
+          <li id="lb1-wi" role="option">Wisconsin</li>
+          <li id="lb1-wy" role="option">Wyoming</li>
+        </ul>
+      </div>
     </div>
     <div role="separator" id="ex_end_sep" aria-labelledby="ex_end_sep ex_label" aria-label="End of"></div>
   </section>
 
   <section>
-    <h2>Accessibility Features</h2>
-    <p class="annotate">Optional section: If appropriate, please replace this content with a list of any special or noteworthy accessibility features
-      demonstrated in this implementation, such as:</p>
-    <ol>
-      <li>What distinguishes this example from related examples.</li>
-      <li>Keyboard chortcuts, live regions,  unusual event handling, or other ancillary best practices that are employed.</li>
-      <li>Do not include information that would be repeated in the following keyboard and attribute sections.</li>
-      <li>Delete this section if not needed.</li>
-    </ol>
-  </section>
+    <h2 id="kbd_label_textbox">Combobox Keyboard Support</h2>
 
-  <section>
-    <h2 id="kbd_label">Keyboard Support</h2>
-    <!--
-      List the keys supported in this example.
-      Remember to:
-      Use kbd tags,e.g. <kbd>KeyName</kbd>.
-      Key names use first-letter caps, e.g., <kbd>Enter</kbd>.
-      Single space between multiple Words, e.g., <kbd>Up Arrow</kbd>.
-      Use + to separate modifiers, e.g., <kbd>Control + Right Arrow</kbd>.
-      One key per row, e.g., do not combine <kbd>Up Arrow</kbd> and <kbd>Down Arrow</kbd> into a single row.
-      Do not use the word "key", e.g., do not write <kbd>Enter Key</kbd> or <kbd>Enter</kbd> key.
-     -->
-    <table aria-labelledby="kbd_label" class="def">
+    <table aria-labelledby="kbd_label_textbox" class="def">
       <thead>
         <tr>
           <th>Key</th>
@@ -92,32 +150,56 @@
       </thead>
       <tbody>
         <tr>
-          <th><kbd>KeyName</kbd></th>
-          <td>
-            Description of key function.
-            <!--  Do not use a list if there is only one function for the key.  -->
-          </td>
-        </tr>
-        <tr>
-          <th><kbd>KeyName</kbd></th>
+          <th><kbd>Down Arrow</kbd></th>
           <td>
             <ul>
-              <li>If condition 1, performs function 1.</li>
-              <li>If condition 2, performs function 2.</li>
-              <li>Only use a list if multiple statements are needed.</li>
+              <li>If the listbox is <strong>closed</strong>, the listbox is opened and <code>aria-activedescendant</code> is set to reference the first option in the listbox.  </li>
+              <li>If the listbox is <strong>open</strong>, <code>aria-activedescendant</code> is updated to reference the next option in the listbox.  <br/>Note: When <code>aria-activedescendant</code> is referencing the last option the reference does not change.</li>
+              <li>If the listbox is <strong>empty</strong> (e.g. no options avaialble), <code>aria-activedescendant</code> is set to an empty string.</li>
             </ul>
           </td>
         </tr>
+        <tr>
+          <th><kbd>Up Arrow</kbd></th>
+          <td>
+            <ul>
+              <li>If the listbox is <strong>closed</strong>, the listbox is opened and <code>aria-activedescendant</code> is set to reference the last option in the listbox.  </li>
+              <li>If the listbox is <strong>open</strong>, <code>aria-activedescendant</code> is updated to reference the previous option in the listbox.  <br/>Note: When <code>aria-activedescendant</code> is referencing the first option the reference does not change.</li>
+              <li>If the listbox is <strong>empty</strong> (e.g. no options avaialble), <code>aria-activedescendant</code> is set to an empty string.</li>
+            </ul>          </td>
+        </tr>
+        <tr>
+          <th><kbd>Left Arrow</kbd>,<br/><kbd>Right Arrow</kbd>,<br/><kbd>Backspace</kbd>,<br/><kbd>Printable characters</kbd></th>
+          <td>
+            <ul>
+              <li>The list of options in the listbox are updated based on the text content of the <code>combobox</code>.</li>
+              <li>The list of options are filtered based on user input before the edit cursor (e.g. <code>sectionStart</code> property of the textbox).</li>
+              <li>After the options are updated:
+                <ul>
+                  <li>If the currently referenced option <strong>remains</strong> in the list, <code>aria-activedescendant</code> will not change.</li>
+                  <li>If the currently referenced option is <strong>not</strong> a match, <code>aria-activedescendant</code> is updated to reference the first item in the new list of options.</li>
+                  <li>If there are <strong>no</strong> options available, <code>aria-activedescendant</code> is set to an empty string.</li>
+                </ul>
+              </li>
+            </ul>
+          </td>
+        </tr>
+        <tr>
+          <th><kbd>Escape</kbd></th>
+          <td>If the listbox is <strong>open</strong>, the listbox is closed and aria-activedescendant</code> is set to an empty string.</td>
+        </tr>
       </tbody>
     </table>
+
   </section>
 
   <section>
-    <h2 id="rps_label">Role, Property, State, and Tabindex  Attributes</h2>
+
+    <h2 id="rps_label_combobox">Combobox Role, Property, State, and Tabindex  Attributes</h2>
     <!--
       Update this table to describe how roles, properties, states, and tabindex are used in this example.
     -->
-    <table aria-labelledby="rps_label" class="data attributes">
+    <table aria-labelledby="rps_label_combobox" class="data attributes">
       <thead>
         <tr>
           <th scope="col">Role</th>
@@ -128,27 +210,149 @@
       </thead>
       <tbody>
         <tr>
-          <th scope="row"><code>RoleName</code></th>
+          <th scope="row"><code>combobox</code></th>
           <td><!--  Leave this cell blank in rows where a role is being described. --></td>
-          <td><code>HTML_ELEMENT</code></td>
+          <td><code>input[type="text"]</code></td>
           <td>
-            Describe usage/purpose, e.g., indicates the focusable element that serves as the ...
+            Identifies the <code>input[type=<q>text</q>] as a combobox option.
           </td>
         </tr>
         <tr>
           <td>
-            <!--  Leave this cell blank in rows that describe attributes applied to the element with the previously described role.
-              Make a row like this for each attribute/value pair.
-          -->
           </td>
-          <th scope="row"><code>AttributeName=<q>AttributeValue</q></code></th>
-          <td><code>HTML_ELEMENT</code></td>
+          <th scope="row"><code>aria-autocomplete=<q>both</q></code></th>
+          <td><code>input[type="text"]</code></td>
           <td>
             <ul>
-              <li>explanation of usage, purpose, benefit, and/or guidance relevant to this implementation.</li>
-              <li>If making multiple statements, use list for brevity and clarity</li>
-              <li>Do not make a single item list.</li>
+              <li>The value of <code>both</code> identifies that the combobox will update
+                the <code>input[type=<q>text</q>]</code> value with the currently selected option
+                and the list of options will be filtered based on user input.
+              </li>
+              <li>When there is an autocomplete options, the selection range of
+                <code>input[type=<q>text</q>]</code> will be set to the end of the text being
+                used to filter the list of options and the end of the autocomplete option.
+              </li>
+          </td>
+        </tr>
+        <tr>
+          <td>
+          </td>
+          <th scope="row"><code>aria-haspopup=<q>true</q></code></th>
+          <td><code>input[type="text"]</code></td>
+          <td>
+            Identifies the <code>combobox</code> as having a popup list of options for the value of the textbox.
+          </td>
+        </tr>
+        <tr>
+          <td>
+          </td>
+          <th scope="row"><code>aria-owns=<q>#IDREF</q></code></th>
+          <td><code>input[type="text"]</code></td>
+          <td>
+            Identifies the <code>listbox</code> that is controlled by the combobox.
+          </td>
+        </tr>
+        <tr>
+          <td>
+          </td>
+          <th scope="row"><code>aria-expanded=<q>false</q></code></th>
+          <td><code>input[type="text"]</code></td>
+          <td>
+            Idenitifies the <code>listbox</code> as closed (e.g. hidden from the user).
+          </td>
+        </tr>
+        <tr>
+          <td>
+          </td>
+          <th scope="row"><code>aria-expanded=<q>true</q></code></th>
+          <td><code>input[type="text"]</code></td>
+          <td>
+            Idenitifies the <code>listbox</code> as open (e.g. visible to the user).
+          </td>
+        </tr>
+        <tr>
+          <td>
+          </td>
+          <th scope="row"><code>aria-activedescendant=<q>#IDREF</q></code></th>
+          <td><code>input[type="text"]</code></td>
+          <td>
+            References the current autocomplete <code>option</code> in the <code>listbox</code>.
+          </td>
+        </tr>
+        <tr>
+          <td>
+          </td>
+          <th scope="row"><code>aria-activedescendant=<q></q></code></th>
+          <td><code>input[type="text"]</code></td>
+          <td>
+            If no autocomplete <code>option</code> is selected or the list of <code>option</code>s is emtpy, <code>aria-activedescendant</code> is set to an empty string.</td>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+
+    <h2 id="rps_label_listbox">Listbox Role, Property, State, and Tabindex  Attributes</h2>
+    <!--
+      Update this table to describe how roles, properties, states, and tabindex are used in this example.
+    -->
+    <table aria-labelledby="rps_label_listbox" class="data attributes">
+      <thead>
+        <tr>
+          <th scope="col">Role</th>
+          <th scope="col">Attribute</th>
+          <th scope="col">Element</th>
+          <th scope="col">Usage</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row">
+            <code>listbox</code>
+          </th>
+          <td></td>
+          <td>
+            <code>ul</code>
+          </td>
+          <td>Identifies the <code>ul</code> element as a <code>listbox</code>.</td>
+        </tr>
+        <tr>
+          <td>
+            <code></code>
+          </td>
+          <th scope="row"><code>aria-label=<q>States</q></code></th>
+          <td>
+            <code>ul</code>
+          </td>
+          <td>
+            Provides a label for the <code>listbox</code>.
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <code>option</code>
+          </th>
+          <td></td>
+          <td>
+            <code>li</code>
+          </td>
+          <td>
+            <ul>
+              <li>Identifies the <code>li</code> element as a <code>option</code> in a <cpde>listbox</cpde>.</li>
+              <li>The text content of the <code>li</code> element provides the accessible name of the <code>option</code>.</li>
             </ul>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <code></code>
+          </td>
+          <th scope="row"><code>id=<q>ID</q></code></th>
+          <td>
+            <code>li</code>
+          </td>
+          <td>
+            Provides a unique reference for the option that is referenced by the <code>aria-activedescendant</code> attribute of the <code>combobox</code>.
           </td>
         </tr>
       </tbody>
@@ -161,11 +365,23 @@
     <ul>
       <li>
         CSS:
-        <a href="css/example_name.css" type="tex/css">example_name.css</a>
+        <a href="css/combobox-1.0.css" type="text/css">combobox-1.0.css</a>
+      </li>
+      <li>
+        CSS:
+        <a href="css/listbox.css" type="text/css">listbox.css</a>
       </li>
       <li>
         Javascript:
-        <a href="js/example_name.js" type="text/javascript">example_name.js</a>
+        <a href="js/combobox-1.0-list.js" type="text/javascript">combobox-1.0-list.js</a>
+      </li>
+      <li>
+        Javascript:
+        <a href="js/listbox.js" type="text/javascript">listbox.js</a>
+      </li>
+      <li>
+        Javascript:
+        <a href="js/listboxOption.js" type="text/javascript">listboxOption.js</a>
       </li>
     </ul>
   </section>

--- a/examples/combobox/aria1.0pattern/combobox-autocomplete-list.html
+++ b/examples/combobox/aria1.0pattern/combobox-autocomplete-list.html
@@ -13,9 +13,9 @@
 
 <!--  js and css for this example. -->
 <link href="css/combobox-1.0.css" rel="stylesheet">
-<link href="css/listbox.css" rel="stylesheet">
-<script src="js/combobox-1.0-listbox.js" type="text/javascript"></script>
-<script src="js/listbox.js" type="text/javascript"></script>
+<link  href="css/listbox.css"     rel="stylesheet">
+<script src="js/combobox-1.0-list.js"  type="text/javascript"></script>
+<script src="js/listbox.js"       type="text/javascript"></script>
 <script src="js/listboxOption.js" type="text/javascript"></script>
 </head>
 <body>
@@ -28,13 +28,11 @@
     <p>
       The below combobox for choosing the name of a state in the USA demonstrates the
       <a href="../../../#combobox">ARIA 1.0 design pattern for combobox.</a>
-      This example illustrates the autocomplete behavior known as list autocomplete with manual selection. If the user
-      types one or more characters in the edit box and the typed characters match the beginning of the name of one or more
-      states or territories, a listbox popup appears containing the matching names. When the listbox appears, none of the
-      names are automatically selected. Thus, after typing, if the user tabs or clicks out of the combobox without
-      choosing a value from the listbox, the typed string becomes the value of the combobox. In other words, this
-      implementation enables users to input the name of a state or territory but does not prevent input of any other
-      arbetrary value.
+      This example illustrates the autocomplete behavior known as list autocomplete with manual selection.
+      If the user types one or more characters in the edit box and the typed characters match the beginning of the name of one or more states or territories, a listbox popup appears containing the matching names.
+      When the listbox appears, a suggested name is not automatically selected.
+      Thus, after typing, if the user tabs or clicks out of the combobox without choosing a value from the listbox, the typed string becomes the value of the combobox.
+      Note that this implementation enables users to input the name of a state or territory but does not prevent input of any other arbetrary value.
     </p>
     <p>Similar examples include:</p>
     <ul>
@@ -141,10 +139,6 @@
             <td>Opens the listbox and moves focus to the first suggested value.</td>
           </tr>
           <tr>
-            <th><kbd>Alt+Down Arrow</kbd></th>
-            <td>Opens the listbox without moving focus out of the textbox.</td>
-          </tr>
-          <tr>
             <th><kbd>Up Arrow</kbd></th>
             <td>Opens the listbox and moves focus to the last suggested value.</td>
           </tr>
@@ -152,9 +146,25 @@
             <th><kbd>Escape</kbd></th>
             <td>if open, closes the listbox.</td>
           </tr>
+          <tr>
+            <th><li>Standard single line text editing keys</th>
+            <td>
+              <ul>
+                <li>Keys used for cursor movement and text manipulation, such as <kbd>Delete</kbd> and <kbd>Shift + Right Arrow</kbd>.</li>
+                <li>As the value of the textbox changes, suggestions in the listbox change to show values that match the input; if there are no matches, the listbox is not visible.</li>
+                <li>Note: An HTML <code>input</code> with <code>type=<q>text</q></code> is used for the textbox so the browser will provide platform-specific editing keys.</li>
+              </ul>
+            </td>
+          </tr>
         </tbody>
       </table>
       <h3 id="kbd_label_listbox">Listbox Popup</h3>
+      <p>
+        <strong>NOTE:</strong> When visual focus is in the listbox, DOM focus remains on the textbox and the value of <code>aria-activedescendant</code> on the textbox is set to a value that refers to the listbox option that is visually indicated as focused.
+        Where the following descriptions of keyboard commands mention focus, they are referring to the visual focus indicator.
+        For more information about this focus management technique, see 
+        <a href="../../../#kbd_focus_activedescendant">Using aria-activedescendant to Manage Focus.</a>
+      </p>
       <table aria-labelledby="kbd_label_listbox kbd_label" class="def">
         <thead>
           <tr>
@@ -196,6 +206,24 @@
             </td>
           </tr>
           <tr>
+            <th><kbd>Right Arrow</kbd></th>
+            <td>
+              <ul>
+                <li>Returns focus to the textbox without closing the listbox.</li>
+                <li>Moves the input cursor one character to the right. If the input cursor is on the right-most character, the cursor does not move.</li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <th><kbd>Left Arrow</kbd></th>
+            <td>
+              <ul>
+                <li>Returns focus to the textbox without closing the listbox.</li>
+                <li>Moves the input cursor one character to the left. If the input cursor is on the left-most character, the cursor does not move.</li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
             <th><kbd>Home</kbd></th>
             <td>Moves focus to the first <code>option</code>.</td>
           </tr>
@@ -204,13 +232,21 @@
             <td>Moves focus to the last <code>option</code>.</td>
           </tr>
           <tr>
-            <th>
-              <kbd>A-Z</kbd><br> <kbd>a-z</kbd>
-            </th>
+            <th>Printable Characters</th>
             <td>
               <ul>
-                <li>Moves focus to the option with a label that starts with the typed character if such an option exists.</li>
-                <li>Otherwise, focus does not move.</li>
+                <li>Returns focus to the textbox without closing the popup and types the character.</li>
+                <li>Note: the listbox content may change due to the new textbox value.</li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <th>Standard Editing Keys<br>e.g., <kbd>Delete</kbd></th>
+            <td>
+              <ul>
+                <li>Return focus to the textbox without closing the popup.</li>
+                <li>Executes the platform-specific function for the key.</li>
+                <li>Note: the listbox content may change due to the new textbox value.</li>
               </ul>
             </td>
           </tr>

--- a/examples/combobox/aria1.0pattern/combobox-autocomplete-list.html
+++ b/examples/combobox/aria1.0pattern/combobox-autocomplete-list.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8" />
-<title>Example of Legacy ARIA 1.0 Combobox With an Autocomplete List | WAI-ARIA Authoring Practices 1.1</title>
+<title>Legacy ARIA 1.0 Combobox With List Autocomplete Example | WAI-ARIA Authoring Practices 1.1</title>
 
 <!--  Core js and css shared by all examples; do not modify when using this template. -->
 <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/base.css">
@@ -13,184 +13,394 @@
 
 <!--  js and css for this example. -->
 <link href="css/combobox-1.0.css" rel="stylesheet">
-<script src="js/combobox-1.0.js" type="text/javascript"></script>
+<link href="css/listbox.css" rel="stylesheet">
+<script src="js/combobox-1.0-listbox.js" type="text/javascript"></script>
+<script src="js/listbox.js" type="text/javascript"></script>
+<script src="js/listboxOption.js" type="text/javascript"></script>
 </head>
 <body>
   <main>
-  <h1>Example of Legacy ARIA 1.0 Combobox With an Autocomplete List</h1>
-  <p>
-    <strong>NOTE:</strong> This page is work in progress; it is not ready for review.
-    This work is tracked by <a href="https://github.com/w3c/aria-practices/issues/99">issue 99</a>.
-  </p>
-  <p>
-    <!-- Provide an overview of the example where the first sentence provides a link to the section of aria-practices.html that describes the pattern this example implements. -->
-    Replace this paragraph with an overview of the example that is something like the following. The
-    below example section demonstrates a simple checkbox that implements the
-    <a href="../../#checkbox">design pattern for checkbox.</a>
-    This example uses ... summarize salient techniques )
-  </p>
-  <p>Similar examples include: </p>
-  <ul>
-    <li><a href="#">example name</a>: summarize what this related example demonstrates.</li>
-    <!--  list other examples that implement the same design pattern. -->
-  </ul>
-
-  <section>
-    <h2 id="ex_label">Example</h2>
-    <div role="separator" id="ex_start_sep" aria-labelledby="ex_start_sep ex_label" aria-label="Start of"></div>
-    <!--
-      Note the ID of the following div that contains the example HTML is used as a parameter for the sourceCode.add() function.
-      The sourceCode functions in the examples/js/examples.js render the HTML source to show it to the reader of the example page.
-      If you change the ID of this div, be sure to update the parameters of the sourceCode.add() function call, which is made following the div with id="sc1" where the HTML is render.
-      The div for the rendered HTML source is in the last section of the page.
-    -->
-    <div id="ex1">
-      <!--  Replace content of this div with the example.  -->
-      <p>This is the place where the reader will experience the functioning example.</p>
-      <ul>
-        <li>The HTML in this section along with the javascript and CSS it uses demonstrate
-          the design pattern.</li>
-        <li>
-          When developing an example implementation for this guide, please follow the
-          <a href="https://ianpouncey.github.io/code-guide/">APG example coding guidelines</a>
-          .
-        </li>
-        <!--  Target of previous link will need to be updated when we move the guidelines into the wiki from Ian's repo.  -->
-      </ul>
-    </div>
-    <div role="separator" id="ex_end_sep" aria-labelledby="ex_end_sep ex_label" aria-label="End of"></div>
-  </section>
-
-  <section>
-    <h2>Accessibility Features</h2>
-    <p class="annotate">Optional section: If appropriate, please replace this content with a list of any special or noteworthy accessibility features
-      demonstrated in this implementation, such as:</p>
-    <ol>
-      <li>What distinguishes this example from related examples.</li>
-      <li>Keyboard chortcuts, live regions,  unusual event handling, or other ancillary best practices that are employed.</li>
-      <li>Do not include information that would be repeated in the following keyboard and attribute sections.</li>
-      <li>Delete this section if not needed.</li>
-    </ol>
-  </section>
-
-  <section>
-    <h2 id="kbd_label">Keyboard Support</h2>
-    <!--
-      List the keys supported in this example.
-      Remember to:
-      Use kbd tags,e.g. <kbd>KeyName</kbd>.
-      Key names use first-letter caps, e.g., <kbd>Enter</kbd>.
-      Single space between multiple Words, e.g., <kbd>Up Arrow</kbd>.
-      Use + to separate modifiers, e.g., <kbd>Control + Right Arrow</kbd>.
-      One key per row, e.g., do not combine <kbd>Up Arrow</kbd> and <kbd>Down Arrow</kbd> into a single row.
-      Do not use the word "key", e.g., do not write <kbd>Enter Key</kbd> or <kbd>Enter</kbd> key.
-     -->
-    <table aria-labelledby="kbd_label" class="def">
-      <thead>
-        <tr>
-          <th>Key</th>
-          <th>Function</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <th><kbd>KeyName</kbd></th>
-          <td>
-            Description of key function.
-            <!--  Do not use a list if there is only one function for the key.  -->
-          </td>
-        </tr>
-        <tr>
-          <th><kbd>KeyName</kbd></th>
-          <td>
-            <ul>
-              <li>If condition 1, performs function 1.</li>
-              <li>If condition 2, performs function 2.</li>
-              <li>Only use a list if multiple statements are needed.</li>
-            </ul>
-          </td>
-        </tr>
-      </tbody>
-    </table>
-  </section>
-
-  <section>
-    <h2 id="rps_label">Role, Property, State, and Tabindex  Attributes</h2>
-    <!--
-      Update this table to describe how roles, properties, states, and tabindex are used in this example.
-    -->
-    <table aria-labelledby="rps_label" class="data attributes">
-      <thead>
-        <tr>
-          <th scope="col">Role</th>
-          <th scope="col">Attribute</th>
-          <th scope="col">Element</th>
-          <th scope="col">Usage</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <th scope="row"><code>RoleName</code></th>
-          <td><!--  Leave this cell blank in rows where a role is being described. --></td>
-          <td><code>HTML_ELEMENT</code></td>
-          <td>
-            Describe usage/purpose, e.g., indicates the focusable element that serves as the ...
-          </td>
-        </tr>
-        <tr>
-          <td>
-            <!--  Leave this cell blank in rows that describe attributes applied to the element with the previously described role.
-              Make a row like this for each attribute/value pair.
-          -->
-          </td>
-          <th scope="row"><code>AttributeName=<q>AttributeValue</q></code></th>
-          <td><code>HTML_ELEMENT</code></td>
-          <td>
-            <ul>
-              <li>explanation of usage, purpose, benefit, and/or guidance relevant to this implementation.</li>
-              <li>If making multiple statements, use list for brevity and clarity</li>
-              <li>Do not make a single item list.</li>
-            </ul>
-          </td>
-        </tr>
-      </tbody>
-    </table>
-  </section>
-
-  <section>
-    <h2>Javascript and CSS Source Code</h2>
-    <!--  After the js and css files are named with the name of this example, change the href and text of the following 2 links to refer to the appropriate js and css files.  -->
+    <h1>Legacy ARIA 1.0 Combobox With List Autocomplete Example</h1>
+    <p>
+      <strong>NOTE:</strong> This page is work in progress; it is not ready for review. This work is tracked by
+      <a href="https://github.com/w3c/aria-practices/issues/99">issue 99.</a>
+    </p>
+    <p>
+      The below combobox for choosing the name of a state in the USA demonstrates the
+      <a href="../../../#combobox">ARIA 1.0 design pattern for combobox.</a>
+      This example illustrates the autocomplete behavior known as list autocomplete with manual selection. If the user
+      types one or more characters in the edit box and the typed characters match the beginning of the name of one or more
+      states or territories, a listbox popup appears containing the matching names. When the listbox appears, none of the
+      names are automatically selected. Thus, after typing, if the user tabs or clicks out of the combobox without
+      choosing a value from the listbox, the typed string becomes the value of the combobox. In other words, this
+      implementation enables users to input the name of a state or territory but does not prevent input of any other
+      arbetrary value.
+    </p>
+    <p>Similar examples include:</p>
     <ul>
-      <li>
-        CSS:
-        <a href="css/example_name.css" type="tex/css">example_name.css</a>
-      </li>
-      <li>
-        Javascript:
-        <a href="js/example_name.js" type="text/javascript">example_name.js</a>
-      </li>
+      <li><a href="combobox-autocomplete-both.html">ARIA 1.0 Combobox with Both List and Inline Autocompletion</a></li>
+      <li><a href="../aria1.1pattern/listbox-combo.html">ARIA 1.1 Combobox with Listbox Popup</a>: Comboboxes that demonstrate the various forms of autocomplete behavior using a listbox popup.</li>
+            <li><a href="../aria1.1pattern/grid-combo.html">ARIA 1.1 Combobox with Grid Popup</a>: A combobox that presents suggestions in a grid, enabling users to navigate descriptive information about each suggestion.</li>
     </ul>
-  </section>
-
-  <section>
-    <h2 id="sc1_label">HTML Source Code</h2>
-    <div role="separator" id="sc1_start_sep" aria-labelledby="sc1_start_sep sc1_label" aria-label="Start of"></div>
-    <pre><code id="sc1"></code></pre>
-    <div role="separator" id="sc1_end_sep" aria-labelledby="sc1_end_sep sc1_label" aria-label="End of"></div>
-    <!--
-      The following script will show the reader the HTML source for the example that is in the div with ID 'ex1'.
-      It renders the HTML in the preceding pre element with ID 'sc1'.
-      If you change the ID of either the 'ex1' div or the 'sc1' pre, be sure to update the sourceCode.add function parameters.
-      -->
-    <script>
-      sourceCode.add('sc1', 'ex1');
-      sourceCode.make();
-    </script>
-  </section>
+  
+    <section>
+      <h2 id="ex_label">Example</h2>
+      <div role="separator" id="ex_start_sep" aria-labelledby="ex_start_sep ex_label" aria-label="Start of"></div>
+      <div id="ex1">
+        <div class="combobox-listbox">
+          <label for="cb1-input">State</label>
+  
+          <div class="group">
+            <input id="cb1-input" class="cb_edit" type="text" role="combobox" aria-autocomplete="list"
+              aria-expanded="false" aria-haspopup="true" aria-owns="cb1-listbox"
+            />
+            <button id="cb1-button" tabindex="-1" aria-label="open">&#9661;</button>
+          </div>
+  
+          <ul id="cb1-listbox" role="listbox" aria-label="States">
+            <li role="option" tabindex="-1">Alabama</li>
+            <li role="option" tabindex="-1">Alaska</li>
+            <li role="option" tabindex="-1">American Samoa</li>
+            <li role="option" tabindex="-1">Arizona</li>
+            <li role="option" tabindex="-1">Arkansas</li>
+            <li role="option" tabindex="-1">California</li>
+            <li role="option" tabindex="-1">Colorado</li>
+            <li role="option" tabindex="-1">Connecticut</li>
+            <li role="option" tabindex="-1">Delaware</li>
+            <li role="option" tabindex="-1">District of Columbia</li>
+            <li role="option" tabindex="-1">Florida</li>
+            <li role="option" tabindex="-1">Georgia</li>
+            <li role="option" tabindex="-1">Guam</li>
+            <li role="option" tabindex="-1">Hawaii</li>
+            <li role="option" tabindex="-1">Idaho</li>
+            <li role="option" tabindex="-1">Illinois</li>
+            <li role="option" tabindex="-1">Indiana</li>
+            <li role="option" tabindex="-1">Iowa</li>
+            <li role="option" tabindex="-1">Kansas</li>
+            <li role="option" tabindex="-1">Kentucky</li>
+            <li role="option" tabindex="-1">Louisiana</li>
+            <li role="option" tabindex="-1">Maine</li>
+            <li role="option" tabindex="-1">Maryland</li>
+            <li role="option" tabindex="-1">Massachusetts</li>
+            <li role="option" tabindex="-1">Michigan</li>
+            <li role="option" tabindex="-1">Minnesota</li>
+            <li role="option" tabindex="-1">Mississippi</li>
+            <li role="option" tabindex="-1">Missouri</li>
+            <li role="option" tabindex="-1">Montana</li>
+            <li role="option" tabindex="-1">Nebraska</li>
+            <li role="option" tabindex="-1">Nevada</li>
+            <li role="option" tabindex="-1">New Hampshire</li>
+            <li role="option" tabindex="-1">New Jersey</li>
+            <li role="option" tabindex="-1">New Mexico</li>
+            <li role="option" tabindex="-1">New York</li>
+            <li role="option" tabindex="-1">North Carolina</li>
+            <li role="option" tabindex="-1">North Dakota</li>
+            <li role="option" tabindex="-1">Northern Marianas Islands</li>
+            <li role="option" tabindex="-1">Ohio</li>
+            <li role="option" tabindex="-1">Oklahoma</li>
+            <li role="option" tabindex="-1">Oregon</li>
+            <li role="option" tabindex="-1">Pennsylvania</li>
+            <li role="option" tabindex="-1">Puerto Rico</li>
+            <li role="option" tabindex="-1">Rhode Island</li>
+            <li role="option" tabindex="-1">South Carolina</li>
+            <li role="option" tabindex="-1">South Dakota</li>
+            <li role="option" tabindex="-1">Tennessee</li>
+            <li role="option" tabindex="-1">Texas</li>
+            <li role="option" tabindex="-1">Utah</li>
+            <li role="option" tabindex="-1">Vermont</li>
+            <li role="option" tabindex="-1">Virginia</li>
+            <li role="option" tabindex="-1">Virgin Islands</li>
+            <li role="option" tabindex="-1">Washington</li>
+            <li role="option" tabindex="-1">West Virginia</li>
+            <li role="option" tabindex="-1">Wisconsin</li>
+            <li role="option" tabindex="-1">Wyoming</li>
+          </ul>
+        </div>
+      </div>
+      <div role="separator" id="ex_end_sep" aria-labelledby="ex_end_sep ex_label" aria-label="End of"></div>
+    </section>
+  
+    <section>
+      <h2 id="kbd_label">Keyboard Support</h2>
+      <p>
+      The example combobox on this page implements the following keyboard interface. 
+        Other variations and options for the keyboard interface are described in the  
+        <a href="../../../#combobox_kbd_interaction">Keyboard Interaction section of the combobox design pattern.</a>
+      </p>
+      <h3 id="kbd_label_textbox">Textbox</h3>
+      <table aria-labelledby="kbd_label_textbox kbd_label" class="def">
+        <thead>
+          <tr>
+            <th>Key</th>
+            <th>Function</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th><kbd>Down Arrow</kbd></th>
+            <td>Opens the listbox and moves focus to the first suggested value.</td>
+          </tr>
+          <tr>
+            <th><kbd>Alt+Down Arrow</kbd></th>
+            <td>Opens the listbox without moving focus out of the textbox.</td>
+          </tr>
+          <tr>
+            <th><kbd>Up Arrow</kbd></th>
+            <td>Opens the listbox and moves focus to the last suggested value.</td>
+          </tr>
+          <tr>
+            <th><kbd>Escape</kbd></th>
+            <td>if open, closes the listbox.</td>
+          </tr>
+        </tbody>
+      </table>
+      <h3 id="kbd_label_listbox">Listbox Popup</h3>
+      <table aria-labelledby="kbd_label_listbox kbd_label" class="def">
+        <thead>
+          <tr>
+            <th>Key</th>
+            <th>Function</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th><kbd>Enter</kbd></th>
+            <td>
+              <ul>
+                <li>Sets the textbox value to the content of the focused option in the listbox.</li>
+                <li>Closes the listbox.</li>
+                <li>Sets focus on the textbox.</li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <th><kbd>Escape</kbd></th>
+            <td>Closes the listbox and sets focus on the textbox.</td>
+          </tr>
+          <tr>
+            <th><kbd>Down Arrow</kbd></th>
+            <td>
+              <ul>
+                <li>Moves focus to the next <code>option</code>.</li>
+                <li>If focus is on the last <code>option</code>, the focus does not move.</li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <th><kbd>Up Arrow</kbd></th>
+            <td>
+              <ul>
+                <li>Moves focus to the previous <code>option</code>.</li>
+                <li>If focus is on the first <code>option</code>, the focus does not move.</li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <th><kbd>Home</kbd></th>
+            <td>Moves focus to the first <code>option</code>.</td>
+          </tr>
+          <tr>
+            <th><kbd>End</kbd></th>
+            <td>Moves focus to the last <code>option</code>.</td>
+          </tr>
+          <tr>
+            <th>
+              <kbd>A-Z</kbd><br> <kbd>a-z</kbd>
+            </th>
+            <td>
+              <ul>
+                <li>Moves focus to the option with a label that starts with the typed character if such an option exists.</li>
+                <li>Otherwise, focus does not move.</li>
+              </ul>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+  
+    <section>
+      <h2 id="rps_label">Role, Property, State, and Tabindex Attributes</h2>
+      <p>
+        The example combobox on this page implements the following ARIA roles, states, and properties. 
+        Information about other ways of applying ARIA roles, states, and properties is available in the    
+        <a href="../../../#combobox_roles_states_props">Roles, States, and Properties section of the combobox design pattern.</a>
+      </p>
+      <h3 id="rps_label_textbox">Textbox</h3>
+      <table aria-labelledby="rps_label_textbox rps_label" class="data attributes">
+        <thead>
+          <tr>
+            <th scope="col">Role</th>
+            <th scope="col">Attribute</th>
+            <th scope="col">Element</th>
+            <th scope="col">Usage</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th scope="row">
+              <code>combobox</code>
+            </th>
+            <td></td>
+            <td><code>input[type="text"]</code></td>
+            <td>
+              <ul>
+                <li>Identifies the input as a combobox.</li>
+                <li>Note: The primary difference between the ARIA 1.0 pattern and the ARIA 1.1 pattern is the placement of the <code>combobox</code> role.</li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td></td>
+            <th scope="row">
+              <code>aria-autocomplete=<q>list</q></code>
+            </th>
+            <td><code>input[type="text"]</code></td>
+            <td>Indicates that the autocomplete behavior is to suggest values in a listbox.</td>
+          </tr>
+          <tr>
+            <td></td>
+            <th scope="row">
+              <code>aria-haspopup=<q>true</q></code>
+            </th>
+            <td><code>input[type="text"]</code></td>
+            <td>
+              <ul>
+                <li>Indicates that the combobox can popup another element to suggest values.</li>
+                <li>This is the default value for elements with the <code>combobox</code> role.</li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td></td>
+            <th scope="row">
+              <code>aria-owns=<q>#IDREF</q></code>
+            </th>
+            <td><code>input[type="text"]</code></td>
+            <td>
+              <ul>
+                <li>Identifies the element that serves as the popup.</li>
+                <li>Note: In the ARIA 1.1 combobox pattern, the combobox uses <code>aria-controls</code> instead of <code>aria-owns</code>.</li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td></td>
+            <th scope="row">
+              <code>aria-expanded=<q>false</q></code>
+            </th>
+            <td><code>input[type="text"]</code></td>
+            <td>Indicates that the popup element <strong>is not</strong> displayed.</td>
+          </tr>
+          <tr>
+            <td></td>
+            <th scope="row">
+              <code>aria-expanded=<q>true</q></code>
+            </th>
+            <td><code>input[type="text"]</code></td>
+            <td>Indicates that the popup element <strong>is</strong> displayed.</td>
+          </tr>
+        </tbody>
+      </table>
+      <h3 id="rps_label_listbox">Listbox Popup</h3>
+      <table aria-labelledby="rps_label_listbox rps_label" class="data attributes">
+        <thead>
+          <tr>
+            <th scope="col">Role</th>
+            <th scope="col">Attribute</th>
+            <th scope="col">Element</th>
+            <th scope="col">Usage</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th scope="row">
+              <code>listbox</code>
+            </th>
+            <td></td>
+            <td>
+              <code>ul</code>
+            </td>
+            <td>Identifies the <code>ul</code> element as a <code>listbox</code>.</td>
+          </tr>
+          <tr>
+            <td></td>
+            <th scope="row">
+              <code>aria-label=<q>States<q></code>
+            </th>
+            <td><code>ul</code></td>
+            <td>Provides a label for the <code>listbox</code>.</td>
+          </tr>
+          <tr>
+            <th scope="row">
+              <code>option</code>
+            </th>
+            <td></td>
+            <td><code>li</code></td>
+            <td>
+              <ul>
+                <li>Identifies the element as a <code>listbox</code> <code>option</code>.</li>
+                <li>The text content of the element provides the accessible name of the <code>option</code>.</li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td></td>
+            <th scope="row">
+              <code>tabindex=&quot;-1&quot;</code>
+            </th>
+            <td><code>li</code></td>
+            <td>
+              <ul>
+                <li>Allows DOM focus to be set on the element with the JavaScript focus method.</li>
+                <li>Dynamically added by the JavaScript.</li>
+              </ul>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+  
+    <section>
+      <h2>Javascript and CSS Source Code</h2>
+      <ul>
+        <li>
+          CSS:
+          <a href="css/combobox-1.0.css" type="text/css">combobox-1.0.css</a>
+        </li>
+        <li>
+          CSS:
+          <a href="css/listbox.css" type="text/css">listbox.css</a>
+        </li>
+        <li>
+          Javascript:
+          <a href="js/combobox-1.0-listbox.js" type="text/javascript">combobox-1.0-listbox.js</a>
+        </li>
+        <li>
+          Javascript:
+          <a href="js/listbox.js" type="text/javascript">listbox.js</a>
+        </li>
+        <li>
+          Javascript:
+          <a href="js/listboxOption.js" type="text/javascript">listboxOption.js</a>
+        </li>
+      </ul>
+    </section>
+  
+    <section>
+      <h2 id="sc1_label">HTML Source Code</h2>
+      <div role="separator" id="sc1_start_sep" aria-labelledby="sc1_start_sep sc1_label" aria-label="Start of"></div>
+      <pre>
+        <code id="sc1"></code>
+      </pre>
+      <div role="separator" id="sc1_end_sep" aria-labelledby="sc1_end_sep sc1_label" aria-label="End of"></div>
+      <script>
+        sourceCode.add('sc1', 'ex1');
+        sourceCode.make();
+      </script>
+    </section>
   </main>
   <nav>
-    <!--  Update the pattern_ID parameter of this link to refer to the APG design pattern section related to this example.  -->
-    <a href="../../#pattern_ID">EXAMPLE_NAME Design Pattern in WAI-ARIA Authoring Practices 1.1</a>
+    <a href="../../../#combobox">Combobox Design Pattern in WAI-ARIA Authoring Practices 1.1</a>
   </nav>
 </body>
 </html>

--- a/examples/combobox/aria1.0pattern/combobox-autocomplete-list.html
+++ b/examples/combobox/aria1.0pattern/combobox-autocomplete-list.html
@@ -22,100 +22,100 @@
   <main>
     <h1>Legacy ARIA 1.0 Combobox With List Autocomplete Example</h1>
     <p>
-      <strong>NOTE:</strong> This page is work in progress; it is not ready for review. This work is tracked by
+      <strong>NOTE:</strong> This page is work in progress. Please provide feedback in
       <a href="https://github.com/w3c/aria-practices/issues/99">issue 99.</a>
     </p>
     <p>
-      The below combobox for choosing the name of a state in the USA demonstrates the
+      The below combobox for choosing the name of a US state or territory demonstrates the
       <a href="../../../#combobox">ARIA 1.0 design pattern for combobox.</a>
+      The design pattern describes four types of autocomplete behavior.
       This example illustrates the autocomplete behavior known as list autocomplete with manual selection.
       If the user types one or more characters in the edit box and the typed characters match the beginning of the name of one or more states or territories, a listbox popup appears containing the matching names.
       When the listbox appears, a suggested name is not automatically selected.
       Thus, after typing, if the user tabs or clicks out of the combobox without choosing a value from the listbox, the typed string becomes the value of the combobox.
-      Note that this implementation enables users to input the name of a state or territory but does not prevent input of any other arbetrary value.
+      Note that this implementation enables users to input the name of a state or territory, but it does not prevent input of any other arbetrary value.
     </p>
     <p>Similar examples include:</p>
     <ul>
-      <li><a href="combobox-autocomplete-both.html">ARIA 1.0 Combobox with Both List and Inline Autocompletion</a></li>
-      <li><a href="../aria1.1pattern/listbox-combo.html">ARIA 1.1 Combobox with Listbox Popup</a>: Comboboxes that demonstrate the various forms of autocomplete behavior using a listbox popup.</li>
-            <li><a href="../aria1.1pattern/grid-combo.html">ARIA 1.1 Combobox with Grid Popup</a>: A combobox that presents suggestions in a grid, enabling users to navigate descriptive information about each suggestion.</li>
+      <li><a href="combobox-autocomplete-both.html">ARIA 1.0 Combobox with Both List and Inline Autocomplete</a>: A combobox that demonstrates the autocomplete behavior known as <q>list with inline autocomplete</q> and uses the ARIA 1.0 implementation pattern.</li>
+      <li><a href="combobox-autocomplete-none.html">ARIA 1.0 Combobox Without Autocomplete</a>: A combo box that demonstrates the behavior associated with <code>aria-autocomplete=none</code> and uses the ARIA 1.0 implementation pattern.</li>
+      <li><a href="../aria1.1pattern/listbox-combo.html">ARIA 1.1 Combobox with Listbox Popup</a>: Comboboxes that demonstrate the various forms of autocomplete behavior using a listbox popup and use the ARIA 1.1 implementation pattern.</li>
+      <li><a href="../aria1.1pattern/grid-combo.html">ARIA 1.1 Combobox with Grid Popup</a>: A combobox that presents suggestions in a grid, enabling users to navigate descriptive information about each suggestion.</li>
     </ul>
   
     <section>
       <h2 id="ex_label">Example</h2>
       <div role="separator" id="ex_start_sep" aria-labelledby="ex_start_sep ex_label" aria-label="Start of"></div>
       <div id="ex1">
-        <div class="combobox-listbox">
+        <div class="combobox-list">
           <label for="cb1-input">State</label>
-  
           <div class="group">
             <input id="cb1-input" class="cb_edit" type="text" role="combobox" aria-autocomplete="list"
               aria-expanded="false" aria-haspopup="true" aria-owns="cb1-listbox"
             />
-            <button id="cb1-button" tabindex="-1" aria-label="open">&#9661;</button>
+            <button id="cb1-button" tabindex="-1" aria-label="Open">&#9661;</button>
           </div>
-  
           <ul id="cb1-listbox" role="listbox" aria-label="States">
-            <li role="option" tabindex="-1">Alabama</li>
-            <li role="option" tabindex="-1">Alaska</li>
-            <li role="option" tabindex="-1">American Samoa</li>
-            <li role="option" tabindex="-1">Arizona</li>
-            <li role="option" tabindex="-1">Arkansas</li>
-            <li role="option" tabindex="-1">California</li>
-            <li role="option" tabindex="-1">Colorado</li>
-            <li role="option" tabindex="-1">Connecticut</li>
-            <li role="option" tabindex="-1">Delaware</li>
-            <li role="option" tabindex="-1">District of Columbia</li>
-            <li role="option" tabindex="-1">Florida</li>
-            <li role="option" tabindex="-1">Georgia</li>
-            <li role="option" tabindex="-1">Guam</li>
-            <li role="option" tabindex="-1">Hawaii</li>
-            <li role="option" tabindex="-1">Idaho</li>
-            <li role="option" tabindex="-1">Illinois</li>
-            <li role="option" tabindex="-1">Indiana</li>
-            <li role="option" tabindex="-1">Iowa</li>
-            <li role="option" tabindex="-1">Kansas</li>
-            <li role="option" tabindex="-1">Kentucky</li>
-            <li role="option" tabindex="-1">Louisiana</li>
-            <li role="option" tabindex="-1">Maine</li>
-            <li role="option" tabindex="-1">Maryland</li>
-            <li role="option" tabindex="-1">Massachusetts</li>
-            <li role="option" tabindex="-1">Michigan</li>
-            <li role="option" tabindex="-1">Minnesota</li>
-            <li role="option" tabindex="-1">Mississippi</li>
-            <li role="option" tabindex="-1">Missouri</li>
-            <li role="option" tabindex="-1">Montana</li>
-            <li role="option" tabindex="-1">Nebraska</li>
-            <li role="option" tabindex="-1">Nevada</li>
-            <li role="option" tabindex="-1">New Hampshire</li>
-            <li role="option" tabindex="-1">New Jersey</li>
-            <li role="option" tabindex="-1">New Mexico</li>
-            <li role="option" tabindex="-1">New York</li>
-            <li role="option" tabindex="-1">North Carolina</li>
-            <li role="option" tabindex="-1">North Dakota</li>
-            <li role="option" tabindex="-1">Northern Marianas Islands</li>
-            <li role="option" tabindex="-1">Ohio</li>
-            <li role="option" tabindex="-1">Oklahoma</li>
-            <li role="option" tabindex="-1">Oregon</li>
-            <li role="option" tabindex="-1">Pennsylvania</li>
-            <li role="option" tabindex="-1">Puerto Rico</li>
-            <li role="option" tabindex="-1">Rhode Island</li>
-            <li role="option" tabindex="-1">South Carolina</li>
-            <li role="option" tabindex="-1">South Dakota</li>
-            <li role="option" tabindex="-1">Tennessee</li>
-            <li role="option" tabindex="-1">Texas</li>
-            <li role="option" tabindex="-1">Utah</li>
-            <li role="option" tabindex="-1">Vermont</li>
-            <li role="option" tabindex="-1">Virginia</li>
-            <li role="option" tabindex="-1">Virgin Islands</li>
-            <li role="option" tabindex="-1">Washington</li>
-            <li role="option" tabindex="-1">West Virginia</li>
-            <li role="option" tabindex="-1">Wisconsin</li>
-            <li role="option" tabindex="-1">Wyoming</li>
+            <li id="lb1-al" role="option">Alabama</li>
+            <li id="lb1-ak" role="option">Alaska</li>
+            <li id="lb1-as" role="option">American Samoa</li>
+            <li id="lb1-az" role="option">Arizona</li>
+            <li id="lb1-ar" role="option">Arkansas</li>
+            <li id="lb1-ca" role="option">California</li>
+            <li id="lb1-co" role="option">Colorado</li>
+            <li id="lb1-ct" role="option">Connecticut</li>
+            <li id="lb1-de" role="option">Delaware</li>
+            <li id="lb1-dc" role="option">District of Columbia</li>
+            <li id="lb1-fl" role="option">Florida</li>
+            <li id="lb1-ga" role="option">Georgia</li>
+            <li id="lb1-gm" role="option">Guam</li>
+            <li id="lb1-hi" role="option">Hawaii</li>
+            <li id="lb1-id" role="option">Idaho</li>
+            <li id="lb1-il" role="option">Illinois</li>
+            <li id="lb1-in" role="option">Indiana</li>
+            <li id="lb1-ia" role="option">Iowa</li>
+            <li id="lb1-ks" role="option">Kansas</li>
+            <li id="lb1-ky" role="option">Kentucky</li>
+            <li id="lb1-la" role="option">Louisiana</li>
+            <li id="lb1-me" role="option">Maine</li>
+            <li id="lb1-md" role="option">Maryland</li>
+            <li id="lb1-ma" role="option">Massachusetts</li>
+            <li id="lb1-mi" role="option">Michigan</li>
+            <li id="lb1-mn" role="option">Minnesota</li>
+            <li id="lb1-ms" role="option">Mississippi</li>
+            <li id="lb1-mo" role="option">Missouri</li>
+            <li id="lb1-mn" role="option">Montana</li>
+            <li id="lb1-ne" role="option">Nebraska</li>
+            <li id="lb1-nv" role="option">Nevada</li>
+            <li id="lb1-nh" role="option">New Hampshire</li>
+            <li id="lb1-nj" role="option">New Jersey</li>
+            <li id="lb1-nm" role="option">New Mexico</li>
+            <li id="lb1-ny" role="option">New York</li>
+            <li id="lb1-nc" role="option">North Carolina</li>
+            <li id="lb1-nd" role="option">North Dakota</li>
+            <li id="lb1-nm" role="option">Northern Marianas Islands</li>
+            <li id="lb1-oh" role="option">Ohio</li>
+            <li id="lb1-ok" role="option">Oklahoma</li>
+            <li id="lb1-or" role="option">Oregon</li>
+            <li id="lb1-pa" role="option">Pennsylvania</li>
+            <li id="lb1-pr" role="option">Puerto Rico</li>
+            <li id="lb1-ri" role="option">Rhode Island</li>
+            <li id="lb1-sc" role="option">South Carolina</li>
+            <li id="lb1-sd" role="option">South Dakota</li>
+            <li id="lb1-tn" role="option">Tennessee</li>
+            <li id="lb1-tx" role="option">Texas</li>
+            <li id="lb1-ut" role="option">Utah</li>
+            <li id="lb1-ve" role="option">Vermont</li>
+            <li id="lb1-va" role="option">Virginia</li>
+            <li id="lb1-vi" role="option">Virgin Islands</li>
+            <li id="lb1-wa" role="option">Washington</li>
+            <li id="lb1-wv" role="option">West Virginia</li>
+            <li id="lb1-wi" role="option">Wisconsin</li>
+            <li id="lb1-wy" role="option">Wyoming</li>
           </ul>
         </div>
       </div>
-      <div role="separator" id="ex_end_sep" aria-labelledby="ex_end_sep ex_label" aria-label="End of"></div>
+    <div role="separator" id="ex_end_sep" aria-labelledby="ex_end_sep ex_label" aria-label="End of"></div>
     </section>
   
     <section>
@@ -291,7 +291,7 @@
               <code>aria-autocomplete=<q>list</q></code>
             </th>
             <td><code>input[type="text"]</code></td>
-            <td>Indicates that the autocomplete behavior is to suggest values in a listbox.</td>
+            <td>Indicates that the autocomplete behavior of the text input is to suggest a list of possible values in a popup and that the suggestions are related to the string that is present in the textbox.</td>
           </tr>
           <tr>
             <td></td>
@@ -299,12 +299,7 @@
               <code>aria-haspopup=<q>true</q></code>
             </th>
             <td><code>input[type="text"]</code></td>
-            <td>
-              <ul>
-                <li>Indicates that the combobox can popup another element to suggest values.</li>
-                <li>This is the default value for elements with the <code>combobox</code> role.</li>
-              </ul>
-            </td>
+            <td>Indicates that the combobox can popup another element to suggest values.</td>
           </tr>
           <tr>
             <td></td>
@@ -334,6 +329,24 @@
             </th>
             <td><code>input[type="text"]</code></td>
             <td>Indicates that the popup element <strong>is</strong> displayed.</td>
+          </tr>
+          <tr>
+            <td></td>
+            <th scope="row">
+              <code>aria-activedescendant=<q>IDREF</q></code>
+            </th>
+            <td><code>input[type="text"]</code></td>
+            <td>
+              <ul>
+                <li>When an option in the listbox is visually indicated as having keyboard focus, refers to that option.</li>
+                <li>When navigation keys, such as <kbd>Down Arrow</kbd>, are pressed, the JavaScript changes the value.</li>
+                <li>Enables assistive technologies to know which element the application regards as focused while DOM focus remains on the <code>input</code> element.</li>
+                <li>
+                  For more information about this focus management technique, see 
+                  <a href="../../../#kbd_focus_activedescendant">Using aria-activedescendant to Manage Focus.</a>
+                </li>
+              </ul>
+            </td>
           </tr>
         </tbody>
       </table>
@@ -382,13 +395,13 @@
           <tr>
             <td></td>
             <th scope="row">
-              <code>tabindex=&quot;-1&quot;</code>
+              <code>aria-selected=<q>true</q></code>
             </th>
             <td><code>li</code></td>
             <td>
               <ul>
-                <li>Allows DOM focus to be set on the element with the JavaScript focus method.</li>
-                <li>Dynamically added by the JavaScript.</li>
+                <li>Specified on an option in the listbox when it is visually highlighted as selected.</li>
+                <li>Occurs only when an option in the list is referenced by <code>aria-activedescendant</code>.</li>
               </ul>
             </td>
           </tr>

--- a/examples/combobox/aria1.0pattern/combobox-autocomplete-none.html
+++ b/examples/combobox/aria1.0pattern/combobox-autocomplete-none.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8" />
-<title>Example of Legacy ARIA 1.0 Combobox Without Autocomplete | WAI-ARIA Authoring Practices 1.0</title>
+<title>Legacy ARIA 1.0 Combobox without Autocomplete Example | WAI-ARIA Authoring Practices 1.0</title>
 
 <!--  Core js and css shared by all examples; do not modify when using this template. -->
 <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/base.css">
@@ -14,328 +14,391 @@
 <!--  js and css for this example. -->
 <link href="css/combobox-1.0.css" rel="stylesheet">
 <link  href="css/listbox.css"     rel="stylesheet">
-
 <script src="js/combobox-1.0-list.js"  type="text/javascript"></script>
 <script src="js/listbox.js"       type="text/javascript"></script>
 <script src="js/listboxOption.js" type="text/javascript"></script>
-
 </head>
 <body>
   <main>
-  <h1>Example of Legacy ARIA 1.0 Combobox Without Autocomplete</h1>
-  <p>
-    <strong>NOTE:</strong> This page is ready to start reviewing.
-    This work is tracked by <a href="https://github.com/w3c/aria-practices/issues/99">issue 99</a>.
-  </p>
-  <p>
-    The below example section demonstrates a <code>combobox</code> that implements the
-    <a href="../../#combobox">ARIA 1.0 design pattern for combobox.</a>
-    This example demonstrates a combobox that provides a list of options to the user.
-    The options available in the listbox are fixed and do <strong>not</strong> change based
-    on user input into the textbox.  Tis pattern is common for providing options based on
-    previous input into the textbox, for example a user name, address or phone number.
-    The user can select an option from the list to set the value of the textbox.
-  </p>
-  </p>The major design feature of the ARIA 1.0 combobox pattern is the use of
-    <code>aria-activedescendant</code> to reference options in a listbox, while keyboard
-    focus remains on the textbox.
-  <p>
-  <p>Similar examples include: </p>
-  <ul>
-    <li>
-      <a href="combobox-autocomplete-list.html">Combobox With an List Autocomplete</a>
-      : example demonstrates the behavior associated with <code>aria-autocomplete=list</code>.
-    </li>
-    <li>
-      <a href="combobox-autocomplete-both.html">Combobox With Both List and Inline Autocompletion</a>
-      : example demonstrates the behavior associated with <code>aria-autocomplete=both</code>.
-    </li>
-  </ul>
-
-  <section>
-    <h2 id="ex_label">Example</h2>
-    <div role="separator" id="ex_start_sep" aria-labelledby="ex_start_sep ex_label" aria-label="Start of"></div>
-    <div id="ex1">
-      <div class="combobox-list">
-        <label for="cb1-input">Search</label>
-
-        <div class="group">
-          <input id="cb1-input" class="cb_edit" type="text"
-                 role="combobox"
-                 aria-autocomplete="none"
-                 aria-expanded="false"
-                 aria-haspopup="true"
-                 aria-owns="cb1-listbox"
-                 aria-activedescendant=""
-          />
-          <button id="cb1-button" tabindex="-1" aria-label="open button">
-            &#9661;
-          </button>
-        </div>
-
-        <ul id="cb1-listbox" role="listbox" aria-label="States">
-          <li id="lb1-01" role="option">weather</li>
-          <li id="lb1-02" role="option">salsa recipes</li>
-          <li id="lb1-03" role="option">cheap flights to NY</li>
-          <li id="lb1-04" role="option">dictionary</li>
-          <li id="lb1-05" role="option">baseball scores</li>
-          <li id="lb1-06" role="option">hotels in NY</li>
-          <li id="lb1-07" role="option">mortgage calculator</li>
-          <li id="lb1-08" role="option">restaurants near me</li>
-          <li id="lb1-09" role="option">free games</li>
-          <li id="lb1-10" role="option">gas prices</li>
-          <li id="lb1-11" role="option">classical music</li>
-        </ul>
-      </div>
-    </div>
-    <div role="separator" id="ex_end_sep" aria-labelledby="ex_end_sep ex_label" aria-label="End of"></div>
-  </section>
-
-  <section>
-    <h2 id="kbd_label_textbox">Combobox Keyboard Support</h2>
-
-    <table aria-labelledby="kbd_label_textbox" class="def">
-      <thead>
-        <tr>
-          <th>Key</th>
-          <th>Function</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <th><kbd>Down Arrow</kbd></th>
-          <td>
-            <ul>
-              <li>If the listbox is <strong>closed</strong>, the listbox is opened and <code>aria-activedescendant</code> is set to reference the first option in the listbox.  </li>
-              <li>If the listbox is <strong>open</strong>, <code>aria-activedescendant</code> is updated to reference the next option in the listbox.  <br/>Note: When <code>aria-activedescendant</code> is referencing the last option the reference does not change.</li>
-              <li>If the listbox is <strong>empty</strong> (e.g. no options avaialble), <code>aria-activedescendant</code> is set to an empty string.</li>
-            </ul>
-          </td>
-        </tr>
-        <tr>
-          <th><kbd>Up Arrow</kbd></th>
-          <td>
-            <ul>
-              <li>If the listbox is <strong>closed</strong>, the listbox is opened and <code>aria-activedescendant</code> is set to reference the last option in the listbox.  </li>
-              <li>If the listbox is <strong>open</strong>, <code>aria-activedescendant</code> is updated to reference the previous option in the listbox.  <br/>Note: When <code>aria-activedescendant</code> is referencing the first option the reference does not change.</li>
-              <li>If the listbox is <strong>empty</strong> (e.g. no options avaialble), <code>aria-activedescendant</code> is set to an empty string.</li>
-            </ul>          </td>
-        </tr>
-        <tr>
-          <th><kbd>Escape</kbd></th>
-          <td>If the listbox is <strong>open</strong>, the listbox is closed and aria-activedescendant</code> is set to an empty string.</td>
-        </tr>
-      </tbody>
-    </table>
-
-  </section>
-
-  <section>
-
-    <h2 id="rps_label_combobox">Combobox Role, Property, State, and Tabindex  Attributes</h2>
-    <!--
-      Update this table to describe how roles, properties, states, and tabindex are used in this example.
-    -->
-    <table aria-labelledby="rps_label_combobox" class="data attributes">
-      <thead>
-        <tr>
-          <th scope="col">Role</th>
-          <th scope="col">Attribute</th>
-          <th scope="col">Element</th>
-          <th scope="col">Usage</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <th scope="row"><code>combobox</code></th>
-          <td><!--  Leave this cell blank in rows where a role is being described. --></td>
-          <td><code>input[type="text"]</code></td>
-          <td>
-            Identifies the <code>input[type=<q>text</q>] as a combobox option.
-          </td>
-        </tr>
-        <tr>
-          <td>
-          </td>
-          <th scope="row"><code>aria-autocomplete=<q>none</q></code></th>
-          <td><code>input[type="text"]</code></td>
-          <td>
-            The value of <code>none</code> identifies that the combobox list of options does
-            <strong>not</strong> change based on user input and the <code>input[type=<q>text</q>]</code> does
-            <strong>not</strong> provide inline autocompletion.
-          </td>
-        </tr>
-        <tr>
-          <td>
-          </td>
-          <th scope="row"><code>aria-haspopup=<q>true</q></code></th>
-          <td><code>input[type="text"]</code></td>
-          <td>
-            Identifies the <code>combobox</code> as having a popup list of options for the value of the textbox.
-          </td>
-        </tr>
-        <tr>
-          <td>
-          </td>
-          <th scope="row"><code>aria-owns=<q>#IDREF</q></code></th>
-          <td><code>input[type="text"]</code></td>
-          <td>
-            Identifies the <code>listbox</code> that is controlled by the combobox.
-          </td>
-        </tr>
-        <tr>
-          <td>
-          </td>
-          <th scope="row"><code>aria-expanded=<q>false</q></code></th>
-          <td><code>input[type="text"]</code></td>
-          <td>
-            Idenitifies the <code>listbox</code> as closed (e.g. hidden from the user).
-          </td>
-        </tr>
-        <tr>
-          <td>
-          </td>
-          <th scope="row"><code>aria-expanded=<q>true</q></code></th>
-          <td><code>input[type="text"]</code></td>
-          <td>
-            Idenitifies the <code>listbox</code> as open (e.g. visible to the user).
-          </td>
-        </tr>
-        <tr>
-          <td>
-          </td>
-          <th scope="row"><code>aria-activedescendant=<q>#IDREF</q></code></th>
-          <td><code>input[type="text"]</code></td>
-          <td>
-            References the current autocomplete <code>option</code> in the <code>listbox</code>.
-          </td>
-        </tr>
-        <tr>
-          <td>
-          </td>
-          <th scope="row"><code>aria-activedescendant=<q></q></code></th>
-          <td><code>input[type="text"]</code></td>
-          <td>
-            If no autocomplete <code>option</code> is selected or the list of <code>option</code>s is emtpy, <code>aria-activedescendant</code> is set to an empty string.</td>
-          </td>
-        </tr>
-      </tbody>
-    </table>
-
-
-    <h2 id="rps_label_listbox">Listbox Role, Property, State, and Tabindex  Attributes</h2>
-    <!--
-      Update this table to describe how roles, properties, states, and tabindex are used in this example.
-    -->
-    <table aria-labelledby="rps_label_listbox" class="data attributes">
-      <thead>
-        <tr>
-          <th scope="col">Role</th>
-          <th scope="col">Attribute</th>
-          <th scope="col">Element</th>
-          <th scope="col">Usage</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <th scope="row">
-            <code>listbox</code>
-          </th>
-          <td></td>
-          <td>
-            <code>ul</code>
-          </td>
-          <td>Identifies the <code>ul</code> element as a <code>listbox</code>.</td>
-        </tr>
-        <tr>
-          <td>
-            <code></code>
-          </td>
-          <th scope="row"><code>aria-label=<q>States</q></code></th>
-          <td>
-            <code>ul</code>
-          </td>
-          <td>
-            Provides a label for the <code>listbox</code>.
-          </td>
-        </tr>
-        <tr>
-          <th scope="row">
-            <code>option</code>
-          </th>
-          <td></td>
-          <td>
-            <code>li</code>
-          </td>
-          <td>
-            <ul>
-              <li>Identifies the <code>li</code> element as a <code>option</code> in a <cpde>listbox</cpde>.</li>
-              <li>The text content of the <code>li</code> element provides the accessible name of the <code>option</code>.</li>
-            </ul>
-          </td>
-        </tr>
-        <tr>
-          <td>
-            <code></code>
-          </td>
-          <th scope="row"><code>id=<q>ID</q></code></th>
-          <td>
-            <code>li</code>
-          </td>
-          <td>
-            Provides a unique reference for the option that is referenced by the <code>aria-activedescendant</code> attribute of the <code>combobox</code>.
-          </td>
-        </tr>
-      </tbody>
-    </table>
-  </section>
-
-  <section>
-    <h2>Javascript and CSS Source Code</h2>
-    <!--  After the js and css files are named with the name of this example, change the href and text of the following 2 links to refer to the appropriate js and css files.  -->
+    <h1>Legacy ARIA 1.0 Combobox without Autocomplete Example</h1>
+    <p>
+      <strong>NOTE:</strong> This page is work in progress. Please provide feedback in
+      <a href="https://github.com/w3c/aria-practices/issues/99">issue 99.</a>
+    </p>
+    <p>
+      The below combobox that enables users to choose a term from a hypothetical list of previously searched terms demonstrates the
+      <a href="../../../#combobox">ARIA 1.0 design pattern for combobox.</a>
+      The design pattern describes four types of autocomplete behavior.
+      This example illustrates the autocomplete behavior known as <q>no autocomplete</q>.
+      The terms that appear in the listbox popup are not related to the string that is present in the textbox.
+      In this implementation, The listbox popup is not automatically triggered; it is displayed only when the user opens it.
+    </p>
+    <p>Similar examples include: </p>
     <ul>
-      <li>
-        CSS:
-        <a href="css/combobox-1.0.css" type="text/css">combobox-1.0.css</a>
-      </li>
-      <li>
-        CSS:
-        <a href="css/listbox.css" type="text/css">listbox.css</a>
-      </li>
-      <li>
-        Javascript:
-        <a href="js/combobox-1.0-list.js" type="text/javascript">combobox-1.0-list.js</a>
-      </li>
-      <li>
-        Javascript:
-        <a href="js/listbox.js" type="text/javascript">listbox.js</a>
-      </li>
-      <li>
-        Javascript:
-        <a href="js/listboxOption.js" type="text/javascript">listboxOption.js</a>
-      </li>
+    <li><a href="combobox-autocomplete-list.html">ARIA 1.0 Combobox with List Autocomplete</a>: A combobox that demonstrates the autocomplete behavior known as <q>list with manual selection</q> and uses the ARIA 1.0 implementation pattern.</li>
+    <li><a href="combobox-autocomplete-both.html">ARIA 1.0 Combobox with Both List and Inline Autocomplete</a>: A combobox that demonstrates the autocomplete behavior known as <q>list with inline autocomplete</q> and uses the ARIA 1.0 implementation pattern.</li>
+      <li><a href="../aria1.1pattern/listbox-combo.html">ARIA 1.1 Combobox with Listbox Popup</a>: Comboboxes that demonstrate the various forms of autocomplete behavior using a listbox popup and use the ARIA 1.1 implementation pattern.</li>
+      <li><a href="../aria1.1pattern/grid-combo.html">ARIA 1.1 Combobox with Grid Popup</a>: A combobox that presents suggestions in a grid, enabling users to navigate descriptive information about each suggestion.</li>
     </ul>
-  </section>
+    <section>
+      <h2 id="ex_label">Example</h2>
+      <div role="separator" id="ex_start_sep" aria-labelledby="ex_start_sep ex_label" aria-label="Start of"></div>
+      <div id="ex1">
+        <div class="combobox-list">
+          <label for="cb1-input">Search</label>
+          <div class="group">
+            <input id="cb1-input" class="cb_edit" type="text"
+                   role="combobox"
+                   aria-autocomplete="none"
+                   aria-expanded="false"
+                   aria-haspopup="true"
+                   aria-owns="cb1-listbox"
+            />
+            <button id="cb1-button" tabindex="-1" aria-label="Open">
+              &#9661;
+            </button>
+          </div>
+          <ul id="cb1-listbox" role="listbox" aria-label="Previous Searches">
+            <li id="lb1-01" role="option">weather</li>
+            <li id="lb1-02" role="option">salsa recipes</li>
+            <li id="lb1-03" role="option">cheap flights to NY</li>
+            <li id="lb1-04" role="option">dictionary</li>
+            <li id="lb1-05" role="option">baseball scores</li>
+            <li id="lb1-06" role="option">hotels in NY</li>
+            <li id="lb1-07" role="option">mortgage calculator</li>
+            <li id="lb1-08" role="option">restaurants near me</li>
+            <li id="lb1-09" role="option">free games</li>
+            <li id="lb1-10" role="option">gas prices</li>
+            <li id="lb1-11" role="option">classical music</li>
+          </ul>
+        </div>
+      </div>
+      <div role="separator" id="ex_end_sep" aria-labelledby="ex_end_sep ex_label" aria-label="End of"></div>
+    </section>
+    
+    <section>
+      <h2 id="kbd_label">Keyboard Support</h2>
+      <p>
+      The example combobox on this page implements the following keyboard interface. 
+        Other variations and options for the keyboard interface are described in the  
+        <a href="../../../#combobox_kbd_interaction">Keyboard Interaction section of the combobox design pattern.</a>
+      </p>
+      <h3 id="kbd_label_textbox">Textbox</h3>
+      <table aria-labelledby="kbd_label_textbox kbd_label" class="def">
+        <thead>
+          <tr>
+            <th>Key</th>
+            <th>Function</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th><kbd>Down Arrow</kbd></th>
+            <td>Opens the listbox and moves focus to the first suggested value.</td>
+          </tr>
+          <tr>
+            <th><kbd>Up Arrow</kbd></th>
+            <td>Opens the listbox and moves focus to the last suggested value.</td>
+          </tr>
+          <tr>
+            <th><kbd>Escape</kbd></th>
+            <td>if open, closes the listbox.</td>
+          </tr>
+          <tr>
+            <th><li>Standard single line text editing keys</th>
+            <td>
+              <ul>
+                <li>Keys used for cursor movement and text manipulation, such as <kbd>Delete</kbd> and <kbd>Shift + Right Arrow</kbd>.</li>
+                <li>Note: An HTML <code>input</code> with <code>type=<q>text</q></code> is used for the textbox so the browser will provide platform-specific editing keys.</li>
+              </ul>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <h3 id="kbd_label_listbox">Listbox Popup</h3>
+      <p>
+        <strong>NOTE:</strong> When visual focus is in the listbox, DOM focus remains on the textbox and the value of <code>aria-activedescendant</code> on the textbox is set to a value that refers to the listbox option that is visually indicated as focused.
+        Where the following descriptions of keyboard commands mention focus, they are referring to the visual focus indicator.
+        For more information about this focus management technique, see 
+        <a href="../../../#kbd_focus_activedescendant">Using aria-activedescendant to Manage Focus.</a>
+      </p>
+      <table aria-labelledby="kbd_label_listbox kbd_label" class="def">
+        <thead>
+          <tr>
+            <th>Key</th>
+            <th>Function</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th><kbd>Enter</kbd></th>
+            <td>
+              <ul>
+                <li>Sets the textbox value to the content of the focused option in the listbox.</li>
+                <li>Closes the listbox.</li>
+                <li>Sets focus on the textbox.</li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <th><kbd>Escape</kbd></th>
+            <td>Closes the listbox and sets focus on the textbox.</td>
+          </tr>
+          <tr>
+            <th><kbd>Down Arrow</kbd></th>
+            <td>
+              <ul>
+                <li>Moves focus to the next <code>option</code>.</li>
+                <li>If focus is on the last <code>option</code>, the focus does not move.</li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <th><kbd>Up Arrow</kbd></th>
+            <td>
+              <ul>
+                <li>Moves focus to the previous <code>option</code>.</li>
+                <li>If focus is on the first <code>option</code>, the focus does not move.</li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <th><kbd>Right Arrow</kbd></th>
+            <td>
+              <ul>
+                <li>Returns focus to the textbox without closing the listbox.</li>
+                <li>Moves the input cursor one character to the right. If the input cursor is on the right-most character, the cursor does not move.</li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <th><kbd>Left Arrow</kbd></th>
+            <td>
+              <ul>
+                <li>Returns focus to the textbox without closing the listbox.</li>
+                <li>Moves the input cursor one character to the left. If the input cursor is on the left-most character, the cursor does not move.</li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <th><kbd>Home</kbd></th>
+            <td>Moves focus to the first <code>option</code>.</td>
+          </tr>
+          <tr>
+            <th><kbd>End</kbd></th>
+            <td>Moves focus to the last <code>option</code>.</td>
+          </tr>
+          <tr>
+            <th>Printable Characters</th>
+            <td>Returns focus to the textbox without closing the popup and types the character.</td>
+          </tr>
+          <tr>
+            <th>Standard Editing Keys<br>e.g., <kbd>Delete</kbd></th>
+            <td>
+              <ul>
+                <li>Return focus to the textbox without closing the popup.</li>
+                <li>Executes the platform-specific function for the key.</li>
+              </ul>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+  
+    <section>
+      <h2 id="rps_label">Role, Property, State, and Tabindex Attributes</h2>
+      <p>
+        The example combobox on this page implements the following ARIA roles, states, and properties. 
+        Information about other ways of applying ARIA roles, states, and properties is available in the    
+        <a href="../../../#combobox_roles_states_props">Roles, States, and Properties section of the combobox design pattern.</a>
+      </p>
+      <h3 id="rps_label_textbox">Textbox</h3>
+      <table aria-labelledby="rps_label_textbox rps_label" class="data attributes">
+        <thead>
+          <tr>
+            <th scope="col">Role</th>
+            <th scope="col">Attribute</th>
+            <th scope="col">Element</th>
+            <th scope="col">Usage</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th scope="row">
+              <code>combobox</code>
+            </th>
+            <td></td>
+            <td><code>input[type="text"]</code></td>
+            <td>
+              <ul>
+                <li>Identifies the input as a combobox.</li>
+                <li>Note: The primary difference between the ARIA 1.0 pattern and the ARIA 1.1 pattern is the placement of the <code>combobox</code> role.</li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td></td>
+            <th scope="row">
+              <code>aria-autocomplete=<q>none</q></code>
+            </th>
+            <td><code>input[type="text"]</code></td>
+            <td>Indicates that the suggestions in the combobox popup are not values that complete the current textbox input.</td>
+          </tr>
+          <tr>
+            <td></td>
+            <th scope="row">
+              <code>aria-haspopup=<q>true</q></code>
+            </th>
+            <td><code>input[type="text"]</code></td>
+            <td>Indicates that the combobox can popup another element to suggest values.</td>
+          </tr>
+          <tr>
+            <td></td>
+            <th scope="row">
+              <code>aria-owns=<q>#IDREF</q></code>
+            </th>
+            <td><code>input[type="text"]</code></td>
+            <td>
+              <ul>
+                <li>Identifies the element that serves as the popup.</li>
+                <li>Note: In the ARIA 1.1 combobox pattern, the combobox uses <code>aria-controls</code> instead of <code>aria-owns</code>.</li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td></td>
+            <th scope="row">
+              <code>aria-expanded=<q>false</q></code>
+            </th>
+            <td><code>input[type="text"]</code></td>
+            <td>Indicates that the popup element <strong>is not</strong> displayed.</td>
+          </tr>
+          <tr>
+            <td></td>
+            <th scope="row">
+              <code>aria-expanded=<q>true</q></code>
+            </th>
+            <td><code>input[type="text"]</code></td>
+            <td>Indicates that the popup element <strong>is</strong> displayed.</td>
+          </tr>
+          <tr>
+            <td></td>
+            <th scope="row">
+              <code>aria-activedescendant=<q>IDREF</q></code>
+            </th>
+            <td><code>input[type="text"]</code></td>
+            <td>
+              <ul>
+                <li>When an option in the listbox is visually indicated as having keyboard focus, refers to that option.</li>
+                <li>When navigation keys, such as <kbd>Down Arrow</kbd>, are pressed, the JavaScript changes the value.</li>
+                <li>Enables assistive technologies to know which element the application regards as focused while DOM focus remains on the <code>input</code> element.</li>
+                <li>
+                  For more information about this focus management technique, see 
+                  <a href="../../../#kbd_focus_activedescendant">Using aria-activedescendant to Manage Focus.</a>
+                </li>
+              </ul>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <h3 id="rps_label_listbox">Listbox Popup</h3>
+      <table aria-labelledby="rps_label_listbox rps_label" class="data attributes">
+        <thead>
+          <tr>
+            <th scope="col">Role</th>
+            <th scope="col">Attribute</th>
+            <th scope="col">Element</th>
+            <th scope="col">Usage</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th scope="row">
+              <code>listbox</code>
+            </th>
+            <td></td>
+            <td>
+              <code>ul</code>
+            </td>
+            <td>Identifies the <code>ul</code> element as a <code>listbox</code>.</td>
+          </tr>
+          <tr>
+            <td></td>
+            <th scope="row">
+              <code>aria-label=<q>Previous Searches<q></code>
+            </th>
+            <td><code>ul</code></td>
+            <td>Provides a label for the <code>listbox</code>.</td>
+          </tr>
+          <tr>
+            <th scope="row">
+              <code>option</code>
+            </th>
+            <td></td>
+            <td><code>li</code></td>
+            <td>
+              <ul>
+                <li>Identifies the element as a <code>listbox</code> <code>option</code>.</li>
+                <li>The text content of the element provides the accessible name of the <code>option</code>.</li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td></td>
+            <th scope="row">
+              <code>aria-selected=<q>true</q></code>
+            </th>
+            <td><code>li</code></td>
+            <td>
+              <ul>
+                <li>Specified on an option in the listbox when it is visually highlighted as selected.</li>
+                <li>Occurs only when an option in the list is referenced by <code>aria-activedescendant</code>.</li>
+              </ul>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
 
-  <section>
-    <h2 id="sc1_label">HTML Source Code</h2>
-    <div role="separator" id="sc1_start_sep" aria-labelledby="sc1_start_sep sc1_label" aria-label="Start of"></div>
-    <pre><code id="sc1"></code></pre>
-    <div role="separator" id="sc1_end_sep" aria-labelledby="sc1_end_sep sc1_label" aria-label="End of"></div>
-    <!--
-      The following script will show the reader the HTML source for the example that is in the div with ID 'ex1'.
-      It renders the HTML in the preceding pre element with ID 'sc1'.
-      If you change the ID of either the 'ex1' div or the 'sc1' pre, be sure to update the sourceCode.add function parameters.
-      -->
-    <script>
-      sourceCode.add('sc1', 'ex1');
-      sourceCode.make();
-    </script>
-  </section>
+    <section>
+      <h2>Javascript and CSS Source Code</h2>
+      <ul>
+        <li>
+          CSS:
+          <a href="css/combobox-1.0.css" type="text/css">combobox-1.0.css</a>
+        </li>
+        <li>
+          CSS:
+          <a href="css/listbox.css" type="text/css">listbox.css</a>
+        </li>
+        <li>
+          Javascript:
+          <a href="js/combobox-1.0-list.js" type="text/javascript">combobox-1.0-list.js</a>
+        </li>
+        <li>
+          Javascript:
+          <a href="js/listbox.js" type="text/javascript">listbox.js</a>
+        </li>
+        <li>
+          Javascript:
+          <a href="js/listboxOption.js" type="text/javascript">listboxOption.js</a>
+        </li>
+      </ul>
+    </section>
+
+    <section>
+      <h2 id="sc1_label">HTML Source Code</h2>
+      <div role="separator" id="sc1_start_sep" aria-labelledby="sc1_start_sep sc1_label" aria-label="Start of"></div>
+      <pre><code id="sc1"></code></pre>
+      <div role="separator" id="sc1_end_sep" aria-labelledby="sc1_end_sep sc1_label" aria-label="End of"></div>
+      <script>
+        sourceCode.add('sc1', 'ex1');
+        sourceCode.make();
+      </script>
+    </section>
   </main>
   <nav>
-    <!--  Update the pattern_ID parameter of this link to refer to the APG design pattern section related to this example.  -->
-    <a href="../../#pattern_ID">EXAMPLE_NAME Design Pattern in WAI-ARIA Authoring Practices 1.1</a>
+    <a href="../../../#combobox">Combobox Design Pattern in WAI-ARIA Authoring Practices 1.1</a>
   </nav>
 </body>
 </html>

--- a/examples/combobox/aria1.0pattern/combobox-autocomplete-none.html
+++ b/examples/combobox/aria1.0pattern/combobox-autocomplete-none.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8" />
-<title>Example of Legacy ARIA 1.0 Combobox Without Autocomplete | WAI-ARIA Authoring Practices 1.1</title>
+<title>Example of Legacy ARIA 1.0 Combobox Without Autocomplete | WAI-ARIA Authoring Practices 1.0</title>
 
 <!--  Core js and css shared by all examples; do not modify when using this template. -->
 <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/base.css">
@@ -13,79 +13,88 @@
 
 <!--  js and css for this example. -->
 <link href="css/combobox-1.0.css" rel="stylesheet">
-<script src="js/combobox-1.0.js" type="text/javascript"></script>
+<link  href="css/listbox.css"     rel="stylesheet">
+
+<script src="js/combobox-1.0-list.js"  type="text/javascript"></script>
+<script src="js/listbox.js"       type="text/javascript"></script>
+<script src="js/listboxOption.js" type="text/javascript"></script>
+
 </head>
 <body>
   <main>
   <h1>Example of Legacy ARIA 1.0 Combobox Without Autocomplete</h1>
   <p>
-    <strong>NOTE:</strong> This page is work in progress; it is not ready for review.
+    <strong>NOTE:</strong> This page is ready to start reviewing.
     This work is tracked by <a href="https://github.com/w3c/aria-practices/issues/99">issue 99</a>.
   </p>
   <p>
-    <!-- Provide an overview of the example where the first sentence provides a link to the section of aria-practices.html that describes the pattern this example implements. -->
-    Replace this paragraph with an overview of the example that is something like the following. The
-    below example section demonstrates a simple checkbox that implements the
-    <a href="../../#checkbox">design pattern for checkbox.</a>
-    This example uses ... summarize salient techniques )
+    The below example section demonstrates a <code>combobox</code> that implements the
+    <a href="../../#combobox">ARIA 1.0 design pattern for combobox.</a>
+    This example demonstrates a combobox that provides a list of options to the user.
+    The options available in the listbox are fixed and do <strong>not</strong> change based
+    on user input into the textbox.  Tis pattern is common for providing options based on
+    previous input into the textbox, for example a user name, address or phone number.
+    The user can select an option from the list to set the value of the textbox.
   </p>
+  </p>The major design feature of the ARIA 1.0 combobox pattern is the use of
+    <code>aria-activedescendant</code> to reference options in a listbox, while keyboard
+    focus remains on the textbox.
+  <p>
   <p>Similar examples include: </p>
   <ul>
-    <li><a href="#">example name</a>: summarize what this related example demonstrates.</li>
-    <!--  list other examples that implement the same design pattern. -->
+    <li>
+      <a href="combobox-autocomplete-list.html">Combobox With an List Autocomplete</a>
+      : example demonstrates the behavior associated with <code>aria-autocomplete=list</code>.
+    </li>
+    <li>
+      <a href="combobox-autocomplete-both.html">Combobox With Both List and Inline Autocompletion</a>
+      : example demonstrates the behavior associated with <code>aria-autocomplete=both</code>.
+    </li>
   </ul>
 
   <section>
     <h2 id="ex_label">Example</h2>
     <div role="separator" id="ex_start_sep" aria-labelledby="ex_start_sep ex_label" aria-label="Start of"></div>
-    <!--
-      Note the ID of the following div that contains the example HTML is used as a parameter for the sourceCode.add() function.
-      The sourceCode functions in the examples/js/examples.js render the HTML source to show it to the reader of the example page.
-      If you change the ID of this div, be sure to update the parameters of the sourceCode.add() function call, which is made following the div with id="sc1" where the HTML is render.
-      The div for the rendered HTML source is in the last section of the page.
-    -->
     <div id="ex1">
-      <!--  Replace content of this div with the example.  -->
-      <p>This is the place where the reader will experience the functioning example.</p>
-      <ul>
-        <li>The HTML in this section along with the javascript and CSS it uses demonstrate
-          the design pattern.</li>
-        <li>
-          When developing an example implementation for this guide, please follow the
-          <a href="https://ianpouncey.github.io/code-guide/">APG example coding guidelines</a>
-          .
-        </li>
-        <!--  Target of previous link will need to be updated when we move the guidelines into the wiki from Ian's repo.  -->
-      </ul>
+      <div class="combobox-list">
+        <label for="cb1-input">Search</label>
+
+        <div class="group">
+          <input id="cb1-input" class="cb_edit" type="text"
+                 role="combobox"
+                 aria-autocomplete="none"
+                 aria-expanded="false"
+                 aria-haspopup="true"
+                 aria-owns="cb1-listbox"
+                 aria-activedescendant=""
+          />
+          <button id="cb1-button" tabindex="-1" aria-label="open button">
+            &#9661;
+          </button>
+        </div>
+
+        <ul id="cb1-listbox" role="listbox" aria-label="States">
+          <li id="lb1-01" role="option">weather</li>
+          <li id="lb1-02" role="option">salsa recipes</li>
+          <li id="lb1-03" role="option">cheap flights to NY</li>
+          <li id="lb1-04" role="option">dictionary</li>
+          <li id="lb1-05" role="option">baseball scores</li>
+          <li id="lb1-06" role="option">hotels in NY</li>
+          <li id="lb1-07" role="option">mortgage calculator</li>
+          <li id="lb1-08" role="option">restaurants near me</li>
+          <li id="lb1-09" role="option">free games</li>
+          <li id="lb1-10" role="option">gas prices</li>
+          <li id="lb1-11" role="option">classical music</li>
+        </ul>
+      </div>
     </div>
     <div role="separator" id="ex_end_sep" aria-labelledby="ex_end_sep ex_label" aria-label="End of"></div>
   </section>
 
   <section>
-    <h2>Accessibility Features</h2>
-    <p class="annotate">Optional section: If appropriate, please replace this content with a list of any special or noteworthy accessibility features
-      demonstrated in this implementation, such as:</p>
-    <ol>
-      <li>What distinguishes this example from related examples.</li>
-      <li>Keyboard chortcuts, live regions,  unusual event handling, or other ancillary best practices that are employed.</li>
-      <li>Do not include information that would be repeated in the following keyboard and attribute sections.</li>
-      <li>Delete this section if not needed.</li>
-    </ol>
-  </section>
+    <h2 id="kbd_label_textbox">Combobox Keyboard Support</h2>
 
-  <section>
-    <h2 id="kbd_label">Keyboard Support</h2>
-    <!--
-      List the keys supported in this example.
-      Remember to:
-      Use kbd tags,e.g. <kbd>KeyName</kbd>.
-      Key names use first-letter caps, e.g., <kbd>Enter</kbd>.
-      Single space between multiple Words, e.g., <kbd>Up Arrow</kbd>.
-      Use + to separate modifiers, e.g., <kbd>Control + Right Arrow</kbd>.
-      One key per row, e.g., do not combine <kbd>Up Arrow</kbd> and <kbd>Down Arrow</kbd> into a single row.
-      Do not use the word "key", e.g., do not write <kbd>Enter Key</kbd> or <kbd>Enter</kbd> key.
-     -->
-    <table aria-labelledby="kbd_label" class="def">
+    <table aria-labelledby="kbd_label_textbox" class="def">
       <thead>
         <tr>
           <th>Key</th>
@@ -94,32 +103,40 @@
       </thead>
       <tbody>
         <tr>
-          <th><kbd>KeyName</kbd></th>
-          <td>
-            Description of key function.
-            <!--  Do not use a list if there is only one function for the key.  -->
-          </td>
-        </tr>
-        <tr>
-          <th><kbd>KeyName</kbd></th>
+          <th><kbd>Down Arrow</kbd></th>
           <td>
             <ul>
-              <li>If condition 1, performs function 1.</li>
-              <li>If condition 2, performs function 2.</li>
-              <li>Only use a list if multiple statements are needed.</li>
+              <li>If the listbox is <strong>closed</strong>, the listbox is opened and <code>aria-activedescendant</code> is set to reference the first option in the listbox.  </li>
+              <li>If the listbox is <strong>open</strong>, <code>aria-activedescendant</code> is updated to reference the next option in the listbox.  <br/>Note: When <code>aria-activedescendant</code> is referencing the last option the reference does not change.</li>
+              <li>If the listbox is <strong>empty</strong> (e.g. no options avaialble), <code>aria-activedescendant</code> is set to an empty string.</li>
             </ul>
           </td>
         </tr>
+        <tr>
+          <th><kbd>Up Arrow</kbd></th>
+          <td>
+            <ul>
+              <li>If the listbox is <strong>closed</strong>, the listbox is opened and <code>aria-activedescendant</code> is set to reference the last option in the listbox.  </li>
+              <li>If the listbox is <strong>open</strong>, <code>aria-activedescendant</code> is updated to reference the previous option in the listbox.  <br/>Note: When <code>aria-activedescendant</code> is referencing the first option the reference does not change.</li>
+              <li>If the listbox is <strong>empty</strong> (e.g. no options avaialble), <code>aria-activedescendant</code> is set to an empty string.</li>
+            </ul>          </td>
+        </tr>
+        <tr>
+          <th><kbd>Escape</kbd></th>
+          <td>If the listbox is <strong>open</strong>, the listbox is closed and aria-activedescendant</code> is set to an empty string.</td>
+        </tr>
       </tbody>
     </table>
+
   </section>
 
   <section>
-    <h2 id="rps_label">Role, Property, State, and Tabindex  Attributes</h2>
+
+    <h2 id="rps_label_combobox">Combobox Role, Property, State, and Tabindex  Attributes</h2>
     <!--
       Update this table to describe how roles, properties, states, and tabindex are used in this example.
     -->
-    <table aria-labelledby="rps_label" class="data attributes">
+    <table aria-labelledby="rps_label_combobox" class="data attributes">
       <thead>
         <tr>
           <th scope="col">Role</th>
@@ -130,27 +147,143 @@
       </thead>
       <tbody>
         <tr>
-          <th scope="row"><code>RoleName</code></th>
+          <th scope="row"><code>combobox</code></th>
           <td><!--  Leave this cell blank in rows where a role is being described. --></td>
-          <td><code>HTML_ELEMENT</code></td>
+          <td><code>input[type="text"]</code></td>
           <td>
-            Describe usage/purpose, e.g., indicates the focusable element that serves as the ...
+            Identifies the <code>input[type=<q>text</q>] as a combobox option.
           </td>
         </tr>
         <tr>
           <td>
-            <!--  Leave this cell blank in rows that describe attributes applied to the element with the previously described role.
-              Make a row like this for each attribute/value pair.
-          -->
           </td>
-          <th scope="row"><code>AttributeName=<q>AttributeValue</q></code></th>
-          <td><code>HTML_ELEMENT</code></td>
+          <th scope="row"><code>aria-autocomplete=<q>none</q></code></th>
+          <td><code>input[type="text"]</code></td>
+          <td>
+            The value of <code>none</code> identifies that the combobox list of options does
+            <strong>not</strong> change based on user input and the <code>input[type=<q>text</q>]</code> does
+            <strong>not</strong> provide inline autocompletion.
+          </td>
+        </tr>
+        <tr>
+          <td>
+          </td>
+          <th scope="row"><code>aria-haspopup=<q>true</q></code></th>
+          <td><code>input[type="text"]</code></td>
+          <td>
+            Identifies the <code>combobox</code> as having a popup list of options for the value of the textbox.
+          </td>
+        </tr>
+        <tr>
+          <td>
+          </td>
+          <th scope="row"><code>aria-owns=<q>#IDREF</q></code></th>
+          <td><code>input[type="text"]</code></td>
+          <td>
+            Identifies the <code>listbox</code> that is controlled by the combobox.
+          </td>
+        </tr>
+        <tr>
+          <td>
+          </td>
+          <th scope="row"><code>aria-expanded=<q>false</q></code></th>
+          <td><code>input[type="text"]</code></td>
+          <td>
+            Idenitifies the <code>listbox</code> as closed (e.g. hidden from the user).
+          </td>
+        </tr>
+        <tr>
+          <td>
+          </td>
+          <th scope="row"><code>aria-expanded=<q>true</q></code></th>
+          <td><code>input[type="text"]</code></td>
+          <td>
+            Idenitifies the <code>listbox</code> as open (e.g. visible to the user).
+          </td>
+        </tr>
+        <tr>
+          <td>
+          </td>
+          <th scope="row"><code>aria-activedescendant=<q>#IDREF</q></code></th>
+          <td><code>input[type="text"]</code></td>
+          <td>
+            References the current autocomplete <code>option</code> in the <code>listbox</code>.
+          </td>
+        </tr>
+        <tr>
+          <td>
+          </td>
+          <th scope="row"><code>aria-activedescendant=<q></q></code></th>
+          <td><code>input[type="text"]</code></td>
+          <td>
+            If no autocomplete <code>option</code> is selected or the list of <code>option</code>s is emtpy, <code>aria-activedescendant</code> is set to an empty string.</td>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+
+    <h2 id="rps_label_listbox">Listbox Role, Property, State, and Tabindex  Attributes</h2>
+    <!--
+      Update this table to describe how roles, properties, states, and tabindex are used in this example.
+    -->
+    <table aria-labelledby="rps_label_listbox" class="data attributes">
+      <thead>
+        <tr>
+          <th scope="col">Role</th>
+          <th scope="col">Attribute</th>
+          <th scope="col">Element</th>
+          <th scope="col">Usage</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row">
+            <code>listbox</code>
+          </th>
+          <td></td>
+          <td>
+            <code>ul</code>
+          </td>
+          <td>Identifies the <code>ul</code> element as a <code>listbox</code>.</td>
+        </tr>
+        <tr>
+          <td>
+            <code></code>
+          </td>
+          <th scope="row"><code>aria-label=<q>States</q></code></th>
+          <td>
+            <code>ul</code>
+          </td>
+          <td>
+            Provides a label for the <code>listbox</code>.
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <code>option</code>
+          </th>
+          <td></td>
+          <td>
+            <code>li</code>
+          </td>
           <td>
             <ul>
-              <li>explanation of usage, purpose, benefit, and/or guidance relevant to this implementation.</li>
-              <li>If making multiple statements, use list for brevity and clarity</li>
-              <li>Do not make a single item list.</li>
+              <li>Identifies the <code>li</code> element as a <code>option</code> in a <cpde>listbox</cpde>.</li>
+              <li>The text content of the <code>li</code> element provides the accessible name of the <code>option</code>.</li>
             </ul>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <code></code>
+          </td>
+          <th scope="row"><code>id=<q>ID</q></code></th>
+          <td>
+            <code>li</code>
+          </td>
+          <td>
+            Provides a unique reference for the option that is referenced by the <code>aria-activedescendant</code> attribute of the <code>combobox</code>.
           </td>
         </tr>
       </tbody>
@@ -163,11 +296,23 @@
     <ul>
       <li>
         CSS:
-        <a href="css/example_name.css" type="tex/css">example_name.css</a>
+        <a href="css/combobox-1.0.css" type="text/css">combobox-1.0.css</a>
+      </li>
+      <li>
+        CSS:
+        <a href="css/listbox.css" type="text/css">listbox.css</a>
       </li>
       <li>
         Javascript:
-        <a href="js/example_name.js" type="text/javascript">example_name.js</a>
+        <a href="js/combobox-1.0-list.js" type="text/javascript">combobox-1.0-list.js</a>
+      </li>
+      <li>
+        Javascript:
+        <a href="js/listbox.js" type="text/javascript">listbox.js</a>
+      </li>
+      <li>
+        Javascript:
+        <a href="js/listboxOption.js" type="text/javascript">listboxOption.js</a>
       </li>
     </ul>
   </section>

--- a/examples/combobox/aria1.0pattern/css/combobox-1.0.css
+++ b/examples/combobox/aria1.0pattern/css/combobox-1.0.css
@@ -2,3 +2,30 @@
 	font-style: italic;
 	color: #366ED4;
 }
+
+.combobox-list {
+  position: relative;
+}
+
+.combobox-inline label,
+.combobox-list label {
+  margin: 0;
+  padding: 0;
+  display: block;
+}
+
+.combobox-list .group input,
+.combobox-list .group button {
+  display: inline;
+}
+
+.combobox-list .group button {
+  margin: 0;
+  padding: 0 0.125em 0 0.125em;
+  position: relative;
+  top: 1px;
+  left: -2px;
+  font-size: 85%;
+  background-color: #eee;
+}
+

--- a/examples/combobox/aria1.0pattern/css/listbox.css
+++ b/examples/combobox/aria1.0pattern/css/listbox.css
@@ -1,0 +1,43 @@
+
+ul[role="listbox"] {
+  margin: 0;
+  padding: 0;
+  position: absolute;
+  top: 3em;
+  list-style: none;
+  background-color: #EEEEEE;
+  display: none;
+  border: thin #333 solid;
+  height: 12em;
+  width: 12em;
+  overflow: scroll;
+}
+
+ul[role="listbox"] li[role="option"]{
+  display: block;
+  margin: 0.25em;
+  padding: 0;
+  background-color: #EEEEEE;
+  font-size: 100%;
+}
+
+/* focus and hover styling */
+
+button:focus,
+button:hover,
+input:focus,
+input:hover {
+  outline: 2px solid black;
+}
+
+input:focus,
+input:hover {
+  background-color: #EEEEEE;
+}
+
+ul[role="listbox"] li[role="option"].focus,
+ul[role="listbox"] li[role="option"]:hover{
+  background-color: black;
+  color: white;
+}
+

--- a/examples/combobox/aria1.0pattern/js/combobox-1.0-list.js
+++ b/examples/combobox/aria1.0pattern/js/combobox-1.0-list.js
@@ -1,0 +1,278 @@
+/*
+*   This content is licensed according to the W3C Software License at
+*   https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document
+*/
+var ComboboxList = function (domNode) {
+
+  this.domNode  = domNode;
+  this.listbox  = false;
+  this.option   = false;
+
+  this.hasFocus = false;
+  this.hasHover = false;
+  this.filter   = '';
+
+  this.keyCode = Object.freeze({
+    'BACKSPACE': 8,
+    'TAB': 9,
+    'RETURN': 13,
+    'ESC': 27,
+    'SPACE': 32,
+    'PAGEUP': 33,
+    'PAGEDOWN': 34,
+    'END': 35,
+    'HOME': 36,
+    'LEFT': 37,
+    'UP': 38,
+    'RIGHT': 39,
+    'DOWN': 40
+  });
+};
+
+ComboboxList.prototype.init = function () {
+
+  this.domNode.setAttribute('aria-haspopup', 'true');
+
+  this.autocomplete = this.domNode.getAttribute('aria-autocomplete');
+
+  if (this.autocomplete) {
+    this.autocomplete = this.autocomplete.toLowerCase();
+  }
+
+  this.domNode.addEventListener('keydown', this.handleKeydown.bind(this));
+  this.domNode.addEventListener('keyup',   this.handleKeyup.bind(this));
+  this.domNode.addEventListener('click',   this.handleClick.bind(this));
+  this.domNode.addEventListener('focus',   this.handleFocus.bind(this));
+  this.domNode.addEventListener('blur',    this.handleBlur.bind(this));
+
+  // initialize pop up menus
+
+  var listbox = document.getElementById(this.domNode.getAttribute('aria-owns'));
+
+  if (listbox) {
+    this.listbox = new Listbox(listbox, this);
+    this.listbox.init();
+  }
+
+  // Open Button
+
+  var button = this.domNode.nextElementSibling;
+
+  if (button && button.tagName === 'BUTTON') {
+    button.addEventListener('click',   this.handleButtonClick.bind(this));
+  }
+
+};
+
+ComboboxList.prototype.updateValue = function () {
+  if (this.autocomplete === 'both') {
+
+    if (this.filter.length && this.option && this.listbox.isOpen()) {
+      this.domNode.value = this.option.textContent;
+      this.domNode.setSelectionRange(this.filter.length,this.filter.length);
+    }
+    else {
+      this.domNode.value = this.filter;
+    }
+  }
+};
+
+ComboboxList.prototype.setValue = function (value) {
+  this.filter = value;
+  this.domNode.value = this.filter;
+  this.domNode.setSelectionRange(this.filter.length,this.filter.length);
+  if (this.autocomplete !== 'none') {
+    this.listbox.filterOptions(this.filter, this.option);
+  }
+};
+
+ComboboxList.prototype.setOption = function (option) {
+  if (option) {
+    this.option = option;
+    this.listbox.setFocusStyle(this.option);
+    this.updateValue();
+  }
+};
+
+/* Event Handlers */
+
+ComboboxList.prototype.handleKeydown = function (event) {
+  var tgt = event.currentTarget,
+    flag = false,
+    char = event.key,
+    shiftKey = event.shiftKey,
+    ctrlKey  = event.ctrlKey,
+    altKey   = event.altKey;
+
+  switch (event.keyCode) {
+
+    case this.keyCode.RETURN:
+      if (this.option) {
+        this.setValue(this.option.textContent);
+        this.listbox.close(true);
+      }
+      flag = true;
+      break;
+
+    case this.keyCode.DOWN:
+
+      if (this.listbox.hasOptions()) {
+        if (this.listbox.isOpen()) {
+          this.setOption(this.listbox.getNextItem(this.option));
+        }
+        else {
+          this.listbox.open();
+          if (!altKey) {
+            this.setOption(this.listbox.getFirstItem());
+          }
+        }
+      }
+      flag = true;
+      break;
+
+    case this.keyCode.UP:
+      if (this.listbox.hasOptions()) {
+        if (this.listbox.isOpen()) {
+          this.setOption(this.listbox.getPreviousItem(this.option));
+        }
+        else {
+          this.listbox.open();
+          if (!altKey) {
+            this.setOption(this.listbox.getLastItem());
+          }
+        }
+      }
+      flag = true;
+      break;
+
+    case this.keyCode.HOME:
+    case this.keyCode.PAGEUP:
+      if (this.listbox.hasOptions()) {
+        if (this.listbox.isOpen()) {
+          this.setOption(this.listbox.getFirstItem());
+        }
+      }
+      flag = true;
+      break;
+
+    case this.keyCode.END:
+    case this.keyCode.PAGEDOWN:
+      if (this.listbox.hasOptions()) {
+        if (this.listbox.isOpen()) {
+          this.setOption(this.listbox.getLastItem());
+        }
+      }
+      flag = true;
+      break;
+
+    case this.keyCode.ESC:
+      if (this.listbox.isOpen()) {
+        this.listbox.close(true);
+      }
+      this.setValue(this.filter);
+      flag = true;
+      break;
+
+    default:
+      break;
+  }
+
+  if (flag) {
+    event.stopPropagation();
+    event.preventDefault();
+  }
+
+};
+
+ComboboxList.prototype.handleKeyup = function (event) {
+  var tgt = event.currentTarget,
+    flag = false,
+    option = false,
+    char = event.key;
+
+  function isPrintableCharacter (str) {
+    return str.length === 1 && str.match(/\S/);
+  }
+
+  this.filter = this.domNode.value.substring(0,this.domNode.selectionEnd);
+
+  if (this.autocomplete !== 'none') {
+    option = this.listbox.filterOptions(this.filter, this.option);
+  }
+
+  switch (event.keyCode) {
+
+    case this.keyCode.BACKSPACE:
+      if (this.autocomplete === 'both') {
+        this.setValue(this.filter);
+      }
+      flag = true;
+      break;
+
+    case this.keyCode.LEFT:
+    case this.keyCode.RIGHT:
+      flag = true;
+      break;
+
+    default:
+
+      if (isPrintableCharacter(char)) {
+        if (option) {
+          this.setOption(option);
+        }
+        else {
+          this.setValue(this.filter);
+        }
+      }
+      flag = true;
+      break;
+  }
+
+  if (flag) {
+    event.stopPropagation();
+    event.preventDefault();
+  }
+
+};
+
+ComboboxList.prototype.handleClick = function (event) {
+  if (this.listbox.isOpen()) {
+    this.listbox.close(true);
+  }
+  else {
+    this.listbox.open();
+  }
+};
+
+ComboboxList.prototype.handleFocus = function (event) {
+  this.listbox.hasFocus = true;
+};
+
+ComboboxList.prototype.handleBlur = function (event) {
+  this.listbox.hasFocus = false;
+  setTimeout(this.listbox.close.bind(this.listbox, false), 300);
+
+};
+
+ComboboxList.prototype.handleButtonClick = function (event) {
+  if (this.listbox.isOpen()) {
+    this.listbox.close(true);
+  }
+  else {
+    this.listbox.open();
+  }
+};
+
+
+// Initialize comboboxes
+
+window.addEventListener('load', function () {
+
+  var comboboxes = document.querySelectorAll('.combobox-list [role="combobox"]');
+
+  for (var i = 0; i < comboboxes.length; i++) {
+    var combobox = new ComboboxList(comboboxes[i]);
+    combobox.init();
+  }
+
+});

--- a/examples/combobox/aria1.0pattern/js/combobox-1.0-listbox.js
+++ b/examples/combobox/aria1.0pattern/js/combobox-1.0-listbox.js
@@ -1,0 +1,200 @@
+/*
+*   This content is licensed according to the W3C Software License at
+*   https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document
+*
+*   File:   combobox-1.0.js
+*
+*   Desc:   Combobox widget that implements ARIA Authoring Practices for
+*           ARIA 1.0 definition of combobox using a Listbox
+*
+*   Author: Jon Gunderson and Nicholas Hoyt
+*/
+
+/*
+*   @constructor ComboboxListbox
+*
+*   @desc
+*       Wrapper object for a combobox with a listbox option
+*
+*   @param domNode
+*       The DOM element node that serves as the listbox container. Each
+*       child element of domNode that represents a option must have a
+*       'role' attribute with value 'option'.
+*
+*/
+var ComboboxListbox = function (domNode) {
+
+  this.domNode      = domNode;
+  this.listbox      = false;
+
+  this.hasFocus = false;
+  this.hasHover = false;
+  this.filter   = '';
+
+  this.keyCode = Object.freeze({
+    'BACKSPACE': 8,
+    'TAB': 9,
+    'RETURN': 13,
+    'ESC': 27,
+    'SPACE': 32,
+    'PAGEUP': 33,
+    'PAGEDOWN': 34,
+    'END': 35,
+    'HOME': 36,
+    'LEFT': 37,
+    'UP': 38,
+    'RIGHT': 39,
+    'DOWN': 40
+  });
+};
+
+ComboboxListbox.prototype.init = function () {
+
+  this.domNode.setAttribute('aria-haspopup', 'true');
+
+  this.autocomplete = this.domNode.getAttribute('aria-autocomplete');
+
+  if (this.autocomplete) {
+    this.autocomplete = this.autocomplete.toLowerCase();
+  }
+
+  this.domNode.addEventListener('keydown', this.handleKeydown.bind(this));
+  this.domNode.addEventListener('keyup',   this.handleKeyup.bind(this));
+  this.domNode.addEventListener('click',   this.handleClick.bind(this));
+  this.domNode.addEventListener('focus',   this.handleFocus.bind(this));
+  this.domNode.addEventListener('blur',    this.handleBlur.bind(this));
+
+  // initialize pop up menus
+
+  var listbox = document.getElementById(this.domNode.getAttribute('aria-owns'));
+
+  if (listbox) {
+    this.listbox = new Listbox(listbox, this);
+    this.listbox.init();
+  }
+
+  // Open Button
+
+  var button = this.domNode.nextElementSibling;
+
+  if (button && button.tagName === 'BUTTON') {
+    button.addEventListener('click',   this.handleButtonClick.bind(this));
+  }
+
+};
+
+ComboboxListbox.prototype.updateValue = function (value) {
+  if (this.domNode.getAttribute('aria-autocomplete') === 'both') {
+    this.domNode.value = value;
+    this.domNode.setSelectionRange(this.filter.length,this.filter.length);
+  }
+};
+
+ComboboxListbox.prototype.setValue = function (value) {
+  this.domNode.value = value;
+};
+
+/* Event Handlers */
+
+ComboboxListbox.prototype.handleKeydown = function (event) {
+  var tgt = event.currentTarget,
+    flag = false,
+    char = event.key,
+    shiftKey = event.shiftKey,
+    ctrlKey  = event.ctrlKey,
+    altKey   = event.altKey;
+
+  switch (event.keyCode) {
+
+    case this.keyCode.DOWN:
+      if (this.listbox) {
+        this.listbox.filterOptions(this.filter);
+        this.listbox.open();
+        if (!altKey) {
+          this.listbox.setFocusToFirstItem();
+        }
+      }
+      flag = true;
+      break;
+
+    case this.keyCode.UP:
+      if (this.listbox) {
+        this.listbox.filterOptions(this.filter);
+        this.listbox.open();
+        if (!altKey) {
+          this.listbox.setFocusToLastItem();
+        }
+        flag = true;
+      }
+      break;
+
+    case this.keyCode.ESC:
+      this.listbox.close(true);
+      flag = true;
+      break;
+
+    default:
+      break;
+  }
+
+  if (flag) {
+    event.stopPropagation();
+    event.preventDefault();
+  }
+};
+
+ComboboxListbox.prototype.handleKeyup = function (event) {
+  var tgt = event.currentTarget,
+    flag = false,
+    char = event.key;
+
+  if (this.autocomplete !== 'none') {
+    this.filter = this.domNode.value.substring(0,this.domNode.selectionEnd);
+    this.option = this.listbox.filterOptions(this.filter);
+  }
+
+};
+
+ComboboxListbox.prototype.handleClick = function (event) {
+  if (this.domNode.getAttribute('aria-expanded') == 'true') {
+    this.listbox.close(true);
+  }
+  else {
+    this.listbox.open();
+    this.listbox.setFocusToFirstItem();
+  }
+};
+
+ComboboxListbox.prototype.handleFocus = function (event) {
+  this.listbox.hasFocus = true;
+};
+
+ComboboxListbox.prototype.handleBlur = function (event) {
+  this.listbox.hasFocus = false;
+  setTimeout(this.listbox.close.bind(this.listbox, false), 300);
+
+};
+
+ComboboxListbox.prototype.handleButtonClick = function (event) {
+  if (this.domNode.getAttribute('aria-expanded') == 'true') {
+    this.listbox.close(true);
+  }
+  else {
+    this.listbox.open();
+    this.listbox.setFocusToFirstItem();
+  }
+};
+
+
+// Initialize comboboxes
+
+window.addEventListener('load', function () {
+
+  var comboboxes = document.querySelectorAll('.combobox-listbox [role="combobox"]');
+
+  for (var i = 0; i < comboboxes.length; i++) {
+    var combobox = new ComboboxListbox(comboboxes[i]);
+    combobox.init();
+  }
+
+});

--- a/examples/combobox/aria1.0pattern/js/combobox-1.0.js
+++ b/examples/combobox/aria1.0pattern/js/combobox-1.0.js
@@ -1,3 +1,0 @@
-/**
- * Rename this file to the name of the example, e.g., checkbox.js.
- */

--- a/examples/combobox/aria1.0pattern/js/listbox.js
+++ b/examples/combobox/aria1.0pattern/js/listbox.js
@@ -1,0 +1,223 @@
+/*
+*   This content is licensed according to the W3C Software License at
+*   https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document
+*/
+var Listbox = function (domNode, comboboxObj) {
+  var elementChildren,
+    msgPrefix = 'Listbox constructor argument domNode ';
+
+  // Check whether domNode is a DOM element
+  if (!domNode instanceof Element) {
+    throw new TypeError(msgPrefix + 'is not a DOM Element.');
+  }
+
+  // Check whether domNode has child elements
+  if (domNode.childElementCount === 0) {
+    throw new Error(msgPrefix + 'has no element children.');
+  }
+
+  // Check whether domNode child elements are A elements
+  var childElement = domNode.firstElementChild;
+  while (childElement) {
+    var option = childElement.firstElementChild;
+    childElement = childElement.nextElementSibling;
+  }
+
+  this.domNode = domNode;
+  this.combobox = comboboxObj;
+
+  this.allOptions = [];
+
+  this.options    = [];      // see PopupMenu init method
+
+  this.firstOption  = null;    // see PopupMenu init method
+  this.lastOption   = null;    // see PopupMenu init method
+
+  this.hasFocus   = false;   // see MenuItem handleFocus, handleBlur
+  this.hasHover   = false;   // see PopupMenu handleMouseover, handleMouseout
+};
+
+/*
+*   @method Listbox.prototype.init
+*
+*   @desc
+*       Add domNode event listeners for mouseover and mouseout. Traverse
+*       domNode children to configure each option and populate.options
+*       array. Initialize firstOption and lastOption properties.
+*/
+Listbox.prototype.init = function () {
+  var childElement, optionElement, firstChildElement, option, textContent, numItems;
+
+  // Configure the domNode itself
+  this.domNode.tabIndex = -1;
+
+  this.domNode.setAttribute('role', 'listbox');
+
+  this.domNode.addEventListener('mouseover', this.handleMouseover.bind(this));
+  this.domNode.addEventListener('mouseout',  this.handleMouseout.bind(this));
+
+  // Traverse the element children of domNode: configure each with
+  // option role behavior and store reference in.options array.
+  optionElements = this.domNode.getElementsByTagName('LI');
+
+  for (var i = 0; i < optionElements.length; i++) {
+
+    optionElement = optionElements[i];
+
+    if (!optionElement.firstElementChild && optionElement.getAttribute('role') != 'separator') {
+      option = new Option(optionElement, this);
+      option.init();
+      this.allOptions.push(option);
+    }
+  }
+
+  this.filterOptions('');
+
+};
+
+Listbox.prototype.filterOptions = function (filter, currentOption) {
+
+  if (typeof filter !== 'string') {
+    filter = '';
+  }
+
+  var firstMatch = false,
+    i,
+    option,
+    textContent,
+    numItems;
+
+  this.filter = filter;
+  filter = filter.toLowerCase();
+
+  this.options    = [];
+  this.firstChars = [];
+  this.domNode.innerHTML = '';
+
+  for (i = 0; i < this.allOptions.length; i++) {
+    option = this.allOptions[i];
+    if (filter.length === 0 || option.textComparision.indexOf(filter) === 0) {
+      this.options.push(option);
+      textContent = option.textContent.trim();
+      this.firstChars.push(textContent.substring(0, 1).toLowerCase());
+      this.domNode.appendChild(option.domNode);
+    }
+  }
+
+  // Use populated.options array to initialize firstOption and lastOption.
+  numItems = this.options.length;
+  if (numItems > 0) {
+    this.firstOption = this.options[0];
+    this.lastOption  = this.options[numItems - 1];
+
+    if (currentOption && this.options.indexOf(currentOption) >= 0) {
+      option = currentOption;
+    }
+    else {
+      option = this.firstOption;
+    }
+  }
+  else {
+    this.firstOption = false;
+    option = false;
+    this.lastOption  = false;
+  }
+
+  return option;
+};
+
+Listbox.prototype.setFocusStyle = function (option) {
+  this.combobox.domNode.setAttribute('aria-activedescendant', '');
+
+  for (var i = 0; i < this.options.length; i++) {
+    if (this.options[i] === option) {
+      this.combobox.domNode.setAttribute('aria-activedescendant', option.domNode.id);
+      option.domNode.classList.add('focus');
+      this.domNode.scrollTop = option.domNode.offsetTop;
+    }
+    else {
+      this.options[i].domNode.classList.remove('focus');
+    }
+  }
+
+};
+
+Listbox.prototype.setOption = function (option) {
+  this.combobox.setOption(option);
+  this.combobox.setValue(option.textContent);
+  this.close();
+};
+
+/* EVENT HANDLERS */
+
+Listbox.prototype.handleMouseover = function (event) {
+  this.hasHover = true;
+};
+
+Listbox.prototype.handleMouseout = function (event) {
+  this.hasHover = false;
+  setTimeout(this.close.bind(this, false), 300);
+};
+
+/* FOCUS MANAGEMENT METHODS */
+
+
+Listbox.prototype.getFirstItem = function () {
+  return this.firstOption;
+};
+
+Listbox.prototype.getLastItem = function () {
+  return this.lastOption;
+};
+
+Listbox.prototype.getPreviousItem = function (currentOption) {
+  var index;
+
+  if (currentOption !== this.firstOption) {
+    index = this.options.indexOf(currentOption);
+    return this.options[index - 1];
+  }
+  return currentOption;
+};
+
+Listbox.prototype.getNextItem = function (currentOption) {
+  var index;
+
+  if (currentOption !== this.lastOption) {
+    index = this.options.indexOf(currentOption);
+    return this.options[index + 1];
+  }
+  return currentOption;
+};
+
+/* MENU DISPLAY METHODS */
+
+Listbox.prototype.isOpen = function () {
+  return this.domNode.style.display === 'block';
+};
+
+Listbox.prototype.hasOptions = function () {
+  return this.options.length;
+};
+
+Listbox.prototype.open = function () {
+  // set CSS properties
+  this.domNode.style.display = 'block';
+
+  // set aria-expanded attribute
+  this.combobox.domNode.setAttribute('aria-expanded', 'true');
+};
+
+Listbox.prototype.close = function (force) {
+  if (typeof force !== 'boolean') {
+    force = false;
+  }
+
+  if (force || (!this.hasFocus && !this.hasHover && !this.combobox.hasHover)) {
+    this.domNode.style.display = 'none';
+    this.combobox.domNode.setAttribute('aria-expanded', 'false');
+    this.combobox.domNode.setAttribute('aria-activedescendant', '');
+  }
+};
+
+

--- a/examples/combobox/aria1.0pattern/js/listboxOption.js
+++ b/examples/combobox/aria1.0pattern/js/listboxOption.js
@@ -1,0 +1,42 @@
+/*
+*   This content is licensed according to the W3C Software License at
+*   https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document
+*/
+var Option = function (domNode, listboxObj) {
+
+  this.domNode = domNode;
+  this.listbox = listboxObj;
+  this.textContent     = domNode.textContent;
+  this.textComparision = domNode.textContent.toLowerCase();
+
+};
+
+Option.prototype.init = function () {
+
+  if (!this.domNode.getAttribute('role')) {
+    this.domNode.setAttribute('role', 'option');
+  }
+
+  this.domNode.addEventListener('click',      this.handleClick.bind(this));
+  this.domNode.addEventListener('mouseover',  this.handleMouseover.bind(this));
+  this.domNode.addEventListener('mouseout',   this.handleMouseout.bind(this));
+
+};
+
+/* EVENT HANDLERS */
+
+Option.prototype.handleClick = function (event) {
+  this.listbox.setOption(this);
+  this.listbox.close(true);
+};
+
+Option.prototype.handleMouseover = function (event) {
+  this.listbox.hasHover = true;
+  this.listbox.open();
+
+};
+
+Option.prototype.handleMouseout = function (event) {
+  this.listbox.hasHover = false;
+  setTimeout(this.listbox.close.bind(this.listbox, false), 300);
+};

--- a/examples/combobox/aria1.1pattern/grid-combo.html
+++ b/examples/combobox/aria1.1pattern/grid-combo.html
@@ -19,405 +19,412 @@
 </head>
 <body>
   <main>
-  <h1>ARIA 1.1 Combobox with Grid Popup Example</h1>
-  <p>
-    <strong>NOTE:</strong> Please provide feedback on this example in 
-    <a href="https://github.com/w3c/aria-practices/issues/500">issue 500.</a>
-  </p>
-  <p>
-    The following example combobox implements the 
-    <a href="../../../#combobox">combobox design pattern</a>
-    using a grid for the suggested values popup.
-  </p>
-  <p>
-    In this example, users can specify the name of a fruit or vegetable by either typing a value in the box or choosing from the set of values presented in a grid popup.
-    The popup becomes available after the textbox contains a character that matches the beginning of the name of one of the items in the set of value suggestions.
-    Users may type any value in the textbox; this implementation does not limit input to values that are in the set of value suggestions.
-  </p>
-  <p>
-    The grid that presents suggested values has two columns.
-    Each row of the grid represents one suggestion; column one contains the name of the fruit or vegetable and column two identifies whether it is a fruit or vegetable.
-  </p>
-  <p>Similar examples include: </p>
-  <ul>
-    <li><a href="listbox-combo.html">Examples of ARIA 1.1 Combobox with Listbox Popup</a>: Comboboxes that demonstrate the various forms of autocomplete behavior using a listbox popup.</li>
-    <li><a href="../aria1.0pattern/combobox-autocomplete-list.html">ARIA 1.0 Combobox with List Autocomplete</a></li>
-  </ul>
-
-  <section>
-    <h2 id="ex_label">Example</h2>
-    <div role="separator" id="ex_start_sep" aria-labelledby="ex_start_sep ex_label" aria-label="Start of"></div>
-    <div id="ex1">
-      <label id="ex1-label" class="combobox-label">
-        Fruits and vegetables
-      </label>
-      <div class="combobox-wrapper">
-        <div role="combobox"
-          aria-expanded="false"
-          aria-owns="ex1-grid"
-          aria-haspopup="grid"
-          id="ex1-combobox">
-          <input type="text"
-            aria-autocomplete="list"
-            aria-controls="ex1-grid"
+    <h1>ARIA 1.1 Combobox with Grid Popup Example</h1>
+    <p>
+      <strong>NOTE:</strong> Please provide feedback on this example in 
+      <a href="https://github.com/w3c/aria-practices/issues/500">issue 500.</a>
+    </p>
+    <p>
+      The following example combobox implements the 
+      <a href="../../../#combobox">combobox design pattern</a>
+      using a grid for the suggested values popup.
+    </p>
+    <p>
+      In this example, users can specify the name of a fruit or vegetable by either typing a value in the box or choosing from the set of values presented in a grid popup.
+      The popup becomes available after the textbox contains a character that matches the beginning of the name of one of the items in the set of value suggestions.
+      Users may type any value in the textbox; this implementation does not limit input to values that are in the set of value suggestions.
+    </p>
+    <p>
+      The grid that presents suggested values has two columns.
+      Each row of the grid represents one suggestion; column one contains the name of the fruit or vegetable and column two identifies whether it is a fruit or vegetable.
+    </p>
+    <p>Similar examples include: </p>
+    <ul>
+      <li><a href="listbox-combo.html">Examples of ARIA 1.1 Combobox with Listbox Popup</a>: Comboboxes that demonstrate the various forms of autocomplete behavior using a listbox popup and use the ARIA 1.1 implementation pattern.</li>
+    <li><a href="../aria1.0pattern/combobox-autocomplete-both.html">ARIA 1.0 Combobox with Both List and Inline Autocomplete</a>: A combobox that demonstrates the autocomplete behavior known as <q>list with inline autocomplete</q> and uses the ARIA 1.0 implementation pattern.</li>
+      <li><a href="../aria1.0pattern/combobox-autocomplete-list.html">ARIA 1.0 Combobox with List Autocomplete</a>: A combobox that demonstrates the autocomplete behavior known as <q>list with manual selection</q> and uses the ARIA 1.0 implementation pattern.</li>
+      <li><a href="../aria1.0pattern/combobox-autocomplete-none.html">ARIA 1.0 Combobox Without Autocomplete</a>: A combo box that demonstrates the behavior associated with <code>aria-autocomplete=none</code> and uses the ARIA 1.0 implementation pattern.</li>
+    </ul>
+    <section>
+      <h2 id="ex_label">Example</h2>
+      <div role="separator" id="ex_start_sep" aria-labelledby="ex_start_sep ex_label" aria-label="Start of"></div>
+      <div id="ex1">
+        <label id="ex1-label" class="combobox-label">
+          Fruits and vegetables
+        </label>
+        <div class="combobox-wrapper">
+          <div role="combobox"
+            aria-expanded="false"
+            aria-owns="ex1-grid"
+            aria-haspopup="grid"
+            id="ex1-combobox">
+            <input type="text"
+              aria-autocomplete="list"
+              aria-controls="ex1-grid"
+              aria-labelledby="ex1-label"
+              id="ex1-input">
+          </div>
+          <div
             aria-labelledby="ex1-label"
-            id="ex1-input">
-        </div>
-        <div
-          aria-labelledby="ex1-label"
-          role="grid"
-          id="ex1-grid"
-          class="grid hidden">
+            role="grid"
+            id="ex1-grid"
+            class="grid hidden">
+          </div>
         </div>
       </div>
-    </div>
-    </div>
-    <div role="separator" id="ex_end_sep" aria-labelledby="ex_end_sep ex_label" aria-label="End of"></div>
-  </section>
+      </div>
+      <div role="separator" id="ex_end_sep" aria-labelledby="ex_end_sep ex_label" aria-label="End of"></div>
+    </section>
   
-  <section>
-    <h2 id="kbd_label">Keyboard Support</h2>
-    <p>
-    The example combobox on this page implements the following keyboard interface. 
-      Other variations and options for the keyboard interface are described in the  
-      <a href="../../../#combobox_kbd_interaction">Keyboard Interaction section of the combobox design pattern.</a>
-    </p>
-    <h3 id="kbd_label_textbox">Textbox</h3>
-    <table aria-labelledby="kbd_label_textbox kbd_label" class="def">
-      <thead>
-        <tr>
-          <th>Key</th>
-          <th>Function</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <th><kbd>Down Arrow</kbd></th>
-          <td>If the grid is displayed, moves focus to the first suggested value.</td>
-        </tr>
-        <tr>
-          <th><kbd>Up Arrow</kbd></th>
-          <td>If the grid is displayed, moves focus to the last suggested value.</td>
-        </tr>
-        <tr>
-          <th><kbd>Escape</kbd></th>
-          <td>
-            <ul>
-              <li>Clears the textbox</li>
-              <li>If the grid is displayed, closes it.</li>
-            </ul>
-          </td>
-        </tr>
-        <tr>
-          <th><li>Standard single line text editing keys</th>
-          <td>
-            <ul>
-              <li>Keys used for cursor movement and text manipulation, such as <kbd>Delete</kbd> and <kbd>Shift + Right Arrow</kbd>.</li>
-              <li>An HTML <code>input</code> with <code>type=<q>text</q></code> is used for the textbox so the browser will provide platform-specific editing keys.</li>
-            </ul>
-          </td>
-        </tr>
-      </tbody>
-    </table>
-    <h3 id="kbd_label_popup">Grid Popup</h3>
-    <table aria-labelledby="kbd_label_popup kbd_label" class="def">
-      <thead>
-        <tr>
-          <th>Key</th>
-          <th>Function</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <th><kbd>Enter</kbd></th>
-          <td>
-            <ul>
-              <li>Sets the textbox value to the content of the first cell in the row containing focus.</li>
-              <li>Closes the grid popup.</li>
-              <li>Sets focus on the textbox.</li>
-            </ul>
-          </td>
-        </tr>
-        <tr>
-          <th><kbd>Escape</kbd></th>
-          <td>
-            <ul>
-              <li>Closes the grid popup.</li>
-              <li>Sets focus on the textbox.</li>
-              <li>Clears the textbox.</li>
-            </ul>
-          </td>
-        </tr>
-        <tr>
-          <th><kbd>Down Arrow</kbd></th>
-          <td>
-            <ul>
-              <li>Moves focus to the next row.</li>
-              <li>If focus is in the last row, moves focus to the first row.</li>
-              <li>Note: This wrapping behavior is useful when <kbd>Home</kbd> and <kbd>End</kbd> move the editing cursor as described below.</li>
-            </ul>
-          </td>
-        </tr>
-        <tr>
-          <th><kbd>Up Arrow</kbd></th>
-          <td>
-            <ul>
-              <li>Moves focus to the previous row.</li>
-              <li>If focus is in the first row, moves focus to the last row.</li>
-              <li>Note: This wrapping behavior is useful when <kbd>Home</kbd> and <kbd>End</kbd> move the editing cursor as described below.</li>
-            </ul>
-          </td>
-        </tr>
-        <tr>
-          <th><kbd>Right Arrow</kbd></th>
-          <td>
-            <ul>
-              <li>Moves focus to the next cell.</li>
-              <li>If focus is in the last cell in a row, moves focus to the first cell in the next row.</li>
-              <li>If focus is in the last cell in the last row, moves focus to the first cell in the first row.</li>
-            </ul>
-          </td>
-        </tr>
-        <tr>
-          <th><kbd>Left Arrow</kbd></th>
-          <td>
-            <ul>
-              <li>Moves focus to the previous cell.</li>
-              <li>If focus is in the first cell in a row, moves focus to the last cell in the previous row.</li>
-              <li>If focus is in the first cell in the first row, moves focus to the last cell in the last row.</li>
-            </ul>
-          </td>
-        </tr>
-        <tr>
-          <th><kbd>Home</kbd></th>
-          <td>Moves focus to the textbox and places the editing cursor at the beginning of the field.</td>
-        </tr>
-        <tr>
-          <th><kbd>End</kbd></th>
-          <td>Moves focus to the textbox and places the editing cursor at the end of the field.</td>
-        </tr>
-        <tr>
-          <th>Printable Characters</th>
-          <td>
-            <ul>
-              <li>Moves focus to the textbox.</li>
-              <li>Types the character in the textbox.</li>
-            </ul>
-          </td>
-        </tr>
-      </tbody>
-    </table>
-  </section>
+    <section>
+      <h2 id="kbd_label">Keyboard Support</h2>
+      <p>
+      The example combobox on this page implements the following keyboard interface. 
+        Other variations and options for the keyboard interface are described in the  
+        <a href="../../../#combobox_kbd_interaction">Keyboard Interaction section of the combobox design pattern.</a>
+      </p>
+      <h3 id="kbd_label_textbox">Textbox</h3>
+      <table aria-labelledby="kbd_label_textbox kbd_label" class="def">
+        <thead>
+          <tr>
+            <th>Key</th>
+            <th>Function</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th><kbd>Down Arrow</kbd></th>
+            <td>If the grid is displayed, moves focus to the first suggested value.</td>
+          </tr>
+          <tr>
+            <th><kbd>Up Arrow</kbd></th>
+            <td>If the grid is displayed, moves focus to the last suggested value.</td>
+          </tr>
+          <tr>
+            <th><kbd>Escape</kbd></th>
+            <td>
+              <ul>
+                <li>Clears the textbox</li>
+                <li>If the grid is displayed, closes it.</li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <th><li>Standard single line text editing keys</th>
+            <td>
+              <ul>
+                <li>Keys used for cursor movement and text manipulation, such as <kbd>Delete</kbd> and <kbd>Shift + Right Arrow</kbd>.</li>
+                <li>An HTML <code>input</code> with <code>type=<q>text</q></code> is used for the textbox so the browser will provide platform-specific editing keys.</li>
+              </ul>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <h3 id="kbd_label_popup">Grid Popup</h3>
+      <p>
+          <strong>NOTE:</strong> When visual focus is in the grid, DOM focus remains on the textbox and the value of <code>aria-activedescendant</code> on the textbox is set to a value that refers to an element in the grid that is visually indicated as focused.
+          Where the following descriptions of keyboard commands mention focus, they are referring to the visual focus indicator.
+          For more information about this focus management technique, see 
+          <a href="../../../#kbd_focus_activedescendant">Using aria-activedescendant to Manage Focus.</a>
+        </p>
+      <table aria-labelledby="kbd_label_popup kbd_label" class="def">
+        <thead>
+          <tr>
+            <th>Key</th>
+            <th>Function</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th><kbd>Enter</kbd></th>
+            <td>
+              <ul>
+                <li>Sets the textbox value to the content of the first cell in the row containing focus.</li>
+                <li>Closes the grid popup.</li>
+                <li>Sets focus on the textbox.</li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <th><kbd>Escape</kbd></th>
+            <td>
+              <ul>
+                <li>Closes the grid popup.</li>
+                <li>Sets focus on the textbox.</li>
+                <li>Clears the textbox.</li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <th><kbd>Down Arrow</kbd></th>
+            <td>
+              <ul>
+                <li>Moves focus to the next row.</li>
+                <li>If focus is in the last row, moves focus to the first row.</li>
+                <li>Note: This wrapping behavior is useful when <kbd>Home</kbd> and <kbd>End</kbd> move the editing cursor as described below.</li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <th><kbd>Up Arrow</kbd></th>
+            <td>
+              <ul>
+                <li>Moves focus to the previous row.</li>
+                <li>If focus is in the first row, moves focus to the last row.</li>
+                <li>Note: This wrapping behavior is useful when <kbd>Home</kbd> and <kbd>End</kbd> move the editing cursor as described below.</li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <th><kbd>Right Arrow</kbd></th>
+            <td>
+              <ul>
+                <li>Moves focus to the next cell.</li>
+                <li>If focus is in the last cell in a row, moves focus to the first cell in the next row.</li>
+                <li>If focus is in the last cell in the last row, moves focus to the first cell in the first row.</li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <th><kbd>Left Arrow</kbd></th>
+            <td>
+              <ul>
+                <li>Moves focus to the previous cell.</li>
+                <li>If focus is in the first cell in a row, moves focus to the last cell in the previous row.</li>
+                <li>If focus is in the first cell in the first row, moves focus to the last cell in the last row.</li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <th><kbd>Home</kbd></th>
+            <td>Moves focus to the textbox and places the editing cursor at the beginning of the field.</td>
+          </tr>
+          <tr>
+            <th><kbd>End</kbd></th>
+            <td>Moves focus to the textbox and places the editing cursor at the end of the field.</td>
+          </tr>
+          <tr>
+            <th>Printable Characters</th>
+            <td>
+              <ul>
+                <li>Moves focus to the textbox.</li>
+                <li>Types the character in the textbox.</li>
+              </ul>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
   
-  <section>
-    <h2 id="rps_label">Role, Property, State, and Tabindex Attributes</h2>
-    <p>
-      The example comboboxes on this page implement the following ARIA roles, states, and properties. 
-      Information about other ways of applying ARIA roles, states, and properties is available in the    
-      <a href="../../../#combobox_roles_states_props">Roles, States, and Properties section of the combobox design pattern.</a>
-    </p>
-    <h3 id="rps_label_combobox">Combobox Container</h3>
-    <table aria-labelledby="rps_label_combobox rps_label" class="data attributes">
-      <thead>
-        <tr>
-          <th scope="col">Role</th>
-          <th scope="col">Attribute</th>
-          <th scope="col">Element</th>
-          <th scope="col">Usage</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <th scope="row">
-            <code>combobox</code>
-          </th>
-          <td></td>
-          <td><code>div</</code></td>
-          <td>
-            <ul>
-              <li>Identifies the element as a combobox.</li>
-              <li>Note: The primary difference between the ARIA 1.0 pattern and the ARIA 1.1 pattern is the placement of the <code>combobox</code> role.</li>
-            </ul>
-          </td>
-        </tr>
-        <tr>
-          <td></td>
-          <th scope="row">
-            <code>aria-haspopup=<q>grid</q></code>
-          </th>
-          <td><code>div</code></td>
-          <td>Indicates that the combobox can popup a <code>grid</code> to suggest values.</td>
-        </tr>
-        <tr>
-          <td></td>
-          <th scope="row">
-            <code>aria-owns=<q>IDREF</q></code>
-          </th>
-          <td><code>div</code></td>
-          <td>Identifies the element that serves as the grid popup.</td>
-        </tr>
-        <tr>
-          <td></td>
-          <th scope="row">
-            <code>aria-expanded=<q>false</q></code>
-          </th>
-          <td><code>div</code></td>
-          <td>Indicates that the popup element <strong>is not</strong> displayed.</td>
-        </tr>
-        <tr>
-          <td></td>
-          <th scope="row">
-            <code>aria-expanded=<q>true</q></code>
-          </th>
-          <td><code>div</code></td>
-          <td>Indicates that the popup element <strong>is</strong> displayed.</td>
-        </tr>
-      </tbody>
-    </table>
-    <h3 id="rps_label_textbox">Textbox</h3>
-    <table aria-labelledby="rps_label_textbox rps_label" class="data attributes">
-      <thead>
-        <tr>
-          <th scope="col">Role</th>
-          <th scope="col">Attribute</th>
-          <th scope="col">Element</th>
-          <th scope="col">Usage</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td></td>
-          <th scope="row">
-            <code>aria-labelledby=<q>IDREF</q></code>
-          </th>
-          <td><code>input[type="text"]</code></td>
-          <td>Provides a label for the textbox element of the combobox.</td>
-        </tr>
-        <tr>
-          <td></td>
-          <th scope="row">
-            <code>aria-autocomplete=<q>list</q></code>
-          </th>
-          <td><code>input[type="text"]</code></td>
-          <td>Indicates that the autocomplete behavior of the text input is to suggest a list of possible values in a popup.</td>
-        </tr>
-        <tr>
-          <td></td>
-          <th scope="row">
-            <code>aria-controls=<q>IDREF</q></code>
-          </th>
-          <td><code>input[type="text"]</code></td>
-          <td>
-            <ul>
-              <li>Identifies the popup element that lists suggested values.</li>
-              <li>Note: In the ARIA 1.0 combobox pattern, the textbox uses <code>aria-owns</code> instead of <code>aria-controls</code>.</li>
-            </ul>
-          </td>
-        </tr>
-        <tr>
-          <td></td>
-          <th scope="row">
-            <code>aria-activedescendant=<q>IDREF</q></code>
-          </th>
-          <td><code>input[type="text"]</code></td>
-          <td>
-            <ul>
-              <li>When a cell in the grid is visually indicated as having keyboard focus, refers to that cell.</li>
-              <li>When navigation keys, such as <kbd>Down Arrow</kbd>, are pressed, the JavaScript changes the value.</li>
-              <li>Enables assistive technologies to know which element the application regards as focused while DOM focus remains on the <code>input</code> element.</li>
-              <li>
-                For more information about this focus management technique, see 
-                <a href="../../../#kbd_focus_activedescendant">Using aria-activedescendant to Manage Focus.</a>
-              </li>
-            </ul>
-          </td>
-        </tr>
-      </tbody>
-    </table>
-    <h3 id="rps_label_popup">Grid Popup</h3>
-    <table aria-labelledby="rps_label_listbox rps_label" class="data attributes">
-      <thead>
-        <tr>
-          <th scope="col">Role</th>
-          <th scope="col">Attribute</th>
-          <th scope="col">Element</th>
-          <th scope="col">Usage</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <th scope="row">
-            <code>grid</code>
-          </th>
-          <td></td>
-          <td>
-            <code>div</code>
-          </td>
-          <td>Identifies the element as a <code>grid</code>.</td>
-        </tr>
-        <tr>
-          <td></td>
-          <th scope="row">
-            <code>aria-labelledby=<q>IDREF</q></code>
-          </th>
-          <td><code>div</code></td>
-          <td>Provides a label for the <code>grid</code> element of the combobox.</td>
-        </tr>
-        <tr>
-          <th scope="row">
-            <code>row</code>
-          </th>
-          <td></td>
-          <td><code>div</code></td>
-          <td>Identifies the element containing all the cells for a row.</td>
-        </tr>
-        <tr>
-          <td></td>
-          <th scope="row">
-            <code>aria-selected=<q>true</q></code>
-          </th>
-          <td><code>div</code></td>
-          <td>
-            <ul>
-              <li>Specified on a row in the grid when it is visually indicated as selected.</li>
-              <li>Occurs only when a cell in the grid is referenced by <code>aria-activedescendant</code>.</li>
-            </ul>
-          </td>
-        </tr>
-        <tr>
-          <th scope="row"><code>gridcell</code></th>
-          <td></td>
-          <td><code>div</code></td>
-          <td>Identifies the element containing the content for a single cell.</td>
-        </tr>
-      </tbody>
-    </table>
-  </section>
+    <section>
+      <h2 id="rps_label">Role, Property, State, and Tabindex Attributes</h2>
+      <p>
+        The example comboboxes on this page implement the following ARIA roles, states, and properties. 
+        Information about other ways of applying ARIA roles, states, and properties is available in the    
+        <a href="../../../#combobox_roles_states_props">Roles, States, and Properties section of the combobox design pattern.</a>
+      </p>
+      <h3 id="rps_label_combobox">Combobox Container</h3>
+      <table aria-labelledby="rps_label_combobox rps_label" class="data attributes">
+        <thead>
+          <tr>
+            <th scope="col">Role</th>
+            <th scope="col">Attribute</th>
+            <th scope="col">Element</th>
+            <th scope="col">Usage</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th scope="row">
+              <code>combobox</code>
+            </th>
+            <td></td>
+            <td><code>div</</code></td>
+            <td>
+              <ul>
+                <li>Identifies the element as a combobox.</li>
+                <li>Note: The primary difference between the ARIA 1.0 pattern and the ARIA 1.1 pattern is the placement of the <code>combobox</code> role.</li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td></td>
+            <th scope="row">
+              <code>aria-haspopup=<q>grid</q></code>
+            </th>
+            <td><code>div</code></td>
+            <td>Indicates that the combobox can popup a <code>grid</code> to suggest values.</td>
+          </tr>
+          <tr>
+            <td></td>
+            <th scope="row">
+              <code>aria-owns=<q>IDREF</q></code>
+            </th>
+            <td><code>div</code></td>
+            <td>Identifies the element that serves as the grid popup.</td>
+          </tr>
+          <tr>
+            <td></td>
+            <th scope="row">
+              <code>aria-expanded=<q>false</q></code>
+            </th>
+            <td><code>div</code></td>
+            <td>Indicates that the popup element <strong>is not</strong> displayed.</td>
+          </tr>
+          <tr>
+            <td></td>
+            <th scope="row">
+              <code>aria-expanded=<q>true</q></code>
+            </th>
+            <td><code>div</code></td>
+            <td>Indicates that the popup element <strong>is</strong> displayed.</td>
+          </tr>
+        </tbody>
+      </table>
+      <h3 id="rps_label_textbox">Textbox</h3>
+      <table aria-labelledby="rps_label_textbox rps_label" class="data attributes">
+        <thead>
+          <tr>
+            <th scope="col">Role</th>
+            <th scope="col">Attribute</th>
+            <th scope="col">Element</th>
+            <th scope="col">Usage</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td></td>
+            <th scope="row">
+              <code>aria-labelledby=<q>IDREF</q></code>
+            </th>
+            <td><code>input[type="text"]</code></td>
+            <td>Provides a label for the textbox element of the combobox.</td>
+          </tr>
+          <tr>
+            <td></td>
+            <th scope="row">
+              <code>aria-autocomplete=<q>list</q></code>
+            </th>
+            <td><code>input[type="text"]</code></td>
+            <td>Indicates that the autocomplete behavior of the text input is to suggest a list of possible values in a popup.</td>
+          </tr>
+          <tr>
+            <td></td>
+            <th scope="row">
+              <code>aria-controls=<q>IDREF</q></code>
+            </th>
+            <td><code>input[type="text"]</code></td>
+            <td>
+              <ul>
+                <li>Identifies the popup element that lists suggested values.</li>
+                <li>Note: In the ARIA 1.0 combobox pattern, the textbox uses <code>aria-owns</code> instead of <code>aria-controls</code>.</li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td></td>
+            <th scope="row">
+              <code>aria-activedescendant=<q>IDREF</q></code>
+            </th>
+            <td><code>input[type="text"]</code></td>
+            <td>
+              <ul>
+                <li>When a cell in the grid is visually indicated as having keyboard focus, refers to that cell.</li>
+                <li>When navigation keys, such as <kbd>Down Arrow</kbd>, are pressed, the JavaScript changes the value.</li>
+                <li>Enables assistive technologies to know which element the application regards as focused while DOM focus remains on the <code>input</code> element.</li>
+                <li>
+                  For more information about this focus management technique, see 
+                  <a href="../../../#kbd_focus_activedescendant">Using aria-activedescendant to Manage Focus.</a>
+                </li>
+              </ul>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <h3 id="rps_label_popup">Grid Popup</h3>
+      <table aria-labelledby="rps_label_listbox rps_label" class="data attributes">
+        <thead>
+          <tr>
+            <th scope="col">Role</th>
+            <th scope="col">Attribute</th>
+            <th scope="col">Element</th>
+            <th scope="col">Usage</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th scope="row">
+              <code>grid</code>
+            </th>
+            <td></td>
+            <td>
+              <code>div</code>
+            </td>
+            <td>Identifies the element as a <code>grid</code>.</td>
+          </tr>
+          <tr>
+            <td></td>
+            <th scope="row">
+              <code>aria-labelledby=<q>IDREF</q></code>
+            </th>
+            <td><code>div</code></td>
+            <td>Provides a label for the <code>grid</code> element of the combobox.</td>
+          </tr>
+          <tr>
+            <th scope="row">
+              <code>row</code>
+            </th>
+            <td></td>
+            <td><code>div</code></td>
+            <td>Identifies the element containing all the cells for a row.</td>
+          </tr>
+          <tr>
+            <td></td>
+            <th scope="row">
+              <code>aria-selected=<q>true</q></code>
+            </th>
+            <td><code>div</code></td>
+            <td>
+              <ul>
+                <li>Specified on a row in the grid when it is visually indicated as selected.</li>
+                <li>Occurs only when a cell in the grid is referenced by <code>aria-activedescendant</code>.</li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <th scope="row"><code>gridcell</code></th>
+            <td></td>
+            <td><code>div</code></td>
+            <td>Identifies the element containing the content for a single cell.</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
   
-  <section>
-    <h2>Javascript and CSS Source Code</h2>
-    <ul>
-      <li> CSS: <a href="css/combobox-1.1.css" type="tex/css">combobox-1.1.css</a></li>
-      <li>Javascript: <a href="js/grid-combobox.js" type="text/javascript">grid-combobox.js</a></li>
-      <li>Javascript: <a href="js/grid-combo-example.js" type="text/javascript">grid-combo-example.js</a></li>
-    </ul>
-  </section>
+    <section>
+      <h2>Javascript and CSS Source Code</h2>
+      <ul>
+        <li> CSS: <a href="css/combobox-1.1.css" type="tex/css">combobox-1.1.css</a></li>
+        <li>Javascript: <a href="js/grid-combobox.js" type="text/javascript">grid-combobox.js</a></li>
+        <li>Javascript: <a href="js/grid-combo-example.js" type="text/javascript">grid-combo-example.js</a></li>
+      </ul>
+    </section>
 
-  <section>
-    <h2 id="sc1_label">HTML Source Code</h2>
-    <div role="separator" id="sc1_start_sep" aria-labelledby="sc1_start_sep sc1_label" aria-label="Start of"></div>
-    <pre><code id="sc1"></code></pre>
-    <div role="separator" id="sc1_end_sep" aria-labelledby="sc1_end_sep sc1_label" aria-label="End of"></div>
-    <!--
-      The following script will show the reader the HTML source for the example that is in the div with ID 'ex1'.
-      It renders the HTML in the preceding pre element with ID 'sc1'.
-      If you change the ID of either the 'ex1' div or the 'sc1' pre, be sure to update the sourceCode.add function parameters.
-      -->
-    <script>
-      sourceCode.add('sc1', 'ex1');
-      sourceCode.make();
-    </script>
-  </section>
+    <section>
+      <h2 id="sc1_label">HTML Source Code</h2>
+      <div role="separator" id="sc1_start_sep" aria-labelledby="sc1_start_sep sc1_label" aria-label="Start of"></div>
+      <pre><code id="sc1"></code></pre>
+      <div role="separator" id="sc1_end_sep" aria-labelledby="sc1_end_sep sc1_label" aria-label="End of"></div>
+      <!--
+        The following script will show the reader the HTML source for the example that is in the div with ID 'ex1'.
+        It renders the HTML in the preceding pre element with ID 'sc1'.
+        If you change the ID of either the 'ex1' div or the 'sc1' pre, be sure to update the sourceCode.add function parameters.
+        -->
+      <script>
+        sourceCode.add('sc1', 'ex1');
+        sourceCode.make();
+      </script>
+    </section>
   </main>
   <nav>
     <a href="../../../#combobox">Combobox Design Pattern in WAI-ARIA Authoring Practices 1.1</a>

--- a/examples/combobox/aria1.1pattern/listbox-combo.html
+++ b/examples/combobox/aria1.1pattern/listbox-combo.html
@@ -19,527 +19,535 @@
 </head>
 <body>
   <main>
-  <h1>ARIA 1.1 Combobox with Listbox Popup Examples</h1>
-  <p>
-    <strong>NOTE:</strong> Please provide feedback on this page in 
-    <a href="https://github.com/w3c/aria-practices/issues/496">issue 496.</a>
-  </p>
-  <p>
-    The following three example comboboxes implement the ARIA 1.1 form of the
-    <a href="../../../#combobox">combobox design pattern</a>
-    using a listbox popup.
-    Each of the three comboboxes also demonstrates a different form of the autocomplete behaviors described in the design pattern.
-  </p>
-  <p>
-    In these examples, users can specify the name of a fruit or vegetable by either typing a value in the box or choosing from the list.
-    The list becomes available after the textbox contains a character that matches the beginning of the name of one of the items in the list of suggested values.
-    Users may type any value in the textbox; this implementation does not limit input to values that are in the list of suggested values.
-  </p>
-  <p>Similar examples include: </p>
-  <ul>
-            <li><a href="grid-combo.html">ARIA 1.1 Combobox with Grid Popup</a>: A combobox that presents suggestions in a grid, enabling users to navigate descriptive information about each suggestion.</li>
-            <li><a href="../aria1.0pattern/combobox-autocomplete-list.html">ARIA 1.0 Combobox with List Autocomplete</a></li>
+    <h1>ARIA 1.1 Combobox with Listbox Popup Examples</h1>
+    <p>
+      <strong>NOTE:</strong> Please provide feedback on this page in 
+      <a href="https://github.com/w3c/aria-practices/issues/496">issue 496.</a>
+    </p>
+    <p>
+      The following three example comboboxes implement the ARIA 1.1 form of the
+      <a href="../../../#combobox">combobox design pattern</a>
+      using a listbox popup.
+      Each of the three comboboxes also demonstrates a different form of the autocomplete behaviors described in the design pattern.
+    </p>
+    <p>
+      In these examples, users can specify the name of a fruit or vegetable by either typing a value in the box or choosing from the list.
+      The list becomes available after the textbox contains a character that matches the beginning of the name of one of the items in the list of suggested values.
+      Users may type any value in the textbox; this implementation does not limit input to values that are in the list of suggested values.
+    </p>
+    <p>Similar examples include: </p>
+    <ul>
+      <li><a href="grid-combo.html">ARIA 1.1 Combobox with Grid Popup</a>: A combobox that presents suggestions in a grid, enabling users to navigate descriptive information about each suggestion.</li>
+      <li><a href="../aria1.0pattern/combobox-autocomplete-both.html">ARIA 1.0 Combobox with Both List and Inline Autocomplete</a>: A combobox that demonstrates the autocomplete behavior known as <q>list with inline autocomplete</q> and uses the ARIA 1.0 implementation pattern.</li>
+      <li><a href="../aria1.0pattern/combobox-autocomplete-list.html">ARIA 1.0 Combobox with List Autocomplete</a>: A combobox that demonstrates the autocomplete behavior known as <q>list with manual selection</q> and uses the ARIA 1.0 implementation pattern.</li>
+      <li><a href="../aria1.0pattern/combobox-autocomplete-none.html">ARIA 1.0 Combobox Without Autocomplete</a>: A combo box that demonstrates the behavior associated with <code>aria-autocomplete=none</code> and uses the ARIA 1.0 implementation pattern.</li>
     </ul>
   
-  <section>
-    <h2 id="ex_label">Examples</h2>
-    <h3 id="ex1_label">Example 1: List Autocomplete with Manual Selection</h3>
-    <div role="separator" id="ex1_start_sep" aria-labelledby="ex1_start_sep ex1_label" aria-label="Start of"></div>
-    <div id="ex1">
-      <label id="ex1-label" class="combobox-label">
-        Choice 1 Fruit or Vegetable
-      </label>
-      <div class="combobox-wrapper">
-        <div role="combobox"
-          aria-expanded="false"
-          aria-owns="ex1-listbox"
-          aria-haspopup="listbox"
-          id="ex1-combobox">
-          <input type="text"
-            aria-autocomplete="list"
-            aria-controls="ex1-listbox"
-            aria-labelledby="ex1-label"
-            id="ex1-input">
-        </div>
-        <ul
-          aria-labelledby="ex1-label"
-          role="listbox"
-          id="ex1-listbox"
-          class="listbox hidden">
-        </ul>
-      </div>
-    </div>
-    <div role="separator" id="ex1_end_sep" aria-labelledby="ex1_end_sep ex1_label" aria-label="End of"></div>
-    <h4>Notes</h4>
-    <p>List autocomplete with manual selection means that:</p>
-    <ol>
-      <li>
-        When the listbox popup is displayed, it contains suggested values that complete or logically correspond to the characters typed in the textbox.
-        In this implementation, the values in the listbox have names that start with the characters typed in the textbox.
-      </li>
-      <li>Users may set the value of the combobox by choosing a value from the list of suggested values.</li>
-      <li>If the user does not choose a value from the listbox before moving focus outside the combobox, the value that the user typed, if any, becomes the value of the combobox.</li>
-    </ol>
-    <h3 id="ex2_label">Example 2: List Autocomplete with Automatic Selection</h3>
-    <div role="separator" id="ex2_start_sep" aria-labelledby="ex2_start_sep ex2_label" aria-label="Start of"></div>
-    <div id="ex2">
-      <label id="ex2-label" class="combobox-label">
-        Choice 2 Fruit or Vegetable
-      </label>
-      <div class="combobox-wrapper">
-        <div role="combobox" 
-          aria-expanded="false"
-          aria-owns="ex2-listbox"
-          aria-haspopup="listbox"
-          id="ex2-combobox">
-          <input type="text"
-            aria-autocomplete="list"
-            aria-controls="ex2-listbox"
-            aria-labelledby="ex2-label"
-            id="ex2-input">
-        </div>
-        <ul
-          aria-labelledby="ex2-label"
-          role="listbox"
-          id="ex2-listbox"
-          class="listbox hidden">
-        </ul>
-      </div>
-    </div>
-    <div role="separator" id="ex2_end_sep" aria-labelledby="ex2_end_sep ex2_label" aria-label="End of"></div>
-    <h4>Notes</h4>
-    <p>List autocomplete with automatic selection means that:</p>
-    <ol>
-      <li>
-        When the listbox popup is displayed, it contains suggested values that complete or logically correspond to the characters typed in the textbox.
-        In this implementation, the values in the listbox have names that start with the characters typed in the textbox.
-      </li>
-      <li>The first suggestion is automatically highlighted as selected.</li>
-      <li>The automatically selected suggestion becomes the value of the textbox when the combobox loses focus unless the user chooses a different suggestion or changes the character string in the textbox.</li>
-    </ol>
-    <h3 id="ex3_label">Example 3: List with Inline Autocomplete</h3>
-    <div role="separator" id="ex3_start_sep" aria-labelledby="ex3_start_sep ex3_label" aria-label="Start of"></div>
-    <div id="ex3">
-      <label id="ex3-label" class="combobox-label">
-        Choice 3 Fruit or Vegetable
-      </label>
-      <div class="combobox-wrapper">
-        <div role="combobox"
-          aria-expanded="false"
-          aria-owns="ex3-listbox"
-          aria-haspopup="listbox"
-          id="ex3-combobox">
-          <input type="text"
-            aria-autocomplete="both"
-            aria-controls="ex3-listbox"
-            aria-labelledby="ex3-label"
-            id="ex3-input">
-          <div
-            class="combobox-dropdown"
-            id="ex3-combobox-arrow"
-            tabindex="-1"
-            role="button"
-            aria-label="Show vegetable options">
-            <img src="imgs/arrow_drop_down_grey_27x27.png" alt="">
+    <section>
+      <h2 id="ex_label">Examples</h2>
+      <h3 id="ex1_label">Example 1: List Autocomplete with Manual Selection</h3>
+      <div role="separator" id="ex1_start_sep" aria-labelledby="ex1_start_sep ex1_label" aria-label="Start of"></div>
+      <div id="ex1">
+        <label id="ex1-label" class="combobox-label">
+          Choice 1 Fruit or Vegetable
+        </label>
+        <div class="combobox-wrapper">
+          <div role="combobox"
+            aria-expanded="false"
+            aria-owns="ex1-listbox"
+            aria-haspopup="listbox"
+            id="ex1-combobox">
+            <input type="text"
+              aria-autocomplete="list"
+              aria-controls="ex1-listbox"
+              aria-labelledby="ex1-label"
+              id="ex1-input">
           </div>
+          <ul
+            aria-labelledby="ex1-label"
+            role="listbox"
+            id="ex1-listbox"
+            class="listbox hidden">
+          </ul>
         </div>
-        <ul
-          aria-labelledby="ex3-label"
-          role="listbox"
-          id="ex3-listbox"
-          class="listbox hidden">
-        </ul>
       </div>
-    </div>
-    <div role="separator" id="ex3_end_sep" aria-labelledby="ex3_end_sep ex3_label" aria-label="End of"></div>
-    <h4>Notes</h4>
-    <p>List with inline autocomplete means that:</p>
-    <ol>
-      <li>With the exception of one additional feature, this example has the same autocomplete behavior as the previous example that has list with automatic selection.</li>
-      <li>The additional feature is that the portion of the selected suggestion that has not been typed by the user, a completion string, appears inline after the input cursor in the textbox.</li>
-      <li>The inline completion string is visually highlighted and has a selected state.</li>
-    </ol>
-  </section>
+      <div role="separator" id="ex1_end_sep" aria-labelledby="ex1_end_sep ex1_label" aria-label="End of"></div>
+      <h4>Notes</h4>
+      <p>List autocomplete with manual selection means that:</p>
+      <ol>
+        <li>
+          When the listbox popup is displayed, it contains suggested values that complete or logically correspond to the characters typed in the textbox.
+          In this implementation, the values in the listbox have names that start with the characters typed in the textbox.
+        </li>
+        <li>Users may set the value of the combobox by choosing a value from the list of suggested values.</li>
+        <li>If the user does not choose a value from the listbox before moving focus outside the combobox, the value that the user typed, if any, becomes the value of the combobox.</li>
+      </ol>
+      <h3 id="ex2_label">Example 2: List Autocomplete with Automatic Selection</h3>
+      <div role="separator" id="ex2_start_sep" aria-labelledby="ex2_start_sep ex2_label" aria-label="Start of"></div>
+      <div id="ex2">
+        <label id="ex2-label" class="combobox-label">
+          Choice 2 Fruit or Vegetable
+        </label>
+        <div class="combobox-wrapper">
+          <div role="combobox" 
+            aria-expanded="false"
+            aria-owns="ex2-listbox"
+            aria-haspopup="listbox"
+            id="ex2-combobox">
+            <input type="text"
+              aria-autocomplete="list"
+              aria-controls="ex2-listbox"
+              aria-labelledby="ex2-label"
+              id="ex2-input">
+          </div>
+          <ul
+            aria-labelledby="ex2-label"
+            role="listbox"
+            id="ex2-listbox"
+            class="listbox hidden">
+          </ul>
+        </div>
+      </div>
+      <div role="separator" id="ex2_end_sep" aria-labelledby="ex2_end_sep ex2_label" aria-label="End of"></div>
+      <h4>Notes</h4>
+      <p>List autocomplete with automatic selection means that:</p>
+      <ol>
+        <li>
+          When the listbox popup is displayed, it contains suggested values that complete or logically correspond to the characters typed in the textbox.
+          In this implementation, the values in the listbox have names that start with the characters typed in the textbox.
+        </li>
+        <li>The first suggestion is automatically highlighted as selected.</li>
+        <li>The automatically selected suggestion becomes the value of the textbox when the combobox loses focus unless the user chooses a different suggestion or changes the character string in the textbox.</li>
+      </ol>
+      <h3 id="ex3_label">Example 3: List with Inline Autocomplete</h3>
+      <div role="separator" id="ex3_start_sep" aria-labelledby="ex3_start_sep ex3_label" aria-label="Start of"></div>
+      <div id="ex3">
+        <label id="ex3-label" class="combobox-label">
+          Choice 3 Fruit or Vegetable
+        </label>
+        <div class="combobox-wrapper">
+          <div role="combobox"
+            aria-expanded="false"
+            aria-owns="ex3-listbox"
+            aria-haspopup="listbox"
+            id="ex3-combobox">
+            <input type="text"
+              aria-autocomplete="both"
+              aria-controls="ex3-listbox"
+              aria-labelledby="ex3-label"
+              id="ex3-input">
+            <div
+              class="combobox-dropdown"
+              id="ex3-combobox-arrow"
+              tabindex="-1"
+              role="button"
+              aria-label="Show vegetable options">
+              <img src="imgs/arrow_drop_down_grey_27x27.png" alt="">
+            </div>
+          </div>
+          <ul
+            aria-labelledby="ex3-label"
+            role="listbox"
+            id="ex3-listbox"
+            class="listbox hidden">
+          </ul>
+        </div>
+      </div>
+      <div role="separator" id="ex3_end_sep" aria-labelledby="ex3_end_sep ex3_label" aria-label="End of"></div>
+      <h4>Notes</h4>
+      <p>List with inline autocomplete means that:</p>
+      <ol>
+        <li>With the exception of one additional feature, this example has the same autocomplete behavior as the previous example that has list with automatic selection.</li>
+        <li>The additional feature is that the portion of the selected suggestion that has not been typed by the user, a completion string, appears inline after the input cursor in the textbox.</li>
+        <li>The inline completion string is visually highlighted and has a selected state.</li>
+      </ol>
+    </section>
 
-  <section>
-    <h2 id="kbd_label">Keyboard Support</h2>
-    <p>
-    The example comboboxes on this page implement the following keyboard interface. 
-      Other variations and options for the keyboard interface are described in the  
-      <a href="../../../#combobox_kbd_interaction">Keyboard Interaction section of the combobox design pattern.</a>
-    </p>
-    <h3 id="kbd_label_textbox">Textbox</h3>
-    <table aria-labelledby="kbd_label_textbox kbd_label" class="def">
-      <thead>
-        <tr>
-          <th>Key</th>
-          <th>Function</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <th><kbd>Down Arrow</kbd></th>
-          <td>
-            <ul>
-              <li>If the listbox is displayed:
-                <ul>
-                  <li>Example 1: Moves focus to the first suggested value.</li>
-                  <li>Examples 2 and 3: Moves focus to the second suggested value. Note that the first value is automatically selected.</li>
-                </ul>
-              </li>
-              <li>If the listbox is not displayed, in example 3 only, opens the listbox and moves focus to the first value.</li>           
-            </ul>
-          </td>
-        </tr>
-        <tr>
-          <th><kbd>Up Arrow</kbd></th>
-          <td>
-            <ul>
-              <li>If the listbox is displayed, moves focus to the last suggested value.</li>
-              <li>If the listbox is not displayed, in example 3 only, opens the listbox and moves focus to the last value.</li>           
-            </ul>
-          </td>
-        </tr>
-        <tr>
-          <th><kbd>Enter</kbd></th>
-          <td>
-            <ul>
-              <li>Example 1: Does nothing.</li>
-              <li>Examples 2 and 3: If the listbox is displayed and the first option is automatically selected:
-                <ul>
-                  <li>Sets the textbox value to the content of the selected option.</li>
-                  <li>Closes the listbox.</li>
-                </ul>
-              </li>
-            </ul>
-          </td>
-        </tr>
-        <tr>
-          <th><kbd>Escape</kbd></th>
-          <td>
-            <ul>
-              <li>Clears the textbox</li>
-              <li>If the listbox is displayed, closes it.</li>
-            </ul>
-          </td>
-        </tr>
-        <tr>
-          <th><li>Standard single line text editing keys</th>
-          <td>
-            <ul>
-              <li>Keys used for cursor movement and text manipulation, such as <kbd>Delete</kbd> and <kbd>Shift + Right Arrow</kbd>.</li>
-              <li>An HTML <code>input</code> with <code>type=<q>text</q></code> is used for the textbox so the browser will provide platform-specific editing keys.</li>
-            </ul>
-          </td>
-        </tr>
-      </tbody>
-    </table>
-    <h3 id="kbd_label_listbox">Listbox Popup</h3>
-    <table aria-labelledby="kbd_label_listbox kbd_label" class="def">
-      <thead>
-        <tr>
-          <th>Key</th>
-          <th>Function</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <th><kbd>Enter</kbd></th>
-          <td>
-            <ul>
-              <li>Sets the textbox value to the content of the focused option in the listbox.</li>
-              <li>Closes the listbox.</li>
-              <li>Sets focus on the textbox.</li>
-            </ul>
-          </td>
-        </tr>
-        <tr>
-          <th><kbd>Escape</kbd></th>
-          <td>
-            <ul>
-              <li>Closes the listbox.</li>
-              <li>Sets focus on the textbox.</li>
-              <li>Clears the textbox.</li>
-            </ul>
-          </td>
-        </tr>
-        <tr>
-          <th><kbd>Down Arrow</kbd></th>
-          <td>
-            <ul>
-              <li>Moves focus to the next option.</li>
-              <li>If focus is on the last option, moves focus to the first option.</li>
-              <li>Note: This wrapping behavior is useful when <kbd>Home</kbd> and <kbd>End</kbd> move the editing cursor as described below.</li>
-            </ul>
-          </td>
-        </tr>
-        <tr>
-          <th><kbd>Up Arrow</kbd></th>
-          <td>
-            <ul>
-              <li>Moves focus to the previous option.</li>
-              <li>If focus is on the first option, moves focus to the last option.</li>
-              <li>Note: This wrapping behavior is useful when <kbd>Home</kbd> and <kbd>End</kbd> move the editing cursor as described below.</li>
-            </ul>
-          </td>
-        </tr>
-        <tr>
-          <th><kbd>Right Arrow</kbd></th>
-          <td>Moves focus to the textbox and moves the editing cursor one character to the right.</td>
-        </tr>
-        <tr>
-          <th><kbd>Left Arrow</kbd></th>
-          <td>Moves focus to the textbox and moves the editing cursor one character to the leftt.</td>
-        </tr>
-        <tr>
-          <th><kbd>Home</kbd></th>
-          <td>Moves focus to the textbox and places the editing cursor at the beginning of the field.</td>
-        </tr>
-        <tr>
-          <th><kbd>End</kbd></th>
-          <td>Moves focus to the textbox and places the editing cursor at the end of the field.</td>
-        </tr>
-        <tr>
-          <th>Printable Characters</th>
-          <td>
-            <ul>
-              <li>Moves focus to the textbox.</li>
-              <li>Types the character in the textbox.</li>
-            </ul>
-          </td>
-        </tr>
-      </tbody>
-    </table>
-  </section>
+    <section>
+      <h2 id="kbd_label">Keyboard Support</h2>
+      <p>
+      The example comboboxes on this page implement the following keyboard interface. 
+        Other variations and options for the keyboard interface are described in the  
+        <a href="../../../#combobox_kbd_interaction">Keyboard Interaction section of the combobox design pattern.</a>
+      </p>
+      <h3 id="kbd_label_textbox">Textbox</h3>
+      <table aria-labelledby="kbd_label_textbox kbd_label" class="def">
+        <thead>
+          <tr>
+            <th>Key</th>
+            <th>Function</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th><kbd>Down Arrow</kbd></th>
+            <td>
+              <ul>
+                <li>If the listbox is displayed:
+                  <ul>
+                    <li>Example 1: Moves focus to the first suggested value.</li>
+                    <li>Examples 2 and 3: Moves focus to the second suggested value. Note that the first value is automatically selected.</li>
+                  </ul>
+                </li>
+                <li>If the listbox is not displayed, in example 3 only, opens the listbox and moves focus to the first value.</li>           
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <th><kbd>Up Arrow</kbd></th>
+            <td>
+              <ul>
+                <li>If the listbox is displayed, moves focus to the last suggested value.</li>
+                <li>If the listbox is not displayed, in example 3 only, opens the listbox and moves focus to the last value.</li>           
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <th><kbd>Enter</kbd></th>
+            <td>
+              <ul>
+                <li>Example 1: Does nothing.</li>
+                <li>Examples 2 and 3: If the listbox is displayed and the first option is automatically selected:
+                  <ul>
+                    <li>Sets the textbox value to the content of the selected option.</li>
+                    <li>Closes the listbox.</li>
+                  </ul>
+                </li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <th><kbd>Escape</kbd></th>
+            <td>
+              <ul>
+                <li>Clears the textbox</li>
+                <li>If the listbox is displayed, closes it.</li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <th><li>Standard single line text editing keys</th>
+            <td>
+              <ul>
+                <li>Keys used for cursor movement and text manipulation, such as <kbd>Delete</kbd> and <kbd>Shift + Right Arrow</kbd>.</li>
+                <li>An HTML <code>input</code> with <code>type=<q>text</q></code> is used for the textbox so the browser will provide platform-specific editing keys.</li>
+              </ul>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <h3 id="kbd_label_listbox">Listbox Popup</h3>
+      <p>
+        <strong>NOTE:</strong> When visual focus is in the listbox, DOM focus remains on the textbox and the value of <code>aria-activedescendant</code> on the textbox is set to a value that refers to the listbox option that is visually indicated as focused.
+        Where the following descriptions of keyboard commands mention focus, they are referring to the visual focus indicator.
+        For more information about this focus management technique, see 
+        <a href="../../../#kbd_focus_activedescendant">Using aria-activedescendant to Manage Focus.</a>
+      </p>
+      <table aria-labelledby="kbd_label_listbox kbd_label" class="def">
+        <thead>
+          <tr>
+            <th>Key</th>
+            <th>Function</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th><kbd>Enter</kbd></th>
+            <td>
+              <ul>
+                <li>Sets the textbox value to the content of the focused option in the listbox.</li>
+                <li>Closes the listbox.</li>
+                <li>Sets focus on the textbox.</li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <th><kbd>Escape</kbd></th>
+            <td>
+              <ul>
+                <li>Closes the listbox.</li>
+                <li>Sets focus on the textbox.</li>
+                <li>Clears the textbox.</li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <th><kbd>Down Arrow</kbd></th>
+            <td>
+              <ul>
+                <li>Moves focus to the next option.</li>
+                <li>If focus is on the last option, moves focus to the first option.</li>
+                <li>Note: This wrapping behavior is useful when <kbd>Home</kbd> and <kbd>End</kbd> move the editing cursor as described below.</li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <th><kbd>Up Arrow</kbd></th>
+            <td>
+              <ul>
+                <li>Moves focus to the previous option.</li>
+                <li>If focus is on the first option, moves focus to the last option.</li>
+                <li>Note: This wrapping behavior is useful when <kbd>Home</kbd> and <kbd>End</kbd> move the editing cursor as described below.</li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <th><kbd>Right Arrow</kbd></th>
+            <td>Moves focus to the textbox and moves the editing cursor one character to the right.</td>
+          </tr>
+          <tr>
+            <th><kbd>Left Arrow</kbd></th>
+            <td>Moves focus to the textbox and moves the editing cursor one character to the leftt.</td>
+          </tr>
+          <tr>
+            <th><kbd>Home</kbd></th>
+            <td>Moves focus to the textbox and places the editing cursor at the beginning of the field.</td>
+          </tr>
+          <tr>
+            <th><kbd>End</kbd></th>
+            <td>Moves focus to the textbox and places the editing cursor at the end of the field.</td>
+          </tr>
+          <tr>
+            <th>Printable Characters</th>
+            <td>
+              <ul>
+                <li>Moves focus to the textbox.</li>
+                <li>Types the character in the textbox.</li>
+              </ul>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
 
-  <section>
-    <h2 id="rps_label">Role, Property, State, and Tabindex Attributes</h2>
-    <p>
-      The example comboboxes on this page implement the following ARIA roles, states, and properties. 
-      Information about other ways of applying ARIA roles, states, and properties is available in the    
-      <a href="../../../#combobox_roles_states_props">Roles, States, and Properties section of the combobox design pattern.</a>
-    </p>
-    <h3 id="rps_label_combobox">Combobox Container</h3>
-    <table aria-labelledby="rps_label_combobox rps_label" class="data attributes">
-      <thead>
-        <tr>
-          <th scope="col">Role</th>
-          <th scope="col">Attribute</th>
-          <th scope="col">Element</th>
-          <th scope="col">Usage</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <th scope="row">
-            <code>combobox</code>
-          </th>
-          <td></td>
-          <td><code>div</</code></td>
-          <td>
-            <ul>
-              <li>Identifies the element as a combobox.</li>
-              <li>Note: The primary difference between the ARIA 1.0 pattern and the ARIA 1.1 pattern is the placement of the <code>combobox</code> role.</li>
-            </ul>
-          </td>
-        </tr>
-        <tr>
-          <td></td>
-          <th scope="row">
-            <code>aria-haspopup=<q>listbox</q></code>
-          </th>
-          <td><code>div</code></td>
-          <td>
-            <ul>
-              <li>Indicates that the combobox can popup a <code>listbox</code> to suggest values.</li>
-              <li>This is the default value for elements with the <code>combobox</code> role.</li>
-            </ul>
-          </td>
-        </tr>
-        <tr>
-          <td></td>
-          <th scope="row">
-            <code>aria-owns=<q>IDREF</q></code>
-          </th>
-          <td><code>div</code></td>
-          <td>Identifies the element that serves as the listbox popup.</td>
-        </tr>
-        <tr>
-          <td></td>
-          <th scope="row">
-            <code>aria-expanded=<q>false</q></code>
-          </th>
-          <td><code>div</code></td>
-          <td>Indicates that the popup element <strong>is not</strong> displayed.</td>
-        </tr>
-        <tr>
-          <td></td>
-          <th scope="row">
-            <code>aria-expanded=<q>true</q></code>
-          </th>
-          <td><code>div</code></td>
-          <td>Indicates that the popup element <strong>is</strong> displayed.</td>
-        </tr>
-      </tbody>
-    </table>
-    <h3 id="rps_label_textbox">Textbox</h3>
-    <table aria-labelledby="rps_label_textbox rps_label" class="data attributes">
-      <thead>
-        <tr>
-          <th scope="col">Role</th>
-          <th scope="col">Attribute</th>
-          <th scope="col">Element</th>
-          <th scope="col">Usage</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td></td>
-          <th scope="row">
-            <code>aria-labelledby=<q>IDREF</q></code>
-          </th>
-          <td><code>input[type="text"]</code></td>
-          <td>Provides a label for the textbox element of the combobox.</td>
-        </tr>
-        <tr>
-          <td></td>
-          <th scope="row">
-            <code>aria-autocomplete=<q>list</q></code>
-          </th>
-          <td><code>input[type="text"]</code></td>
-          <td>Examples 1 and 2: Indicates that the autocomplete behavior of the text input is to suggest a list of possible values in a popup.</td>
-        </tr>
-        <tr>
-          <td></td>
-          <th scope="row">
-            <code>aria-autocomplete=<q>both</q></code>
-          </th>
-          <td><code>input[type="text"]</code></td>
-          <td>Example 3: Indicates that the autocomplete behavior of the text input is to both show an inline completion string and suggest a list of possible values in a popup.</td>
-        </tr>
-        <tr>
-          <td></td>
-          <th scope="row">
-            <code>aria-controls=<q>IDREF</q></code>
-          </th>
-          <td><code>input[type="text"]</code></td>
-          <td>
-            <ul>
-              <li>Identifies the popup element that lists suggested values.</li>
-              <li>Note: In the ARIA 1.0 combobox pattern, the textbox uses <code>aria-owns</code> instead of <code>aria-controls</code>.</li>
-            </ul>
-          </td>
-        </tr>
-        <tr>
-          <td></td>
-          <th scope="row">
-            <code>aria-activedescendant=<q>IDREF</q></code>
-          </th>
-          <td><code>input[type="text"]</code></td>
-          <td>
-            <ul>
-              <li>When an option in the listbox is visually indicated as having keyboard focus, refers to that option.</li>
-              <li>When navigation keys, such as <kbd>Down Arrow</kbd>, are pressed, the JavaScript changes the value.</li>
-              <li>Enables assistive technologies to know which element the application regards as focused while DOM focus remains on the <code>input</code> element.</li>
-              <li>
-                For more information about this focus management technique, see 
-                <a href="../../../#kbd_focus_activedescendant">Using aria-activedescendant to Manage Focus.</a>
-              </li>
-            </ul>
-          </td>
-        </tr>
-      </tbody>
-    </table>
-    <h3 id="rps_label_listbox">Listbox Popup</h3>
-    <table aria-labelledby="rps_label_listbox rps_label" class="data attributes">
-      <thead>
-        <tr>
-          <th scope="col">Role</th>
-          <th scope="col">Attribute</th>
-          <th scope="col">Element</th>
-          <th scope="col">Usage</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <th scope="row">
-            <code>listbox</code>
-          </th>
-          <td></td>
-          <td>
-            <code>ul</code>
-          </td>
-          <td>Identifies the <code>ul</code> element as a <code>listbox</code>.</td>
-        </tr>
-        <tr>
-          <td></td>
-          <th scope="row">
-            <code>aria-labelledby=<q>IDREF</q></code>
-          </th>
-          <td><code>ul</code></td>
-          <td>Provides a label for the <code>listbox</code> element of the combobox.</td>
-        </tr>
-        <tr>
-          <th scope="row">
-            <code>option</code>
-          </th>
-          <td></td>
-          <td><code>li</code></td>
-          <td>
-            <ul>
-              <li>Identifies the element as a <code>listbox</code> <code>option</code>.</li>
-              <li>The text content of the element provides the accessible name of the <code>option</code>.</li>
-            </ul>
-          </td>
-        </tr>
-        <tr>
-          <td></td>
-          <th scope="row">
-            <code>aria-selected=<q>true</q></code>
-          </th>
-          <td><code>li</code></td>
-          <td>
-            <ul>
-              <li>Specified on an option in the listbox when it is visually highlighted as selected.</li>
-              <li>In example 1, occurs only when an option in the list is referenced by <code>aria-activedescendant</code>.</li>
-              <li>In examples 2 and 3, also occurs when focus is in the textbox and the first option is automatically selected.</li>
-            </ul>
-          </td>
-        </tr>
-      </tbody>
-    </table>
-  </section>
+    <section>
+      <h2 id="rps_label">Role, Property, State, and Tabindex Attributes</h2>
+      <p>
+        The example comboboxes on this page implement the following ARIA roles, states, and properties. 
+        Information about other ways of applying ARIA roles, states, and properties is available in the    
+        <a href="../../../#combobox_roles_states_props">Roles, States, and Properties section of the combobox design pattern.</a>
+      </p>
+      <h3 id="rps_label_combobox">Combobox Container</h3>
+      <table aria-labelledby="rps_label_combobox rps_label" class="data attributes">
+        <thead>
+          <tr>
+            <th scope="col">Role</th>
+            <th scope="col">Attribute</th>
+            <th scope="col">Element</th>
+            <th scope="col">Usage</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th scope="row">
+              <code>combobox</code>
+            </th>
+            <td></td>
+            <td><code>div</</code></td>
+            <td>
+              <ul>
+                <li>Identifies the element as a combobox.</li>
+                <li>Note: The primary difference between the ARIA 1.0 pattern and the ARIA 1.1 pattern is the placement of the <code>combobox</code> role.</li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td></td>
+            <th scope="row">
+              <code>aria-haspopup=<q>listbox</q></code>
+            </th>
+            <td><code>div</code></td>
+            <td>
+              <ul>
+                <li>Indicates that the combobox can popup a <code>listbox</code> to suggest values.</li>
+                <li>This is the default value for elements with the <code>combobox</code> role.</li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td></td>
+            <th scope="row">
+              <code>aria-owns=<q>IDREF</q></code>
+            </th>
+            <td><code>div</code></td>
+            <td>Identifies the element that serves as the listbox popup.</td>
+          </tr>
+          <tr>
+            <td></td>
+            <th scope="row">
+              <code>aria-expanded=<q>false</q></code>
+            </th>
+            <td><code>div</code></td>
+            <td>Indicates that the popup element <strong>is not</strong> displayed.</td>
+          </tr>
+          <tr>
+            <td></td>
+            <th scope="row">
+              <code>aria-expanded=<q>true</q></code>
+            </th>
+            <td><code>div</code></td>
+            <td>Indicates that the popup element <strong>is</strong> displayed.</td>
+          </tr>
+        </tbody>
+      </table>
+      <h3 id="rps_label_textbox">Textbox</h3>
+      <table aria-labelledby="rps_label_textbox rps_label" class="data attributes">
+        <thead>
+          <tr>
+            <th scope="col">Role</th>
+            <th scope="col">Attribute</th>
+            <th scope="col">Element</th>
+            <th scope="col">Usage</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td></td>
+            <th scope="row">
+              <code>aria-labelledby=<q>IDREF</q></code>
+            </th>
+            <td><code>input[type="text"]</code></td>
+            <td>Provides a label for the textbox element of the combobox.</td>
+          </tr>
+          <tr>
+            <td></td>
+            <th scope="row">
+              <code>aria-autocomplete=<q>list</q></code>
+            </th>
+            <td><code>input[type="text"]</code></td>
+            <td>Examples 1 and 2: Indicates that the autocomplete behavior of the text input is to suggest a list of possible values in a popup and that the suggestions are related to the string that is present in the textbox.</td>
+          </tr>
+          <tr>
+            <td></td>
+            <th scope="row">
+              <code>aria-autocomplete=<q>both</q></code>
+            </th>
+            <td><code>input[type="text"]</code></td>
+            <td>Example 3: Indicates that the autocomplete behavior of the text input is to both show an inline completion string and suggest a list of possible values in a popup where the suggestions are related to the string that is present in the textbox.</td>
+          </tr>
+          <tr>
+            <td></td>
+            <th scope="row">
+              <code>aria-controls=<q>IDREF</q></code>
+            </th>
+            <td><code>input[type="text"]</code></td>
+            <td>
+              <ul>
+                <li>Identifies the popup element that lists suggested values.</li>
+                <li>Note: In the ARIA 1.0 combobox pattern, the textbox uses <code>aria-owns</code> instead of <code>aria-controls</code>.</li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td></td>
+            <th scope="row">
+              <code>aria-activedescendant=<q>IDREF</q></code>
+            </th>
+            <td><code>input[type="text"]</code></td>
+            <td>
+              <ul>
+                <li>When an option in the listbox is visually indicated as having keyboard focus, refers to that option.</li>
+                <li>When navigation keys, such as <kbd>Down Arrow</kbd>, are pressed, the JavaScript changes the value.</li>
+                <li>Enables assistive technologies to know which element the application regards as focused while DOM focus remains on the <code>input</code> element.</li>
+                <li>
+                  For more information about this focus management technique, see 
+                  <a href="../../../#kbd_focus_activedescendant">Using aria-activedescendant to Manage Focus.</a>
+                </li>
+              </ul>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <h3 id="rps_label_listbox">Listbox Popup</h3>
+      <table aria-labelledby="rps_label_listbox rps_label" class="data attributes">
+        <thead>
+          <tr>
+            <th scope="col">Role</th>
+            <th scope="col">Attribute</th>
+            <th scope="col">Element</th>
+            <th scope="col">Usage</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th scope="row">
+              <code>listbox</code>
+            </th>
+            <td></td>
+            <td>
+              <code>ul</code>
+            </td>
+            <td>Identifies the <code>ul</code> element as a <code>listbox</code>.</td>
+          </tr>
+          <tr>
+            <td></td>
+            <th scope="row">
+              <code>aria-labelledby=<q>IDREF</q></code>
+            </th>
+            <td><code>ul</code></td>
+            <td>Provides a label for the <code>listbox</code> element of the combobox.</td>
+          </tr>
+          <tr>
+            <th scope="row">
+              <code>option</code>
+            </th>
+            <td></td>
+            <td><code>li</code></td>
+            <td>
+              <ul>
+                <li>Identifies the element as a <code>listbox</code> <code>option</code>.</li>
+                <li>The text content of the element provides the accessible name of the <code>option</code>.</li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td></td>
+            <th scope="row">
+              <code>aria-selected=<q>true</q></code>
+            </th>
+            <td><code>li</code></td>
+            <td>
+              <ul>
+                <li>Specified on an option in the listbox when it is visually highlighted as selected.</li>
+                <li>In example 1, occurs only when an option in the list is referenced by <code>aria-activedescendant</code>.</li>
+                <li>In examples 2 and 3, also occurs when focus is in the textbox and the first option is automatically selected.</li>
+              </ul>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
 
-  <section>
-    <h2>Javascript and CSS Source Code</h2>
-    <ul>
-      <li>CSS: <a href="css/combobox-1.1.css" type="tex/css">combobox-1.1.css</a></li>
-      <li>Javascript: <a href="js/listbox-combobox.js" type="text/javascript">listbox-combobox.js</a></li>
-      <li>Javascript: <a href="js/listbox-combo-example.js" type="text/javascript">listbox-combo-example.js</a></li>
-    </ul>
-  </section>
+    <section>
+      <h2>Javascript and CSS Source Code</h2>
+      <ul>
+        <li>CSS: <a href="css/combobox-1.1.css" type="tex/css">combobox-1.1.css</a></li>
+        <li>Javascript: <a href="js/listbox-combobox.js" type="text/javascript">listbox-combobox.js</a></li>
+        <li>Javascript: <a href="js/listbox-combo-example.js" type="text/javascript">listbox-combo-example.js</a></li>
+      </ul>
+    </section>
 
-  <section>
-    <h2 id="sc_label">HTML Source Code</h2>
-    <h3 id="sc1_label">Example 1</h3>
-    <div role="separator" id="sc1_start_sep" aria-labelledby="sc1_start_sep sc1_label sc_label" aria-label="Start of"></div>
-    <pre><code id="sc1"></code></pre>
-    <div role="separator" id="sc1_end_sep" aria-labelledby="sc1_end_sep sc1_label sc_label" aria-label="End of"></div>
-    <h3 id="sc2_label">Example 2</h3>
-    <div role="separator" id="sc2_start_sep" aria-labelledby="sc2_start_sep sc2_label sc_label" aria-label="Start of"></div>
-    <pre><code id="sc2"></code></pre>
-    <div role="separator" id="sc2_end_sep" aria-labelledby="sc2_end_sep sc2_label sc_label" aria-label="End of"></div>
-    <h3 id="sc3_label">Example 3</h3>
-    <div role="separator" id="sc3_start_sep" aria-labelledby="sc3_start_sep sc3_label sc_label" aria-label="Start of"></div>
-    <pre><code id="sc3"></code></pre>
-    <div role="separator" id="sc3_end_sep" aria-labelledby="sc3_end_sep sc3_label sc_label" aria-label="End of"></div>
-    <script>
-      sourceCode.add('sc1', 'ex1');
-      sourceCode.add('sc2', 'ex2');
-      sourceCode.add('sc3', 'ex3');
-      sourceCode.make();
-    </script>
-  </section>
+    <section>
+      <h2 id="sc_label">HTML Source Code</h2>
+      <h3 id="sc1_label">Example 1</h3>
+      <div role="separator" id="sc1_start_sep" aria-labelledby="sc1_start_sep sc1_label sc_label" aria-label="Start of"></div>
+      <pre><code id="sc1"></code></pre>
+      <div role="separator" id="sc1_end_sep" aria-labelledby="sc1_end_sep sc1_label sc_label" aria-label="End of"></div>
+      <h3 id="sc2_label">Example 2</h3>
+      <div role="separator" id="sc2_start_sep" aria-labelledby="sc2_start_sep sc2_label sc_label" aria-label="Start of"></div>
+      <pre><code id="sc2"></code></pre>
+      <div role="separator" id="sc2_end_sep" aria-labelledby="sc2_end_sep sc2_label sc_label" aria-label="End of"></div>
+      <h3 id="sc3_label">Example 3</h3>
+      <div role="separator" id="sc3_start_sep" aria-labelledby="sc3_start_sep sc3_label sc_label" aria-label="Start of"></div>
+      <pre><code id="sc3"></code></pre>
+      <div role="separator" id="sc3_end_sep" aria-labelledby="sc3_end_sep sc3_label sc_label" aria-label="End of"></div>
+      <script>
+        sourceCode.add('sc1', 'ex1');
+        sourceCode.add('sc2', 'ex2');
+        sourceCode.add('sc3', 'ex3');
+        sourceCode.make();
+      </script>
+    </section>
   </main>
   <nav>
     <a href="../../../#combobox">combobox design pattern in WAI-ARIA Authoring Practices 1.1</a>


### PR DESCRIPTION
For issue #99, integrate contributions from @jongund and @mcking65 on three ARIA 1.0 style combobox examples.
Each example demonstrates a different type of autocomplete:
* List with manual selection
* List with inline autocomplete
* No autocomplete.

This includes updates to the links from the design pattern as well as updates to links from the ARIA 1.1 combobox example pages.