### PR TITLE
Editor Menubar Example: Add notes about hover and focus movement

### DIFF
--- a/aria-practices.html
+++ b/aria-practices.html
@@ -2393,13 +2393,17 @@
           <li>When focus is on a tab in a tablist with either horizontal or vertical orientation:
             <ul>
               <li><kbd>Space or Enter</kbd>: Activates the tab if it was not activated automatically on focus.</li>
-              <li><kbd>Home</kbd> (Optional): Moves focus to the first tab</li>
-              <li><kbd>End</kbd> (Optional): Moves focus to the last tab.</li>
+              <li><kbd>Home</kbd> (Optional): Moves focus to the first tab. Optionally, activates the newly focused tab (See note below).</li>
+              <li><kbd>End</kbd> (Optional): Moves focus to the last tab. Optionally, activates the newly focused tab (See note below).</li>
               <li><kbd>Shift + F10</kbd>: If the tab has an associated pop-up menu, opens the menu. </li>
               <li>
-                <kbd>Delete</kbd> (Optional): If deletion is allowed, deletes (closes) the current tab element and its associated tab panel.
-                If any tabs remain, sets focus to the tab following the tab that was closed and activates the newly focused tab.
-                Alternatively, or in addition, the delete function is available in a context menu.
+                <kbd>Delete</kbd> (Optional): If deletion is allowed, deletes (closes) the current tab element and its associated tab panel, 
+                sets focus on the tab following the tab that was closed, and optionally activates the newly focused tab. If there is not a tab that followed the tab that was deleted,
+                e.g., the deleted tab was the right-most tab in a left-to-right horizontal tab list,
+                sets focus on and optionally activates the tab that preceded the deleted tab.
+                 If the application allows all tabs to be deleted, and the user deletes the last remaining tab in the tab list,
+                the application moves focus to another element that provides a logical work flow.
+                As an alternative to <kbd>Delete</kbd>, or in addition to supporting <kbd>Delete</kbd>, the delete function is available in a context menu.
               </li>
             </ul>
           </li>

--- a/aria-practices.html
+++ b/aria-practices.html
@@ -1227,7 +1227,7 @@
 
     <section class="widget" id="grid">
       <h3>Grids : Interactive Tabular Data and Layout Containers</h3>
-      
+
       <p>
         A <a href="#grid" class="role-reference">grid</a> widget is a container that enables users to navigate the information or interactive elements it contains using directional navigation keys, such as arrow keys, <kbd>Home</kbd> , and <kbd>End</kbd>.
         As a generic container widget that offers flexible keyboard navigation, it can serve a wide variety of needs.
@@ -2290,7 +2290,7 @@
         If the number of widgets is large, replacing the table with a grid can dramatically reduce the length of the page tab sequence because a grid is a composite widget that can contain other widgets.
       </p>
       <p class="note">
-        As with other WAI-ARIA roles that have a native host language equivalent, 
+        As with other WAI-ARIA roles that have a native host language equivalent,
         authors are strongly encouraged to use a native HTML <code>table</code> element whenever possible.
         This is especially important with role <code>table</code> because it is a new feature of WAI-ARIA 1.1.
         It is thus advisable to test implementations thoroughly with each browser and assistive technology combination that could be used by the target audience.
@@ -2509,7 +2509,7 @@
       <h3>Tooltip Widget</h3>
       <p>
         <strong>NOTE:</strong> This design pattern is work in progress; it does not yet have task force consensus.
-        Progress and discussions are captured in 
+        Progress and discussions are captured in
         <a href="https://github.com/w3c/aria-practices/issues/128">issue 128.</a>
       </p>
       <p>
@@ -2736,6 +2736,244 @@
         </p>
       </section>
     </section>
