### PR TITLE
Editor menubar example: Make Escape close submenu when focus in menubar

### DIFF
--- a/examples/menubar/menubar-2/js/MenubarItemAction.js
+++ b/examples/menubar/menubar-2/js/MenubarItemAction.js
@@ -134,6 +134,13 @@ MenubarItemAction.prototype.handleKeydown = function (event) {
       flag = true;
       break;
 
+    case this.keyCode.ESC:
+      if (this.popupMenu) {
+        this.popupMenu.close();
+      }
+      flag = true;
+      break;
+
     default:
       if (isPrintableCharacter(char)) {
         this.menubar.setFocusByFirstCharacter(this, char);

--- a/examples/menubar/menubar-2/menubar-2.html
+++ b/examples/menubar/menubar-2/menubar-2.html
@@ -161,6 +161,14 @@
         </tr>
         <tr>
           <th>
+            <kbd>Escape</kbd>
+          </th>
+          <td>
+            Closes submenu.
+          </td>
+        </tr>
+        <tr>
+          <th>
             <kbd>Right Arrow</kbd>
           </th>
           <td>

--- a/examples/menubar/menubar-2/menubar-2.html
+++ b/examples/menubar/menubar-2/menubar-2.html
@@ -164,7 +164,7 @@
             <kbd>Escape</kbd>
           </th>
           <td>
-            Closes submenu.
+            If a submenu is open, closes it. Otherwise, does nothing.
           </td>
         </tr>
         <tr>


### PR DESCRIPTION
For issue #451.