### PR TITLE
Navigation Menu Button Example: fix unreachable code and shift-tab not closing menu

### DIFF
--- a/examples/menu-button/css/MenubuttonLinks.css
+++ b/examples/menu-button/css/MenubuttonLinks.css
@@ -3,16 +3,20 @@
 }
 
 .menu_button button {
+  margin: 1px;
   font-size: 110%;
   display: block;
-  padding: 0.25em;
-  border: inset 2px gray;
+  padding: 0.375em;
+  border: solid 0.125em gray;
+  border-radius: 8px;
   width: 12em;
   text-align: center;
-  background-color: #EEEEEE;
-  text-decoration: none;
+  background-color: #EEE;
   color: black;
+  outline: none;
 }
+
+
 
 ul[role="menu"] {
   margin: 0;
@@ -20,8 +24,11 @@ ul[role="menu"] {
   position: absolute;
   font-size: 110%;
 
+  border: solid 0.125em gray;
+  border-radius: 5px;
+
   list-style: none;
-  background-color: #EEEEEE;
+  background-color: #FFF;
   display: none;
 }
 
@@ -33,25 +40,31 @@ ul[role="menu"] li {
 ul[role="menu"] a[role="menuitem"],
 ul[role="menu"] a[role="menuitem"]:visited {
   display: block;
+  border: none;
   text-decoration: none;
   padding: 0.25em;
   padding-left: 0.5em;
   padding-right: 0.5em;
-  background-color: #E0E0E0;
+  background-color: #FFF;
   width: 22em;
   color: black;
+  outline: solid 0.125em transparent;
 }
 
 /* focus and hover styling */
 
-a[role="button"]:focus,
-a[role="button"]:hover {
-  border: 2px solid black;
-  background-color: #F8F8F8;
+.menu_button button:focus {
+  padding: 0.25em;
+  border-width: 0.25em;
+  border-color: hsl(216, 94%, 70%);
+  background-color: hsl(216, 80%, 97%);
 }
 
-ul[role="menu"] a[role="menuitem"]:focus,
+ul[role="menu"] a[role="menuitem"]:focus {
+  outline-color: hsl(216, 94%, 70%);
+  background-color: hsl(216, 80%, 97%);
+}
+
 ul[role="menu"] a[role="menuitem"]:hover{
-  background-color: black;
-  color: white;
+  background-color: hsl(216, 80%, 90%);
 }

--- a/examples/menu-button/css/MenubuttonLinks.css
+++ b/examples/menu-button/css/MenubuttonLinks.css
@@ -3,20 +3,16 @@
 }
 
 .menu_button button {
-  margin: 1px;
   font-size: 110%;
   display: block;
-  padding: 0.375em;
-  border: solid 0.125em gray;
-  border-radius: 8px;
+  padding: 0.25em;
+  border: inset 2px gray;
   width: 12em;
   text-align: center;
-  background-color: #EEE;
+  background-color: #EEEEEE;
+  text-decoration: none;
   color: black;
-  outline: none;
 }
-
-
 
 ul[role="menu"] {
   margin: 0;
@@ -24,11 +20,8 @@ ul[role="menu"] {
   position: absolute;
   font-size: 110%;
 
-  border: solid 0.125em gray;
-  border-radius: 5px;
-
   list-style: none;
-  background-color: #FFF;
+  background-color: #EEEEEE;
   display: none;
 }
 
@@ -40,31 +33,25 @@ ul[role="menu"] li {
 ul[role="menu"] a[role="menuitem"],
 ul[role="menu"] a[role="menuitem"]:visited {
   display: block;
-  border: none;
   text-decoration: none;
   padding: 0.25em;
   padding-left: 0.5em;
   padding-right: 0.5em;
-  background-color: #FFF;
+  background-color: #E0E0E0;
   width: 22em;
   color: black;
-  outline: solid 0.125em transparent;
 }
 
 /* focus and hover styling */
 
-.menu_button button:focus {
-  padding: 0.25em;
-  border-width: 0.25em;
-  border-color: hsl(216, 94%, 70%);
-  background-color: hsl(216, 80%, 97%);
+a[role="button"]:focus,
+a[role="button"]:hover {
+  border: 2px solid black;
+  background-color: #F8F8F8;
 }
 
-ul[role="menu"] a[role="menuitem"]:focus {
-  outline-color: hsl(216, 94%, 70%);
-  background-color: hsl(216, 80%, 97%);
-}
-
+ul[role="menu"] a[role="menuitem"]:focus,
 ul[role="menu"] a[role="menuitem"]:hover{
-  background-color: hsl(216, 80%, 90%);
+  background-color: black;
+  color: white;
 }

--- a/examples/menu-button/js/MenuItemLinks.js
+++ b/examples/menu-button/js/MenuItemLinks.js
@@ -78,14 +78,16 @@ MenuItemLinks.prototype.handleKeydown = function (event) {
   if (event.shiftKey) {
     if (isPrintableCharacter(char)) {
       this.menu.setFocusByFirstCharacter(this, char);
+      flag = true;
+    }
+
+    if (event.keyCode === this.keyCode.TAB) {
+      this.menu.setFocusToController();
+      this.menu.close(true);
     }
   }
   else {
     switch (event.keyCode) {
-
-      case this.keyCode.SPACE:
-        flag = true;
-        break;
 
       case this.keyCode.ESC:
         this.menu.setFocusToController();

--- a/examples/menu-button/js/PopupMenuLinks.js
+++ b/examples/menu-button/js/PopupMenuLinks.js
@@ -48,7 +48,7 @@ var PopupMenuLinks = function (domNode, controllerObj) {
   var childElement = domNode.firstElementChild;
   while (childElement) {
     var menuitem = childElement.firstElementChild;
-    if (menuitem && menuitem === 'A') {
+    if (menuitem && menuitem.tagName !== 'A') {
       throw new Error(msgPrefix + 'has descendant elements that are not A elements.');
     }
     childElement = childElement.nextElementSibling;


### PR DESCRIPTION
Issue #396: Fixes the unreachable code problem
Issue #588: Fixes shift-tab not closing the menu
Updated CSS focus styling

#### Preview link

[Navigation menu button example in Jon's fork](https://rawgit.com/jongund/aria-practices/issues-396-588-menubutton/examples/menu-button/menu-button-links.html)