### PR TITLE
For menu button links example, collapse menu when clicking button

### DIFF
--- a/examples/menu-button/js/Menubutton2.js
+++ b/examples/menu-button/js/Menubutton2.js
@@ -108,7 +108,7 @@ Menubutton.prototype.handleKeydown = function (event) {
 
 Menubutton.prototype.handleClick = function (event) {
   if (this.domNode.getAttribute('aria-expanded') == 'true') {
-    this.popupMenu.close();
+    this.popupMenu.close(true);
   }
   else {
     this.popupMenu.open();


### PR DESCRIPTION
For the menu button links example, currently, with the menu expanded, clicking the button trigger does not cause the menu to collapse. It does, however, do this in the menu button actions example, and I think this is the correct behavior, especially since, without that, this means, on touch devices, there is essentially no intuitive way of collapsing the menu. The issue appears to be that line 111 of Menubutton2.js is not passed the true boolean argument, as it is on Menubutton.js. I've fixed this and it appears to work now.