### PR TITLE
Fix and clean up modal dialog example

### DIFF
--- a/examples/dialog-modal/css/dialog.css
+++ b/examples/dialog-modal/css/dialog.css
@@ -1,76 +1,26 @@
-html, body {
-  height: 100%;
-}
-
-body {
-  max-width: 100%;
-  padding: 0;
-  margin: 0;
-  overflow: hidden;
-}
-
-body:not(.toc-inline) {
-  padding: 0;
-}
-
-#base_window_layer {
-  box-sizing: border-box;
-  height: 100%;
-  width: 100%;
-  /* Use overflow scroll and webkit-overflow-scrolling to add momentum scroll*/
-  overflow: scroll;
-  -webkit-overflow-scrolling: touch;
-  padding: 1.6em 0 2em;
-}
-
-#base_window_layer main, #base_window_layer nav {
-  max-width: 50em;
-  margin: auto;
-  padding-right: 1.5em;
-  padding-left: 50px;
-  padding-left: calc(26px + 1.5em);
-}
-
-@media screen and (min-width: 78em) {
-  body:not(.toc-inline) #base_window_layer main, body:not(.toc-inline) #base_window_layer nav  {
-    padding-left: 29em;
-  }
-
-  body:not(.toc-inline) {
-    padding: 0;
-  }
-}
-
-body:not(.toc-inline) #main_content main, body:not(.toc-inline) #main_content nav  {
-  padding-left: 1.5em;
-}
-
-
 .hidden {
   display: none
 }
 
 [role="dialog"] {
-  width: 50%;
-  margin: 10vh auto;
+  box-sizing: border-box;
+  width: 100%;
+  margin-top: 0;
+  margin-bottom: 0;
   padding: 5px;
   border: thin #000 solid;
   background-color: #fff;
 }
 
