### PR TITLE
ARIA 1.0 Combobox Example: Make escape clear textbox

### DIFF
--- a/examples/combobox/aria1.0pattern/js/combobox-1.0-list.js
+++ b/examples/combobox/aria1.0pattern/js/combobox-1.0-list.js
@@ -193,12 +193,10 @@ ComboboxList.prototype.handleKeydown = function (event) {
       break;
 
     case this.keyCode.ESC:
-      if (this.listbox.hasFocus) {
-        this.listbox.close(true);
-        this.setVisualFocusTextbox();
-        this.setValue('');
-        this.option = false;
-      }
+      this.listbox.close(true);
+      this.setVisualFocusTextbox();
+      this.setValue('');
+      this.option = false;
       flag = true;
       break;
 
@@ -242,6 +240,9 @@ ComboboxList.prototype.handleKeyup = function (event) {
     this.option = false;
   }
 
+  if (event.keyCode === this.keyCode.ESC) {
+    return;
+  }
 
   switch (event.keyCode) {
 


### PR DESCRIPTION
For issue #559, fix the escape key behavior so that it will clear the textbox.