### PR TITLE
ARIA 1.1 Combobox Examples: Use `for` attribute on label element instead of aria-labelledby on `input` element 

### DIFF
--- a/examples/combobox/aria1.1pattern/grid-combo.html
+++ b/examples/combobox/aria1.1pattern/grid-combo.html
@@ -53,7 +53,7 @@
       <h2 id="ex_label">Example</h2>
       <div role="separator" id="ex_start_sep" aria-labelledby="ex_start_sep ex_label" aria-label="Start of"></div>
       <div id="ex1">
-        <label id="ex1-label" class="combobox-label">
+        <label for="ex1-input" id="ex1-label" class="combobox-label">
           Fruits and vegetables
         </label>
         <div class="combobox-wrapper">
@@ -65,7 +65,6 @@
             <input type="text"
               aria-autocomplete="list"
               aria-controls="ex1-grid"
-              aria-labelledby="ex1-label"
               id="ex1-input">
           </div>
           <div

--- a/examples/combobox/aria1.1pattern/grid-combo.html
+++ b/examples/combobox/aria1.1pattern/grid-combo.html
@@ -297,10 +297,15 @@
           <tr>
             <td></td>
             <th scope="row">
-              <code>aria-labelledby=<q>IDREF</q></code>
+              <code>id="string"</code>
             </th>
             <td><code>input[type="text"]</code></td>
-            <td>Provides a label for the textbox element of the combobox.</td>
+            <td>
+              <ul>
+                <li>Referenced by <code>for</code> attribute of <code>label</code> element to provide an accessible label.</li>
+                <li>Recommended labeling method for HTML input elements so clicking label focuses input.</li>
+              </ul>
+            </td>
           </tr>
           <tr>
             <td></td>

--- a/examples/combobox/aria1.1pattern/listbox-combo.html
+++ b/examples/combobox/aria1.1pattern/listbox-combo.html
@@ -52,7 +52,7 @@
       <h3 id="ex1_label">Example 1: List Autocomplete with Manual Selection</h3>
       <div role="separator" id="ex1_start_sep" aria-labelledby="ex1_start_sep ex1_label" aria-label="Start of"></div>
       <div id="ex1">
-        <label id="ex1-label" class="combobox-label">
+        <label for="ex1-input" id="ex1-label" class="combobox-label">
           Choice 1 Fruit or Vegetable
         </label>
         <div class="combobox-wrapper">
@@ -64,7 +64,6 @@
             <input type="text"
               aria-autocomplete="list"
               aria-controls="ex1-listbox"
-              aria-labelledby="ex1-label"
               id="ex1-input">
           </div>
           <ul

--- a/examples/combobox/aria1.1pattern/listbox-combo.html
+++ b/examples/combobox/aria1.1pattern/listbox-combo.html
@@ -407,10 +407,15 @@
           <tr>
             <td></td>
             <th scope="row">
-              <code>aria-labelledby=<q>IDREF</q></code>
+              <code>id="string"</code>
             </th>
             <td><code>input[type="text"]</code></td>
-            <td>Provides a label for the textbox element of the combobox.</td>
+            <td>
+              <ul>
+                <li>Referenced by <code>for</code> attribute of <code>label</code> element to provide an accessible label.</li>
+                <li>Recommended labeling method for HTML input elements so clicking label focuses input.</li>
+              </ul>
+            </td>
           </tr>
           <tr>
             <td></td>


### PR DESCRIPTION
Fixes #542.