+
+    <section class="widget" id="treegrid">
+      <h3>Treegrid</h3>
+        <p>
+          A <a href="#treegrid" class="role-reference">treegrid</a> widget presents a hierarchical data grid consisting of tabular information that is editable or interactive.
+          Any row in the hierarchy may have child rows, and rows with children may be expanded or collapsed to show or hide the children.
+          For example, a hierarchical e-mail discussion list uses a <code>treegrid</code> to display messages and responses to that message, a message row with responses can be expanded to reveal the response messages.
+        </p>
+        <p>
+          In a treegrid both rows and cells are focusable.  Every row and cell contains a focusable element or is itself focusable, regardless of whether individual cell content is editable or interactive.
+          There is one exception: if column cells do not provide functions, such as sort or filter, they do not need to be focusable.
+          One reason it is important for all cells to be able to receive or contain keyboard focus is that screen readers will typically be in their application reading mode, rather than their document reading mode, when users are interacting with the grid.
+          While in application mode, a screen reader user hears only focusable elements and content that labels focusable elements.
+          So, screen reader users may unknowingly overlook elements contained in a <code>treegrid</code> that are either not focusable or not used to label a column or row.
+        </p>
+      <p>
+        When using a keyboard to navigate a <code>treegrid</code>, a visual keyboard indicator informs the user which row or cell is focused.
+        If the <code>treegrid</code> allows the user to choose just one item for an action, then it is known as a single-select <code>treegrid</code>, and the item with focus also has a selected state.
+        However, in multi-select <code>treegrid</code>s, which enable the user to select more than one row or cell for an action, the selected state is independent of the focus.
+        For example, in a hierarchical e-mail discussion grid, the user can move focus to select any number of rows for an action, such as delete or move.
+        It is important that the visual design distinguish between items that are selected and the item that has focus.
+        For more details, see <a href="#kbd_focus_vs_selection">this description of differences between focus and selection.</a>
+      </p>
+
+      <section class="notoc">
+        <h4>Examples</h4>
+        <ul>
+          <li>
+            <a href="examples/treegrid/treegrid-1.html">Hierarchical E-mail list <code>treegrid</code> Example with three types of focus navigation</a>: Rows first, cells first and cells only interaction options.
+          </li>
+        </ul>
+
+        <section class="notoc">
+          <h4>Keyboard Interaction For Data Grids</h4>
+          <p>
+            The following keys provide <code>treegrid</code> navigation by moving focus among rows and cells of the grid.
+            Implementations of <code>treegrid</code> make these key commands available when an element in the grid has received focus, e.g., after a user has moved focus to the grid with <kbd>Tab</kbd>.  Moving focus into the grid may result in the first cell or the first row being focused.  Whether focus goes to a cell or the row depends on author preferences and whether row focus is supported, since some <code>treegrid</code>s may not provide focus to rows.
+          </p>
+          <ul>
+            <li>
+              <kbd>Enter</kbd>:  If cell only focus is enabled and focus is on the first cell with the <code>aria-expanded</code> property it will will open or close the child rows, otherwise performs the default action for the cell.</li>
+            <li>
+              <kbd>Tab</kbd>:  If there are focusable elements in the current row (e.g. inputs, buttons, links, ..) focus moves to the next input in the row.  If on the last input in the row, focus moves out of the <code>treegrid</code> widget to the next focusable control on the page. </li>
+            <li>
+              <kbd>Right Arrow</kbd>:
+              <ul>
+                <li>If focus is on a row and the row is expandable, but not expanded, the row is expanded.</li>
+                <li>If focus is on a row and the row is not expandable or is expanded, focus moves to the first cell in the row.</li>
+                <li>If focus is on the right-most cell in the row, focus does not move.</li>
+                <li>If focus is on any other cell, focus one cell to the right.</li>
+              </ul>
+            </li>
+            <li><kbd>Left Arrow</kbd>:
+              <ul>
+                <li>If focus is on a row and the row is expanded, the row is collapsed.</li>
+                <li>If focus is on a row and the row is not expandable or is collapsed, focus does not move.</li>
+                <li>If focus is on a first cell in the row and row focus is supported, focus moves to the row.</li>
+                <li>If focus is on a first cell in the row and row focus is not supported,focus does not move.</li>
+                <li>If focus is on a any other cell, focus one cell to the left.</li>
+              </ul>
+            </li>
+            <li>
+              <kbd>Down Arrow</kbd>:
+              <ul>
+                <li>If focus is on a row, moves focus one row down.  If focus is on the last row, focus does not move.</li>
+                <li>If focus is on a cell, moves focus one cell down.  If focus is on the bottom cell in the column, focus does not move.</li>
+              </ul>
+            <li>
+              <kbd>Up Arrow</kbd>:
+              <ul>
+                <li>If focus is on a row, moves focus one row up.  If focus is on the first row, focus does not move.</li>
+                <li>If focus is on a cell, moves focus one cell up.  If focus is on the top cell in the column, focus does not move.</li>
+              </ul>
+            <li>
+              <kbd>Page Down</kbd>:
+              <ul>
+                <li>If focus is on a row, moves focus down an author-determined number of rows, typically scrolling so the bottom row in the currently visible set of rows becomes one of the first visible rows. If focus is in the last row of the grid, focus does not move.</li>
+                <li>If focus is on a cell, moves focus down an author-determined number of cells, typically scrolling so the bottom row in the currently visible set of rows becomes one of the first visible rows. If focus is in the last row of the grid, focus does not move.</li>
+              </ul>
+            </li>
+            <li>
+              <kbd>Page Up</kbd>:
+               <ul>
+                  <li>If focus is on a row, moves focus up an author-determined number of rows, typically scrolling so the top row in the currently visible set of rows becomes one of the last visible rows. If focus is in the first row of the grid, focus does not move.</li>
+                  <li>If focus is on a cell, moves focus up an author-determined number of cells, typically scrolling so the top row in the currently visible set of rows becomes one of the last visible rows. If focus is in the first row of the grid, focus does not move.</li>
+                </ul>
+            </li>
+            <li>
+              <kbd>Home</kbd>:
+               <ul>
+                  <li>If focus is on a row, moves focus up to the first row.  If focus is in the first row of the grid, focus does not move.</li>
+                  <li>If focus is on a cell, moves focus to the first cell in the row. If focus is in the first cell of the row, focus does not move.</li>
+                </ul>
+            </li>
+            <li>
+              <kbd>End</kbd>:
+               <ul>
+                  <li>If focus is on a row, moves focus to the last row.  If focus is in the last row of the grid, focus does not move.</li>
+                  <li>If focus is on a cell, moves focus to the last cell in the row. If focus is in the last cell of the row, focus does not move.</li>
+                </ul>
+            </li>
+            <li>
+              <kbd>Control + Home</kbd>:
+               <ul>
+                  <li>If focus is on a row, moves focus up to the first row.  If focus is in the first row of the grid, focus does not move.</li>
+                  <li>If focus is on a cell, moves focus to the first cell in the column. If focus is in the first row of the grid, focus does not move.</li>
+                </ul>
+            </li>
+            <li>
+              <kbd>Control + End</kbd>:
+               <ul>
+                  <li>If focus is on a row, moves focus to the last row.  If focus is in the last row of the grid, focus does not move.</li>
+                  <li>If focus is on a cell, moves focus to the last cell in the column. If focus is in the last row of the grid, focus does not move.</li>
+                </ul>
+            </li>
+          </ul>
+          <ul class="note">
+            <li>
+              When the above <code>treegrid</code> navigation keys move focus, whether the focus is set on an element inside the cell or the grid cell depends on cell content.
+              See <a href="#gridNav_focus">Whether to Focus on a Cell or an Element Inside It</a>.
+            </li>
+            <li>
+              While navigation keys, such as arrow keys, are moving focus from cell to cell, they are not available to do something like operate a combobox or move an editing caret inside of a cell.
+              If this functionality is needed, see <a href="#gridNav_inside">Editing and Navigating Inside a Cell</a>.
+            </li>
+            <li>If navigation functions can dynamically add more rows or columns to the DOM, key events that move focus to the beginning or end of the grid, such as <kbd>control + End</kbd>, may move focus to the last row in the DOM rather than the last available row in the back-end data.</li>
+          </ul>
+          <p>If a grid supports selection of cells, rows, or columns, the following keys are commonly used for these functions.</p>
+          <ul>
+            <li>
+              <kbd>Control + Space</kbd>:
+              <ul>
+                <li>If focus on a row, selects all cells.</li>
+                <li>If focus is on a call, selects the column that contains the focus.</li>
+              </ul>
+            </li>
+            <li>
+              <kbd>Shift + Space</kbd>:
+              <ul>
+                <li>If focus on a row, no change in selection.</li>
+                <li>If focus on a cell, selects the row that contains the focus. If the grid includes a column with checkboxes for selecting rows, this key can serve as a shortcut for checking the box when focus is not on the checkbox.</li>
+              </ul>
+            </li>
+            <li><kbd>Control + A</kbd>: Selects all cells.</li>
+            <li>
+              <kbd>Shift + Right Arrow</kbd>:
+              <ul>
+                <li>If focus on a row, no change in selection.</li>
+                <li>if focus on a cell, extends selection one cell to the right.</li>
+              </ul>
+            </li>
+            <li>
+              <kbd>Shift + Left Arrow</kbd>:
+              <ul>
+                <li>If focus on a row, no change in selection.</li>
+                <li>if focus on a cell, extends selection one cell to the left.</li>
+              </ul>
+            </li>
+            <li>
+              <kbd>Shift + Down Arrow</kbd>:
+              <ul>
+                <li>If focus on a row, extends selection to all the cells in the next row.</li>
+                <li>If focus on a cell, extends selection one cell down.</li>
+              </ul>
+            </li>
+            <li>
+              <kbd>Shift + Up Arrow</kbd>:
+              <ul>
+                <li>If focus on a row, extends selection to all the cells in the previous row.</li>
+                <li>If focus on a cell, extends selection one cell up.</li>
+              </ul>
+            </li>
+          </ul>
+          <p class="note">See <a href="#kbd_common_conventions"></a> for cut, copy, and paste key assignments.</p>
+        </section>
+      </section>
+
+      <section id="treegrid_roles_states_props" class="notoc">
+        <h4>WAI-ARIA Roles, States, and Properties</h4>
+        <ul>
+          <li>The treegrid container has role <a href="#treegrid" class="role-reference">treegrid</a>. </li>
+          <li>Each row container has role <a href="#row" class="role-reference">row</a> and is either a DOM descendant of or owned by the <code>treegrid</code> element or an element with role <a href="#rowgroup" class="role-reference">rowgroup</a>. </li>
+          <li>Each cell is either a DOM descendant of or owned by a <code>row</code> element and has one of the following roles:
+            <ul>
+              <li><a href="#columnheader"  class="role-reference">columnheader</a> if the cell contains a title or header information for the column.</li>
+              <li><a href="#rowheader"  class="role-reference">rowheader</a> if the cell contains title or header information for the row.</li>
+              <li><a href="#gridcell" class="role-reference">gridcell</a> if the cell does not contain column or row header information.</li>
+            </ul>
+          </li>
+          <li>
+            Each <code>row</code> with the <a class="property-reference" href="#aria-expanded">aria-expanded</a> state or  that contains a <code>gridcell</code> with the <code>aria-expanded</code> state identifies the row as a parent row.
+            Set to <code>aria-expanded</code> to <code>false</code> when the child rows are in a closed state and set to <code>true</code> when the child rows are in an open state.
+            End rows cannot have the <code>aria-expanded</code> attribute because, if they were to have it, they would be incorrectly described to assistive technologies as parent nodes.
+          </li>
+          <li>If the treegrid supports selection of more than one row or cell, the element with role <code>treegrid</code> has <a class="property-reference" href="#aria-multiselectable">aria-multiselectable</a> set to <code>true</code>. Otherwise, <code>aria-multiselectable</code> is either set to <code>false</code> or the default value of <code>false</code> is implied.</li>
+          <li>If the treegrid does not support multiple selection, <a href="#aria-selected" class="property-reference">aria-selected</a> is set to <code>true</code> for the selected row or cell and it is not present on any other row or cell in the treegrid.</li>
+          <li>if the treegrid supports multiple selection:
+          <ul>
+          <li>All selected rows or cells have <a href="#aria-selected" class="state-reference">aria-selected</a> set to <code>true</code>.</li>
+          <li>All rows and cells that are not selected have <a href="#aria-selected" class="state-reference">aria-selected</a> set to <code>false</code>.</li>
+          </ul>
+          </li>
+          <li>
+            If there is an element in the user interface that serves as a label for the treegrid, <a href="#aria-labelledby" class="property-reference">aria-labelledby</a> is set on the grid element with a value that refers to the labeling element.
+            Otherwise, a label is specified for the grid element using <a href="#aria-label" class="property-reference">aria-label</a>.
+          </li>
+          <li>If the treegrid has a caption or description, <a href="#aria-describedby" class="property-reference">aria-describedby</a> is set on the grid element with a value referring to the element containing the description.</li>
+          <li>If the treegrid provides sort functions, <a href="#aria-sort" class="property-reference">aria-sort</a> is set to an appropriate value on the header cell element for the sorted column or row as described in the section on <a href="#gridAndTableProperties">grid and table properties</a>. </li>
+          <li>If the treegrid supports selection, when a cell or row is selected, the selected element has <a href="#aria-selected" class="state-reference">aria-selected</a> set <code>true</code>. </li>
+          <li>
+            If the treegrid provides content editing functionality and contains cells that may have edit capabilities disabled in certain conditions, <a href="#aria-readonly" class="state-reference">aria-readonly</a> may be set <code>true</code> on cells where editing is disabled.
+            If edit functions are disabled for all cells, <code>aria-readonly</code> may be set <code>true</code> on the grid element.
+            Grids that do not provide editing functions do not include the <code>aria-readonly</code> attribute on any of their elements.
+          </li>
+          <li>
+            If there are conditions where some rows or columns are hidden or not present in the DOM, e.g., data is dynamically loaded when scrolling or the grid provides functions for hiding rows or columns, the following properties are applied as described in the section on <a href="#gridAndTableProperties">grid and table properties</a>.
+            <ul>
+              <li><a href="#aria-colcount" class="property-reference">aria-colcount</a> or <a href="#aria-rowcount" class="property-reference">aria-rowcount</a> is set to the total number of columns or rows, respectively. </li>
+              <li><a href="#aria-colindex" class="property-reference">aria-colindex</a> or <a href="#aria-rowindex" class="property-reference">aria-rowindex</a> is set to the position of a cell within a row or column, respectively. </li>
+            </ul>
+          </li>
+          <li>If the treegrid includes cells that span multiple rows or multiple columns, and if the <code>treegrid</code> role is NOT applied to an HTML <code>table</code> element, then <a href="#aria-rowspan" class="property-reference">aria-rowspan</a> or <a href="#aria-colspan" class="property-reference">aria-colspan</a> is applied as described in <a href="#gridAndTableProperties">grid and table properties</a>.</li>
+        </ul>
+
+        <ul class="note">
+          <li>
+            If the element with the <code>treegrid</code> role is an HTML <code>table</code> element, then it is not necessary to use ARIA roles for rows and cells because the HTML elements have implied ARIA semantics.
+            For example, an HTML <code>&lt;TR&gt;</code> has an implied ARIA role of <code>row</code>.
+            A <code>treegrid</code> built from an HTML <code>table</code> that includes cells that span multiple rows or columns must use HTML <code>rowspan</code> and <code>colspan</code> and must not use <code>aria-rowspan</code> or <code>aria-colspan</code>.
+          </li>
+          <li>
+            If rows or cells are included in a treegrid via <a href="#aria-owns" class="property-reference">aria-owns</a>,
+            they will be presented to assistive technologies after the DOM descendants of the <code>treegrid</code> element unless the DOM descendants are also included in the <code>aria-owns</code> attribute.
+          </li>
+        </ul>
+      </section>
+
+   </section>
 
     <section class="widget" id="windowsplitter">
       <h3>Window Splitter</h3>

