### PR TITLE
Tabs Pattern: Clarify where focus should go when deleting tabs to fix issue 602

### DIFF
--- a/aria-practices.html
+++ b/aria-practices.html
@@ -2391,15 +2391,17 @@
           <li>When focus is on a tab in a tablist with either horizontal or vertical orientation:
             <ul>
               <li><kbd>Space or Enter</kbd>: Activates the tab if it was not activated automatically on focus.</li>
-              <li><kbd>Home</kbd> (Optional): Moves focus to the first tab</li>
-              <li><kbd>End</kbd> (Optional): Moves focus to the last tab.</li>
+              <li><kbd>Home</kbd> (Optional): Moves focus to the first tab. Optionally, activates the newly focused tab (See note below).</li>
+              <li><kbd>End</kbd> (Optional): Moves focus to the last tab. Optionally, activates the newly focused tab (See note below).</li>
               <li><kbd>Shift + F10</kbd>: If the tab has an associated pop-up menu, opens the menu. </li>
               <li>
                 <kbd>Delete</kbd> (Optional): If deletion is allowed, deletes (closes) the current tab element and its associated tab panel, 
-                sets focus to the tab following the tab that was closed, and activates the newly focused tab. If there is no following tab then
-                sets focus to the previous tab to the tab that was closed and activates it. If the user can close all the tabs 
-                then the application must decide where to move focus.
-                Alternatively, or in addition, the delete function is available in a context menu.
+                sets focus on the tab following the tab that was closed, and optionally activates the newly focused tab. If there is not a tab that followed the tab that was deleted,
+                e.g., the deleted tab was the right-most tab in a left-to-right horizontal tab list,
+                sets focus on and optionally activates the tab that preceded the deleted tab.
+                 If the application allows all tabs to be deleted, and the user deletes the last remaining tab in the tab list,
+                the application moves focus to another element that provides a logical work flow.
+                As an alternative to <kbd>Delete</kbd>, or in addition to supporting <kbd>Delete</kbd>, the delete function is available in a context menu.
               </li>
             </ul>
           </li>

--- a/aria-practices.html
+++ b/aria-practices.html
@@ -2397,8 +2397,8 @@
               <li>
                 <kbd>Delete</kbd> (Optional): If deletion is allowed, deletes (closes) the current tab element and its associated tab panel, 
                 sets focus to the tab following the tab that was closed, and activates the newly focused tab. If there is no following tab then
-                sets focus to the previous tab to the tab that was close and activates it. If the user can close all the tabs 
-                then the application must decide where to mocve focus.
+                sets focus to the previous tab to the tab that was closed and activates it. If the user can close all the tabs 
+                then the application must decide where to move focus.
                 Alternatively, or in addition, the delete function is available in a context menu.
               </li>
             </ul>

--- a/aria-practices.html
+++ b/aria-practices.html
@@ -2395,8 +2395,10 @@
               <li><kbd>End</kbd> (Optional): Moves focus to the last tab.</li>
               <li><kbd>Shift + F10</kbd>: If the tab has an associated pop-up menu, opens the menu. </li>
               <li>
-                <kbd>Delete</kbd> (Optional): If deletion is allowed, deletes (closes) the current tab element and its associated tab panel.
-                If any tabs remain, sets focus to the tab following the tab that was closed and activates the newly focused tab.
+                <kbd>Delete</kbd> (Optional): If deletion is allowed, deletes (closes) the current tab element and its associated tab panel, 
+                sets focus to the tab following the tab that was closed, and activates the newly focused tab. If there is no following tab then
+                sets focus to the previous tab to the tab that was close and activates it. If the user can close all the tabs 
+                then the application must decide where to mocve focus.
                 Alternatively, or in addition, the delete function is available in a context menu.
               </li>
             </ul>


### PR DESCRIPTION
Fix for #602. Please review


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria-practices/pull/683.html" title="Last updated on Jun 14, 2018, 10:20 PM GMT (8c19170)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria-practices/683/398d711...8c19170.html" title="Last updated on Jun 14, 2018, 10:20 PM GMT (8c19170)">Diff</a>