### PR TITLE
Work in progress: add tests for LayoutGrid

### DIFF
--- a/examples/grid/LayoutGrids.html
+++ b/examples/grid/LayoutGrids.html
@@ -455,7 +455,7 @@
         </tr>
       </thead>
       <tbody>
-        <tr>
+        <tr data-test-id="key-right-arrow">
           <th>
             <kbd>Right Arrow</kbd>
           </th>
@@ -468,7 +468,7 @@
             </ul>
           </td>
         </tr>
-        <tr>
+        <tr data-test-id="key-left-arrow">
           <th>
             <kbd>Left Arrow</kbd>
           </th>
@@ -481,7 +481,7 @@
             </ul>
           </td>
         </tr>
-        <tr>
+        <tr data-test-id="key-down-arrow">
           <th>
             <kbd>Down Arrow</kbd>
           </th>
@@ -496,7 +496,7 @@
             </ul>
           </td>
         </tr>
-        <tr>
+        <tr data-test-id="key-up-arrow">
           <th>
             <kbd>Up Arrow</kbd>
           </th>
@@ -511,7 +511,7 @@
             </ul>
           </td>
         </tr>
-        <tr>
+        <tr data-test-id="key-page-down">
           <th>
             <kbd>Page Down</kbd> (Example 3)
           </th>
@@ -523,7 +523,7 @@
             </ul>
           </td>
         </tr>
-        <tr>
+        <tr data-test-id="key-page-up">
           <th>
             <kbd>Page Up</kbd> (Example 3)
           </th>
@@ -535,25 +535,25 @@
             </ul>
           </td>
         </tr>
-        <tr>
+        <tr data-test-id="key-home">
           <th>
             <kbd>Home</kbd>
           </th>
           <td>Moves focus to the first cell in the row that contains focus.</td>
         </tr>
-        <tr>
+        <tr data-test-id="key-end">
           <th>
             <kbd>End</kbd>
           </th>
           <td>Moves focus to the last cell in the row that contains focus.</td>
         </tr>
-        <tr>
+        <tr data-test-id="key-control-home">
           <th>
             <kbd>Control + Home</kbd>
           </th>
           <td>Moves focus to the first cell in the first row.</td>
         </tr>
-        <tr>
+        <tr data-test-id="key-control-end">
           <th>
             <kbd>Control + End</kbd>
           </th>
@@ -575,7 +575,7 @@
         </tr>
       </thead>
       <tbody>
-        <tr>
+        <tr data-test-id="grid-role">
           <th scope="row"><code>grid</code></th>
           <td></td>
           <td><code>div</code></td>
@@ -584,7 +584,7 @@
             Because focus is managed using <a href="../../#kbd_roving_tabindex">roving tabindex</a>, the grid element is not focusable.
           </td>
         </tr>
-        <tr>
+        <tr data-test-id="aria-labelledby">
           <td></td>
           <th scope="row">
             <code>aria-labelledby=&quot;ID_REF&quot;</code>
@@ -592,7 +592,7 @@
           <td><code>div</code></td>
           <td>In examples 1 and 2, refers to the element that labels the grid.</td>
         </tr>
-        <tr>
+        <tr data-test-id="aria-label">
           <td></td>
           <th scope="row">
             <code>aria-label=&quot;Search Results&quot;</code>
@@ -600,7 +600,7 @@
           <td><code>div</code></td>
           <td>In example 3, the grid does not have a visible label so the label is specified with <code>aria-label</code>.</td>
         </tr>
-        <tr>
+        <tr data-test-id="aria-rowcount">
           <td></td>
           <th scope="row"><code>aria-rowcount=&quot;19&quot;</code></th>
           <td><code>div</code></td>
@@ -612,7 +612,7 @@
             </ul>
           </td>
         </tr>
-        <tr>
+        <tr data-test-id="row-role">
           <th scope="row"><code>row</code></th>
           <td></td>
           <td><code>div</code></td>
@@ -628,7 +628,7 @@
             </ul>
           </td>
         </tr>
-        <tr>
+        <tr data-test-id="aria-rowindex">
           <td></td>
           <th scope="row"><code>aria-rowindex=&quot;INDEX_VALUE&quot;</code></th>
           <td><code>div</code></td>
@@ -641,13 +641,13 @@
             </ul>
           </td>
         </tr>
-        <tr>
+        <tr data-test-id="gridcell-role">
           <th scope="row"><code>gridcell</code></th>
           <td></td>
-          <td><code>span</code></td>
+          <td><code>span, div</code></td>
           <td>Identifies the element containing the content for a single cell.</td>
         </tr>
-        <tr>
+        <tr data-test-id="tabindex">
           <td></td>
           <th scope="row"><code>tabindex=&quot;-1&quot;</code></th>
           <td><code>span</code></td>
@@ -658,7 +658,7 @@
             </ul>
           </td>
         </tr>
-        <tr>
+        <tr data-test-id="tabindex">
           <td></td>
           <th scope="row"><code>tabindex=&quot;-1&quot;</code></th>
           <td>Widgets inside cells</td>

--- a/examples/link/link.html
+++ b/examples/link/link.html
@@ -147,7 +147,7 @@
             </ul>
           </td>
         </tr>
-        <tr data-test-id="tab-index">
+        <tr data-test-id="tabindex">
           <td></td>
           <th scope="row"><code>tabindex=&quot;0&quot;</code></th>
           <td><code>span</code>, <br/><code>img</code></td>