-@media screen and (max-width: 640px) {
+@media screen and (min-width: 640px) {
   [role="dialog"] {
-    box-sizing: border-box;
-    top: 0px;
-    left: 0px;
-    margin: 0 auto;
-    min-height: 100%;
-    width: 100%;
+    width: 50%;
+    margin: 10vh auto;
   }
 }
 
 [role="dialog"] h2:first-of-type {
-  text-align:center;
+  text-align: center;
 }
 
 .dialog_form {
@@ -131,15 +81,15 @@ body:not(.toc-inline) #main_content main, body:not(.toc-inline) #main_content na
 }
 
 .dialog_close_button {
-  float:right;
-  position:absolute;
-  top:10px;
-  left:92%;
-  height:25px;
+  float: right;
+  position: absolute;
+  top: 10px;
+  left: 92%;
+  height: 25px;
 }
 
 .dialog_close_button img {
-  border:0;
+  border: 0;
 }
 
 .dialog_desc {
@@ -151,9 +101,9 @@ body:not(.toc-inline) #main_content main, body:not(.toc-inline) #main_content na
 .dialog-backdrop.active {
   position: fixed;
   overflow-y: scroll;
-  top: 0px;
-  right: 0px;
-  bottom: 0px;
-  left: 0px;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
   background: rgba(0, 0, 0, 0.3);
 }

--- a/examples/dialog-modal/dialog.html
+++ b/examples/dialog-modal/dialog.html
@@ -223,7 +223,7 @@
       <section>
         <h2 id="sc1_label">HTML Source Code</h2>
         <div role="separator" id="sc1_start_sep" aria-labelledby="sc1_start_sep sc1_label" aria-label="Start of"></div>
-        <div id="sc1"></div>
+        <pre><code id="sc1"></code></pre>
         <div role="separator" id="sc1_end_sep" aria-labelledby="sc1_end_sep sc1_label" aria-label="End of"></div>
 
       </section>

--- a/examples/dialog-modal/dialog.html
+++ b/examples/dialog-modal/dialog.html
@@ -19,234 +19,232 @@
   <script src="js/dialog.js"></script>
 </head>
 <body>
-  <div id="base_window_layer">
-    <nav aria-label="Related Links" class="feedback">
-      <ul>
-        <li><a href="../../#browser_and_AT_support">Browser and Assistive Technology Support</a></li>
-        <li><a href="https://github.com/w3c/aria-practices/issues/new">Report Issue</a></li>
-        <li><a href="https://github.com/w3c/aria-practices/projects/6">Related Issues</a></li>
-        <li><a href="../../#dialog_modal">Design Pattern</a></li>
-      </ul>
-    </nav>
+  <nav aria-label="Related Links" class="feedback">
+    <ul>
+      <li><a href="../../#browser_and_AT_support">Browser and Assistive Technology Support</a></li>
+      <li><a href="https://github.com/w3c/aria-practices/issues/new">Report Issue</a></li>
+      <li><a href="https://github.com/w3c/aria-practices/projects/6">Related Issues</a></li>
+      <li><a href="../../#dialog_modal">Design Pattern</a></li>
+    </ul>
+  </nav>
 
-    <main>
-      <h1>Modal Dialog Example</h1>
+  <main>
+    <h1>Modal Dialog Example</h1>
 
-      <p>Following is an example implementation of the <a href="../../#dialog_modal">design pattern for modal dialogs</a>. The below <q>Add Delivery Address</q> button opens a modal dialog that contains two buttons that open other dialogs. The accessibility features section explains the rationale for initial focus placement and use of <code>aria-describedby</code> in each dialog.</p>
-
-      <section>
-        <h2 id="ex_label">Example</h2>
-
-        <div role="separator" id="ex_start_sep" aria-labelledby="ex_start_sep ex_label" aria-label="Start of"></div>
-
-        <div id="ex1">
-          <button onclick="openDialog('dialog1', this)">Add Delivery Address</button>
-          <!--
-            Important: Note that the dialog container divs are all in a div at
-            the end of the body that is outside the div containing all content
-            for the base window layer.
-          -->
-        </div>
-
-        <div role="separator" id="ex_end_sep" aria-labelledby="ex_end_sep ex_label" aria-label="End of"></div>
-      </section>
-
-      <section>
-        <h2>Accessibility Features</h2>
-
-        <ol>
-          <li>
-            To make the content easier to read when displayed on small screens, the dialog fills 100% of the screen. Completely covering the background window also hides background movement that occurs on some mobile devices when scrolling content inside the dialog.
-          </li>
-          <li>
-            Focus and accessible descriptions are set based on the content of each dialog.
-
-            <ol>
-              <li>
-                <q>Add Delivery Address</q> dialog (with <code>id="dialog1"</code>):
-
-                <ul>
-                  <li>Initial focus is set on the first input, which is the first focusable element.</li>
-                  <li>The dialog does not need <code>aria-describedby</code> since there is no static text that describes it.</li>
-                  <li>
-                    When the dialog closes as a result of the <q>Cancel</q> action, the user’s point of regard is maintained by returning focus to the <q>Add Delivery Address</q> button.
-                  </li>
-                  <li>
-                    When the dialog closes as a result of the <q>Add</q> action and the <q>Address Added</q> dialog replaces the <q>Add Delivery Address</q> dialog, the <q>Add Delivery Address</q> dialog passes a reference to the <q>Add Delivery Address</q> button to the the <q>Address Added</q> dialog so that it can maintain the user’s point of regard when it closes.
-                  </li>
-                </ul>
-              </li>
-              <li>
-                <q>Verification Result</q> dialog (with <code>id="dialog2"</code>):
-
-                <ul>
-                  <li>Initial focus is set on the first paragraph because the first interactive element is at the bottom, which is out of view due to the length of the text.</li>
-                  <li>To support screen reader user awareness of the dialog text, the dialog text is wrapped in a <code>div</code> that is referenced by <code>aria-describedby</code>.</li>
-                  <li>When the dialog closes, to maintain the user’s point of regard, focus returns to the <q>Verify Address</q> button.</li>
-                  <li>The text of this dialog describes design considerations for initial focus and accessible descriptions in dialogs with large amounts of text.</li>
-                </ul>
-              </li>
-              <li>
-                <q>Address Added</q> dialog (with <code>id="dialog3"</code>):
-
-                <ul>
-                  <li>
-                    Initial focus is set on the <q>OK</q> button, which is the last focusable element. This is for efficiency since most users will simply dismiss the dialog as soon as they have read the message. Users can press <kbd>Tab</kbd> to focus on the <q>My Profile</q> link.
-                  </li>
-                  <li>
-                    The element containing the dialog message is referenced by <code>aria-describedby</code> to hint to screen readers that it should be announced when the dialog opens.
-                  </li>
-                  <li>When the dialog closes, the user’s point of regard is maintained by setting focus on the <q>Add Delivery Address</q> button.</li>
-                </ul>
-              </li>
-              <li>
-                <q>End of the Road!</q> dialog (with <code>id="dialog4"</code>):
-
-                <ul>
-                  <li>This dialog has only one focusable element, which receives focus when the dialog opens.</li>
-                  <li>Like dialog3, <code>aria-describedby</code> is used to facilitate message announcement for screen reader users.</li>
-                  <li>
-                    Like all other dialogs in this example except for the <q>Address Added</q> confirmation dialog, when it closes, the user’s point of regard is maintained by returning focus to the element that triggered display of the dialog.
-                  </li>
-                </ul>
-              </li>
-            </ol>
-          </li>
-        </ol>
-      </section>
+    <p>Following is an example implementation of the <a href="../../#dialog_modal">design pattern for modal dialogs</a>. The below <q>Add Delivery Address</q> button opens a modal dialog that contains two buttons that open other dialogs. The accessibility features section explains the rationale for initial focus placement and use of <code>aria-describedby</code> in each dialog.</p>
 
     <section>
-        <h2 id="kbd_label">Keyboard Support</h2>
-        <table aria-labelledby="kbd_label" class="def">
-          <thead>
-            <tr>
-              <th>Key</th>
-              <th>Function</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <th><kbd>Tab</kbd></th>
-              <td>
-                <ul>
-                  <li>Moves focus to next focusable element inside the dialog.</li>
-                  <li>When focus is on the last focusable element in the dialog, moves focus to the first focusable element in the dialog.</li>
-                </ul>
-              </td>
-            </tr>
-            <tr>
-              <th><kbd>Shift + Tab</kbd></th>
-              <td>
-                <ul>
-                  <li>Moves focus to previous focusable element inside the dialog.</li>
-                  <li>When focus is on the first focusable element in the dialog, moves focus to the last focusable element in the dialog.</li>
-                </ul>
-              </td>
-            </tr>
-            <tr>
-              <th><kbd>Escape</kbd></th>
-              <td>Closes the dialog.</td>
-            </tr>
-          </tbody>
-        </table>
-      </section>
+      <h2 id="ex_label">Example</h2>
 
-      <section>
-        <h2 id="rps_label">Role, Property, State, and Tabindex Attributes</h2>
-        <table aria-labelledby="rps_label" class="data attributes">
-          <thead>
-            <tr>
-              <th scope="col">Role</th>
-              <th scope="col">Attribute</th>
-              <th scope="col">Element</th>
-              <th scope="col">Usage</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <th scope="row"><code>dialog</code></th>
-              <td></td>
-              <td><code>div</code></td>
-              <td>Identifies the element that serves as the dialog container.</td>
-            </tr>
-            <tr>
-              <td></td>
-              <th scope="row"><code>aria-labelledby="IDREF"</code></th>
-              <td><code>div</code></td>
-              <td>Gives the dialog an accessible name by referring to the element that provides the dialog title.</td>
-            </tr>
-            <tr>
-              <td></td>
-              <th scope="row"><code>aria-describedby="IDREF"</code></th>
-              <td><code>div</code></td>
-              <td>
-                <ul>
-                  <li>Gives the dialog an accessible description by referring to the dialog content that describes the primary message or purpose of the dialog.</li>
-                  <li>Used in three of the four dialogs included in the example. See the above accessibility features section for an explanation.</li>
-                </ul>
-              </td>
-            </tr>
-            <tr>
-              <td></td>
-              <th scope="row"><code>aria-modal="true"</code></th>
-              <td><code>div</code></td>
-              <td>Tells assistive technologies that the windows underneath the current dialog are not available for interaction (inert).</td>
-            </tr>
-          </tbody>
-        </table>
+      <div role="separator" id="ex_start_sep" aria-labelledby="ex_start_sep ex_label" aria-label="Start of"></div>
 
-        <h3>Notes on <code>aria-modal</code> and <code>aria-hidden</code></h3>
+      <div id="ex1">
+        <button onclick="openDialog('dialog1', this)">Add Delivery Address</button>
+        <!--
+          Important: Note that the dialog container divs are all in a div at
+          the end of the body that is outside the div containing all content
+          for the base window layer.
+        -->
+      </div>
 
-        <ol>
-          <li>
-            The <code>aria-modal</code> property was introduced in ARIA 1.1.
-            As a new property, screen reader users may experience varying degrees of support for it.
-          </li>
-          <li>
-            Applying the <code>aria-modal</code> property to the <code>dialog</code> element
-            replaces the technique of using <code>aria-hidden</code> on the background for informing assistive technologies that content outside a dialog is inert.
-          </li>
-          <li>
-            In legacy dialog implementations where <code>aria-hidden</code> is used to make content outside a dialog inert for assistive technology users, it is important that:
+      <div role="separator" id="ex_end_sep" aria-labelledby="ex_end_sep ex_label" aria-label="End of"></div>
+    </section>
 
-            <ol>
-              <li><code>aria-hidden</code> is set to <code>true</code> on each element containing a portion of the inert layer.</li>
-              <li>The dialog element is not a descendant of any element that has <code>aria-hidden</code> set to <code>true</code>.</li>
-            </ol>
-          </li>
-        </ol>
-      </section>
+    <section>
+      <h2>Accessibility Features</h2>
 
-      <section>
-        <h2>Javascript and CSS Source Code</h2>
+      <ol>
+        <li>
+          To make the content easier to read when displayed on small screens, the dialog fills 100% of the screen. Completely covering the background window also hides background movement that occurs on some mobile devices when scrolling content inside the dialog.
+        </li>
+        <li>
+          Focus and accessible descriptions are set based on the content of each dialog.
 
-        <ul>
-          <li>
-            CSS:
-            <a href="css/dialog.css" type="text/css">dialog.css</a>
-          </li>
-          <li>
-            Javascript:
-            <a href="js/dialog.js" type="text/javascript">dialog.js</a>
-          </li>
-        </ul>
-      </section>
+          <ol>
+            <li>
+              <q>Add Delivery Address</q> dialog (with <code>id="dialog1"</code>):
 
-      <section>
-        <h2 id="sc1_label">HTML Source Code</h2>
+              <ul>
+                <li>Initial focus is set on the first input, which is the first focusable element.</li>
+                <li>The dialog does not need <code>aria-describedby</code> since there is no static text that describes it.</li>
+                <li>
+                  When the dialog closes as a result of the <q>Cancel</q> action, the user’s point of regard is maintained by returning focus to the <q>Add Delivery Address</q> button.
+                </li>
+                <li>
+                  When the dialog closes as a result of the <q>Add</q> action and the <q>Address Added</q> dialog replaces the <q>Add Delivery Address</q> dialog, the <q>Add Delivery Address</q> dialog passes a reference to the <q>Add Delivery Address</q> button to the the <q>Address Added</q> dialog so that it can maintain the user’s point of regard when it closes.
+                </li>
+              </ul>
+            </li>
+            <li>
+              <q>Verification Result</q> dialog (with <code>id="dialog2"</code>):
 
-        <div role="separator" id="sc1_start_sep" aria-labelledby="sc1_start_sep sc1_label" aria-label="Start of"></div>
+              <ul>
+                <li>Initial focus is set on the first paragraph because the first interactive element is at the bottom, which is out of view due to the length of the text.</li>
+                <li>To support screen reader user awareness of the dialog text, the dialog text is wrapped in a <code>div</code> that is referenced by <code>aria-describedby</code>.</li>
+                <li>When the dialog closes, to maintain the user’s point of regard, focus returns to the <q>Verify Address</q> button.</li>
+                <li>The text of this dialog describes design considerations for initial focus and accessible descriptions in dialogs with large amounts of text.</li>
+              </ul>
+            </li>
+            <li>
+              <q>Address Added</q> dialog (with <code>id="dialog3"</code>):
 
-        <pre><code id="sc1"></code></pre>
+              <ul>
+                <li>
+                  Initial focus is set on the <q>OK</q> button, which is the last focusable element. This is for efficiency since most users will simply dismiss the dialog as soon as they have read the message. Users can press <kbd>Tab</kbd> to focus on the <q>My Profile</q> link.
+                </li>
+                <li>
+                  The element containing the dialog message is referenced by <code>aria-describedby</code> to hint to screen readers that it should be announced when the dialog opens.
+                </li>
+                <li>When the dialog closes, the user’s point of regard is maintained by setting focus on the <q>Add Delivery Address</q> button.</li>
+              </ul>
+            </li>
+            <li>
+              <q>End of the Road!</q> dialog (with <code>id="dialog4"</code>):
 
-        <div role="separator" id="sc1_end_sep" aria-labelledby="sc1_end_sep sc1_label" aria-label="End of"></div>
-      </section>
-    </main>
+              <ul>
+                <li>This dialog has only one focusable element, which receives focus when the dialog opens.</li>
+                <li>Like dialog3, <code>aria-describedby</code> is used to facilitate message announcement for screen reader users.</li>
+                <li>
+                  Like all other dialogs in this example except for the <q>Address Added</q> confirmation dialog, when it closes, the user’s point of regard is maintained by returning focus to the element that triggered display of the dialog.
+                </li>
+              </ul>
+            </li>
+          </ol>
+        </li>
+      </ol>
+    </section>
 
-    <nav>
-      <a href="../../#dialog_modal">Modal Dialog Design Pattern in WAI-ARIA Authoring Practices 1.1</a>
-    </nav>
-  </div>
+  <section>
+      <h2 id="kbd_label">Keyboard Support</h2>
+      <table aria-labelledby="kbd_label" class="def">
+        <thead>
+          <tr>
+            <th>Key</th>
+            <th>Function</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th><kbd>Tab</kbd></th>
+            <td>
+              <ul>
+                <li>Moves focus to next focusable element inside the dialog.</li>
+                <li>When focus is on the last focusable element in the dialog, moves focus to the first focusable element in the dialog.</li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <th><kbd>Shift + Tab</kbd></th>
+            <td>
+              <ul>
+                <li>Moves focus to previous focusable element inside the dialog.</li>
+                <li>When focus is on the first focusable element in the dialog, moves focus to the last focusable element in the dialog.</li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <th><kbd>Escape</kbd></th>
+            <td>Closes the dialog.</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section>
+      <h2 id="rps_label">Role, Property, State, and Tabindex Attributes</h2>
+      <table aria-labelledby="rps_label" class="data attributes">
+        <thead>
+          <tr>
+            <th scope="col">Role</th>
+            <th scope="col">Attribute</th>
+            <th scope="col">Element</th>
+            <th scope="col">Usage</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th scope="row"><code>dialog</code></th>
+            <td></td>
+            <td><code>div</code></td>
+            <td>Identifies the element that serves as the dialog container.</td>
+          </tr>
+          <tr>
+            <td></td>
+            <th scope="row"><code>aria-labelledby="IDREF"</code></th>
+            <td><code>div</code></td>
+            <td>Gives the dialog an accessible name by referring to the element that provides the dialog title.</td>
+          </tr>
+          <tr>
+            <td></td>
+            <th scope="row"><code>aria-describedby="IDREF"</code></th>
+            <td><code>div</code></td>
+            <td>
+              <ul>
+                <li>Gives the dialog an accessible description by referring to the dialog content that describes the primary message or purpose of the dialog.</li>
+                <li>Used in three of the four dialogs included in the example. See the above accessibility features section for an explanation.</li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td></td>
+            <th scope="row"><code>aria-modal="true"</code></th>
+            <td><code>div</code></td>
+            <td>Tells assistive technologies that the windows underneath the current dialog are not available for interaction (inert).</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h3>Notes on <code>aria-modal</code> and <code>aria-hidden</code></h3>
+
+      <ol>
+        <li>
+          The <code>aria-modal</code> property was introduced in ARIA 1.1.
+          As a new property, screen reader users may experience varying degrees of support for it.
+        </li>
+        <li>
+          Applying the <code>aria-modal</code> property to the <code>dialog</code> element
+          replaces the technique of using <code>aria-hidden</code> on the background for informing assistive technologies that content outside a dialog is inert.
+        </li>
+        <li>
+          In legacy dialog implementations where <code>aria-hidden</code> is used to make content outside a dialog inert for assistive technology users, it is important that:
+
+          <ol>
+            <li><code>aria-hidden</code> is set to <code>true</code> on each element containing a portion of the inert layer.</li>
+            <li>The dialog element is not a descendant of any element that has <code>aria-hidden</code> set to <code>true</code>.</li>
+          </ol>
+        </li>
+      </ol>
+    </section>
+
+    <section>
+      <h2>Javascript and CSS Source Code</h2>
+
+      <ul>
+        <li>
+          CSS:
+          <a href="css/dialog.css" type="text/css">dialog.css</a>
+        </li>
+        <li>
+          Javascript:
+          <a href="js/dialog.js" type="text/javascript">dialog.js</a>
+        </li>
+      </ul>
+    </section>
+
+    <section>
+      <h2 id="sc1_label">HTML Source Code</h2>
+
+      <div role="separator" id="sc1_start_sep" aria-labelledby="sc1_start_sep sc1_label" aria-label="Start of"></div>
+
+      <pre><code id="sc1"></code></pre>
+
+      <div role="separator" id="sc1_end_sep" aria-labelledby="sc1_end_sep sc1_label" aria-label="End of"></div>
+    </section>
+  </main>
+
+  <nav>
+    <a href="../../#dialog_modal">Modal Dialog Design Pattern in WAI-ARIA Authoring Practices 1.1</a>
+  </nav>
 
   <div id="dialog_layer" class="dialogs">
     <div role="dialog" id="dialog1" aria-labelledby="dialog1_label" aria-modal="true" class="hidden">

--- a/examples/dialog-modal/dialog.html
+++ b/examples/dialog-modal/dialog.html
@@ -1,22 +1,22 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<meta charset="utf-8" />
-<title>Modal Dialog Example | WAI-ARIA Authoring Practices 1.1</title>
+  <meta charset="utf-8">
+  <title>Modal Dialog Example | WAI-ARIA Authoring Practices 1.1</title>
 
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-<!--  Core js and css shared by all examples; do not modify when using this template. -->
-<link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/base.css">
-<link href="../css/core.css" rel="stylesheet">
-<script src="../js/examples.js" type="text/javascript"></script>
-<script src="../js/highlight.pack.js"></script>
+  <!-- Core JS and CSS shared by all examples. Do not modify when using this template. -->
+  <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/base.css">
+  <link rel="stylesheet" href="../css/core.css">
+  <script src="../js/examples.js"></script>
+  <script src="../js/highlight.pack.js"></script>
+  <script src="../js/app.js"></script>
 
-<!--  js and css for this example. -->
-<link href="css/dialog.css" rel="stylesheet">
-<script src="../js/utils.js" type="text/javascript"></script>
-<script src="js/dialog.js" type="text/javascript"></script>
-
+  <!-- CSS and JS for this example. -->
+  <link rel="stylesheet" href="css/dialog.css">
+  <script src="../js/utils.js"></script>
+  <script src="js/dialog.js"></script>
 </head>
 <body>
   <div id="base_window_layer">
@@ -28,74 +28,91 @@
         <li><a href="../../#dialog_modal">Design Pattern</a></li>
       </ul>
     </nav>
+
     <main>
       <h1>Modal Dialog Example</h1>
-      <p>
-        Following is an example implementation of the
-        <a href="../../#dialog_modal">design pattern for modal dialogs.</a>
-          The below <q>Add Delivery Address</q> button opens a modal dialog that contains two buttons that open other dialogs.
-          The accessibility features section explains the rationale for initial focus placement and use of <code>aria-describedby</code> in each dialog.
-        </p>
+
+      <p>Following is an example implementation of the <a href="../../#dialog_modal">design pattern for modal dialogs</a>. The below <q>Add Delivery Address</q> button opens a modal dialog that contains two buttons that open other dialogs. The accessibility features section explains the rationale for initial focus placement and use of <code>aria-describedby</code> in each dialog.</p>
+
       <section>
         <h2 id="ex_label">Example</h2>
+
         <div role="separator" id="ex_start_sep" aria-labelledby="ex_start_sep ex_label" aria-label="Start of"></div>
+
         <div id="ex1">
           <button onclick="openDialog('dialog1', this)">Add Delivery Address</button>
-          <!-- Important: Note that the dialog container divs are all in a div at the end of the body that is outside the div containing all content for the base window layer. -->
+          <!--
+            Important: Note that the dialog container divs are all in a div at
+            the end of the body that is outside the div containing all content
+            for the base window layer.
+          -->
         </div>
+
         <div role="separator" id="ex_end_sep" aria-labelledby="ex_end_sep ex_label" aria-label="End of"></div>
       </section>
 
       <section>
         <h2>Accessibility Features</h2>
+
         <ol>
           <li>
-            To make the content easier to read when displayed on small screens, the dialog fills 100% of the screen.
-            Completely covering the background window also hides background movement that occurs on some mobile devices when scrolling content inside the dialog.
+            To make the content easier to read when displayed on small screens, the dialog fills 100% of the screen. Completely covering the background window also hides background movement that occurs on some mobile devices when scrolling content inside the dialog.
           </li>
-          <li>Focus and accessible descriptions are set based on the content of each dialog.
-          <ol>
-            <li><q>Add Delivery Address</q> dialog (id=dialog1):
-              <ul>
-                <li>Initial focus is set on the first input, which is the first focusable element.</li>
-                <li>The dialog does not need <code>aria-describedby</code> since there is no static text that describes it.</li>
-                <li>When the dialog closes as a result of the <q>Cancel</q> action, the user's point of regard is maintained by returning focus to the <q>Add Delivery Address</q> button.
-                <li>
-                  When the dialog closes as a result of the <q>Add</q> action and the <q>Address Added</q> dialog replaces the <q>Add Delivery Address</q> dialog,
-                  the <q>Add Delivery Address</q> dialog passes a reference to the <q>Add Delivery Address</q> button to the the <q>Address Added</q> dialog
-                  so that it can maintain the user's point of regard when it closes.
-                </li>
-              </ul>
-            </li>
-            <li><q>Verification Result</q> dialog  (id=dialog2):
-              <ul>
-                <li>Initial focus is set on the first paragraph because the first interactive element is at the bottom, which is out of view due to the length of the text.</li>
-                <li>To support screen reader user awareness of the dialog text, the dialog text is wrapped in a <code>div</code> that is referenced by <code>aria-describedby</code>.</li>
-                <li>When the dialog closes, to maintain the user's point of regard, focus returns to the <q>Verify Address</q> button.</li>
-                <li>The text of this dialog describes design considerations for initial focus and accessible descriptions in dialogs with large amounts of text.</li>
-              </ul>
-            </li>
-            <li><q>Address Added</q> dialog (id=dialog3):
-              <ul>
-                <li>
-                  Initial focus is set on the <q>OK</q> button, which is the last focusable element.
-                  This is for efficiency since most users will simply dismiss the dialog as soon as they have read the message.
-                  Users can press <kbd>Tab</kbd> to focus on the <q>My Profile</q> link.
-                </li>
-                <li>The element containing the dialog message is referenced by <code>aria-describedby</code> to hint to screen readers that it should be announced when the dialog opens.</li>
-                <li>When the dialog closes, the user's point of regard is maintained by setting focus on the <q>Add Delivery Address</q> button.</li>
-              </ul>
-            </li>
-            <li><q>End of the Road!</q> dialog (id=dialog4):
-              <ul>
-                <li>This dialog has only one focusable element, which receives focus when the dialog opens.</li>
-                <li>Like dialog3, <code>aria-describedby</code> is used to facilitate message announcement for screen reader users.</li>
-                <li>Like all other dialogs in this example except for the <q>Address Added</q> confirmation dialog, when it closes, the user's point of regard is maintained by returning focus to the element that triggered display of the dialog.</li>
-              </ul>
-            </li>
-          </ol>
-        </li>
-      </ol>
+          <li>
+            Focus and accessible descriptions are set based on the content of each dialog.
+
+            <ol>
+              <li>
+                <q>Add Delivery Address</q> dialog (with <code>id="dialog1"</code>):
+
+                <ul>
+                  <li>Initial focus is set on the first input, which is the first focusable element.</li>
+                  <li>The dialog does not need <code>aria-describedby</code> since there is no static text that describes it.</li>
+                  <li>
+                    When the dialog closes as a result of the <q>Cancel</q> action, the user’s point of regard is maintained by returning focus to the <q>Add Delivery Address</q> button.
+                  </li>
+                  <li>
+                    When the dialog closes as a result of the <q>Add</q> action and the <q>Address Added</q> dialog replaces the <q>Add Delivery Address</q> dialog, the <q>Add Delivery Address</q> dialog passes a reference to the <q>Add Delivery Address</q> button to the the <q>Address Added</q> dialog so that it can maintain the user’s point of regard when it closes.
+                  </li>
+                </ul>
+              </li>
+              <li>
+                <q>Verification Result</q> dialog (with <code>id="dialog2"</code>):
+
+                <ul>
+                  <li>Initial focus is set on the first paragraph because the first interactive element is at the bottom, which is out of view due to the length of the text.</li>
+                  <li>To support screen reader user awareness of the dialog text, the dialog text is wrapped in a <code>div</code> that is referenced by <code>aria-describedby</code>.</li>
+                  <li>When the dialog closes, to maintain the user’s point of regard, focus returns to the <q>Verify Address</q> button.</li>
+                  <li>The text of this dialog describes design considerations for initial focus and accessible descriptions in dialogs with large amounts of text.</li>
+                </ul>
+              </li>
+              <li>
+                <q>Address Added</q> dialog (with <code>id="dialog3"</code>):
+
+                <ul>
+                  <li>
+                    Initial focus is set on the <q>OK</q> button, which is the last focusable element. This is for efficiency since most users will simply dismiss the dialog as soon as they have read the message. Users can press <kbd>Tab</kbd> to focus on the <q>My Profile</q> link.
+                  </li>
+                  <li>
+                    The element containing the dialog message is referenced by <code>aria-describedby</code> to hint to screen readers that it should be announced when the dialog opens.
+                  </li>
+                  <li>When the dialog closes, the user’s point of regard is maintained by setting focus on the <q>Add Delivery Address</q> button.</li>
+                </ul>
+              </li>
+              <li>
+                <q>End of the Road!</q> dialog (with <code>id="dialog4"</code>):
+
+                <ul>
+                  <li>This dialog has only one focusable element, which receives focus when the dialog opens.</li>
+                  <li>Like dialog3, <code>aria-describedby</code> is used to facilitate message announcement for screen reader users.</li>
+                  <li>
+                    Like all other dialogs in this example except for the <q>Address Added</q> confirmation dialog, when it closes, the user’s point of regard is maintained by returning focus to the element that triggered display of the dialog.
+                  </li>
+                </ul>
+              </li>
+            </ol>
+          </li>
+        </ol>
       </section>
 
     <section>
@@ -135,7 +152,7 @@
       </section>
 
       <section>
-        <h2 id="rps_label">Role, Property, State, and Tabindex  Attributes</h2>
+        <h2 id="rps_label">Role, Property, State, and Tabindex Attributes</h2>
         <table aria-labelledby="rps_label" class="data attributes">
           <thead>
             <tr>
@@ -150,43 +167,36 @@
               <th scope="row"><code>dialog</code></th>
               <td></td>
               <td><code>div</code></td>
-              <td>
-                Identifies the element that serves as the dialog container.
-              </td>
+              <td>Identifies the element that serves as the dialog container.</td>
             </tr>
             <tr>
               <td></td>
-              <th scope="row"><code>aria-labelledby=<q>IDREF</q></code></th>
+              <th scope="row"><code>aria-labelledby="IDREF"</code></th>
               <td><code>div</code></td>
-              <td>
-                Gives the dialog an accessible name by referring to the element that provides the dialog title.
-              </td>
+              <td>Gives the dialog an accessible name by referring to the element that provides the dialog title.</td>
             </tr>
             <tr>
               <td></td>
-              <th scope="row"><code>aria-describedby=<q>IDREF</q></code></th>
+              <th scope="row"><code>aria-describedby="IDREF"</code></th>
               <td><code>div</code></td>
               <td>
                 <ul>
                   <li>Gives the dialog an accessible description by referring to the dialog content that describes the primary message or purpose of the dialog.</li>
-                  <li>
-                    Used in three of the four dialogs included in the example.
-                    See the above accessibility features section for an explanation.
-                  </li>
+                  <li>Used in three of the four dialogs included in the example. See the above accessibility features section for an explanation.</li>
                 </ul>
               </td>
             </tr>
             <tr>
               <td></td>
-              <th scope="row"><code>aria-modal=<q>true</q></code></th>
+              <th scope="row"><code>aria-modal="true"</code></th>
               <td><code>div</code></td>
-              <td>
-                Tells assistive technologies that the windows underneath the current dialog are not available for interaction (inert).
-              </td>
+              <td>Tells assistive technologies that the windows underneath the current dialog are not available for interaction (inert).</td>
             </tr>
           </tbody>
         </table>
-        <h3>Notes on <code>aria-modal</code>and <code>aria-hidden</code></h3>
+
+        <h3>Notes on <code>aria-modal</code> and <code>aria-hidden</code></h3>
+
         <ol>
           <li>
             The <code>aria-modal</code> property was introduced in ARIA 1.1.
@@ -198,6 +208,7 @@
           </li>
           <li>
             In legacy dialog implementations where <code>aria-hidden</code> is used to make content outside a dialog inert for assistive technology users, it is important that:
+
             <ol>
               <li><code>aria-hidden</code> is set to <code>true</code> on each element containing a portion of the inert layer.</li>
               <li>The dialog element is not a descendant of any element that has <code>aria-hidden</code> set to <code>true</code>.</li>
@@ -208,10 +219,11 @@
 
       <section>
         <h2>Javascript and CSS Source Code</h2>
+
         <ul>
           <li>
             CSS:
-            <a href="css/dialog.css" type="tex/css">dialog.css</a>
+            <a href="css/dialog.css" type="text/css">dialog.css</a>
           </li>
           <li>
             Javascript:
@@ -222,19 +234,24 @@
 
       <section>
         <h2 id="sc1_label">HTML Source Code</h2>
-        <div role="separator" id="sc1_start_sep" aria-labelledby="sc1_start_sep sc1_label" aria-label="Start of"></div>
-        <pre><code id="sc1"></code></pre>
-        <div role="separator" id="sc1_end_sep" aria-labelledby="sc1_end_sep sc1_label" aria-label="End of"></div>
 
+        <div role="separator" id="sc1_start_sep" aria-labelledby="sc1_start_sep sc1_label" aria-label="Start of"></div>
+
+        <pre><code id="sc1"></code></pre>
+
+        <div role="separator" id="sc1_end_sep" aria-labelledby="sc1_end_sep sc1_label" aria-label="End of"></div>
       </section>
     </main>
+
     <nav>
       <a href="../../#dialog_modal">Modal Dialog Design Pattern in WAI-ARIA Authoring Practices 1.1</a>
     </nav>
   </div>
+
   <div id="dialog_layer" class="dialogs">
     <div role="dialog" id="dialog1" aria-labelledby="dialog1_label" aria-modal="true" class="hidden">
       <h2 id="dialog1_label">Add Delivery Address</h2>
+
       <div class="dialog_form">
         <div class="dialog_form_item">
           <label>
@@ -242,18 +259,21 @@
             <input type="text" class="wide_input">
           </label>
         </div>
+
         <div class="dialog_form_item">
           <label>
             <span class="label_text">City:</span>
             <input type="text" class="city_input">
           </label>
         </div>
+
         <div class="dialog_form_item">
           <label>
             <span class="label_text">State:</span>
             <input type="text" class="state_input">
           </label>
         </div>
+
         <div class="dialog_form_item">
           <label>
             <span class="label_text">Zip:</span>
@@ -265,12 +285,15 @@
           <label for="special_instructions">
             <span class="label_text">Special instructions:</span>
           </label>
+
           <input id="special_instructions" type="text" aria-describedby="special_instructions_desc" class="wide_input">
+
           <div class="label_info" id="special_instructions_desc">
             For example, gate code or other information to help the driver find you
           </div>
         </div>
       </div>
+
       <div class="dialog_form_actions">
         <button onclick="openDialog('dialog2', this, 'dialog2_para1')">Verify Address</button>
         <button onclick="replaceDialog('dialog3', undefined, 'dialog3_close_btn')">Add</button>
@@ -278,59 +301,95 @@
       </div>
     </div>
 
-    <!--  Second modal to open on top of the first modal  -->
+    <!-- Second modal to open on top of the first modal -->
     <div id="dialog2" role="dialog" aria-labelledby="dialog2_label"
       aria-describedby="dialog2_desc" aria-modal="true" class="hidden">
       <h2 id="dialog2_label">Verification Result</h2>
+
       <div id="dialog2_desc" class="dialog_desc">
-        <p tabindex="-1" id="dialog2_para1">This is just a demonstration. If it were a real application, it would
-          provide a message telling whether the entered address is valid.</p>
+        <p tabindex="-1" id="dialog2_para1">
+          This is just a demonstration. If it were a real application, it would
+          provide a message telling whether the entered address is valid.
+        </p>
+
         <p>
-          For demonstration purposes, this dialog has a lot of text. It demonstrates a
-            scenario where:
-          </p>
+          For demonstration purposes, this dialog has a lot of text. It
+          demonstrates a scenario where:
+        </p>
+
         <ul>
-          <li>The first interactive element, the help link, is at the bottom of the dialog.</li>
-          <li>If focus is placed on the first interactive element when the dialog opens, the
-            validation message may not be visible.</li>
-          <li>If the validation message is visible and the focus is on the help link, then
-            the focus may not be visible.</li>
+          <li>
+            The first interactive element, the help link, is at the bottom of
+            the dialog.
+          </li>
+          <li>
+            If focus is placed on the first interactive element when the dialog
+            opens, the validation message may not be visible.
+          </li>
+          <li>
+            If the validation message is visible and the focus is on the help
+            link, then the focus may not be visible.
+          </li>
           <li>
             When the dialog opens, it is important that both:
+
             <ul>
-              <li>The beginning of the text is visible so users do not have to scroll back to
-                start reading.</li>
+              <li>
+                The beginning of the text is visible so users do not have to
+                scroll back to start reading.
+              </li>
               <li>The keyboard focus always remains visible.</li>
             </ul>
           </li>
         </ul>
+
         <p>There are several ways to resolve this issue:</p>
+
         <ul>
-          <li>Place an interactive element at the top of the dialog, e.g., a button or link.</li>
-          <li>Make a static element focusable, e.g., the dialog title or the first block of
-            text.</li>
+          <li>
+            Place an interactive element at the top of the dialog, e.g., a
+            button or link.
+          </li>
+          <li>
+            Make a static element focusable, e.g., the dialog title or the first
+            block of text.
+          </li>
         </ul>
+
         <p>
-          Please <em>DO NOT </em> make the element with role dialog focusable!
+          Please <em>DO NOT</em> make the element with role dialog focusable!
         </p>
+
         <ul>
-          <li>The larger a focusable element is, the more difficult it is to visually
-            identify the location of focus, especially for users with a narrow field of view.</li>
-          <li>The dialog has a visual boarder. So creating a clear visual indicator of focus
-            when the entire dialog has focus is not very feasible.
-          <li>Screen readers read the label and content of focusable elements. The dialog
-            contains its label and a lot of content! If a dialog like this one has focus, the
-            actual focus is difficult to comprehend.</li>
+          <li>
+            The larger a focusable element is, the more difficult it is to
+            visually identify the location of focus, especially for users with a
+            narrow field of view.
+          </li>
+          <li>
+            The dialog has a visual boarder. So creating a clear visual
+            indicator of focus when the entire dialog has focus is not very
+            feasible.
+          </li>
+          <li>
+            Screen readers read the label and content of focusable elements. The
+            dialog contains its label and a lot of content! If a dialog like
+            this one has focus, the actual focus is difficult to comprehend.
+          </li>
         </ul>
+
         <p>
-          In this dialog, the first paragraph has <code>tabindex=<q>-1</q></code>. The first
-          paragraph is also contained inside the element that provides the dialog description, i.e., the element that is referenced
-          by <code>aria-describedby</code>. With some screen readers, this may have one negative
-          but relatively insignificant side effect when the dialog opens -- the first paragraph
-          may be announced twice. Nonetheless, making the first paragraph focusable and setting
-          the initial focus on it is the most broadly accessible option.
+          In this dialog, the first paragraph has <code>tabindex="-1"</code>.
+          The first paragraph is also contained inside the element that provides
+          the dialog description, i.e., the element that is referenced by
+          <code>aria-describedby</code>. With some screen readers, this may have
+          one negative but relatively insignificant side effect when the dialog
+          opens – the first paragraph may be announced twice. Nonetheless,
+          making the first paragraph focusable and setting the initial focus on
+          it is the most broadly accessible option.
         </p>
       </div>
+
       <div class="dialog_form_actions">
         <a href="#" onclick="openDialog('dialog4', this)">link to help</a>
         <button onclick="openDialog('dialog4', this)">accepting an alternative form</button>
@@ -338,28 +397,31 @@
       </div>
     </div>
 
-    <!--  Dialog that replaces dialog 1.  -->
+    <!-- Dialog that replaces dialog 1. -->
     <div id="dialog3" role="dialog" aria-labelledby="dialog3_label"
       aria-describedby="dialog3_desc" aria-modal="true" class="hidden">
       <h2 id="dialog3_label">Address Added</h2>
+
       <p id="dialog3_desc" class="dialog_desc">
-        The address you provided has been added to your list of delivery addresses. It is ready
-        for immediate use. If you wish to remove it, you can do so from
-        <a href="#" onclick="openDialog('dialog4', this)">your profile.</a>
+        The address you provided has been added to your list of delivery
+        addresses. It is ready for immediate use. If you wish to remove it, you
+        can do so from <a href="#" onclick="openDialog('dialog4', this)">your profile.</a>
       </p>
+
       <div class="dialog_form_actions">
         <button id="dialog3_close_btn" onclick="closeDialog(this)">OK</button>
       </div>
     </div>
 
     <div id="dialog4" role="dialog" aria-labelledby="dialog4_label"
-      aria-describedby="dialog4_desc" class="hidden"
-      aria-modal="true">
+      aria-describedby="dialog4_desc" class="hidden" aria-modal="true">
       <h2 id="dialog4_label">End of the Road!</h2>
+
       <p id="dialog4_desc" class="dialog_desc">
-        You activated a fake link or button that goes nowhere!
-        The link or button is present for demonstration purposes only.
+        You activated a fake link or button that goes nowhere! The link or
+        button is present for demonstration purposes only.
       </p>
+
       <div class="dialog_form_actions">
         <button id="dialog4_close_btn" onclick="closeDialog(this)">Close</button>
       </div>

--- a/examples/dialog-modal/js/dialog.js
+++ b/examples/dialog-modal/js/dialog.js
@@ -1,7 +1,7 @@
 /**
  * This content is licensed according to the W3C Software License at
  * https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document
-*/
+ */
 
 var aria = aria || {};
 
@@ -122,6 +122,12 @@ aria.Utils = aria.Utils || {};
    * element in the dialog will receive focus.
    */
   aria.Dialog = function (dialogId, focusAfterClosed, focusFirst) {
+    if (aria.OpenDialogList.length === 0 && this.storedOverflowProperty !== 'hidden') {
+      var docElementStyle = getComputedStyle(document.documentElement);
+      this.storedOverflowProperty = docElementStyle.getPropertyValue('overflow');
+      document.documentElement.style.setProperty('overflow', 'hidden');
+    }
+
     this.dialogNode = document.getElementById(dialogId);
 
     if (this.dialogNode === null || this.dialogNode.getAttribute('role') !== 'dialog') {
@@ -204,6 +210,9 @@ aria.Utils = aria.Utils || {};
    */
   aria.Dialog.prototype.close = function () {
     aria.OpenDialogList.pop();
+    if (aria.OpenDialogList.length === 0) {
+      document.documentElement.style.setProperty('overflow', this.storedOverflowProperty);
+    }
     this.removeListeners();
     aria.Utils.remove(this.preNode);
     aria.Utils.remove(this.postNode);
@@ -231,6 +240,9 @@ aria.Utils = aria.Utils || {};
    */
   aria.Dialog.prototype.replace = function (newDialogId, newFocusAfterClosed, newFocusFirst) {
     aria.OpenDialogList.pop();
+    if (aria.OpenDialogList.length === 0) {
+      document.documentElement.style.setProperty('overflow', this.storedOverflowProperty);
+    }
     this.removeListeners();
     aria.Utils.remove(this.preNode);
     aria.Utils.remove(this.postNode);


### PR DESCRIPTION
This pull request addresses the following issues:

**Clean up HTML**:

- Fixed highlight.js not being triggered due to code markup using a `<div>` element instead of `<pre>` and `<code>` elements.
- HTML head:
  - Consistent attribute order
  - Omitting unnecessary type attributes and closing slashes
- Content:
  - When used inside code, replaced `<q>` elements with regular double quote characters (i.e. `"`)
  - Added manual line breaks to the example code so that the example code block doesn’t have a scrollbar on medium to large screens
- Added missing `</li>` closing elements in some places
- Added a bunch of empty lines between some chunks of code for easier readability
- Fixed some minor indentation issues in some places

**Clean up JavaScript**:

- Fixed some documentation comments using JSDoc
- Removed the ability to pass an ID to the `focusAfterClosed` parameter because it isn’t used at all. This added unnecessary complexity to the example.
- Removed the ability to pass an element node to the `focusFirst` parameter. Same reason as above.

**Fixed Layout Issue**:

Removed the `div#base_window_layer` element wrapping the main content that was used to disable scrolling when any modal dialog is open.

The new implementation disables scrolling on the root element as soon as one dialog is open and restores the original property as soon as *all* dialoges are closed.

This fixed a major visual discrepancy of the dialog example page layout compared to the appearance of all other example pages. Most notably, the main content wasn’t aligned to the left of the screen and the main scrollbar was rendered a couple of pixels inside the viewport instead of the viewport border.

**Potential bug**:

The following code looks broken.

[**`aria.Utils.attemptFocus`**](https://github.com/w3c/aria-practices/blob/master/examples/dialog-modal/js/dialog.js#L67-L72):

```js
try {
  element.focus();
}
catch (e) {
}
aria.Utils.IgnoreUtilFocusChanges = false;
```

Is the last line supposed to be called inside the `catch` block? If not, what’s the purpose of the try-catch block if nothing happens?
