### PR TITLE
Fix Grid Layout Instructions

### DIFF
--- a/examples/grid/js/layoutGrids.js
+++ b/examples/grid/js/layoutGrids.js
@@ -29,31 +29,24 @@ window.addEventListener('load', function () {
 
   var gridNUX = document.getElementById('grid-nux');
   var firstGridCell = document.querySelector('#ex1 [tabindex="0"]');
-  firstGridCell.addEventListener(
-    'focus',
-    function () {
-      aria.Utils.removeClass(gridNUX, 'hidden');
-    },
-    {
-      once: true
-    }
-  );
-
   var NUXclose = document.getElementById('close-nux-button');
   var closeNUX = function () {
     aria.Utils.addClass(gridNUX, 'hidden');
-    try {
-      firstGridCell.focus();
-    }
-    catch (error) { }
+    firstGridCell.focus();
   };
-  NUXclose.addEventListener('click', closeNUX);
-  NUXclose.addEventListener('keyup', function (event) {
-    var key = event.which || event.keyCode;
-    if (key === aria.KeyCode.RETURN) {
-      closeNUX();
-    }
-  });
+  var setupInstructions = function () {
+    firstGridCell.removeEventListener('focus', setupInstructions);
+    aria.Utils.removeClass(gridNUX, 'hidden');
+
+    NUXclose.addEventListener('click', closeNUX);
+    NUXclose.addEventListener('keyup', function (event) {
+      if (event.which === aria.KeyCode.RETURN) {
+        closeNUX();
+      }
+    });
+  };
+
+  firstGridCell.addEventListener('focus', setupInstructions);
 });
 
 function PillList (grid, input, submitButton, formUpdateText) {


### PR DESCRIPTION
Fix #531 issue with NUX instructions not closing as expected with IE11.

A loop was created on focus, where the instructions where displayed and then dismissing the instructions set focus to the element that displayed the instructions on focus. This happened because the `once` option was used for the event listener, which is not supported in IE11.

Created an event listener that, when fired, removed the event listener and setup the instructions and close listeners/ handlers.

Tested with IE11 on Win7 and Win8, as well as Chrome/ Safari/ Firefox on Safari.