--- a/aria-practices.html
+++ b/aria-practices.html
@@ -2903,7 +2903,12 @@
       <p id="aria_lh_step3"><strong>Step 3: Label areas</strong></p>
 
       <ul>
-        <li>If a specific landmark role is used more than once on a web page, it should have a unique label.</li>
+        <li>
+          If a specific landmark role is used more than once on a page, provide each instance of that landmark with a unique label.
+          There is one rare circumstance where providing the same label to multiple instances of a landmark can be beneficial: the content and purpose of each instance is identical.
+          For example, a large search results table has two sets of identical pagination controls -- one above and one below the table, so each set is in a navigation region labeled <q>Search Results</q>.
+          In this case, adding extra information to the label that distinguishes the two instances may be more distracting than helpful.
+        </li>
 
         <li>If a landmark is only used once on the page it may not require a label. See Landmark Roles section below. </li>
 

--- a/aria-practices.html
+++ b/aria-practices.html
@@ -920,7 +920,7 @@
     <section class="widget" id="dialog_modal">
       <h3>Dialog (Modal)</h3>
       <p>
-        A <a href="#dialog" class="role-reference">dialog</a> is a window overlayed on either the primary window or another dialog window.
+        A <a href="#dialog" class="role-reference">dialog</a> is a window overlaid on either the primary window or another dialog window.
         Windows under a modal dialog are inert.
         That is, users cannot interact with content outside an active dialog window.
         Inert content outside an active dialog is typically visually obscured or dimmed so it is difficult to discern,

