### PR TITLE
Updates to aria-activedescendant util function

### DIFF
--- a/test/tests/listbox-combo.js
+++ b/test/tests/listbox-combo.js
@@ -4,7 +4,7 @@ const { ariaTest } = require('..');
 const { By, Key } = require('selenium-webdriver');
 const assertAttributeValues = require('../util/assertAttributeValues');
 const assertAriaLabelledby = require('../util/assertAriaLabelledby');
-const assertActiveDescendantFocus = require('../util/assertActiveDescendantFocus');
+const assertAriaSelectedAndActivedescendant = require('../util/assertAriaSelectedAndActivedescendant');
 
 const exampleFile = 'combobox/aria1.1pattern/listbox-combo.html';
 
@@ -463,7 +463,7 @@ ariaTest('Test down key press with focus on textbox',
       .sendKeys('a', Key.ARROW_DOWN);
 
     // Check that the active descendent focus is correct
-    await assertActiveDescendantFocus(t, ex.textboxSelector, ex.optionsSelector, 0);
+    await assertAriaSelectedAndActivedescendant(t, ex.textboxSelector, ex.optionsSelector, 0);
 
     /* Example 2 */
 
@@ -488,7 +488,7 @@ ariaTest('Test down key press with focus on textbox',
       .sendKeys('a', Key.ARROW_DOWN);
 
     // Check that the active descendent focus is correct
-    await assertActiveDescendantFocus(t, ex.textboxSelector, ex.optionsSelector, 1);
+    await assertAriaSelectedAndActivedescendant(t, ex.textboxSelector, ex.optionsSelector, 1);
 
     /* Example 3 */
 
@@ -506,7 +506,7 @@ ariaTest('Test down key press with focus on textbox',
     );
 
     // Check that the active descendent focus is correct
-    await assertActiveDescendantFocus(t, ex.textboxSelector, ex.optionsSelector, 0);
+    await assertAriaSelectedAndActivedescendant(t, ex.textboxSelector, ex.optionsSelector, 0);
 
     await reload(t.context.session);
 
@@ -516,7 +516,7 @@ ariaTest('Test down key press with focus on textbox',
       .sendKeys('a', Key.ARROW_DOWN);
 
     // Check that the active descendent focus is correct
-    await assertActiveDescendantFocus(t, ex.textboxSelector, ex.optionsSelector, 1);
+    await assertAriaSelectedAndActivedescendant(t, ex.textboxSelector, ex.optionsSelector, 1);
 
   });
 
@@ -550,7 +550,7 @@ ariaTest('Test down key press with focus on list',
       // Account for race condition
       await waitForFocusChange(t, ex.textboxSelector, oldfocus);
 
-      await assertActiveDescendantFocus(t, ex.textboxSelector, ex.optionsSelector, i % numOptions);
+      await assertAriaSelectedAndActivedescendant(t, ex.textboxSelector, ex.optionsSelector, i % numOptions);
     }
 
     /* Example 2 */
@@ -575,7 +575,7 @@ ariaTest('Test down key press with focus on list',
       // Account for race condition
       await waitForFocusChange(t, ex.textboxSelector, oldfocus);
 
-      await assertActiveDescendantFocus(t, ex.textboxSelector, ex.optionsSelector, i % numOptions);
+      await assertAriaSelectedAndActivedescendant(t, ex.textboxSelector, ex.optionsSelector, i % numOptions);
     }
 
     /* Example 3 */
@@ -600,7 +600,7 @@ ariaTest('Test down key press with focus on list',
       // Account for race condition
       await waitForFocusChange(t, ex.textboxSelector, oldfocus);
 
-      await assertActiveDescendantFocus(t, ex.textboxSelector, ex.optionsSelector, i % numOptions);
+      await assertAriaSelectedAndActivedescendant(t, ex.textboxSelector, ex.optionsSelector, i % numOptions);
     }
 
   });
