### PR TITLE
Navigation Menubar Example: Update structure to have parent/child relationships between parent menus and submenus

### DIFF
--- a/examples/menubar/menubar-1/css/menubarLinks.css
+++ b/examples/menubar/menubar-1/css/menubarLinks.css
@@ -62,6 +62,7 @@ ul[role="menubar"] [role="menuitem"] > [role="menu"] {
   padding: 0;
   position: absolute;
   top: 2.5em;
+  left: -0.25em;
 }
 
 ul[role="menubar"] [role="menuitem"] > [role="menu"] [role="menu"] {

--- a/examples/menubar/menubar-1/css/menubarLinks.css
+++ b/examples/menubar/menubar-1/css/menubarLinks.css
@@ -6,66 +6,97 @@ ul[role="menubar"] {
   background-color: #EEEEEE;
 }
 
+ul[role="menubar"] [role="menuitem"] {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  padding: 0.25em;
+  padding-left: 0.5em;
+  padding-right: 0.5em;
+  text-decoration: none;
+  color: black;
+}
+
 ul[role="menubar"] [role="menuitem"],
 ul[role="menubar"] [role="separator"] {
+  margin: 0;
   padding: 0.25em;
   background-color: #EEEEEE;
   border: 2px solid #EEEEEE;
 }
 
-ul[role="menubar"] [role="separator"] {
+
+ul[role="menubar"] [role="menuitem"] > a {
+  text-decoration: none;
+  color: black;
+  border: none;
+}
+
+ul[role="menubar"] > [role="menuitem"] > a {
+  margin-right: 0.5em;
+}
+
+ul[role="menubar"] [role="menu"] [role="menuitem"] {
+  width: 10em;
+}
+
+ul[role="menubar"] [role="menu"] [role="separator"] {
   padding-top: 0.15em;
   background-image: url('../images/separator.png');
   background-position: center;
   background-repeat: repeat-x;
 }
 
-ul[role="menubar"] [role="menuitem"]:focus,
-ul[role="menubar"] [role="menuitem"]:hover,
-ul[role="menubar"] [role="separator"]:focus,
-ul[role="menubar"] [role="separator"]:hover {
-  background-color: black;
-  color: white;
-}
-
-ul[role="menubar"] a[role="menuitem"] {
-  text-decoration: none;
-  color: black;
-}
-
-ul[role="menubar"] li {
+ul[role="menubar"] ul {
   list-style: none;
   margin: 0;
   padding: 0;
 }
 
-ul[role="menubar"] > li {
-  display: inline;
-  position: relative;
-}
-
-ul[role="menubar"] > li > a:after {
-  content: url('../images/down-arrow-brown.png');
-  padding-left: .25em;
-}
-
-
-ul[role="menubar"] ul[role="menu"] {
-  display: none;
-  position: absolute;
-  top: -2px;
-  left: 0;
-  margin: 0;
-  padding: 0;
-}
-
-
-ul[role="menubar"] ul[role="menu"] li a {
-  display: block;
+ul[role="menubar"] [role="menu"] [role="menuitem"] {
   width: 10em;
 }
 
-ul[role="menubar"] ul[role="menu"] a[aria-haspopup="true"]:after {
+ul[role="menubar"] [role="menuitem"] > [role="menu"] {
+  margin: 0;
+  padding: 0;
+  position: absolute;
+  top: 2.5em;
+}
+
+ul[role="menubar"] [role="menuitem"] > [role="menu"] [role="menu"] {
+  margin: 0;
+  padding: 0;
+  position: absolute;
+  top: 0em;
+  left: 10.5em;
+}
+
+ul[role="menubar"] [role="menuitem"][aria-expanded="false"] > [role="menu"] {
+  display: none;
+}
+
+ul[role="menubar"] [role="menuitem"][aria-expanded="true"] > [role="menu"] {
+  display: block;
+}
+
+ul[role="menubar"] [role="menuitem"]:focus,
+ul[role="menubar"] [role="menuitem"]:focus > a,
+ul[role="menubar"] [role="menuitem"]:hover,
+ul[role="menubar"] [role="menuitem"]:hover > a,
+ul[role="menubar"] [role="separator"]:focus,
+ul[role="menubar"] [role="separator"]:hover {
+  background-color: #222;
+  color: white;
+}
+
+
+ul[role="menubar"] > [role="menuitem"] [role="menu"] [role="menuitem"][aria-haspopup="true"] > a:after {
   content: url('../images/right-arrow-brown.png');
   padding-right: 2em;
+}
+
+ul[role="menubar"] > [role="menuitem"] [role="menu"] [role="menuitem"][aria-haspopup="true"][aria-expanded="true"] > a:after {
+  content: url('../images/down-arrow-brown.png');
+  padding-left: .25em;
 }

--- a/examples/menubar/menubar-1/js/MenubarItemLinks.js
+++ b/examples/menubar/menubar-1/js/MenubarItemLinks.js
@@ -6,6 +6,8 @@ var MenubarItem = function (domNode, menuObj) {
 
   this.menu = menuObj;
   this.domNode = domNode;
+  this.linkElem = false;
+
   this.popupMenu = false;
 
   this.hasFocus = false;
@@ -38,12 +40,20 @@ MenubarItem.prototype.init = function () {
   this.domNode.addEventListener('mouseover', this.handleMouseover.bind(this));
   this.domNode.addEventListener('mouseout', this.handleMouseout.bind(this));
 
+  // check to see if the the menu item has a child
+  var elem = this.domNode.firstElementChild;
+
+  if (elem && elem.tagName === 'A') {
+    elem.tabIndex = -1;
+    this.linkElem = elem;
+  }
+
   // Initialize pop up menus
 
-  var nextElement = this.domNode.nextElementSibling;
+  var menuElement = this.domNode.querySelector('[role="menu"]');
 
-  if (nextElement && nextElement.tagName === 'UL') {
-    this.popupMenu = new PopupMenu(nextElement, this);
+  if (menuElement) {
+    this.popupMenu = new PopupMenu(menuElement, this);
     this.popupMenu.init();
   }
 

--- a/examples/menubar/menubar-1/js/MenubarItemLinks.js
+++ b/examples/menubar/menubar-1/js/MenubarItemLinks.js
@@ -71,12 +71,26 @@ MenubarItem.prototype.handleKeydown = function (event) {
 
   switch (event.keyCode) {
     case this.keyCode.SPACE:
-    case this.keyCode.RETURN:
     case this.keyCode.DOWN:
       if (this.popupMenu) {
         this.popupMenu.open();
         this.popupMenu.setFocusToFirstItem();
         flag = true;
+      }
+      break;
+
+    case this.keyCode.RETURN:
+      var anchor = tgt.firstElementChild;
+      if (anchor && anchor.href) {
+        window.location.href = anchor.href;
+        flag = true;
+      }
+      else {
+        if (this.popupMenu) {
+          this.popupMenu.open();
+          this.popupMenu.setFocusToFirstItem();
+          flag = true;
+        }
       }
       break;
 

--- a/examples/menubar/menubar-1/js/MenubarLinks.js
+++ b/examples/menubar/menubar-1/js/MenubarLinks.js
@@ -55,16 +55,15 @@ Menubar.prototype.init = function () {
 
   // Traverse the element children of menubarNode: configure each with
   // menuitem role behavior and store reference in menuitems array.
-  elem = this.domNode.firstElementChild;
+  var elem = this.domNode.firstElementChild;
 
   while (elem) {
-    var menuElement = elem.firstElementChild;
 
-    if (elem && menuElement && menuElement.tagName === 'A') {
-      menubarItem = new MenubarItem(menuElement, this);
+    if (elem.getAttribute('role') === 'menuitem') {
+      menubarItem = new MenubarItem(elem, this);
       menubarItem.init();
       this.menubarItems.push(menubarItem);
-      textContent = menuElement.textContent.trim();
+      textContent = elem.firstElementChild.textContent.trim();
       this.firstChars.push(textContent.substring(0, 1).toLowerCase());
     }
 

--- a/examples/menubar/menubar-1/js/PopupMenuItemLinks.js
+++ b/examples/menubar/menubar-1/js/PopupMenuItemLinks.js
@@ -10,6 +10,7 @@ var MenuItem = function (domNode, menuObj) {
 
   this.domNode = domNode;
   this.menu = menuObj;
+  this.linkElem = false;
   this.popupMenu = false;
   this.isMenubarItem = false;
 
@@ -39,12 +40,20 @@ MenuItem.prototype.init = function () {
   this.domNode.addEventListener('mouseover', this.handleMouseover.bind(this));
   this.domNode.addEventListener('mouseout', this.handleMouseout.bind(this));
 
+  // check to see if the the menu item has a child
+  var elem = this.domNode.firstElementChild;
+
+  if (elem && elem.tagName === 'A') {
+    elem.tabIndex = -1;
+    this.linkElem = elem;
+  }
+
   // Initialize flyout menu
 
-  var nextElement = this.domNode.nextElementSibling;
+  var menuElement = this.domNode.querySelector('[role="menu"]');
 
-  if (nextElement && nextElement.tagName === 'UL') {
-    this.popupMenu = new PopupMenu(nextElement, this);
+  if (menuElement) {
+    this.popupMenu = new PopupMenu(menuElement, this);
     this.popupMenu.init();
   }
 
@@ -91,7 +100,7 @@ MenuItem.prototype.handleKeydown = function (event) {
             clickEvent.initEvent('click', true, true);
           }
         }
-        tgt.dispatchEvent(clickEvent);
+        tgt.firstElementChild.dispatchEvent(clickEvent);
       }
 
       flag = true;
@@ -114,7 +123,6 @@ MenuItem.prototype.handleKeydown = function (event) {
       break;
 
     case this.keyCode.RIGHT:
-      console.log('[MenuItem][handleKeydown]: ' + this.menu.controller.isMenubarItem);
       if (this.popupMenu) {
         this.popupMenu.open();
         this.popupMenu.setFocusToFirstItem();

--- a/examples/menubar/menubar-1/js/PopupMenuItemLinks.js
+++ b/examples/menubar/menubar-1/js/PopupMenuItemLinks.js
@@ -77,7 +77,6 @@ MenuItem.prototype.handleKeydown = function (event) {
 
   switch (event.keyCode) {
     case this.keyCode.SPACE:
-    case this.keyCode.RETURN:
       if (this.popupMenu) {
         this.popupMenu.open();
         this.popupMenu.setFocusToFirstItem();
@@ -104,6 +103,21 @@ MenuItem.prototype.handleKeydown = function (event) {
       }
 
       flag = true;
+      break;
+
+    case this.keyCode.RETURN:
+      var anchor = tgt.firstElementChild;
+      if (anchor && anchor.href) {
+        window.location.href = anchor.href;
+        flag = true;
+      }
+      else {
+        if (this.popupMenu) {
+          this.popupMenu.open();
+          this.popupMenu.setFocusToFirstItem();
+          flag = true;
+        }
+      }
       break;
 
     case this.keyCode.UP:

--- a/examples/menubar/menubar-1/js/PopupMenuLinks.js
+++ b/examples/menubar/menubar-1/js/PopupMenuLinks.js
@@ -60,9 +60,19 @@ PopupMenu.prototype.init = function () {
   childElement = this.domNode.firstElementChild;
 
   while (childElement) {
-    menuElement = childElement.firstElementChild;
+    menuElement = false;
 
-    if (menuElement && menuElement.tagName === 'A') {
+    if (childElement.getAttribute('role') === 'menuitem') {
+      menuElement = childElement;
+    }
+    else {
+      if (childElement.firstElementChild &&
+          childElement.firstElementChild.getAttribute('role') === 'menuitem') {
+        menuElement = childElement.firstElementChild;
+      }
+    }
+
+    if (menuElement) {
       menuItem = new MenuItem(menuElement, this);
       menuItem.init();
       this.menuitems.push(menuItem);
@@ -211,32 +221,12 @@ PopupMenu.prototype.getIndexFirstChars = function (startIndex, char) {
 
 PopupMenu.prototype.open = function () {
   // Get position and bounding rectangle of controller object's DOM node
-  var rect = this.controller.domNode.getBoundingClientRect();
-
-  console.log('[PopupMenu][open]');
-
-  // Set CSS properties
-  if (!this.controller.isMenubarItem) {
-    this.domNode.parentNode.style.position = 'relative';
-    this.domNode.style.display = 'block';
-    this.domNode.style.position = 'absolute';
-    this.domNode.style.left = rect.width + 'px';
-    this.domNode.style.zIndex = 100;
-  }
-  else {
-    this.domNode.style.display = 'block';
-    this.domNode.style.position = 'absolute';
-    this.domNode.style.top = (rect.height - 1) + 'px';
-    this.domNode.style.zIndex = 100;
-  }
 
   this.controller.setExpanded(true);
 
 };
 
 PopupMenu.prototype.close = function (force) {
-
-  console.log('[PopupMenu][close][force]: ' + force);
 
   var controllerHasHover = this.controller.hasHover;
 
@@ -249,15 +239,11 @@ PopupMenu.prototype.close = function (force) {
     }
   }
 
-  console.log('[PopupMenu][close][hasFocus]: ' + hasFocus);
-
   if (!this.controller.isMenubarItem) {
     controllerHasHover = false;
   }
 
   if (force || (!hasFocus && !this.hasHover && !controllerHasHover)) {
-    this.domNode.style.display = 'none';
-    this.domNode.style.zIndex = 0;
     this.controller.setExpanded(false);
   }
 };

--- a/examples/menubar/menubar-1/mb-about.html
+++ b/examples/menubar/menubar-1/mb-about.html
@@ -3,7 +3,11 @@
 <head>
     <title>Menubar Example Landing Page: About</title>
     <link href="../../css/core.css" rel="stylesheet">
-
+    <style>
+    h3 {
+        margin-left: 1em;
+    }
+    </style>
 </head>
 
 <body>
@@ -11,20 +15,39 @@
     <h1>Menubar Example Landing Page</h1>
     </header>
     <main>
-        <h1 id="about">About</h1>
-        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example</a>
+        <h1 id ="about">About</h1>
+        <p  href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example
 
-        <h2 id="overview">Overview</h2>
-        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example</a>
+        <h2 id ="overview">Overview</h2>
+        <p  href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example
 
-        <h2 id="admin">Administration</a></li>
-        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example</a>
+        <h2 id ="admin">Administration</h2>
+        <p  href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example
 
-        <h2 id="facts">Facts</a></li>
-        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example</a>
+        <h2 id ="facts">Facts</h2>
+        <p  href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example
 
-        <h2 id="tours">Campus Tours</a></li>
-        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example</a>
+        <h3 id ="facts-history">History</h3>
+        <p  href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example
+
+        <h3 id ="facts-stats">Current Stats</h3>
+        <p  href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example
+
+        <h3 id ="facts-awards">Awards</h3>
+        <p  href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example
+
+        <h2 id ="tours">Campus Tours</h2>
+        <p  href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example
+
+        <h3 id ="tours-student">Prospective Students</h3>
+        <p  href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example
+
+        <h3 id ="tours-alimni">Alumni</h3>
+        <p  href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example
+
+        <h3 id ="tours-visitor">Vistors</h3>
+        <p  href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example
+
 
     </main>
 </body>

--- a/examples/menubar/menubar-1/mb-about.html
+++ b/examples/menubar/menubar-1/mb-about.html
@@ -16,37 +16,37 @@
     </header>
     <main>
         <h1 id ="about">About</h1>
-        <p  href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example
+        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example</a></p>
 
         <h2 id ="overview">Overview</h2>
-        <p  href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example
+        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example</a></p>
 
         <h2 id ="admin">Administration</h2>
-        <p  href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example
+        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example</a></p>
 
         <h2 id ="facts">Facts</h2>
-        <p  href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example
+        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example</a></p>
 
         <h3 id ="facts-history">History</h3>
-        <p  href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example
+        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example</a></p>
 
         <h3 id ="facts-stats">Current Stats</h3>
-        <p  href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example
+        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example</a></p>
 
         <h3 id ="facts-awards">Awards</h3>
-        <p  href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example
+        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example</a></p>
 
         <h2 id ="tours">Campus Tours</h2>
-        <p  href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example
+        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example</a></p>
 
         <h3 id ="tours-student">Prospective Students</h3>
-        <p  href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example
+        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example</a></p>
 
         <h3 id ="tours-alimni">Alumni</h3>
-        <p  href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example
+        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example</a></p>
 
         <h3 id ="tours-visitor">Vistors</h3>
-        <p  href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example
+        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example</a></p>
 
 
     </main>

--- a/examples/menubar/menubar-1/mb-academics.html
+++ b/examples/menubar/menubar-1/mb-academics.html
@@ -13,40 +13,40 @@
 
     <main>
         <h1 id="academics">Academics</h1>
-        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example</a>
+        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example
 
         <h2 id="colleges">Colleges &amp; Schools</h2>
-        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example</a>
+        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example
 
 
         <h2 id="programs">Programs of Study</h2>
-        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example</a>
+        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example
 
 
         <h2 id="honors">Honors Programs</h2>
-        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example</a>
+        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example
 
 
         <h2 id="online">Online Courses</h2>
-        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example</a>
+        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example
 
 
         <h2 id="explorer">Course Explorer</h2>
-        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example</a>
+        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example
 
 
         <h2 id="register">Register for Class</h2>
-        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example</a>
+        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example
 
 
         <h2 id="academic">Academic Calendar</h2>
-        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example</a>
+        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example
 
 
         <h2 id="tanscripts">Transscripts</h2>
-        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example</a>
+        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example
 
     </main>
 </body>
 
-</html> 
+</html>

--- a/examples/menubar/menubar-1/mb-academics.html
+++ b/examples/menubar/menubar-1/mb-academics.html
@@ -13,38 +13,31 @@
 
     <main>
         <h1 id="academics">Academics</h1>
-        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example
+        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example</a></p>
 
         <h2 id="colleges">Colleges &amp; Schools</h2>
-        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example
-
+        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example</a></p>
 
         <h2 id="programs">Programs of Study</h2>
-        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example
-
+        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example</a></p>
 
         <h2 id="honors">Honors Programs</h2>
-        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example
-
+        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example</a></p>
 
         <h2 id="online">Online Courses</h2>
-        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example
-
+        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example</a></p>
 
         <h2 id="explorer">Course Explorer</h2>
-        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example
-
+        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example</a></p>
 
         <h2 id="register">Register for Class</h2>
-        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example
-
+        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example</a></p>
 
         <h2 id="academic">Academic Calendar</h2>
-        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example
-
+        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example</a></p>
 
         <h2 id="tanscripts">Transscripts</h2>
-        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example
+        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example</a></p>
 
     </main>
 </body>

--- a/examples/menubar/menubar-1/mb-admissions.html
+++ b/examples/menubar/menubar-1/mb-admissions.html
@@ -3,7 +3,11 @@
 <head>
     <title>Menubar Example Landing Page: Admissions</title>
     <link href="../../css/core.css" rel="stylesheet">
-
+    <style>
+    h3 {
+        margin-left: 1em;
+    }
+    </style>
 </head>
 
 <body>
@@ -12,28 +16,37 @@
     </header>
     <main>
         <h1 id="admissions">Admissions</h1>
-        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example</a>
+        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example
 
         <h2 id="apply">Apply</h2>
-        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example</a>
+        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example
 
         <h2 id="tuition">Tuition</h2>
-        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example</a>
+        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example
 
-        <h2 id="signup">Sign Up</h2>
-        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example</a>
+        <h3 id="tuition-undergrad">Undergraduate</h3>
+        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example
 
-        <h2 id="visit">Visit</h2>
-        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example</a>
+        <h3 id ="tuition-graduate">Graduate</h3>
+        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example
 
-        <h2 id="photo">Photo Tour</h2>
-        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example</a>
+        <h3 id ="tuition-professional">Professional Schools</h3>
+        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example
 
-        <h2 id="connect">Connect</h2>
-        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example</a>
- 
+        <h2 id ="signup">Sign Up</h2>
+        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example
+
+        <h2 id ="visit">Visit</h2>
+        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example
+
+        <h2 id ="photo">Photo Tour</h2>
+        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example
+
+        <h2 id ="connect">Connect</h2>
+        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example
+
 
     </main>
 </body>
 
-</html> 
+</html>

--- a/examples/menubar/menubar-1/mb-admissions.html
+++ b/examples/menubar/menubar-1/mb-admissions.html
@@ -16,34 +16,34 @@
     </header>
     <main>
         <h1 id="admissions">Admissions</h1>
-        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example
+        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example</a></p>
 
         <h2 id="apply">Apply</h2>
-        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example
+        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example</a></p>
 
         <h2 id="tuition">Tuition</h2>
-        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example
+        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example</a></p>
 
         <h3 id="tuition-undergrad">Undergraduate</h3>
-        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example
+        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example</a></p>
 
         <h3 id ="tuition-graduate">Graduate</h3>
-        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example
+        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example</a></p>
 
         <h3 id ="tuition-professional">Professional Schools</h3>
-        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example
+        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example</a></p>
 
         <h2 id ="signup">Sign Up</h2>
-        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example
+        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example</a></p>
 
         <h2 id ="visit">Visit</h2>
-        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example
+        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example</a></p>
 
         <h2 id ="photo">Photo Tour</h2>
-        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example
+        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example</a></p>
 
         <h2 id ="connect">Connect</h2>
-        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example
+        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example</a></p>
 
 
     </main>

--- a/examples/menubar/menubar-1/mb-arts.html
+++ b/examples/menubar/menubar-1/mb-arts.html
@@ -13,28 +13,28 @@
 
     <main>
         <h1 id="arts">Arts and Culture</h1>
-        <p href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example
+        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example</a></p>
 
         <h2 id="fas">College of Fine and Applied Arts</h2>
-        <p href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example</p>
+        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example</a></p>
 
         <h2 id="las">College of Liberal Arts and Sciences</h2>
-        <p href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example</p>
+        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example</a></p>
 
         <h2 id="cultural-center">Cultural Center</h2>
-        <p href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example</p>
+        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example</a></p>
 
         <h2 id="perfoming-arts">Performing Arts</h2>
-        <p href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example</p>
+        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example</a></p>
 
         <h2 id="art-museum">Art Museum</li>
-        <p href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example</p>
+        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example</a></p>
 
         <h2 id="history-museum">History Museum</h2>
-        <p href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example</p>
+        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example</a></p>
 
         <h2 id="union">Student Union</li>
-        <p href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example</p>
+        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example</a></p>
 
     </main>
 </body>

--- a/examples/menubar/menubar-1/mb-arts.html
+++ b/examples/menubar/menubar-1/mb-arts.html
@@ -13,30 +13,30 @@
 
     <main>
         <h1 id="arts">Arts and Culture</h1>
-        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example</a>
+        <p href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example
 
         <h2 id="fas">College of Fine and Applied Arts</h2>
-        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example</a></p>
+        <p href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example</p>
 
         <h2 id="las">College of Liberal Arts and Sciences</h2>
-        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example</a></p>
+        <p href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example</p>
 
         <h2 id="cultural-center">Cultural Center</h2>
-        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example</a></p>
+        <p href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example</p>
 
         <h2 id="perfoming-arts">Performing Arts</h2>
-        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example</a></p>
+        <p href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example</p>
 
-        <h2 id="art-museum">Art Museum</a></li>
-        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example</a></p>
+        <h2 id="art-museum">Art Museum</li>
+        <p href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example</p>
 
         <h2 id="history-museum">History Museum</h2>
-        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example</a></p>
+        <p href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example</p>
 
-        <h2 id="union">Student Union</a></li>
-        <p><a href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example</a></p>
+        <h2 id="union">Student Union</li>
+        <p href="menubar-1.html#code-ex-1">Back to <code>menubar</code> example</p>
 
     </main>
 </body>
 
-</html> 
+</html>

--- a/examples/menubar/menubar-1/menubar-1.html
+++ b/examples/menubar/menubar-1/menubar-1.html
@@ -50,108 +50,107 @@
     <div id="ex1">
       <nav aria-label="Mythical University">
         <ul id="menubar1" role="menubar" aria-label="Mythical University">
-          <li>
-            <a role="menuitem" aria-haspopup="true" aria-expanded="false" href="#">About</a>
+          <li role="menuitem" aria-haspopup="true" aria-expanded="false">
+            <a  href="#">About</a>
             <ul role="menu" aria-label="About">
-              <li role="none">
-                <a role="menuitem" href="mb-about.html#overview">Overview</a>
+              <li role="menuitem">
+                <a href="mb-about.html#overview">Overview</a>
               </li>
-              <li role="none">
-                <a role="menuitem" href="mb-about.html#admin">Administration</a>
+              <li role="menuitem">
+                <a href="mb-about.html#admin">Administration</a>
               </li>
-              <li role="none">
-                <a id="menubar113" role="menuitem" href="#" aria-haspopup="true" aria-expanded="false">Facts</a>
-                <ul role="menu" aria-label="Facts">
-                  <li role="none">
-                    <a role="menuitem" href="mb-about.html#facts">History</a>
-                  </li>
-                  <li role="none">
-                    <a role="menuitem" href="mb-about.html#facts">Current Statistics</a>
-                  </li>
-                  <li role="none">
-                    <a role="menuitem" href="mb-about.html#facts">Awards</a>
-                  </li>
-                </ul>
+              <li role="menuitem" tabindex="-1" aria-haspopup="true" aria-expanded="false">
+                  <a href="#">Facts</a>
+                  <ul role="menu" aria-label="Facts">
+                    <li role="menuitem">
+                      <a href="mb-about.html#facts">History</a>
+                    </li>
+                    <li role="menuitem">
+                      <a href="mb-about.html#facts">Current Statistics</a>
+                    </li>
+                    <li role="menuitem" >
+                      <a href="mb-about.html#facts">Awards</a>
+                    </li>
+                  </ul>
               </li>
-              <li>
-                <a role="menuitem" href="#" aria-haspopup="true" aria-expanded="false">Campus
-                  Tours</a>
-                <ul role="menu" aria-label="Campus Tours">
-                  <li role="none">
-                    <a role="menuitem" href="mb-about.html#tours">For prospective students</a>
-                  </li>
-                  <li role="none">
-                    <a role="menuitem" href="mb-about.html#tours">For alumni</a>
-                  </li>
-                  <li role="none">
-                    <a role="menuitem" href="mb-about.html#tours">For visitors</a>
-                  </li>
-                </ul>
+              <li role="menuitem" tabindex="-1" aria-haspopup="true" aria-expanded="false">
+                  <a href="#">Campus Tours</a>
+                  <ul role="menu" aria-label="Campus Tours">
+                    <li role="menuitem">
+                      <a href="mb-about.html#tours">For prospective students</a>
+                    </li>
+                    <li role="menuitem">
+                      <a href="mb-about.html#tours">For alumni</a>
+                    </li>
+                    <li role="menuitem">
+                      <a href="mb-about.html#tours">For visitors</a>
+                    </li>
+                  </ul>
               </li>
             </ul>
           </li>
-          <li>
-            <a role="menuitem" aria-haspopup="true" aria-expanded="false" href="#">Admissions</a>
+          <li role="menuitem" aria-haspopup="true" aria-expanded="false">
+            <a  href="#">Admissions</a>
             <ul role="menu" aria-label="Admissions">
-              <li role="none">
-                <a role="menuitem" href="mb-admissions.html#apply">Apply</a>
+              <li role="menuitem">
+                <a  href="mb-admissions.html#apply">Apply</a>
               </li>
-              <li role="none">
-                <a role="menuitem" href="#" aria-haspopup="true" aria-expanded="false">Tuition</a>
-                <ul role="menu" aria-label="Tuition Information">
-                  <li role="none">
-                    <a role="menuitem" href="mb-admissions.html#tuition">Undergraduate</a>
-                  </li>
-                  <li role="none">
-                    <a role="menuitem" href="mb-admissions.html#tuition">Graduate</a>
-                  </li>
-                  <li role="none">
-                    <a role="menuitem" href="mb-admissions.html#tuition">Professional Schools</a>
-                  </li>
-                </ul>
+              <li role="menuitem" aria-haspopup="true" aria-expanded="false">
+                  <a href="#">Tuition</a>
+                  <ul role="menu" aria-label="Tuition Information">
+                    <li role="menuitem">
+                      <a href="mb-admissions.html#tuition">Undergraduate</a>
+                    </li>
+                    <li role="menuitem">
+                      <a href="mb-admissions.html#tuition">Graduate</a>
+                    </li>
+                    <li role="menuitem">
+                      <a href="mb-admissions.html#tuition">Professional Schools</a>
+                    </li>
+                  </ul>
               </li>
-              <li role="none">
-                <a role="menuitem" href="mb-admissions.html#signup">Sign Up</a>
+              <li role="menuitem" >
+                <a href="mb-admissions.html#signup">Sign Up</a>
               </li>
               <li role="separator"></li>
-              <li role="none">
-                <a role="menuitem" href="mb-admissions.html#visit">Visit</a>
+              <li role="menuitem" >
+                <a href="mb-admissions.html#visit">Visit</a>
               </li>
-              <li role="none">
-                <a role="menuitem" href="mb-admissions.html#photo">Photo Tour</a>
+              <li role="menuitem">
+                <a href="mb-admissions.html#photo">Photo Tour</a>
               </li>
-              <li role="none">
-                <a role="menuitem" href="mb-admissions.html#connect">Connect</a>
+              <li role="menuitem">
+                <a href="mb-admissions.html#connect">Connect</a>
               </li>
             </ul>
           </li>
-          <li>
-            <a role="menuitem" aria-haspopup="true" aria-expanded="false" href="#">Academics</a>
+          <li role="menuitem" aria-haspopup="true" aria-expanded="false">
+            <a href="#">Academics</a>
             <ul role="menu" aria-label="Academics">
-              <li role="none">
-                <a role="menuitem" href="mb-academics.html#colleges">Colleges &amp; Schools</a>
+              <li role="menuitem">
+                <a href="mb-academics.html#colleges">Colleges &amp; Schools</a>
               </li>
-              <li role="none">
-                <a role="menuitem" href="mb-academics.html#programs">Programs of Study</a>
+              <li role="menuitem">
+                <a href="mb-academics.html#programs">Programs of Study</a>
               </li>
-              <li role="none">
-                <a role="menuitem" href="mb-academics.html#honors">Honors Programs</a>
+              <li role="menuitem">
+                <a href="mb-academics.html#honors">Honors Programs</a>
               </li>
-              <li role="none">
-                <a role="menuitem" href="mb-academics.html#online">Online Courses</a>
+              <li role="menuitem">
+                <a href="mb-academics.html#online">Online Courses</a>
               </li>
               <li role="separator"></li>
-              <li role="none">
-                <a role="menuitem" href="mb-academics.html#explorer">Course Explorer</a>
+              <li role="menuitem">
+                <a href="mb-academics.html#explorer">Course Explorer</a>
               </li>
-              <li role="none">
-                <a role="menuitem" href="mb-academics.html#register">Register for Class</a>
+              <li role="menuitem">
+                <a href="mb-academics.html#register">Register for Class</a>
               </li>
-              <li role="none">
-                <a role="menuitem" href="mb-academics.html#academic">Academic Calendar</a>
+              <li role="menuitem">
+                <a href="mb-academics.html#academic">Academic Calendar</a>
               </li>
-              <li role="none">
-                <a role="menuitem" href="mb-academics.html#tanscripts">Transscripts</a>
+              <li role="menuitem">
+                <a href="mb-academics.html#tanscripts">Transscripts</a>
               </li>
             </ul>
           </li>
@@ -417,12 +416,12 @@
           </th>
           <td></td>
           <td>
-            <code>a</code>
+            <code>li</code>
           </td>
           <td>
             <ul>
               <li>Identifies the element as a menu item.</li>
-              <li> The accessible name is calculated from the text content of the <code>a</code> element.</li>
+              <li> The accessible name is calculated from the text content of the <code>li</code> element.</li>
             </ul>
           </td>
         </tr>
@@ -432,10 +431,10 @@
             <code>tabindex=&quot;-1&quot;</code>
           </th>
           <td>
-            <code>a</code>
+            <code>li</code>
           </td>
           <td>
-            Makes the <code>a</code> element keyboard focusable, but <strong>not</strong> part of the tab sequence.
+            Makes the <code>li</code> element keyboard focusable, but <strong>not</strong> part of the tab sequence.
           </td>
         </tr>
         <tr>
@@ -444,7 +443,7 @@
             <code>tabindex=&quot;0&quot;</code>
           </th>
           <td>
-            <code>a</code>
+            <code>li</code>
           </td>
           <td>
             <ul>
@@ -461,7 +460,7 @@
             <code>aria-haspopup=&quot;true&quot;</code>
           </th>
           <td>
-            <code>a</code>
+            <code>li</code>
           </td>
           <td>Indicates the menuitem has a submenu.</td>
         </tr>
@@ -471,7 +470,7 @@
             <code>aria-expanded=&quot;true&quot;</code>
           </th>
           <td>
-            <code>a</code>
+            <code>li</code>
           </td>
           <td>Indicates the submenu is open.</td>
         </tr>
@@ -481,23 +480,20 @@
             <code>aria-expanded=&quot;false&quot;</code>
           </th>
           <td>
-            <code>a</code>
+            <code>li</code>
           </td>
           <td>Indicates the submenu is closed.</td>
         </tr>
         <tr>
-          <th>
-            <code>none</code>
-          </th>
           <td></td>
+          <th>
+            <code>tabindex=&quot;-1&quot;</code>
+          </th>
           <td>
-            <code>li</code>
+            <code>a</code>
           </td>
           <td>
-            <ul>
-              <li>Removes the implied <code>listitem</code> role of the <code>li</code> element.</li>
-              <li>Necessary because the parent <code>ul</code> is serving as a <code>menu</code> so the <code>li</code> elements are not in their required list context.</li>
-            </ul>
+            Rmeoves the <code>a</code> element from the tab sequence.
           </td>
         </tr>
       </tbody>
@@ -548,12 +544,12 @@
           </th>
           <td></td>
           <td>
-            <code>a</code>
+            <code>li</code>
           </td>
           <td>
             <ul>
               <li>Identifies the element as a menu item.</li>
-              <li>The accessible name is calculated from the text content of the <code>a</code> element.</li>
+              <li> The accessible name is calculated from the text content of the <code>li</code> element.</li>
             </ul>
           </td>
         </tr>
@@ -563,9 +559,28 @@
             <code>tabindex=&quot;-1&quot;</code>
           </th>
           <td>
-            <code>a</code>
+            <code>li</code>
           </td>
-          <td>Keeps the <code>a</code> element focusable but removes it from the <kbd>Tab</kbd> sequence.</td>
+          <td>
+            Makes the <code>li</code> element keyboard focusable, but <strong>not</strong> part of the tab sequence.
+          </td>
+        </tr>
+        <tr>
+          <td></td>
+          <th>
+            <code>tabindex=&quot;0&quot;</code>
+          </th>
+          <td>
+            <code>li</code>
+          </td>
+          <td>
+            <ul>
+              <li>Includes the element in the <kbd>Tab</kbd> sequence.</li>
+              <li>Only one menubar item has <code>tabindex=&quot;0&quot;</code>.</li>
+              <li>On page load, the first menubar item has <code>tabindex=&quot;0&quot;</code>.</li>
+              <li>Focus is managed using <a href="../../../#kbd_roving_tabindex">roving tabindex</a>.</li>
+            </ul>
+          </td>
         </tr>
         <tr>
           <td></td>
@@ -573,9 +588,9 @@
             <code>aria-haspopup=&quot;true&quot;</code>
           </th>
           <td>
-            <code>a</code>
+            <code>li</code>
           </td>
-          <td>Indicates the menu item has a submenu.</td>
+          <td>Indicates the menuitem has a submenu.</td>
         </tr>
         <tr>
           <td></td>
@@ -583,7 +598,7 @@
             <code>aria-expanded=&quot;true&quot;</code>
           </th>
           <td>
-            <code>a</code>
+            <code>li</code>
           </td>
           <td>Indicates the submenu is open.</td>
         </tr>
@@ -593,26 +608,23 @@
             <code>aria-expanded=&quot;false&quot;</code>
           </th>
           <td>
-            <code>a</code>
+            <code>li</code>
           </td>
           <td>Indicates the submenu is closed.</td>
         </tr>
         <tr>
-          <th>
-            <code>none</code>
-          </th>
           <td></td>
+          <th>
+            <code>tabindex=&quot;-1&quot;</code>
+          </th>
           <td>
-            <code>li</code>
+            <code>a</code>
           </td>
           <td>
-            <ul>
-              <li>Removes the implied <code>listitem</code> role of the <code>li</code> element.</li>
-              <li>Necessary because the parent <code>ul</code> is serving as a <code>menu</code> so the <code>li</code> elements are not in their required list context.</li>
-            </ul>
+            Rmeoves the <code>a</code> element from the tab sequence.
           </td>
         </tr>
-      </tbody>
+     </tbody>
     </table>
   </section>
 

--- a/examples/menubar/menubar-1/menubar-1.html
+++ b/examples/menubar/menubar-1/menubar-1.html
@@ -51,7 +51,7 @@
       <nav aria-label="Mythical University">
         <ul id="menubar1" role="menubar" aria-label="Mythical University">
           <li role="menuitem" aria-haspopup="true" aria-expanded="false">
-            <a  href="#">About</a>
+            <a  href="mb-about.html">About</a>
             <ul role="menu" aria-label="About">
               <li role="menuitem">
                 <a href="mb-about.html#overview">Overview</a>
@@ -60,56 +60,56 @@
                 <a href="mb-about.html#admin">Administration</a>
               </li>
               <li role="menuitem" tabindex="-1" aria-haspopup="true" aria-expanded="false">
-                  <a href="#">Facts</a>
+                  <a href="mb-about.html#facts">Facts</a>
                   <ul role="menu" aria-label="Facts">
                     <li role="menuitem">
-                      <a href="mb-about.html#facts">History</a>
+                      <a href="mb-about.html#facts-history">History</a>
                     </li>
                     <li role="menuitem">
-                      <a href="mb-about.html#facts">Current Statistics</a>
+                      <a href="mb-about.html#facts-stats">Current Statistics</a>
                     </li>
                     <li role="menuitem" >
-                      <a href="mb-about.html#facts">Awards</a>
+                      <a href="mb-about.html#facts-awards">Awards</a>
                     </li>
                   </ul>
               </li>
               <li role="menuitem" tabindex="-1" aria-haspopup="true" aria-expanded="false">
-                  <a href="#">Campus Tours</a>
+                  <a href="mb-about.html#tours">Campus Tours</a>
                   <ul role="menu" aria-label="Campus Tours">
                     <li role="menuitem">
-                      <a href="mb-about.html#tours">For prospective students</a>
+                      <a href="mb-about.html#tours-students">For prospective students</a>
                     </li>
                     <li role="menuitem">
-                      <a href="mb-about.html#tours">For alumni</a>
+                      <a href="mb-about.html#tours-alumni">For alumni</a>
                     </li>
                     <li role="menuitem">
-                      <a href="mb-about.html#tours">For visitors</a>
+                      <a href="mb-about.html#tours-vistor">For visitors</a>
                     </li>
                   </ul>
               </li>
             </ul>
           </li>
           <li role="menuitem" aria-haspopup="true" aria-expanded="false">
-            <a  href="#">Admissions</a>
+            <a  href="mb-admissions.html">Admissions</a>
             <ul role="menu" aria-label="Admissions">
               <li role="menuitem">
                 <a  href="mb-admissions.html#apply">Apply</a>
               </li>
               <li role="menuitem" aria-haspopup="true" aria-expanded="false">
-                  <a href="#">Tuition</a>
+                  <a href="mb-admissions.html#tuition">Tuition</a>
                   <ul role="menu" aria-label="Tuition Information">
                     <li role="menuitem">
-                      <a href="mb-admissions.html#tuition">Undergraduate</a>
+                      <a href="mb-admissions.html#tuition-undergrad">Undergraduate</a>
                     </li>
                     <li role="menuitem">
-                      <a href="mb-admissions.html#tuition">Graduate</a>
+                      <a href="mb-admissions.html#tuition-graduate">Graduate</a>
                     </li>
                     <li role="menuitem">
-                      <a href="mb-admissions.html#tuition">Professional Schools</a>
+                      <a href="mb-admissions.html#tuition-professional">Professional Schools</a>
                     </li>
                   </ul>
               </li>
-              <li role="menuitem" >
+              <li role="menuitem">
                 <a href="mb-admissions.html#signup">Sign Up</a>
               </li>
               <li role="separator"></li>
@@ -125,7 +125,7 @@
             </ul>
           </li>
           <li role="menuitem" aria-haspopup="true" aria-expanded="false">
-            <a href="#">Academics</a>
+            <a href="mb-academics.html">Academics</a>
             <ul role="menu" aria-label="Academics">
               <li role="menuitem">
                 <a href="mb-academics.html#colleges">Colleges &amp; Schools</a>
@@ -187,9 +187,19 @@
       <tbody>
         <tr>
           <th>
-            <kbd>Space</kbd><br><kbd>Enter</kbd>
+            <kbd>Space</kbd>
           </th>
           <td>Opens submenu and moves focus to first item in the submenu.</td>
+        </tr>
+        <tr>
+          <th>
+            <kbd>Enter</kbd>
+          </th>
+          <td>
+            <ul>
+              <li>Follows the link associated with the menuitem.</li>
+              <li>If no link associated with the menuitem, the enter key opens submenu and moves focus to first item in the submenu.</li>
+            </td>
         </tr>
         <tr>
           <th>
@@ -549,7 +559,7 @@
           <td>
             <ul>
               <li>Identifies the element as a menu item.</li>
-              <li> The accessible name is calculated from the text content of the <code>li</code> element.</li>
+              <li>The accessible name is calculated from the text content of the <code>li</code> element.</li>
             </ul>
           </td>
         </tr>


### PR DESCRIPTION
Updated the code and CSS to support the parent child relationships for menus and sub-menus.

Note that the memuitem role has been moved from anchor elements to the listitem elements

I also added the feature requested in issue 159 that the expandable menuitem can also be links.