--- a/common/terms.html
+++ b/common/terms.html
@@ -91,7 +91,7 @@
     </dd>
     <dt><dfn>Keyboard Accessible</dfn></dt>
     <dd>
-      <p>Accessible to the user using a keyboard or <a>assistive technologies</a> that mimic keyboard input, such as a sip and puff tube. References in this document relate to <cite><a href="http://www.w3.org/TR/WCAG20/#keyboard-operation"><abbr title="Web Content Accessibility Guidelines">WCAG</abbr> 2.0 Guideline 2.1: Make all functionality available from a keyboard</a></cite> [[WCAG20]].</p>
+    	<p>Accessible to the user using a keyboard or <a>assistive technologies</a> that mimic keyboard input, such as a sip and puff tube. References in this document relate to <cite><a href="http://www.w3.org/TR/WCAG21/#keyboard-accessible"><abbr title="Web Content Accessibility Guidelines">WCAG</abbr> 2.1 Guideline 2.1: Make all functionality available from a keyboard</a></cite> [[WCAG21]].</p>
     </dd>
     <dt><dfn data-lt="landmark|landmarks">Landmark</dfn></dt>
     <dd>
@@ -132,7 +132,7 @@
     </dd>
     <dt><dfn>Operable</dfn></dt>
     <dd>
