### PR TITLE
Fix typo: overlayed/overlaid

### DIFF
--- a/aria-practices.html
+++ b/aria-practices.html
@@ -920,7 +920,7 @@
     <section class="widget" id="dialog_modal">
       <h3>Dialog (Modal)</h3>
       <p>
-        A <a href="#dialog" class="role-reference">dialog</a> is a window overlayed on either the primary window or another dialog window.
+        A <a href="#dialog" class="role-reference">dialog</a> is a window overlaid on either the primary window or another dialog window.
         Windows under a modal dialog are inert.
         That is, users cannot interact with content outside an active dialog window.
         Inert content outside an active dialog is typically visually obscured or dimmed so it is difficult to discern,


### PR DESCRIPTION
This fixes a typo in section [3.8 Dialog (Modal)](http://w3c.github.io/aria-practices/#dialog_modal).