### PR TITLE
Update firefox on travis CI 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ addons:
     packages:
       - oracle-java8-installer
       - oracle-java8-set-default
+  firefox: "60.0.2"
 
 git:
   depth: 3


### PR DESCRIPTION
A link/link.js tests failed when running on travis CI:
https://travis-ci.org/w3c/aria-practices/builds/396923884#L6

I could reproduce the bug by:
- Running with Firefox with 56.0.2
- Making sure the element appears below the fold

It does not appear when I run locally with 60.0.2 -- it appears there is a bug with firefox 56.0.2 not scrolling the element into view before sending a key!