### PR TITLE
Radio Group with Roving tabindex Example: Clean up example HTML and correct supporting documentation

### DIFF
--- a/examples/radio/radio-1/radio-1.html
+++ b/examples/radio/radio-1/radio-1.html
@@ -14,238 +14,226 @@
     <link rel="stylesheet" href="../css/radio.css">
     <script src="js/radioGroup.js" type="text/javascript"></script>
     <script src="js/radioButton.js" type="text/javascript"></script>
-
   </head>
   <body>
     <main role="main">
-      <h1>Radio Button Example</h1>
+      <h1>Radio Group Example</h1>
 
-     <p>This example implements the features of the <a href="../../../#radiobutton">Radio Button Design Pattern</a> for selecting a pizza crust and delivery method.</p>
+      <p>This example implements the features of the <a href="../../../#radiobutton">Radio Button Design Pattern</a> for selecting a pizza crust and delivery method.</p>
 
       <p>Similar examples include: </p>
+      
       <ul>
         <li><a href="../radio-2/radio-2.html">Radio Button Example (aria-activedescendant)</a>: Radio button group using <code>aria-activedescendant</code> for managing keyboard focus.</li>
         <!--  list other examples that implement the same design pattern. -->
       </ul>
 
 
-     <section aria-labelledby="example_label">
-      <h2 id="example_label">Example Start</h2>
-      <div id="ex1">
+      <section aria-labelledby="example_label">
+        <h2 id="example_label">Example</h2>
 
-        <div  role="radiogroup" aria-labelledby="group_label_1" id="rg1">
+        <div id="ex1">
+          <div  role="radiogroup" aria-labelledby="group_label_1" id="rg1">
             <h3 id="group_label_1">Pizza Crust</h3>
 
-            <div role="radio"
-                aria-checked="false"
-                tabindex="0">
+            <div role="radio" aria-checked="false" tabindex="0">
               Regular crust
-           </div>
-           <div role="radio"
-                aria-checked="false"
-                tabindex="-1">
+            </div>
+            <div role="radio" aria-checked="false" tabindex="-1">
               Deep dish
-           </div>
-           <div role="radio"
-                aria-checked="false"
-                tabindex="-1">
+            </div>
+            <div role="radio" aria-checked="false" tabindex="-1">
               Thin crust
-           </div>
-       </div>
+            </div>
+          </div>
 
-        <div  role="radiogroup" aria-labelledby="group_label_2" id="rg2">
+          <div  role="radiogroup" aria-labelledby="group_label_2" id="rg2">
             <h3 id="group_label_2">Pizza Delivery</h3>
-            <div role="radio"
-                aria-checked="false"
-                tabindex="0">
+            <div role="radio" aria-checked="false" tabindex="0">
               Pickup
             </div>
 
-            <div role="radio"
-                aria-checked="false"
-                tabindex="-1">
+            <div role="radio" aria-checked="false" tabindex="-1">
               Home Delivery
             </div>
 
-            <div role="radio"
-                aria-checked="false"
-                tabindex="-1">
-            Dine in
-           </div>
-       </div>
+            <div role="radio" aria-checked="false" tabindex="-1">
+              Dine in
+            </div>
+          </div>
 
-        <script type="text/javascript">
-          var rg1 = new RadioGroup(document.getElementById('rg1'));
-          rg1.init();
-          var rg2 = new RadioGroup(document.getElementById('rg2'));
-          rg2.init();
-        </script>
-      </div>
-     </section>
+          <script type="text/javascript">
+            var rg1 = new RadioGroup(document.getElementById('rg1'));
+            rg1.init();
+            var rg2 = new RadioGroup(document.getElementById('rg2'));
+            rg2.init();
+          </script>
+        </div>
+      </section>
 
-     <section aria-labelledby="information_label">
-        <h2 id="information_label">Radio group Widget Implementation Information</h2>
+      <section aria-labelledby="information_label">
+        <h2 id="information_label">Radio Group Widget Implementation Information</h2>
 
         <h3>Implementation Notes</h3>
         <ul>
           <li>Uses CSS attribute selectors for synchronizing <code>aria-checked</code> state with the visual state indicator.</li>
-          <li>Uses CSS <code>:hover</code> and <code>:focus</code> psuedo selectors for styling visual keyboard focus and hover.</li>
+          <li>Uses CSS <code>:hover</code> and <code>:focus</code> pseudo-selectors for styling visual keyboard focus and hover.</li>
         </ul>
 
 
