### PR TITLE
chore: Update ESLint task globbing and autofix

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,7 +1,4 @@
 **/*.min.js
+common/
 examples/landmarks/js/visua11y.js
-examples/landmarks/js/SkipTo.min.js
-examples/landmarks/js/bootstrap-accessibility.min.js
-examples/landmarks/js/bootstrap.min.js
-examples/landmarks/js/jquery-2.1.1.min.js
 examples/js/highlight.pack.js

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "example": "examples"
   },
   "scripts": {
-    "fix": "eslint --fix bin examples",
-    "lint": "eslint bin examples",
+    "fix": "eslint --fix .",
+    "lint": "eslint .",
     "test": "npm run lint"
   },
   "repository": {

--- a/respec-config.js
+++ b/respec-config.js
@@ -11,7 +11,7 @@ var respecConfig = {
   // publishDate: "2013-08-22",
   noRecTrack: true,
   diffTool: 'http://www.aptest.com/standards/htmldiff/htmldiff.pl',
-  license: "w3c-software-doc",
+  license: 'w3c-software-doc',
 
   // The specifications short name, as in http://www.w3.org/TR/short-name/
   shortName: 'wai-aria-practices-1.1',
@@ -150,5 +150,5 @@ var respecConfig = {
 
   localBiblio: biblio,
 
-  preProcess: [linkCrossReferences]
+  preProcess: [ linkCrossReferences ]
 };


### PR DESCRIPTION
Just noticed that the globbing that ESLint wasn't catching everything. There is already a `.eslintigore` file to exclude third party files that should be excluded.
Ran the `fix` target to apply the formatting after extending the glob pattern.