-      <p>Usable by users in ways they can control. References in this document relate to <cite><a href="http://www.w3.org/TR/WCAG20/#operable"><abbr title="Web Content Accessibility Guidelines">WCAG</abbr> 2.0 Principle 2: Content must be operable</a></cite> [[WCAG20]]. See <a>Keyboard Accessible</a>.</p>
+      <p>Usable by users in ways they can control. References in this document relate to <cite><a href="http://www.w3.org/TR/WCAG21/#operable"><abbr title="Web Content Accessibility Guidelines">WCAG</abbr> 2.1 Principle 2: Content must be operable</a></cite> [[WCAG21]]. See <a>Keyboard Accessible</a>.</p>
     </dd>
     <dt><dfn data-lt="owned element|owned|owned element's|owned elements">Owned Element</dfn></dt>
     <dd>
@@ -144,7 +144,7 @@
     </dd>
     <dt><dfn>Perceivable</dfn></dt>
     <dd>
-      <p>Presentable to users in ways they can sense. References in this document relate to <cite><a href="http://www.w3.org/TR/WCAG20/#perceivable"><abbr title="Web Content Accessibility Guidelines">WCAG</abbr> 2.0 Principle 1: Content must be perceivable</a></cite> [[WCAG20]].</p>
+      <p>Presentable to users in ways they can sense. References in this document relate to <cite><a href="http://www.w3.org/TR/WCAG21/#perceivable"><abbr title="Web Content Accessibility Guidelines">WCAG</abbr> 2.1 Principle 1: Content must be perceivable</a></cite> [[WCAG21]].</p>
     </dd>
     <dt><dfn data-lt="property|properties">Property</dfn></dt>
     <dd>
