### PR TITLE
Escape html tags inside comments in examples

### DIFF
--- a/examples/js/examples.js
+++ b/examples/js/examples.js
@@ -166,7 +166,8 @@ aria.widget.SourceCode.prototype.createCode = function (location, spaces, node, 
       case Node.COMMENT_NODE:
 
         if (hasText(n.nodeValue)) {
-          location.innerHTML = location.innerHTML  + '<br/>' + spaces + '&nbsp;&nbsp;' + '&lt;--&nbsp;&nbsp;' + n.nodeValue + '--&gt;';
+          s = cleanText(n.nodeValue);
+          location.innerHTML = location.innerHTML  + '<br/>' + spaces + '&nbsp;&nbsp;' + '&lt;--&nbsp;&nbsp;' + s + '&nbsp;&nbsp;--&gt;';
         }
         count++;
         break;


### PR DESCRIPTION
Right now when a HTML tag is used in a comment it is not escaped when the example is rendered by example.js
Causing a bug on http://w3c.github.io/aria-practices/examples/accordion/accordion.html where is renders to dl-elements in the example code.