### PR TITLE
Clarify wrap direction when using left arrow

### DIFF
--- a/aria-practices.html
+++ b/aria-practices.html
@@ -1836,7 +1836,7 @@
           </li>
           <li><kbd>Left Arrow</kbd>:
             <ul>
-              <li>When focus is in a <code>menubar</code>, moves focus to the previous item, optionally wrapping from the last to the first.</li>
+              <li>When focus is in a <code>menubar</code>, moves focus to the previous item, optionally wrapping from the first to the last.</li>
               <li>When focus is in a submenu of an item in a <code>menu</code>, closes the submenu and returns focus to the parent <code>menuitem</code>.</li>
               <li>When focus is in a submenu of an item in a <code>menubar</code>, performs the following 3 actions:
                 <ol>


### PR DESCRIPTION
The "wrapping from the last to the first" text is the same for both the right and left arrow instructions. It seems more clear to specify "first to last" when using the left arrow.