@@ -192,7 +192,7 @@
     </dd>
     <dt><dfn>Understandable</dfn></dt>
     <dd>
-      <p>Presentable to users in ways they can construct an appropriate meaning. References in this document relate to <cite><a href="http://www.w3.org/TR/WCAG20/#understandable"><abbr title="Web Content Accessibility Guidelines">WCAG</abbr> 2.0 Principle 3: Information and the operation of user interface must be understandable</a></cite> [[WCAG20]].</p>
+      <p>Presentable to users in ways they can construct an appropriate meaning. References in this document relate to <cite><a href="http://www.w3.org/TR/WCAG21/#understandable"><abbr title="Web Content Accessibility Guidelines">WCAG</abbr> 2.1 Principle 3: Information and the operation of user interface must be understandable</a></cite> [[WCAG21]].</p>
     </dd>
     <dt><dfn data-lt="user agent|user agents">User Agent</dfn></dt>
     <dd>

--- a/examples/listbox/listbox-collapsible.html
+++ b/examples/listbox/listbox-collapsible.html
@@ -193,6 +193,18 @@
       <tbody>
         <tr>
           <td></td>
+          <th scope="row"><code>aria-labelledby=&quot;ID_REF1 ID_REF2&quot;</code></th>
+          <td><code>button</code></td>
+          <td>
+            <ul>
+              <li>References the two elements whose labels are concatenated by the browser to label the button.</li>
+              <li>The first element is a span containing text <q>Choose an element: </q>.</li>
+              <li>The second element is the button itself; the button text is set to the name of the currently chosen element.</li>
+            </ul>
+          </td>
+        </tr>
+        <tr>
+          <td></td>
           <th scope="row"><code>aria-haspopup=&quot;listbox&quot;</code></th>
           <td><code>button</code></td>
           <td>Indicates that activating the button displays a listbox.</td>