@@ -635,7 +635,7 @@ ariaTest('Test up key press with focus on textbox',
 
     // Check that the active descendent focus is correct
     let numOptions = (await t.context.session.findElements(By.css(ex.optionsSelector))).length;
-    await assertActiveDescendantFocus(t, ex.textboxSelector, ex.optionsSelector, numOptions - 1);
+    await assertAriaSelectedAndActivedescendant(t, ex.textboxSelector, ex.optionsSelector, numOptions - 1);
 
     /* Example 2 */
 
@@ -661,7 +661,7 @@ ariaTest('Test up key press with focus on textbox',
 
     // Check that the active descendent focus is correct
     numOptions = (await t.context.session.findElements(By.css(ex.optionsSelector))).length;
-    await assertActiveDescendantFocus(t, ex.textboxSelector, ex.optionsSelector, numOptions - 1);
+    await assertAriaSelectedAndActivedescendant(t, ex.textboxSelector, ex.optionsSelector, numOptions - 1);
 
     /* Example 3 */
 
@@ -680,7 +680,7 @@ ariaTest('Test up key press with focus on textbox',
 
     // Check that the active descendent focus is correct
     numOptions = (await t.context.session.findElements(By.css(ex.optionsSelector))).length;
-    await assertActiveDescendantFocus(t, ex.textboxSelector, ex.optionsSelector, numOptions - 1);
+    await assertAriaSelectedAndActivedescendant(t, ex.textboxSelector, ex.optionsSelector, numOptions - 1);
 
     await reload(t.context.session);
 
@@ -691,7 +691,7 @@ ariaTest('Test up key press with focus on textbox',
 
     // Check that the active descendent focus is correct
     numOptions = (await t.context.session.findElements(By.css(ex.optionsSelector))).length;
-    await assertActiveDescendantFocus(t, ex.textboxSelector, ex.optionsSelector, numOptions - 1);
+    await assertAriaSelectedAndActivedescendant(t, ex.textboxSelector, ex.optionsSelector, numOptions - 1);
 
   });
 
@@ -725,7 +725,7 @@ ariaTest('Test up key press with focus on listbox',
       await waitForFocusChange(t, ex.textboxSelector, oldfocus);
 
       const index = numOptions - 1 - (i % numOptions);
-      await assertActiveDescendantFocus(t, ex.textboxSelector, ex.optionsSelector, index);
+      await assertAriaSelectedAndActivedescendant(t, ex.textboxSelector, ex.optionsSelector, index);
     }
 
     /* Example 2 */
@@ -753,7 +753,7 @@ ariaTest('Test up key press with focus on listbox',
       await waitForFocusChange(t, ex.textboxSelector, oldfocus);
 
       const index = numOptions - 1 - (i % numOptions);
-      await assertActiveDescendantFocus(t, ex.textboxSelector, ex.optionsSelector, index);
+      await assertAriaSelectedAndActivedescendant(t, ex.textboxSelector, ex.optionsSelector, index);
     }
 
     /* Example 3 */
@@ -781,7 +781,7 @@ ariaTest('Test up key press with focus on listbox',
       await waitForFocusChange(t, ex.textboxSelector, oldfocus);
 
       const index = numOptions - 1 - (i % numOptions);
-      await assertActiveDescendantFocus(t, ex.textboxSelector, ex.optionsSelector, index);
+      await assertAriaSelectedAndActivedescendant(t, ex.textboxSelector, ex.optionsSelector, index);
     }
   });
 

--- a/test/util/assertAriaSelectedAndActivedescendant.js
+++ b/test/util/assertAriaSelectedAndActivedescendant.js
@@ -14,6 +14,8 @@ const assert = require('assert');
  */
 module.exports = async function assertAriaSelectedAndActivedescendant (t, ariaDescendantSelector, optionsSelector, index) {
 
+  // Confirm the option at index index has aria-selected set to true
+
   let options = await t.context.session
     .findElements(By.css(optionsSelector));
 
@@ -23,6 +25,8 @@ module.exports = async function assertAriaSelectedAndActivedescendant (t, ariaDe
     'aria-selected should be on item at index ' + index + ' for items: ' + optionsSelector
   );
 
+  // Confrirm aria-activedescendant refers to the correct optoin
+
   let optionId = await options[index].getAttribute('id');
 
   assert.strictEqual(
@@ -31,6 +35,19 @@ module.exports = async function assertAriaSelectedAndActivedescendant (t, ariaDe
       .getAttribute('aria-activedescendant'),
     optionId,
     'aria-activedescendant should be set to ' + optionId + ' for items: ' + ariaDescendantSelector
+  );
+
+  // Confirm the focus is on the aria-activedescendent element
+
+  let focused = await t.context.session.executeScript(function () {
+    const selector = arguments[0];
+    let item = document.querySelector(selector);
+    return item === document.activeElement;
+  }, ariaDescendantSelector);
+
+  assert(
+    focused,
+    'document focus should be on aria-activedescendant element: ' + ariaDescendantSelector
   );
 
   t.pass();

--- a/test/util/assertAriaSelectedAndActivedescendant.js
+++ b/test/util/assertAriaSelectedAndActivedescendant.js
@@ -4,14 +4,15 @@ const { By } = require('selenium-webdriver');
 const assert = require('assert');
 
 /**
- * Assert the aria-activedescendant focus.
+ * Assert the aria-activedescendant focus is correctly set to the item that has
+ * attribute aria-selected set to "true" in a list of options.
  *
  * @param {obj} t                  - ava execution object
  * @param {String} ariaDescendantSelector - selector for element with aria-activeDescendant set
  * @param {String} optionsSelector - selector to select list of canidate elements for focus
  * @param {Number} index           - index of element in list returned by optionsSelector with focus
  */
-module.exports = async function assertActiveDescendantFocus (t, ariaDescendantSelector, optionsSelector, index) {
+module.exports = async function assertAriaSelectedAndActivedescendant (t, ariaDescendantSelector, optionsSelector, index) {
 
   let options = await t.context.session
     .findElements(By.css(optionsSelector));


### PR DESCRIPTION
When noticing #813 in the example `listbox/listbox-scrollable.html` example, I realized that setting the "aria-selected" attribute on the appropriate option is not strictly a part of the aria-activedescendant pattern. I renamed this util function to specify that it is checking for both the aria-activedescendant pattern and a corresponding aria-selected attribution.