-      <h3 id="kbd_label">Keyboard Support</h3>
+        <h3 id="kbd_label">Keyboard Support</h3>
 
-      <table aria-labelledby="kbd_label" class="def">
-        <thead>
-          <tr>
-            <th>Key</th>
-            <th>Function</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <th><kbd>Tab</kbd></th>
-            <td>
-              <ul>
-                <li>Moves keyboard focus to the checked <code>radio</code> button in a <code>radiogroup</code>.</li>
-                <li>If no <code>radio</code> button is checked, focus moves to the first <code>radio</code> button in the group.</li>
-              </ul>
-            </td>
-          </tr>
-          <tr>
-            <th><kbd>Space</kbd></th>
-            <td>
-              <ul>
-                <li>If the <code>radio</code> button with focus is unchecked, it's state will be changed to checked.</li>
-              </ul>
-            </td>
-          </tr>
-          <tr>
-            <th><kbd>Down arrow</kbd></th>
-            <td>
-              <ul>
-                <li>Moves focus to next <code>radio</code> button in the group.</li>
-                <li>If focus is on the last <code>radio</code> button in the group, move focus to the first <code>radio</code> button.</li>
-              </ul>
-            </td>
-          </tr>
-          <tr>
-            <th><kbd>Up arrow</kbd></th>
-            <td>
-              <ul>
-                <li>Moves focus to previous <code>radio</code> button in the group.</li>
-                <li>If focus is on the first <code>radio</code> button in the group, move focus to the last <code>radio</code> button.</li>
-              </ul>
-            </td>
-          </tr>
-        </tbody>
-      </table>
+        <table aria-labelledby="kbd_label" class="def">
+          <thead>
+            <tr>
+              <th>Key</th>
+              <th>Function</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <th><kbd>Tab</kbd></th>
+              <td>
+                <ul>
+                  <li>Moves keyboard focus to the checked <code>radio</code> button in a <code>radiogroup</code>.</li>
+                  <li>If no <code>radio</code> button is checked, focus moves to the first <code>radio</code> button in the group.</li>
+                </ul>
+              </td>
+            </tr>
+            <tr>
+              <th><kbd>Space</kbd></th>
+              <td>
+                <ul>
+                  <li>If the <code>radio</code> button with focus is unchecked, its state will be changed to <code>checked</code>.</li>
+                </ul>
+              </td>
+            </tr>
+            <tr>
+              <th><kbd>Down arrow</kbd></th>
+              <td>
+                <ul>
+                  <li>Moves focus to next <code>radio</code> button in the group.</li>
+                  <li>If focus is on the last <code>radio</code> button in the group, move focus to the first <code>radio</code> button.</li>
+                </ul>
+              </td>
+            </tr>
+            <tr>
+              <th><kbd>Up arrow</kbd></th>
+              <td>
+                <ul>
+                  <li>Moves focus to previous <code>radio</code> button in the group.</li>
+                  <li>If focus is on the first <code>radio</code> button in the group, move focus to the last <code>radio</code> button.</li>
+                </ul>
+              </td>
+            </tr>
+          </tbody>
+        </table>
 
-      <h3 id="rps_label">ARIA Roles, Properties and States</h3>
+        <h3 id="rps_label">ARIA Roles, Properties and States</h3>
 