--- a/test/index.js
+++ b/test/index.js
@@ -44,12 +44,13 @@ test.after.always(() => {
  *                          within the demonstration page
  * @param {Function} body - script which implements the test
  */
-const ariaTest = (page, testId, body) => {
+const ariaTest = (desc, page, testId, body) => {
   const absPath = path.resolve(__dirname, '..', 'examples', ...page.split('/'));
   const url = 'file://' + absPath;
   const selector = '[data-test-id="' + testId + '"]';
 
-  test.serial(page + ' ' + selector, async function (t) {
+  const testName = page + ' ' + selector + ": " + desc;
+  test.serial(testName, async function (t) {
     t.context.url = url;
     await t.context.session.get(url);
 

--- a/test/index.js
+++ b/test/index.js
@@ -49,15 +49,15 @@ const ariaTest = (desc, page, testId, body) => {
   const url = 'file://' + absPath;
   const selector = '[data-test-id="' + testId + '"]';
 
-  const testName = page + ' ' + selector + ": " + desc;
+  const testName = page + ' ' + selector + ": desc";
   test.serial(testName, async function (t) {
     t.context.url = url;
     await t.context.session.get(url);
 
-    t.is(
+    const assert = require('assert');
+    assert(
       (await t.context.session.findElements(t.context.By.css(selector))).length,
-      1,
-      'The behavior description is present in the document:' + testId
+      'Cannot find behavior description for this test in example page:' + testId
     );
 
     return body.apply(this, arguments);

--- a/test/index.js
+++ b/test/index.js
@@ -56,7 +56,7 @@ const ariaTest = (page, testId, body) => {
     t.is(
       (await t.context.session.findElements(t.context.By.css(selector))).length,
       1,
-      'The behavior description is present in the document'
+      'The behavior description is present in the document:' + testId
     );
 
     return body.apply(this, arguments);

--- a/test/index.js
+++ b/test/index.js
@@ -49,7 +49,7 @@ const ariaTest = (desc, page, testId, body) => {
   const url = 'file://' + absPath;
   const selector = '[data-test-id="' + testId + '"]';
 
-  const testName = page + ' ' + selector + ": desc";
+  const testName = page + ' ' + selector + ': desc';
   test.serial(testName, async function (t) {
     t.context.url = url;
     await t.context.session.get(url);

--- a/test/tests/LayoutGrids.js
+++ b/test/tests/LayoutGrids.js
@@ -1,0 +1,398 @@
+'use strict';
+
+const { ariaTest } = require('..');
+
+
+let pageExamples = {
+  'ex1': {
+    gridSelector: '#ex1 [role="grid"]'
+  },
+  'ex2': {
+    gridSelector: '#ex2 [role="grid"]'
+  },
+  'ex3': {
+    gridSelector: '#ex3 [role="grid"]'
+  }
+};
+
+// Attributes
+
+ariaTest('Test "role=grid" attribute exists',
+         'grid/LayoutGrids.html', 'grid-role', async (t) => {
+
+  t.plan(3);
+
+  for (let exId in pageExamples) {
+    let ex = pageExamples[exId];
+    let gridLocator = t.context.By.css(ex.gridSelector);
+
+    t.is(
+      (await t.context.session.findElements(gridLocator)).length,
+      1,
+      'One "role=grid" element should be found by selector: ' + ex.gridSelector
+    );
+  }
+});
+
+ariaTest('Test "aria-labelledby" attribute exists',
+         'grid/LayoutGrids.html', 'aria-labelledby', async (t) => {
+
+  t.plan(6);
+
+  for (let exId in pageExamples) {
+    let ex = pageExamples[exId];
+    let gridLocator = t.context.By.css(ex.gridSelector);
+    let labelId = await t.context.session
+        .findElement(gridLocator)
+        .getAttribute('aria-labelledby');
+
+    t.truthy(
+      labelId,
+      '"aria-labelledby" attribute should exist on element selected by: ' + ex.gridSelector
+    );
+
+    let exLocator = t.context.By.id(exId);
+    let labelLocator = t.context.By.id(labelId);
+    let labelElement = await t.context.session
+        .findElement(exLocator)
+        .findElement(labelLocator);
+
+    t.truthy(
+      await labelElement.getText(),
+      'Element with id "' + labelId + '" should contain text that labels the grid'
+    );
+  }
+});
+
+ariaTest('Test "aria-rowcount" attribute exists',
+         'grid/LayoutGrids.html', 'aria-rowcount', async (t) => {
+
+  t.plan(2);
+
+  // This test only applies to example 3
+  let gridSelector = '#ex3 [role="grid"]'
+  let gridLocator = t.context.By.css(gridSelector);
+  let rowCount = await t.context.session
+      .findElement(gridLocator)
+      .getAttribute('aria-rowcount');
+
+  t.truthy(
+    rowCount,
+    '"aria-rowcount" attribute should exist on element selected by: ' + gridSelector
+  );
+
+  let rowLocator = t.context.By.css('[role="row"]');
+  let rowElements = await t.context.session
+      .findElement(gridLocator)
+      .findElements(rowLocator);
+
+  t.is(
+    rowElements.length,
+    Number(rowCount),
+    '"aria-rowcount" attribute should match the number of [role="row"] divs in example: ' + gridSelector
+  );
+});
+
+ariaTest('Test "role=row" attribute exists',
+         'grid/LayoutGrids.html', 'row-role', async (t) => {
+
+  t.plan(3);
+
+  for (let exId in pageExamples) {
+    let ex = pageExamples[exId];
+
+    let gridLocator = t.context.By.css(ex.gridSelector);
+    let rowLocator = t.context.By.css('div[role="row"]');
+    let rowElements = await t.context.session
+        .findElement(gridLocator)
+        .findElements(rowLocator);
+
+    t.truthy(
+      rowElements.length,
+      '"role=row" elements should exist in example: ' + ex.gridSelector
+    );
+  }
+});
+
+ariaTest('test "aria-rowindex" attribute exists',
+         'grid/LayoutGrids.html', 'aria-rowindex', async (t) => {
+
+  t.plan(19);
+
+  // This test only applies to example 3
+  let exId = 'ex3';
+  let gridSelector = '#ex3 [role="grid"]';
+  let gridLocator = t.context.By.css(gridSelector);
+
+  let rowLocator = t.context.By.css('[role="row"]');
+  let rowElements = await t.context.session
+      .findElement(gridLocator)
+      .findElements(rowLocator);
+
+  for (let i = 0; i < rowElements.length; i++) {
+    let value = (i+1).toString();
+    t.is(
+      await rowElements[i].getAttribute('aria-rowindex'),
+      value,
+      '[aria-rowindex="' + value + '"] attribute added to role="row" elements in: ' + gridSelector
+    );
+  }
+
+});
+
+ariaTest('Test "role=gridcell" attribute exists',
+         'grid/LayoutGrids.html', 'gridcell-role', async (t) => {
+
+  t.plan(3);
+
+  for (let exId in pageExamples) {
+    let ex = pageExamples[exId];
+    let gridLocator = t.context.By.css(ex.gridSelector);
+
+    let gridcellLocator = t.context.By.css('[role="gridcell"]');
+    let gridcellElements = await t.context.session
+        .findElement(gridLocator)
+        .findElements(gridcellLocator);
+
+    t.truthy(
+      gridcellElements.length,
+      '["role=gridcell]" elements should exist in example: ' + ex.gridSelector
+    );
+  }
+});
+
+
+ariaTest('Test "tabindex" appropriately set',
+         'grid/LayoutGrids.html', 'tabindex', async (t) => {
+
+  // TODO: Wait on script load -- answer q: how to decide widget is initialized?
+  await new Promise((resolve) => setTimeout(resolve, 100));
+
+  // This test ASSUMES the grid/LayoutGrids example widgets use on the following two
+  // types of focusable widgets within gridcells
+  let focusableWidget = [
+    t.context.By.css('a'),
+    t.context.By.css('[role="button"]')
+  ];
+
+  for (let exId in pageExamples) {
+    let ex = pageExamples[exId];
+    let gridLocator = t.context.By.css(ex.gridSelector);
+
+    let gridcellLocator = t.context.By.css('[role="gridcell"]');
+    let gridcellElements = await t.context.session
+        .findElement(gridLocator)
+        .findElements(gridcellLocator);
+
+    for (let el = 0; el < gridcellElements.length; el++) {
+      let elementTabindex = await (await gridcellElements[el]).getAttribute('tabindex');
+
+      // The first gridcell element will have tabindex=0
+      let tabindex = el ? '-1' : '0';
+
+      // If attribute "tabindex" has been set, there must be no focusable widgets within the
+      // gridcell div or span
+      if (elementTabindex != null) {
+
+        t.is(
+          elementTabindex,
+          tabindex,
+          '"[role=gridcell]" should have tabindex="-1": ' + ex.gridSelector
+        );
+
+        // Look for a focusable widget
+        let focusableEl = await gridcellElements[el].findElement(focusableWidget[0]).catch(() => {})
+            || await gridcellElements[el].findElement(focusableWidget[1]).catch(() => {});
+
+        t.falsy(
+          focusableEl,
+          '"[role=gridcell]" with tabindex="-1" should not contain focusable widgets: ' + ex.gridSelector
+        );
+      }
+
+      // If attribute "tabindex" has not been set, there must be a focusable widgets
+      // within the gridcell div or span with tabindex appropriately set
+      else {
+
+        // Find the focusable widget
+        let widgetElement = await gridcellElements[el].findElement(focusableWidget[0]).catch(() => {})
+          || await gridcellElements[el].findElement(focusableWidget[1]).catch(() => {});
+
+        t.truthy(
+          widgetElement,
+          '["role=gridcell]" without tabindex set must contain a focusable widget: ' + ex.gridSelector
+        );
+
+        t.is(
+          await widgetElement.getAttribute('tabindex'),
+          tabindex,
+          'Widget within element "[role=gridcell]" must have tabindex set in example: ' + ex.gridSelector
+        );
+      }
+    }
+  }
+});
+
+
+// Keys
+
+const checkActiveElement = function(/* gridcellsSelector, index */) {
+  let gridcellsSelector = arguments[0];
+  let index = arguments[1];
+  let gridcells = document.querySelectorAll(gridcellsSelector);
+  let gridcell = gridcells[index];
+  return (document.activeElement === gridcell) || gridcell.contains(document.activeElement);
+};
+
+const findAndFocus = function(/* element */) {
+  // Assumption: element is focusable or contains only one focusable element.
+  let element = arguments[0];
+  let candidates = [element, ...element.querySelectorAll('*')];
+  for (let candidate of candidates) {
+    candidate.focus();
+    if (document.activeElement === candidate) {
+      return candidate;
+    }
+  }
+}
+
+ariaTest('Right arrow key moves focus',
+         'grid/LayoutGrids.html', 'key-right-arrow', async (t) => {
+
+  t.plan(67);
+
+  for (let exId in pageExamples) {
+    let ex = pageExamples[exId];
+    let gridcellsSelector = ex.gridSelector + ' [role="gridcell"]';
+    let gridcellElements = await t.context.session.findElements(
+      t.context.By.css(gridcellsSelector)
+    );
+
+    // Find the first focusable element
+    let activeElement = await t.context.session.executeScript(findAndFocus, gridcellElements[0]);
+    if (!activeElement) {
+      throw new Error("Could not focus on element or any decendent in the first gridcell: " + gridcellsSelector);
+    }
+
+    // Test focus moves to next element on arrow key
+
+    for (let index = 1; index < gridcellElements.length; index++) {
+
+      await activeElement.sendKeys(t.context.Key.ARROW_RIGHT);
+      let correctActiveElement = await t.context.session.executeScript(checkActiveElement, gridcellsSelector, index);
+
+      t.truthy(
+        correctActiveElement,
+        'Example ' + exId + ': gridcell ' + index + ' should receive focus after arrow right'
+      );
+
+      activeElement = await t.context.session.executeScript(() => {
+        return document.activeElement;
+      });
+    }
+
+    // Test arrow key on final element
+
+    await activeElement.sendKeys(t.context.Key.ARROW_RIGHT);
+    let correctActiveElement = await t.context.session.executeScript(checkActiveElement, gridcellsSelector, gridcellElements.length-1);
+    t.truthy(
+      correctActiveElement,
+      'Example ' + exId + ': Right Arrow sent to final gridcell should not move focus.'
+    );
+  }
+});
+
+ariaTest('Left arrow key moves focus', 'grid/LayoutGrids.html', 'key-left-arrow', async (t) => {
+
+  t.plan(22);
+
+  for (let exId in pageExamples) {
+    let ex = pageExamples[exId];
+    let gridcellsSelector = ex.gridSelector + ' [role="gridcell"]';
+    let allGridcellElements = await t.context.session.findElements(
+      t.context.By.css(gridcellsSelector)
+    );
+
+    // Not all gridcell elements are initially visible. First find all focusable elements.
+
+    let gridcellElements = [];
+    for (let el of allGridcellElements) {
+      if (!await t.context.session.executeScript(findAndFocus, el)) {
+        break;
+      }
+      gridcellElements.push(el);
+    }
+
+    let activeElement = await t.context.session.executeScript(function () {
+      return document.activeElement;
+    });
+    if (!activeElement) {
+      throw new Error("Could not focus on element or any decendent in the final gridcell: " + gridcellsSelector);
+    }
+
+    // Test focus moves to next element on arrow key
+    for (let index = gridcellElements.length - 1; index > 0; index--) {
+      await activeElement.sendKeys(t.context.Key.ARROW_LEFT);
+      let correctActiveElement = await t.context.session.executeScript(checkActiveElement, gridcellsSelector, index);
+
+      t.truthy(
+        correctActiveElement,
+        'Example ' + exId + ': gridcell ' + index + ' should receive focus after arrow left'
+      );
+
+      activeElement = await t.context.session.executeScript(() => {
+        return document.activeElement;
+      });
+    }
+
+    // Test arrow key on final element
+
+    await activeElement.sendKeys(t.context.Key.ARROW_LEFT);
+    let correctActiveElement = await t.context.session.executeScript(checkActiveElement, gridcellsSelector, 0);
+    t.truthy(
+      correctActiveElement,
+      'Example ' + exId + ': Left Arrow sent to first gridcell should not move focus. Focus is on element'
+    );
+  }
+
+});
+
+// ariaTest('grid/LayoutGrids.html', 'key-down-arrow', async (t) => {
+//   await new Promise((resolve) => setTimeout(resolve, 10));
+//   t.pass();
+// });
+
+// ariaTest('grid/LayoutGrids.html', 'key-up-arrow', async (t) => {
+//   await new Promise((resolve) => setTimeout(resolve, 10));
+//   t.pass();
+// });
+
+// ariaTest('grid/LayoutGrids.html', 'key-page-down', async (t) => {
+//   await new Promise((resolve) => setTimeout(resolve, 10));
+//   t.pass();
+// });
+
+// ariaTest('grid/LayoutGrids.html', 'key-page-up', async (t) => {
+//   await new Promise((resolve) => setTimeout(resolve, 10));
+//   t.pass();
+// });
+
+// ariaTest('grid/LayoutGrids.html', 'key-home', async (t) => {
+//   await new Promise((resolve) => setTimeout(resolve, 10));
+//   t.pass();
+// });
+
+// ariaTest('grid/LayoutGrids.html', 'key-end', async (t) => {
+//   await new Promise((resolve) => setTimeout(resolve, 10));
+//   t.pass();
+// });
+
+// ariaTest('grid/LayoutGrids.html', 'key-control-home', async (t) => {
+//   await new Promise((resolve) => setTimeout(resolve, 10));
+//   t.pass();
+// });
+
+// ariaTest('grid/LayoutGrids.html', 'key-control-end', async (t) => {
+//   await new Promise((resolve) => setTimeout(resolve, 10));
+//   t.pass();
+// });

--- a/test/tests/LayoutGrids.js
+++ b/test/tests/LayoutGrids.js
@@ -16,7 +16,7 @@ const clickUntilDisabled = async (session, selector) => {
   }
 };
 
-const checkActiveElement = function(/* gridcellsSelector, index */) {
+const checkActiveElement = function (/* gridcellsSelector, index */) {
   let gridcellsSelector = arguments[0];
   let index = arguments[1];
   let gridcells = document.querySelectorAll(gridcellsSelector);
@@ -24,27 +24,27 @@ const checkActiveElement = function(/* gridcellsSelector, index */) {
   return (document.activeElement === gridcell) || gridcell.contains(document.activeElement);
 };
 
-const findFocusable = function(/* selector */) {
+const findFocusable = function (/* selector */) {
   const selector = arguments[0];
   const original = document.activeElement;
   const focusable = Array.from(document.querySelectorAll(selector))
-      .map((parent) => {
-        const candidates = [parent, ...parent.querySelectorAll('*')];
-        for (let candidate of candidates) {
+    .map((parent) => {
+      const candidates = [parent, ...parent.querySelectorAll('*')];
+      for (let candidate of candidates) {
 
-          candidate.focus();
-          if (document.activeElement === candidate) {
-            return candidate;
-          }
+        candidate.focus();
+        if (document.activeElement === candidate) {
+          return candidate;
         }
-      }).filter((el) => !!el);;
+      }
+    }).filter((el) => !!el);;
 
   original.focus();
 
   return focusable;
 };
 
-const focusWithin = function(/* element */) {
+const focusWithin = function (/* element */) {
   // Assumption: `element is` focusable or contains only one focusable element.
   let element = arguments[0];
   let candidates = [element, ...element.querySelectorAll('*')];
@@ -73,220 +73,220 @@ let pageExamples = {
 // Attributes
 
 ariaTest('Test "role=grid" attribute exists',
-         'grid/LayoutGrids.html', 'grid-role', async (t) => {
+  'grid/LayoutGrids.html', 'grid-role', async (t) => {
 
-  t.plan(3);
+    t.plan(3);
 
-  for (let exId in pageExamples) {
-    let ex = pageExamples[exId];
-    let gridLocator = t.context.By.css(ex.gridSelector);
+    for (let exId in pageExamples) {
+      let ex = pageExamples[exId];
+      let gridLocator = t.context.By.css(ex.gridSelector);
 
-    t.is(
-      (await t.context.session.findElements(gridLocator)).length,
-      1,
-      'One "role=grid" element should be found by selector: ' + ex.gridSelector
-    );
-  }
-});
+      t.is(
+        (await t.context.session.findElements(gridLocator)).length,
+        1,
+        'One "role=grid" element should be found by selector: ' + ex.gridSelector
+      );
+    }
+  });
 
 ariaTest('Test "aria-labelledby" attribute exists',
-         'grid/LayoutGrids.html', 'aria-labelledby', async (t) => {
+  'grid/LayoutGrids.html', 'aria-labelledby', async (t) => {
 
-  t.plan(6);
+    t.plan(6);
 
-  for (let exId in pageExamples) {
-    let ex = pageExamples[exId];
-    let gridLocator = t.context.By.css(ex.gridSelector);
-    let labelId = await t.context.session
+    for (let exId in pageExamples) {
+      let ex = pageExamples[exId];
+      let gridLocator = t.context.By.css(ex.gridSelector);
+      let labelId = await t.context.session
         .findElement(gridLocator)
         .getAttribute('aria-labelledby');
 
-    t.truthy(
-      labelId,
-      '"aria-labelledby" attribute should exist on element selected by: ' + ex.gridSelector
-    );
+      t.truthy(
+        labelId,
+        '"aria-labelledby" attribute should exist on element selected by: ' + ex.gridSelector
+      );
 
-    let exLocator = t.context.By.id(exId);
-    let labelLocator = t.context.By.id(labelId);
-    let labelElement = await t.context.session
+      let exLocator = t.context.By.id(exId);
+      let labelLocator = t.context.By.id(labelId);
+      let labelElement = await t.context.session
         .findElement(exLocator)
         .findElement(labelLocator);
 
-    t.truthy(
-      await labelElement.getText(),
-      'Element with id "' + labelId + '" should contain text that labels the grid'
-    );
-  }
-});
+      t.truthy(
+        await labelElement.getText(),
+        'Element with id "' + labelId + '" should contain text that labels the grid'
+      );
+    }
+  });
 
 ariaTest('Test "aria-rowcount" attribute exists',
-         'grid/LayoutGrids.html', 'aria-rowcount', async (t) => {
+  'grid/LayoutGrids.html', 'aria-rowcount', async (t) => {
 
-  t.plan(2);
+    t.plan(2);
 
-  // This test only applies to example 3
-  let gridSelector = '#ex3 [role="grid"]'
-  let gridLocator = t.context.By.css(gridSelector);
-  let rowCount = await t.context.session
+    // This test only applies to example 3
+    let gridSelector = '#ex3 [role="grid"]';
+    let gridLocator = t.context.By.css(gridSelector);
+    let rowCount = await t.context.session
       .findElement(gridLocator)
       .getAttribute('aria-rowcount');
 
-  t.truthy(
-    rowCount,
-    '"aria-rowcount" attribute should exist on element selected by: ' + gridSelector
-  );
+    t.truthy(
+      rowCount,
+      '"aria-rowcount" attribute should exist on element selected by: ' + gridSelector
+    );
 
-  let rowLocator = t.context.By.css('[role="row"]');
-  let rowElements = await t.context.session
+    let rowLocator = t.context.By.css('[role="row"]');
+    let rowElements = await t.context.session
       .findElement(gridLocator)
       .findElements(rowLocator);
 
-  t.is(
-    rowElements.length,
-    Number(rowCount),
-    '"aria-rowcount" attribute should match the number of [role="row"] divs in example: ' + gridSelector
-  );
-});
+    t.is(
+      rowElements.length,
+      Number(rowCount),
+      '"aria-rowcount" attribute should match the number of [role="row"] divs in example: ' + gridSelector
+    );
+  });
 
 ariaTest('Test "role=row" attribute exists',
-         'grid/LayoutGrids.html', 'row-role', async (t) => {
+  'grid/LayoutGrids.html', 'row-role', async (t) => {
 
-  t.plan(3);
+    t.plan(3);
 
-  for (let exId in pageExamples) {
-    let ex = pageExamples[exId];
+    for (let exId in pageExamples) {
+      let ex = pageExamples[exId];
 
-    let gridLocator = t.context.By.css(ex.gridSelector);
-    let rowLocator = t.context.By.css('div[role="row"]');
-    let rowElements = await t.context.session
+      let gridLocator = t.context.By.css(ex.gridSelector);
+      let rowLocator = t.context.By.css('div[role="row"]');
+      let rowElements = await t.context.session
         .findElement(gridLocator)
         .findElements(rowLocator);
 
-    t.truthy(
-      rowElements.length,
-      '"role=row" elements should exist in example: ' + ex.gridSelector
-    );
-  }
-});
+      t.truthy(
+        rowElements.length,
+        '"role=row" elements should exist in example: ' + ex.gridSelector
+      );
+    }
+  });
 
 ariaTest('test "aria-rowindex" attribute exists',
-         'grid/LayoutGrids.html', 'aria-rowindex', async (t) => {
+  'grid/LayoutGrids.html', 'aria-rowindex', async (t) => {
 
-  t.plan(19);
+    t.plan(19);
 
-  // This test only applies to example 3
-  let exId = 'ex3';
-  let gridSelector = '#ex3 [role="grid"]';
-  let gridLocator = t.context.By.css(gridSelector);
+    // This test only applies to example 3
+    let exId = 'ex3';
+    let gridSelector = '#ex3 [role="grid"]';
+    let gridLocator = t.context.By.css(gridSelector);
 
-  let rowLocator = t.context.By.css('[role="row"]');
-  let rowElements = await t.context.session
+    let rowLocator = t.context.By.css('[role="row"]');
+    let rowElements = await t.context.session
       .findElement(gridLocator)
       .findElements(rowLocator);
 
-  for (let i = 0; i < rowElements.length; i++) {
-    let value = (i+1).toString();
-    t.is(
-      await rowElements[i].getAttribute('aria-rowindex'),
-      value,
-      '[aria-rowindex="' + value + '"] attribute added to role="row" elements in: ' + gridSelector
-    );
-  }
+    for (let i = 0; i < rowElements.length; i++) {
+      let value = (i + 1).toString();
+      t.is(
+        await rowElements[i].getAttribute('aria-rowindex'),
+        value,
+        '[aria-rowindex="' + value + '"] attribute added to role="row" elements in: ' + gridSelector
+      );
+    }
 
-});
+  });
 
 ariaTest('Test "role=gridcell" attribute exists',
-         'grid/LayoutGrids.html', 'gridcell-role', async (t) => {
+  'grid/LayoutGrids.html', 'gridcell-role', async (t) => {
 
-  t.plan(3);
+    t.plan(3);
 
-  for (let exId in pageExamples) {
-    let ex = pageExamples[exId];
-    let gridLocator = t.context.By.css(ex.gridSelector);
+    for (let exId in pageExamples) {
+      let ex = pageExamples[exId];
+      let gridLocator = t.context.By.css(ex.gridSelector);
 
-    let gridcellLocator = t.context.By.css('[role="gridcell"]');
-    let gridcellElements = await t.context.session
+      let gridcellLocator = t.context.By.css('[role="gridcell"]');
+      let gridcellElements = await t.context.session
         .findElement(gridLocator)
         .findElements(gridcellLocator);
 
-    t.truthy(
-      gridcellElements.length,
-      '["role=gridcell]" elements should exist in example: ' + ex.gridSelector
-    );
-  }
-});
+      t.truthy(
+        gridcellElements.length,
+        '["role=gridcell]" elements should exist in example: ' + ex.gridSelector
+      );
+    }
+  });
 
 
 ariaTest('Test "tabindex" appropriately set',
-         'grid/LayoutGrids.html', 'tabindex', async (t) => {
+  'grid/LayoutGrids.html', 'tabindex', async (t) => {
 
   // TODO: Wait on script load -- answer q: how to decide widget is initialized?
-  await new Promise((resolve) => setTimeout(resolve, 100));
+    await new Promise((resolve) => setTimeout(resolve, 100));
 
-  // This test ASSUMES the grid/LayoutGrids example widgets use on the following two
-  // types of focusable widgets within gridcells
-  let focusableWidget = [
-    t.context.By.css('a'),
-    t.context.By.css('[role="button"]')
-  ];
+    // This test ASSUMES the grid/LayoutGrids example widgets use on the following two
+    // types of focusable widgets within gridcells
+    let focusableWidget = [
+      t.context.By.css('a'),
+      t.context.By.css('[role="button"]')
+    ];
 
-  for (let exId in pageExamples) {
-    let ex = pageExamples[exId];
-    let gridLocator = t.context.By.css(ex.gridSelector);
+    for (let exId in pageExamples) {
+      let ex = pageExamples[exId];
+      let gridLocator = t.context.By.css(ex.gridSelector);
 
-    let gridcellLocator = t.context.By.css('[role="gridcell"]');
-    let gridcellElements = await t.context.session
+      let gridcellLocator = t.context.By.css('[role="gridcell"]');
+      let gridcellElements = await t.context.session
         .findElement(gridLocator)
         .findElements(gridcellLocator);
 
-    for (let el = 0; el < gridcellElements.length; el++) {
-      let elementTabindex = await (await gridcellElements[el]).getAttribute('tabindex');
+      for (let el = 0; el < gridcellElements.length; el++) {
+        let elementTabindex = await(await gridcellElements[el]).getAttribute('tabindex');
 
-      // The first gridcell element will have tabindex=0
-      let tabindex = el ? '-1' : '0';
+        // The first gridcell element will have tabindex=0
+        let tabindex = el ? '-1' : '0';
 
-      // If attribute "tabindex" has been set, there must be no focusable widgets within the
-      // gridcell div or span
-      if (elementTabindex != null) {
+        // If attribute "tabindex" has been set, there must be no focusable widgets within the
+        // gridcell div or span
+        if (elementTabindex != null) {
 
-        t.is(
-          elementTabindex,
-          tabindex,
-          '"[role=gridcell]" should have tabindex="-1": ' + ex.gridSelector
-        );
+          t.is(
+            elementTabindex,
+            tabindex,
+            '"[role=gridcell]" should have tabindex="-1": ' + ex.gridSelector
+          );
 
-        // Look for a focusable widget
-        let focusableEl = await gridcellElements[el].findElement(focusableWidget[0]).catch(() => {})
-            || await gridcellElements[el].findElement(focusableWidget[1]).catch(() => {});
+          // Look for a focusable widget
+          let focusableEl = await gridcellElements[el].findElement(focusableWidget[0]).catch(() => {}) ||
+            await gridcellElements[el].findElement(focusableWidget[1]).catch(() => {});
 
-        t.falsy(
-          focusableEl,
-          '"[role=gridcell]" with tabindex="-1" should not contain focusable widgets: ' + ex.gridSelector
-        );
-      }
+          t.falsy(
+            focusableEl,
+            '"[role=gridcell]" with tabindex="-1" should not contain focusable widgets: ' + ex.gridSelector
+          );
+        }
 
-      // If attribute "tabindex" has not been set, there must be a focusable widgets
-      // within the gridcell div or span with tabindex appropriately set
-      else {
+        // If attribute "tabindex" has not been set, there must be a focusable widgets
+        // within the gridcell div or span with tabindex appropriately set
+        else {
 
         // Find the focusable widget
-        let widgetElement = await gridcellElements[el].findElement(focusableWidget[0]).catch(() => {})
-          || await gridcellElements[el].findElement(focusableWidget[1]).catch(() => {});
+          let widgetElement = await gridcellElements[el].findElement(focusableWidget[0]).catch(() => {}) ||
+          await gridcellElements[el].findElement(focusableWidget[1]).catch(() => {});
 
-        t.truthy(
-          widgetElement,
-          '["role=gridcell]" without tabindex set must contain a focusable widget: ' + ex.gridSelector
-        );
+          t.truthy(
+            widgetElement,
+            '["role=gridcell]" without tabindex set must contain a focusable widget: ' + ex.gridSelector
+          );
 
-        t.is(
-          await widgetElement.getAttribute('tabindex'),
-          tabindex,
-          'Widget within element "[role=gridcell]" must have tabindex set in example: ' + ex.gridSelector
-        );
+          t.is(
+            await widgetElement.getAttribute('tabindex'),
+            tabindex,
+            'Widget within element "[role=gridcell]" must have tabindex set in example: ' + ex.gridSelector
+          );
+        }
       }
     }
-  }
-});
+  });
 
 
 // Keys
@@ -331,7 +331,7 @@ ariaTest('Right arrow key moves focus', 'grid/LayoutGrids.html', 'key-right-arro
     // Test arrow key on final element
 
     await activeElement.sendKeys(t.context.Key.ARROW_RIGHT);
-    let correctActiveElement = await t.context.session.executeScript(checkActiveElement, selector, gridcellElements.length-1);
+    let correctActiveElement = await t.context.session.executeScript(checkActiveElement, selector, gridcellElements.length - 1);
     t.truthy(
       correctActiveElement,
       'Example ' + exId + ': Right Arrow sent to final gridcell should not move focus.'
@@ -425,7 +425,7 @@ ariaTest('Down arrow key moves focus', 'grid/LayoutGrids.html', 'key-down-arrow'
     // Test arrow key on final element
 
     await activeElement.sendKeys(t.context.Key.ARROW_DOWN);
-    let correctActiveElement = await t.context.session.executeScript(checkActiveElement, selector, gridcellElements.length-1);
+    let correctActiveElement = await t.context.session.executeScript(checkActiveElement, selector, gridcellElements.length - 1);
     t.truthy(
       correctActiveElement,
       'Example ' + exId + ': Down Arrow sent to final gridcell should not move focus.'

--- a/test/tests/link.js
+++ b/test/tests/link.js
@@ -20,7 +20,6 @@ let pageExamples = [
 ];
 
 ariaTest('link/link.html', 'link-role', async (t) => {
-
   for (let i = 0; i < pageExamples.length; i++) {
     let ex = pageExamples[i];
     let linkLocator = t.context.By.css(ex.linkSelector);
@@ -34,7 +33,7 @@ ariaTest('link/link.html', 'link-role', async (t) => {
   }
 });
 
-ariaTest('link/link.html', 'tab-index', async (t) => {
+ariaTest('link/link.html', 'tabindex', async (t) => {
 
   for (let i = 0; i < pageExamples.length; i++) {
     let ex = pageExamples[i];
@@ -61,7 +60,7 @@ ariaTest('link/link.html', 'alt', async (t) => {
 
     t.truthy(
       await linkElement.getAttribute('alt'),
-      '"alt" attribute should exist on element selected by: ' + ex.linkSelector,
+      '"alt" attribute should exist on element selected by: ' + ex.linkSelector
     );
   }
 

--- a/test/tests/link.js
+++ b/test/tests/link.js
@@ -20,95 +20,95 @@ let pageExamples = [
 ];
 
 ariaTest('Test "role" attribute exists',
-         'link/link.html', 'link-role', async (t) => {
+  'link/link.html', 'link-role', async (t) => {
 
-  for (let i = 0; i < pageExamples.length; i++) {
-    let ex = pageExamples[i];
-    let linkLocator = t.context.By.css(ex.linkSelector);
-    let linkElement = await t.context.session.findElement(linkLocator);
+    for (let i = 0; i < pageExamples.length; i++) {
+      let ex = pageExamples[i];
+      let linkLocator = t.context.By.css(ex.linkSelector);
+      let linkElement = await t.context.session.findElement(linkLocator);
 
-    t.is(
-      await linkElement.getAttribute('role'),
-      'link',
-      '[role="link"] attribute should exist on element select by: ' + ex.linkSelector
-    );
-  }
-});
+      t.is(
+        await linkElement.getAttribute('role'),
+        'link',
+        '[role="link"] attribute should exist on element select by: ' + ex.linkSelector
+      );
+    }
+  });
 
 ariaTest('Test "tabindex" attribute set to 0',
-         'link/link.html', 'tabindex', async (t) => {
+  'link/link.html', 'tabindex', async (t) => {
 
-  for (let i = 0; i < pageExamples.length; i++) {
-    let ex = pageExamples[i];
-    let linkLocator = t.context.By.css(ex.linkSelector);
-    let linkElement = await t.context.session.findElement(linkLocator);
+    for (let i = 0; i < pageExamples.length; i++) {
+      let ex = pageExamples[i];
+      let linkLocator = t.context.By.css(ex.linkSelector);
+      let linkElement = await t.context.session.findElement(linkLocator);
 
-    t.is(
-      await linkElement.getAttribute('tabindex'),
-      '0',
-      '[tab-index=0] attribute should exist on element selected by: ' + ex.linkSelector
-    );
-  }
-});
+      t.is(
+        await linkElement.getAttribute('tabindex'),
+        '0',
+        '[tab-index=0] attribute should exist on element selected by: ' + ex.linkSelector
+      );
+    }
+  });
 
 ariaTest('Test "alt" attribute exists',
-         'link/link.html', 'alt', async (t) => {
+  'link/link.html', 'alt', async (t) => {
 
-  for (let i = 0; i < pageExamples.length; i++) {
-    let ex = pageExamples[i];
-    if (!ex.hasOwnProperty('alt')) {
-      continue;
+    for (let i = 0; i < pageExamples.length; i++) {
+      let ex = pageExamples[i];
+      if (!ex.hasOwnProperty('alt')) {
+        continue;
+      }
+      let linkLocator = t.context.By.css(ex.linkSelector);
+      let linkElement = await t.context.session.findElement(linkLocator);
+
+      t.truthy(
+        await linkElement.getAttribute('alt'),
+        '"alt" attribute should exist on element selected by: ' + ex.linkSelector
+      );
     }
-    let linkLocator = t.context.By.css(ex.linkSelector);
-    let linkElement = await t.context.session.findElement(linkLocator);
 
-    t.truthy(
-      await linkElement.getAttribute('alt'),
-      '"alt" attribute should exist on element selected by: ' + ex.linkSelector
-    );
-  }
-
-});
+  });
 
 ariaTest('Test "aria-label" attribute exists',
-         'link/link.html', 'aria-label', async (t) => {
+  'link/link.html', 'aria-label', async (t) => {
 
-  for (let i = 0; i < pageExamples.length; i++) {
-    let ex = pageExamples[i];
-    if (!ex.hasOwnProperty('ariaLabel')) {
-      continue;
+    for (let i = 0; i < pageExamples.length; i++) {
+      let ex = pageExamples[i];
+      if (!ex.hasOwnProperty('ariaLabel')) {
+        continue;
+      }
+      let linkLocator = t.context.By.css(ex.linkSelector);
+      let linkElement = await t.context.session.findElement(linkLocator);
+
+      t.truthy(
+        await linkElement.getAttribute('aria-label'),
+        '"aria-label" attribute should exist on element selected by: ' + ex.linkSelector,
+      );
     }
-    let linkLocator = t.context.By.css(ex.linkSelector);
-    let linkElement = await t.context.session.findElement(linkLocator);
-
-    t.truthy(
-      await linkElement.getAttribute('aria-label'),
-      '"aria-label" attribute should exist on element selected by: ' + ex.linkSelector,
-    );
-  }
-});
+  });
 
 ariaTest('Test "ENTER" key behavior',
-         'link/link.html', 'key-enter', async (t) => {
+  'link/link.html', 'key-enter', async (t) => {
 
-  for (let i = 0; i < pageExamples.length; i++) {
-    await t.context.session.get(t.context.url);
+    for (let i = 0; i < pageExamples.length; i++) {
+      await t.context.session.get(t.context.url);
 
-    let ex = pageExamples[i];
-    let linkLocator = t.context.By.css(ex.linkSelector);
-    let linkElement = await t.context.session.findElement(linkLocator);
+      let ex = pageExamples[i];
+      let linkLocator = t.context.By.css(ex.linkSelector);
+      let linkElement = await t.context.session.findElement(linkLocator);
 
-    await linkElement.sendKeys(t.context.Key.ENTER);
-    await t.context.session.wait(() => {
-      return t.context.session.getCurrentUrl().then(url => {
-        return url != t.context.url;
-      });
-    }, 1000).catch(() => {});
+      await linkElement.sendKeys(t.context.Key.ENTER);
+      await t.context.session.wait(() => {
+        return t.context.session.getCurrentUrl().then(url => {
+          return url != t.context.url;
+        });
+      }, 1000).catch(() => {});
 
-    t.not(
-      await t.context.session.getCurrentUrl(),
-      t.context.url,
-      'ENTER key on element with selector "' + ex.linkSelector + '" should activate link.'
-    );
-  }
-});
+      t.not(
+        await t.context.session.getCurrentUrl(),
+        t.context.url,
+        'ENTER key on element with selector "' + ex.linkSelector + '" should activate link.'
+      );
+    }
+  });

--- a/test/tests/link.js
+++ b/test/tests/link.js
@@ -19,7 +19,9 @@ let pageExamples = [
   }
 ];
 
-ariaTest('link/link.html', 'link-role', async (t) => {
+ariaTest('Test "role" attribute exists',
+         'link/link.html', 'link-role', async (t) => {
+
   for (let i = 0; i < pageExamples.length; i++) {
     let ex = pageExamples[i];
     let linkLocator = t.context.By.css(ex.linkSelector);
@@ -33,7 +35,8 @@ ariaTest('link/link.html', 'link-role', async (t) => {
   }
 });
 
-ariaTest('link/link.html', 'tabindex', async (t) => {
+ariaTest('Test "tabindex" attribute set to 0',
+         'link/link.html', 'tabindex', async (t) => {
 
   for (let i = 0; i < pageExamples.length; i++) {
     let ex = pageExamples[i];
@@ -48,7 +51,8 @@ ariaTest('link/link.html', 'tabindex', async (t) => {
   }
 });
 
-ariaTest('link/link.html', 'alt', async (t) => {
+ariaTest('Test "alt" attribute exists',
+         'link/link.html', 'alt', async (t) => {
 
   for (let i = 0; i < pageExamples.length; i++) {
     let ex = pageExamples[i];
@@ -66,7 +70,9 @@ ariaTest('link/link.html', 'alt', async (t) => {
 
 });
 
-ariaTest('link/link.html', 'aria-label', async (t) => {
+ariaTest('Test "aria-label" attribute exists',
+         'link/link.html', 'aria-label', async (t) => {
+
   for (let i = 0; i < pageExamples.length; i++) {
     let ex = pageExamples[i];
     if (!ex.hasOwnProperty('ariaLabel')) {
@@ -82,7 +88,9 @@ ariaTest('link/link.html', 'aria-label', async (t) => {
   }
 });
 
-ariaTest('link/link.html', 'key-enter', async (t) => {
+ariaTest('Test "ENTER" key behavior',
+         'link/link.html', 'key-enter', async (t) => {
+
   for (let i = 0; i < pageExamples.length; i++) {
     await t.context.session.get(t.context.url);
 
@@ -95,7 +103,7 @@ ariaTest('link/link.html', 'key-enter', async (t) => {
       return t.context.session.getCurrentUrl().then(url => {
         return url != t.context.url;
       });
-    }, 500).catch(() => {});
+    }, 1000).catch(() => {});
 
     t.not(
       await t.context.session.getCurrentUrl(),

--- a/test/util/start-geckodriver.js
+++ b/test/util/start-geckodriver.js
@@ -66,7 +66,7 @@ const startOnAnyPort = (port, timeout) => {
  * port.
  *
  * @param {Number} port - the TCP/IP port from which to begin search
- * @param {Number{ timeout - the number of milliseconds to attempt to create a
+ * @param {Number} timeout - the number of milliseconds to attempt to create a
  *                           server before reporting a failure
  *
  * @returns {Promise<Object>} - an eventual value for interfacing with the


### PR DESCRIPTION
(This depends on gh-754.)

For this series of tests, we wanted to push the envelope on the idea of flexibility.

The statements made in the test examples document are fairly generic, describing the expected functionality for all cells and focusable elements. To ensure these are honored, this suite of tests are highly dynamic: they query the document and make assertions according to the structure they find.

A bug in code like this could cause entire branches to be skipped. That is particularly dangerous in test code because it can lead to false positives (since it can be difficult to differentiate between passing assertions and mistakenly-skipped assertions). In order to avoid false positives in such cases, we are using the test framework's `expect` method: this gives us confidence that the procedural code is operating as intended (at the expense of some maintenance overhead--modifications to the test may require manually updating those numbers).

Neither @spectranaut nor I feel as though this is a tenable approach to testing. Beyond being labor-intensive to write, these tests are difficult to understand, and that diminishes their value as documentation.

More concerning is their failure mode. Although we attempted to account for future alterations to the examples, we can't guarantee that the tests will be resilient to any arbitrary change. In the event that a contributor attempts to modify an example in a way that violates a test, that contributor will be forced to learn the complexities of this logic and to extend it.

We're submitting tests in this form for review in order to demonstrate those pain points and to verify that simpler patterns are preferable. Specifically: we would prefer to write tests that take the current structure of the examples for granted. Tests written in this way will contain more duplication, but they will also contain less abstraction and less conditional logic. That will make them easier for others to read and to modify. They may be more "brittle" (i.e.  more susceptible to invalidation by future changes to the examples), but correcting a more-or-less declarative list of assertion statements is a far more reasonable task for drive-by contributors.

