### PR TITLE
Modal Dialog Example: Fix HTML source display highlighting

### DIFF
--- a/examples/dialog-modal/alertdialog.html
+++ b/examples/dialog-modal/alertdialog.html
@@ -224,7 +224,8 @@
       </section>
       <section>
         <h2 id="sc1_label">HTML Source Code</h2>
-        <div role="separator" id="sc1_start_sep" aria-labelledby="sc1_start_sep sc1_label" aria-label="Start of"></div> <pre><code id="sc1"></code></pre>
+        <div role="separator" id="sc1_start_sep" aria-labelledby="sc1_start_sep sc1_label" aria-label="Start of"></div>
+        <pre><code id="sc1"></code></pre>
         <div role="separator" id="sc1_end_sep" aria-labelledby="sc1_end_sep sc1_label" aria-label="End of"></div>
         <script>
           sourceCode.add('sc1', 'ex_alertdialog');

--- a/examples/dialog-modal/dialog.html
+++ b/examples/dialog-modal/dialog.html
@@ -11,6 +11,7 @@
 <link href="../css/core.css" rel="stylesheet">
 <script src="../js/examples.js" type="text/javascript"></script>
 <script src="../js/highlight.pack.js"></script>
+<script src="../js/app.js"></script>
 
 <!--  js and css for this example. -->
 <link href="css/dialog.css" rel="stylesheet">

--- a/examples/dialog-modal/dialog.html
+++ b/examples/dialog-modal/dialog.html
@@ -226,7 +226,7 @@
     <section>
       <h2 id="sc1_label">HTML Source Code</h2>
       <div role="separator" id="sc1_start_sep" aria-labelledby="sc1_start_sep sc1_label" aria-label="Start of"></div>
-      <div id="sc1"></div>
+      <pre><code id="sc1"></code></pre>
       <div role="separator" id="sc1_end_sep" aria-labelledby="sc1_end_sep sc1_label" aria-label="End of"></div>
 
     </section>


### PR DESCRIPTION
Fixes #738.

The dialog example was missing the app.js script (874b4cf081f9e884ea8bfbacf201eb8ee11d16d6), and was using the wrong semantics for the code snippet (ca3206c308289707c7e722e12f1ef1bf75a1734f).

In light of this, I looked through all of the other `examples/**/*.html` files to make sure there weren't any similar errors. I wasn't able to find any other issues other than a missing linebreak in my alertdialog example (560c3e360fc74425b002b7d3d4659b01c63cbfa5).