### PR TITLE
Fixed typo in an example's title tag.

### DIFF
--- a/examples/treeview/treeview-2/treeview-2b.html
+++ b/examples/treeview/treeview-2/treeview-2b.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta http-equiv="content-type" content="text/html; charset=UTF-8">
-    <title>Navigation Treeview Example Using Declared Properties | WAI-ARIA Authoring Practices 1.1<</title>
+    <title>Navigation Treeview Example Using Declared Properties | WAI-ARIA Authoring Practices 1.1</title>
 
     <!--  Core js and css shared by all examples; do not modify when using this template. -->
     <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/base.css">


### PR DESCRIPTION
Fixes an error in the markup.