-      <table aria-labelledby="rps_label" class="data attributes">
-        <thead>
-          <tr>
-            <th scope="col">Role</th>
-            <th scope="col">Attributes</th>
-            <th scope="col">Element</th>
-            <th scope="col">Usage</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <th scope="row"><code>radiogroup</code></th>
-            <td></td>
-            <td><code>div</code></td>
-            <td>
-              <ul>
-                <li>The <code>role=&quot;radiogroup&quot;</code> attribute identifies the <code>div</code> element as a container for a group of <code>radio</code> buttons.</li>
-                <li>The descendent <code>radio</code> buttons are considered part of the group.</li>
-                <li>The accessible name comes the <code>aria-labelledby</code> attribute, which points to the element that contains the label text.</li>
-                <li>The <code>radiogroup</code> widget does not need a <code>tabindex</code> value, since the <code>ul[role&quot;radiogroup&quot;]</code> element never receives keyboard focus.</li>
-              </ul>
-            </td>
-          </tr>
-          <tr>
-            <td></td>
-            <th scope="row"><code>aria-labelledby=&quot;[IDREF]&quot;</code></th>
-            <td><code>div</code></td>
-            <td>
-                 <ul>
+        <table aria-labelledby="rps_label" class="data attributes">
+          <thead>
+            <tr>
+              <th scope="col">Role</th>
+              <th scope="col">Attributes</th>
+              <th scope="col">Element</th>
+              <th scope="col">Usage</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <th scope="row"><code>radiogroup</code></th>
+              <td></td>
+              <td><code>div</code></td>
+              <td>
+                <ul>
+                  <li>The <code>role="radiogroup"</code> attribute identifies the <code>div</code> element as a container for a group of <code>radio</code> buttons.</li>
+                  <li>The descendent <code>radio</code> buttons are considered part of the group.</li>
+                  <li>The accessible name comes from the <code>aria-labelledby</code> attribute, which points to the element that contains the label text.</li>
+                  <li>The <code>radiogroup</code> widget does not need a <code>tabindex</code> value, since the <code>ul[role"radiogroup"]</code> element never receives keyboard focus.</li>
+                </ul>
+              </td>
+            </tr>
+            <tr>
+              <td></td>
+              <th scope="row"><code>aria-labelledby="[IDREF]"</code></th>
+              <td><code>div</code></td>
+              <td>
+                <ul>
                   <li>The <code>aria-labelledby</code> attribute points to the element that contains the test for defining an accessible name (e.g. label) for the group of <code>radio</code> buttons.</li>
-                 </ul>
-            </td>
-          </tr>
-          <tr>
-            <th scope="row"><code>radio</code></th>
-            <td></td>
-            <td><code>div</code></td>
-            <td>
-              <ul>
-                <li>The <code>role=&quot;radio&quot;</code> attribute identifies the <code>div</code> element as an ARIA <code>radio</code> button.</li>
-                <li>The accessible name comes the child text content of the <code>div</code> element.</li>
-                <li>The <code>radio</code> widget has a manged <code>tabindex</code> value, one radio button must have a <code>tabindex=&quot;0&quot;</code> and the rest of the daio buttons in the group a <code>tabindex=&quot;-1&quot;</code>.</li>
-                <li>See <a href="../../../#kbd_roving_tabindex">roving tabindex</a> for more information</li>
-              </ul>
-            </td>
-          </tr>
-          <tr>
-            <td></td>
-            <th scope="row"><code>tabindex=&quot;-1&quot;</code></th>
-            <td><code>div</code></td>
-            <td>
+                </ul>
+              </td>
+            </tr>
+            <tr>
+              <th scope="row"><code>radio</code></th>
+              <td></td>
+              <td><code>div</code></td>
+              <td>
+                <ul>
+                  <li>The <code>role="radio"</code> attribute identifies the <code>div</code> element as an ARIA <code>radio</code> button.</li>
+                  <li>The accessible name comes from the child text content of the <code>div</code> element.</li>
+                  <li>The <code>radio</code> widget has a managed <code>tabindex</code> value, one radio button must have <code>tabindex="0"</code> and the rest of the radio buttons in the group <code>tabindex="-1"</code>.</li>
+                  <li>See <a href="../../../#kbd_roving_tabindex">roving tabindex</a> for more information</li>
+                </ul>
+              </td>
+            </tr>
+            <tr>
+              <td></td>
+              <th scope="row"><code>tabindex="-1"</code></th>
+              <td><code>div</code></td>
+              <td>
                 <ul>
                   <li>All <code>radio</code> buttons in a group that are unchecked, except for the first <code>radio</code> button in the case when no <code>radio</code> buttons are checked.</li>
                   <li>See <a href="../../../#kbd_roving_tabindex">roving tabindex</a> for more information</li>
-                 </ul>
-            </td>
-          </tr>
-          <tr>
-            <td></td>
-            <th scope="row"><code>tabindex=&quot;0&quot;</code></th>
-            <td><code>div</code></td>
-            <td>
+                </ul>
+              </td>
+            </tr>
+            <tr>
+              <td></td>
+              <th scope="row"><code>tabindex="0"</code></th>
+              <td><code>div</code></td>
+              <td>
                 <ul>
-                  <li>The <code>radio</code> button that is checked, or if no <code>radio</code> button is checked the first <code>radio</code> button in the radio group.</li>
+                  <li>The <code>radio</code> button that is checked or, if no <code>radio</code> button is checked, the first <code>radio</code> button in the radio group.</li>
                   <li>See <a href="../../../#kbd_roving_tabindex">roving tabindex</a> for more information</li>
