### PR TITLE
Fix Listbox to refer to `option` role when discussing `aria-activedescentant`

### DIFF
--- a/aria-practices.html
+++ b/aria-practices.html
@@ -1701,7 +1701,7 @@
           <li>DOM focus (the active element) is functionally distinct from the selected state. For more details, see <a href="#kbd_focus_vs_selection">this description of differences between focus and selection.</a></li>
           <li>
             The <code>listbox</code> role supports the <a class="property-reference" href="#aria-activedescendant">aria-activedescendant</a> property,
-            which provides an alternative to moving DOM focus among <code>treeitem</code> elements when implementing keyboard navigation.
+            which provides an alternative to moving DOM focus among <code>option</code> elements when implementing keyboard navigation.
             For details, see <a href="#kbd_focus_activedescendant">Managing Focus in Composites Using aria-activedescendant</a>.
           </li>
           <li>


### PR DESCRIPTION
A note to the Listbox pattern discusses `aria-activedescendant`, and incorrectly referred to `treeitem` role, probably due to copy/paste error from a identical note to the [Tree View pattern](https://w3c.github.io/aria-practices/#TreeView), whereas [`listbox` uses the `option` role for its items](https://w3c.github.io/aria/#listbox).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dusek/aria-practices/pull/771.html" title="Last updated on Jul 15, 2018, 11:18 AM GMT (94f95e5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria-practices/771/ca1f155...dusek:94f95e5.html" title="Last updated on Jul 15, 2018, 11:18 AM GMT (94f95e5)">Diff</a>