### PR TITLE
Sppinbutton Pattern: Add aria-invalid guidance for values outside allowed range

### DIFF
--- a/aria-practices.html
+++ b/aria-practices.html
@@ -2269,6 +2269,10 @@
             Otherwise, the spinbutton element has a label provided by
             <a href="#aria-label" class="property-reference">aria-label</a>.
           </li>
+          <li>
+            If it is possible to modify the value of the textbox such that the value is outside of the allowed set of values, the spinbutton element has
+            <a href="#aria-invalid" class="state-reference">aria-invalid</a> set to <code>true</code>.
+          </li>
         </ul>
       </section>
     </section>


### PR DESCRIPTION
In response to issue #704, modified the roles, states, and properties section of the spinbutton pattern in aria-practices.html.

Adds a bullet to the list of roles, states, and properties stating that aria-invalid is set true if it is possible for the textbox to contain a value that is not allowed.