### PR TITLE
link/link.js feedback - minor fixes

### DIFF
--- a/examples/link/link.html
+++ b/examples/link/link.html
@@ -147,7 +147,7 @@
             </ul>
           </td>
         </tr>
-        <tr data-test-id="tab-index">
+        <tr data-test-id="tabindex">
           <td></td>
           <th scope="row"><code>tabindex=&quot;0&quot;</code></th>
           <td><code>span</code>, <br/><code>img</code></td>

--- a/test/index.js
+++ b/test/index.js
@@ -44,12 +44,13 @@ test.after.always(() => {
  *                          within the demonstration page
  * @param {Function} body - script which implements the test
  */
-const ariaTest = (page, testId, body) => {
+const ariaTest = (desc, page, testId, body) => {
   const absPath = path.resolve(__dirname, '..', 'examples', ...page.split('/'));
   const url = 'file://' + absPath;
   const selector = '[data-test-id="' + testId + '"]';
 
-  test.serial(page + ' ' + selector, async function (t) {
+  const testName = page + ' ' + selector + ": " + desc;
+  test.serial(testName, async function (t) {
     t.context.url = url;
     await t.context.session.get(url);
 

--- a/test/index.js
+++ b/test/index.js
@@ -49,15 +49,15 @@ const ariaTest = (desc, page, testId, body) => {
   const url = 'file://' + absPath;
   const selector = '[data-test-id="' + testId + '"]';
 
-  const testName = page + ' ' + selector + ": " + desc;
+  const testName = page + ' ' + selector + ": desc";
   test.serial(testName, async function (t) {
     t.context.url = url;
     await t.context.session.get(url);
 
-    t.is(
+    const assert = require('assert');
+    assert(
       (await t.context.session.findElements(t.context.By.css(selector))).length,
-      1,
-      'The behavior description is present in the document:' + testId
+      'Cannot find behavior description for this test in example page:' + testId
     );
 
     return body.apply(this, arguments);

--- a/test/index.js
+++ b/test/index.js
@@ -56,7 +56,7 @@ const ariaTest = (page, testId, body) => {
     t.is(
       (await t.context.session.findElements(t.context.By.css(selector))).length,
       1,
-      'The behavior description is present in the document'
+      'The behavior description is present in the document:' + testId
     );
 
     return body.apply(this, arguments);

--- a/test/tests/link.js
+++ b/test/tests/link.js
@@ -20,7 +20,6 @@ let pageExamples = [
 ];
 
 ariaTest('link/link.html', 'link-role', async (t) => {
-
   for (let i = 0; i < pageExamples.length; i++) {
     let ex = pageExamples[i];
     let linkLocator = t.context.By.css(ex.linkSelector);
@@ -34,7 +33,7 @@ ariaTest('link/link.html', 'link-role', async (t) => {
   }
 });
 
-ariaTest('link/link.html', 'tab-index', async (t) => {
+ariaTest('link/link.html', 'tabindex', async (t) => {
 
   for (let i = 0; i < pageExamples.length; i++) {
     let ex = pageExamples[i];
@@ -61,7 +60,7 @@ ariaTest('link/link.html', 'alt', async (t) => {
 
     t.truthy(
       await linkElement.getAttribute('alt'),
-      '"alt" attribute should exist on element selected by: ' + ex.linkSelector,
+      '"alt" attribute should exist on element selected by: ' + ex.linkSelector
     );
   }
 

--- a/test/tests/link.js
+++ b/test/tests/link.js
@@ -19,7 +19,9 @@ let pageExamples = [
   }
 ];
 
-ariaTest('link/link.html', 'link-role', async (t) => {
+ariaTest('Test "role" attribute exists',
+         'link/link.html', 'link-role', async (t) => {
+
   for (let i = 0; i < pageExamples.length; i++) {
     let ex = pageExamples[i];
     let linkLocator = t.context.By.css(ex.linkSelector);
@@ -33,7 +35,8 @@ ariaTest('link/link.html', 'link-role', async (t) => {
   }
 });
 
-ariaTest('link/link.html', 'tabindex', async (t) => {
+ariaTest('Test "tabindex" attribute set to 0',
+         'link/link.html', 'tabindex', async (t) => {
 
   for (let i = 0; i < pageExamples.length; i++) {
     let ex = pageExamples[i];
@@ -48,7 +51,8 @@ ariaTest('link/link.html', 'tabindex', async (t) => {
   }
 });
 
-ariaTest('link/link.html', 'alt', async (t) => {
+ariaTest('Test "alt" attribute exists',
+         'link/link.html', 'alt', async (t) => {
 
   for (let i = 0; i < pageExamples.length; i++) {
     let ex = pageExamples[i];
@@ -66,7 +70,9 @@ ariaTest('link/link.html', 'alt', async (t) => {
 
 });
 
-ariaTest('link/link.html', 'aria-label', async (t) => {
+ariaTest('Test "aria-label" attribute exists',
+         'link/link.html', 'aria-label', async (t) => {
+
   for (let i = 0; i < pageExamples.length; i++) {
     let ex = pageExamples[i];
     if (!ex.hasOwnProperty('ariaLabel')) {
@@ -82,7 +88,9 @@ ariaTest('link/link.html', 'aria-label', async (t) => {
   }
 });
 
-ariaTest('link/link.html', 'key-enter', async (t) => {
+ariaTest('Test "ENTER" key behavior',
+         'link/link.html', 'key-enter', async (t) => {
+
   for (let i = 0; i < pageExamples.length; i++) {
     await t.context.session.get(t.context.url);
 
@@ -95,7 +103,7 @@ ariaTest('link/link.html', 'key-enter', async (t) => {
       return t.context.session.getCurrentUrl().then(url => {
         return url != t.context.url;
       });
-    }, 500).catch(() => {});
+    }, 1000).catch(() => {});
 
     t.not(
       await t.context.session.getCurrentUrl(),

--- a/test/util/start-geckodriver.js
+++ b/test/util/start-geckodriver.js
@@ -66,7 +66,7 @@ const startOnAnyPort = (port, timeout) => {
  * port.
  *
  * @param {Number} port - the TCP/IP port from which to begin search
- * @param {Number{ timeout - the number of milliseconds to attempt to create a
+ * @param {Number} timeout - the number of milliseconds to attempt to create a
  *                           server before reporting a failure
  *
  * @returns {Promise<Object>} - an eventual value for interfacing with the


### PR DESCRIPTION
Fix testnames based on @sh0ji 's suggestions and fix one small comment.

I left the ariaTest abstraction for now (including the check for data-test-id) -- we can revisit it later. I did change the "t.is" in ariaTest to an assert in order to not effect the test count for test planning. 