### PR TITLE
Correct text error "withthe" should be "with the"

### DIFF
--- a/aria-practices.html
+++ b/aria-practices.html
@@ -1636,7 +1636,7 @@
         <h4>Examples</h4>
         <ul>
           <li><a href="examples/listbox/listbox-scrollable.html">Scrollable Listbox Example</a>: Single-select listbox that scrolls to reveal more options, similar to HTML <code>select</code> with <code>size</code> attribute greater than one.</li>
-          <li><a href="examples/listbox/listbox-collapsible.html">Collapsible Dropdown Listbox Example</a>: Single-select collapsible listbox that expands when activated, similar to HTML <code>select</code> withthe attribute <code>size=&quot;1&quot;</code>.</li>
+          <li><a href="examples/listbox/listbox-collapsible.html">Collapsible Dropdown Listbox Example</a>: Single-select collapsible listbox that expands when activated, similar to HTML <code>select</code> with the attribute <code>size=&quot;1&quot;</code>.</li>
           <li><a href="examples/listbox/listbox-rearrangeable.html">Example Listboxes with Rearrangeable Options</a>: Examples of both single-select and multi-select listboxes with accompanying toolbars where options can be added, moved, and removed.</li>
         </ul>
       </section>

--- a/examples/listbox/listbox-collapsible.html
+++ b/examples/listbox/listbox-collapsible.html
@@ -35,7 +35,7 @@
   <p>
     The following example implementation of the
     <a href="../../#Listbox">design pattern for listbox</a>
-    demonstrates a collapsible single-select listbox widget that is functionally similar to an HTML <code>select</code> input withthe the attribute <code>size=&quot;1&quot;</code>.
+    demonstrates a collapsible single-select listbox widget that is functionally similar to an HTML <code>select</code> input with the the attribute <code>size=&quot;1&quot;</code>.
     The widget consists of a button that triggers the display of a listbox.
     In its default state, the widget is collapsed (the listbox is not visible)  and the button label shows the currently selected option from the listbox.
     When the button is activated, the listbox is displayed and the current option is focused and selected.

--- a/examples/listbox/listbox-rearrangeable.html
+++ b/examples/listbox/listbox-rearrangeable.html
@@ -43,7 +43,7 @@ while in the second example, they may select multiple options before activating 
   <p>Similar examples include:</p>
   <ul>
     <li><a href="listbox-scrollable.html">Scrollable Listbox Example</a>: Single-select listbox that scrolls to reveal more options, similar to HTML <code>select</code> with <code>size</code> attribute greater than one.</li>
-    <li><a href="listbox-collapsible.html">Collapsible Dropdown Listbox Example</a>: Single-select collapsible listbox that expands when activated, similar to HTML <code>select</code> withthe attribute <code>size=&quot;1&quot;</code>.</li>
+    <li><a href="listbox-collapsible.html">Collapsible Dropdown Listbox Example</a>: Single-select collapsible listbox that expands when activated, similar to HTML <code>select</code> with the attribute <code>size=&quot;1&quot;</code>.</li>
   </ul>
   <section>
     <h2>Examples</h2>

--- a/examples/listbox/listbox-scrollable.html
+++ b/examples/listbox/listbox-scrollable.html
@@ -36,7 +36,7 @@
   <p>Similar examples include:</p>
   <ul>
     <li><a href="listbox-rearrangeable.html">Example Listboxes with Rearrangeable Options</a>: Examples of both single-select and multi-select listboxes with accompanying toolbars where options can be added, moved, and removed.</li>
-    <li><a href="listbox-collapsible.html">Collapsible Dropdown Listbox Example</a>: Single-select collapsible listbox that expands when activated, similar to HTML <code>select</code> withthe attribute <code>size=&quot;1&quot;</code>.</li>
+    <li><a href="listbox-collapsible.html">Collapsible Dropdown Listbox Example</a>: Single-select collapsible listbox that expands when activated, similar to HTML <code>select</code> with the attribute <code>size=&quot;1&quot;</code>.</li>
   </ul>
   <section>
     <h2 id="ex_label">Example</h2>


### PR DESCRIPTION
Fixes a minor text error I encountered while reading the modified files. The text "withthe" should be "with the".

Hope you don't mind the patch. Love the site and work, very helpful!