--- a/examples/menu-button/js/Menubutton2.js
+++ b/examples/menu-button/js/Menubutton2.js
@@ -108,7 +108,7 @@ Menubutton.prototype.handleKeydown = function (event) {
 
 Menubutton.prototype.handleClick = function (event) {
   if (this.domNode.getAttribute('aria-expanded') == 'true') {
-    this.popupMenu.close();
+    this.popupMenu.close(true);
   }
   else {
     this.popupMenu.open();

--- a/examples/menubar/menubar-2/js/MenubarItemAction.js
+++ b/examples/menubar/menubar-2/js/MenubarItemAction.js
@@ -126,6 +126,13 @@ MenubarItemAction.prototype.handleKeydown = function (event) {
       flag = true;
       break;
 
+    case this.keyCode.ESC:
+      if (this.popupMenu) {
+        this.popupMenu.close();
+      }
+      flag = true;
+      break;
+
     default:
       if (isPrintableCharacter(char)) {
         this.menubar.setFocusByFirstCharacter(this, char);

--- a/examples/menubar/menubar-2/menubar-2.html
+++ b/examples/menubar/menubar-2/menubar-2.html
@@ -174,6 +174,14 @@
         </tr>
         <tr>
           <th>
+            <kbd>Escape</kbd>
+          </th>
+          <td>
+            If a submenu is open, closes it. Otherwise, does nothing.
+          </td>
+        </tr>
+        <tr>
+          <th>
             <kbd>Right Arrow</kbd>
           </th>
           <td>

--- a/examples/menubar/menubar-2/menubar-2.html
+++ b/examples/menubar/menubar-2/menubar-2.html
@@ -139,6 +139,19 @@
       <li>Users of assistive technologies can identify which format settings are selected because they are represented by menu item radio and menu item checkbox elements that have a checked state.</li>
       <li>Disabled menu items are demonstrated in the font size menu, which  includes two disabled menuitems        .</li>
       <li>The down arrow and checked icons are made compatible with high contrast mode and hidden from screen readers by using the CSS <code>content</code> property to render images.</li>
+      <li>
+        Like desktop menubars, submenus open on mouse hover over a parent item in the menubar only if another submenu is already open.
+        That is, if all submenus are closed, a click on a parent menu item is required to display a submenu.
+        Minimizing automatic popups makes exploring with a screen magnifier easier.
+      </li>
+      <li>
+        In general, moving focus in response to mouse hover is avoided in accessible widgets; it causes unexpected context changes for keyboard users.
+        However, like desktop menubars, there are two conditions in this example menubar where focus moves in response to hover in order to help maintain context for users who use both keyboard and mouse:
+        <ol>
+          <li>After a parent menu item in the menubar has been activated and the user hovers over a different parent item in the menubar, focus will follow hover.</li>
+          <li>When a submenu is open and the user hovers over an item in the submenu, focus follows hover.</li>
+        </ol>
+      </li>
     </ol>
   </section>
 

--- a/examples/menubar/menubar-2/menubar-2.html
+++ b/examples/menubar/menubar-2/menubar-2.html
@@ -137,7 +137,7 @@
     <h2>Accessibility Features</h2>
     <ol>
       <li>Users of assistive technologies can identify which format settings are selected because they are represented by menu item radio and menu item checkbox elements that have a checked state.</li>
-      <li>Disabled menu items are demonstrated in the font size menu, which  includes two disabled menuitems        .</li>
+      <li>Disabled menu items are demonstrated in the font size menu, which  includes two disabled menuitems.</li>
       <li>The down arrow and checked icons are made compatible with high contrast mode and hidden from screen readers by using the CSS <code>content</code> property to render images.</li>
       <li>
         Like desktop menubars, submenus open on mouse hover over a parent item in the menubar only if another submenu is already open.

--- a/examples/radio/css/radio.css
+++ b/examples/radio/css/radio.css
@@ -9,10 +9,15 @@
 }
 
 [role="radio"] {
+  border: 2px solid transparent;
+  border-radius: 5px;
   display: inline-block;
   position: relative;
-  padding-left: 1.4em;
+  padding: 0.125em;
+  padding-left: 1.5em;
+  padding-right: 0.5em;
   cursor: default;
+  outline: none;
 }
 
 [role="radio"] + [role="radio"] {
@@ -24,7 +29,7 @@
   position: absolute;
   top: 50%;
   left: 7px;
-  transform: translate(-50%, -50%);
+  transform: translate(-20%, -50%);
   content: '';
 }
 
@@ -50,7 +55,7 @@
   display: block;
   border: .1875em solid #fff;
   border-radius: 100%;
-  //transform: translateY(-65%) translateX(-50%);
+  transform: translate(25%, -50%);
 }
 
 [role="radio"][aria-checked="mixed"]:active::before,
@@ -62,17 +67,13 @@
   border-color: hsl(216, 94%, 65%);
 }
 
-[role="radio"]:focus {
-  outline: none;
+[role="radio"].focus {
+  border-color: hsl(216, 94%, 73%);
+  background-color: hsl(216, 80%, 97%);
 }
 
-[role="radio"].focus:before,
-[role="radio"]:focus::before {
-  width: 16px;
-  height: 16px;
-  box-sizing: content-box;
-  border-color: hsl(216, 94%, 73%);
-  border-width: 3px;
-  border-radius: 100%;
-  box-shadow: inset 0 0 0 1px hsl(216, 80%, 50%);
+[role="radio"]:hover {
+  background-color: hsl(216, 80%, 92%);
 }
+
+

--- a/examples/treeview/treeview-1/css/tree.css
+++ b/examples/treeview/treeview-1/css/tree.css
@@ -27,6 +27,7 @@ ul[role="tree"] {
 
 [role="treeitem"],
 [role="treeitem"] span {
+  width: 9em;
   margin: 0;
   padding: 0;
   border: 2px transparent solid;
@@ -45,12 +46,10 @@ ul[role="tree"] {
 [role="treeitem"] span.focus {
   border-color: black;
   background-color: #EEEEEE;
-  width: 9em;  
 }
 
 [role="treeitem"].hover,
 [role="treeitem"] span:hover {
   background-color: #DDDDDD;
-  width: 9em;  
 }
 

--- a/examples/treeview/treeview-2/css/treeLinks.css
+++ b/examples/treeview/treeview-2/css/treeLinks.css
@@ -43,6 +43,7 @@ ul[role="tree"] a {
 
 [role="treeitem"],
 [role="treeitem"] span {
+  width: 16em;
   margin: 0;
   padding: 0;
   border: 2px transparent solid;
@@ -60,12 +61,10 @@ ul[role="tree"] a {
 [role="treeitem"] span.focus {
   border-color: black;
   background-color: #EEEEEE;
-  width: 16em;  
 }
 
 [role="treeitem"].hover,
 [role="treeitem"] span.hover {
   background-color: #DDDDDD;
-  width: 16em;  
 }
 


### PR DESCRIPTION
For issue #603, modified: examples/menubar/menubar-2/menubar-2.html.
In the accessibility features section, added items 4 and 5 describing the conditions when mouse hover can move focus.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria-practices/pull/711.html" title="Last updated on Jun 27, 2018, 7:07 AM GMT (2d297b6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria-practices/711/c555c83...2d297b6.html" title="Last updated on Jun 27, 2018, 7:07 AM GMT (2d297b6)">Diff</a>