-                 </ul>
-            </td>
-          </tr>
-          <tr>
-            <td></td>
-            <th scope="row"><code>aria-checked=&quot;false&quot;</code></th>
-            <td><code>div</code></td>
-            <td>
-                <ul>
-                  <li>Indentifies the <code>radio</code> button is <strong>not</strong> checked.</li>
-                  <li>CSS attribute selectors (e.g. <code>[aria-checked=&quot;false&quot;]</code>) are used to synchornize the visual states with the value of the <code>aria-checked</code> attribute.</li>
-                  <li>The CSS <code>:before</code> psuedo selector and the <code>content</code> property is used to indcate visual state of unchecked to support high contrast setting in operating systems and browsers.</li>
                 </ul>
-            </td>
-          </tr>
-          <tr>
-            <td></td>
-            <th scope="row"><code>aria-checked=&quot;true&quot;</code></th>
-            <td><code>div</code></td>
-            <td>
+              </td>
+            </tr>
+            <tr>
+              <td></td>
+              <th scope="row"><code>aria-checked="false"</code></th>
+              <td><code>div</code></td>
+              <td>
                 <ul>
-                  <li>Indentifies the <code>radio</code> button is checked.</li>
-                  <li>CSS attribute selectors (e.g. <code>[aria-checked=&quot;true&quot;]</code>) are used to synchornize the visual states with the value of the <code>aria-checked</code> attribute.</li>
-                  <li>The CSS <code>:before</code> psuedo selector and the <code>content</code> property is used to indcate visual state of checked to support high contrast setting in operating systems and browsers.</li>
+                  <li>Indentifies <code>radio</code> buttons which are not checked.</li>
+                  <li>CSS attribute selectors (e.g. <code>[aria-checked="false"]</code>) are used to synchornize the visual states with the value of the <code>aria-checked</code> attribute.</li>
+                  <li>The CSS <code>::before</code> pseudo-class is used to indcate visual state of unchecked radio buttons to support high contrast settings in operating systems and browsers.</li>
                 </ul>
-            </td>
-          </tr>
-        </tbody>
-      </table>
+              </td>
+            </tr>
+            <tr>
+              <td></td>
+              <th scope="row"><code>aria-checked="true"</code></th>
+              <td><code>div</code></td>
+              <td>
+                <ul>
+                  <li>Indentifies the <code>radio</code> button which is checked.</li>
+                  <li>CSS attribute selectors (e.g. <code>[aria-checked="true"]</code>) are used to synchornize the visual states with the value of the <code>aria-checked</code> attribute.</li>
+                  <li>The CSS <code>::before</code> pseudo-class is used to indcate visual state of checked radio buttons to support high contrast settings in operating systems and browsers.</li>
+                </ul>
+              </td>
+            </tr>
+          </tbody>
+        </table>
 
       </section>
 
       <section>
         <h2>Javascript and CSS Source Code</h2>
         <ul>
-            <li>CSS: <a href="../css/radio.css" type="tex/css">radio.css</a></li>
-            <li>Javascript: <a href="js/radioGroup.js" type="text/javascript">radioGroup.js</a></li>
-            <li>Javascript: <a href="js/radioButton.js" type="text/javascript">radioButton.js</a></li>
+          <li>CSS: <a href="../css/radio.css">radio.css</a></li>
+          <li>Javascript: <a href="js/radioGroup.js">radioGroup.js</a></li>
+          <li>Javascript: <a href="js/radioButton.js">radioButton.js</a></li>
         </ul>
       </section>
 
@@ -258,7 +246,7 @@
           The following script will show the reader the HTML source for the example that is in the div with ID 'ex1'.
           It renders the HTML in the preceding div with ID 'sc1'.
           If you change the ID of either the 'ex1' div or the 'sc1' div, be sure to update the sourceCode.add function parameters.
-          -->
+        -->
         <script>
           sourceCode.add('sc1', 'ex1');
           sourceCode.make();
@@ -266,7 +254,7 @@
       </section>
     </main>
     <nav>
-      <a href="../../../#radiobutton"> Radio Button Design Pattern in WAI-ARIA Authoring Practices 1.1</a>
+      <a href="../../../#radiobutton">Radio Group Design Pattern in WAI-ARIA Authoring Practices 1.1</a>
     </nav>
   </body>
 </html>


### PR DESCRIPTION
I noticed some grammar errors in this example and tried to correct them. The indentation of code was also fixed.

When I find the time, I try to have a more focused look at the example (and potentially others) and see whether they need any care.