### PR TITLE
Add data-test-id attributes to combobox examples

### DIFF
--- a/examples/combobox/aria1.0pattern/combobox-autocomplete-list.html
+++ b/examples/combobox/aria1.0pattern/combobox-autocomplete-list.html
@@ -142,7 +142,7 @@
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr data-test-id="textbox-key-down-arrow">
             <th><kbd>Down Arrow</kbd></th>
             <td>
               <ul>
@@ -152,7 +152,7 @@
               </ul>
             </td>
           </tr>
-          <tr>
+          <tr data-test-id="textbox-key-up-arrow">
             <th><kbd>Up Arrow</kbd></th>
             <td>
               <ul>
@@ -161,7 +161,7 @@
               </ul>
             </td>
           </tr>
-          <tr>
+          <tr data-test-id="textbox-key-enter">
             <th><kbd>Enter</kbd></th>
             <td>
               <ul>
@@ -170,7 +170,7 @@
               </ul>
             </td>
           </tr>
-          <tr>
+          <tr data-test-id="textbox-key-escape">
             <th><kbd>Escape</kbd></th>
             <td>
               <ul>
@@ -205,7 +205,7 @@
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr data-test-id="listbox-key-enter">
             <th><kbd>Enter</kbd></th>
             <td>
               <ul>
@@ -215,7 +215,7 @@
               </ul>
             </td>
           </tr>
-          <tr>
+          <tr data-test-id="listbox-key-escape">
             <th><kbd>Escape</kbd></th>
             <td>
               <ul>
@@ -225,7 +225,7 @@
               </ul>
             </td>
           </tr>
-          <tr>
+          <tr data-test-id="listbox-key-down-arrow">
             <th><kbd>Down Arrow</kbd></th>
             <td>
               <ul>
@@ -235,7 +235,7 @@
               </ul>
             </td>
           </tr>
-          <tr>
+          <tr data-test-id="listbox-key-up-arrow">
             <th><kbd>Up Arrow</kbd></th>
             <td>
               <ul>
@@ -245,23 +245,23 @@
               </ul>
             </td>
           </tr>
-          <tr>
+          <tr data-test-id="listbox-key-right-arrow">
             <th><kbd>Right Arrow</kbd></th>
             <td>Moves visual focus to the textbox and moves the editing cursor one character to the right.</td>
           </tr>
-          <tr>
+          <tr data-test-id="listbox-key-left-arrow">
             <th><kbd>Left Arrow</kbd></th>
             <td>Moves visual focus to the textbox and moves the editing cursor one character to the left.</td>
           </tr>
-          <tr>
+          <tr data-test-id="listbox-key-home">
             <th><kbd>Home</kbd></th>
             <td>Moves visual focus to the textbox and places the editing cursor at the beginning of the field.</td>
           </tr>
-          <tr>
+          <tr data-test-id="listbox-key-end">
             <th><kbd>End</kbd></th>
             <td>Moves visual focus to the textbox and places the editing cursor at the end of the field.</td>
           </tr>
-          <tr>
+          <tr data-test-id="listbox-key-char">
             <th>Printable Characters</th>
             <td>
               <ul>
@@ -292,7 +292,7 @@
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr data-test-id="combobox-role">
             <th scope="row">
               <code>combobox</code>
             </th>
@@ -305,7 +305,7 @@
               </ul>
             </td>
           </tr>
-          <tr>
+          <tr data-test-id="combobox-aria-autocomplete">
             <td></td>
             <th scope="row">
               <code>aria-autocomplete="list"</code>
@@ -313,7 +313,7 @@
             <td><code>input[type="text"]</code></td>
             <td>Indicates that the autocomplete behavior of the text input is to suggest a list of possible values in a popup and that the suggestions are related to the string that is present in the textbox.</td>
           </tr>
-          <tr>
+          <tr data-test-id="combobox-aria-haspopup">
             <td></td>
             <th scope="row">
               <code>aria-haspopup="true"</code>
@@ -321,7 +321,7 @@
             <td><code>input[type="text"]</code></td>
             <td>Indicates that the combobox can popup another element to suggest values.</td>
           </tr>
-          <tr>
+          <tr data-test-id="combobox-aria-owns">
             <td></td>
             <th scope="row">
               <code>aria-owns="#IDREF"</code>
@@ -334,7 +334,7 @@
               </ul>
             </td>
           </tr>
-          <tr>
+          <tr data-test-id="combobox-aria-expanded">
             <td></td>
             <th scope="row">
               <code>aria-expanded="false"</code>
@@ -342,7 +342,7 @@
             <td><code>input[type="text"]</code></td>
             <td>Indicates that the popup element <strong>is not</strong> displayed.</td>
           </tr>
-          <tr>
+          <tr data-test-id="combobox-aria-expanded">
             <td></td>
             <th scope="row">
               <code>aria-expanded="true"</code>
@@ -350,7 +350,7 @@
             <td><code>input[type="text"]</code></td>
             <td>Indicates that the popup element <strong>is</strong> displayed.</td>
           </tr>
-          <tr>
+          <tr data-test-id="combobox-aria-activedescendant">
             <td></td>
             <th scope="row">
               <code>aria-activedescendant="IDREF"</code>
@@ -381,7 +381,7 @@
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr data-test-id="listbox-role">
             <th scope="row">
               <code>listbox</code>
             </th>
@@ -391,7 +391,7 @@
             </td>
             <td>Identifies the <code>ul</code> element as a <code>listbox</code>.</td>
           </tr>
-          <tr>
+          <tr data-test-id="listbox-aria-label">
             <td></td>
             <th scope="row">
               <code>aria-label="States"</code>
@@ -399,7 +399,7 @@
             <td><code>ul</code></td>
             <td>Provides a label for the <code>listbox</code>.</td>
           </tr>
-          <tr>
+          <tr data-test-id="option-role">
             <th scope="row">
               <code>option</code>
             </th>
@@ -412,7 +412,7 @@
               </ul>
             </td>
           </tr>
-          <tr>
+          <tr data-test-id="option-aria-selected">
             <td></td>
             <th scope="row">
               <code>aria-selected="true"</code>

--- a/examples/combobox/aria1.0pattern/combobox-autocomplete-none.html
+++ b/examples/combobox/aria1.0pattern/combobox-autocomplete-none.html
@@ -100,7 +100,7 @@
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr data-test-id="textbox-key-down-arrow">
             <th><kbd>Down Arrow</kbd></th>
             <td>
               <ul>
@@ -109,7 +109,7 @@
               </ul>
             </td>
           </tr>
-          <tr>
+          <tr data-test-id="textbox-key-up-arrow">
             <th><kbd>Up Arrow</kbd></th>
             <td>
               <ul>
@@ -118,7 +118,7 @@
               </ul>
             </td>
           </tr>
-          <tr>
+          <tr data-test-id="textbox-key-enter">
             <th><kbd>Enter</kbd></th>
             <td>
               <ul>
@@ -153,7 +153,7 @@
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr data-test-id="listbox-key-enter">
             <th><kbd>Enter</kbd></th>
             <td>
               <ul>
@@ -163,7 +163,7 @@
               </ul>
             </td>
           </tr>
-          <tr>
+          <tr data-test-id="listbox-key-escape">
             <th><kbd>Escape</kbd></th>
             <td>
               <ul>
@@ -173,7 +173,7 @@
               </ul>
             </td>
           </tr>
-          <tr>
+          <tr data-test-id="listbox-key-down-arrow">
             <th><kbd>Down Arrow</kbd></th>
             <td>
               <ul>
@@ -183,7 +183,7 @@
               </ul>
             </td>
           </tr>
-          <tr>
+          <tr data-test-id="listbox-key-up-arrow">
             <th><kbd>Up Arrow</kbd></th>
             <td>
               <ul>
@@ -193,23 +193,23 @@
               </ul>
             </td>
           </tr>
-          <tr>
+          <tr data-test-id="listbox-key-right-arrow">
             <th><kbd>Right Arrow</kbd></th>
             <td>Moves visual focus to the textbox and moves the editing cursor one character to the right.</td>
           </tr>
-          <tr>
+          <tr data-test-id="listbox-key-left-arrow">
             <th><kbd>Left Arrow</kbd></th>
             <td>Moves visual focus to the textbox and moves the editing cursor one character to the left.</td>
           </tr>
-          <tr>
+          <tr data-test-id="listbox-key-home">
             <th><kbd>Home</kbd></th>
             <td>Moves visual focus to the textbox and places the editing cursor at the beginning of the field.</td>
           </tr>
-          <tr>
+          <tr data-test-id="listbox-key-end">
             <th><kbd>End</kbd></th>
             <td>Moves visual focus to the textbox and places the editing cursor at the end of the field.</td>
           </tr>
-          <tr>
+          <tr data-test-id="listbox-key-char">
             <th>Printable Characters</th>
             <td>
               <ul>
@@ -240,7 +240,7 @@
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr data-test-id="combobox-role">
             <th scope="row">
               <code>combobox</code>
             </th>
@@ -253,7 +253,7 @@
               </ul>
             </td>
           </tr>
-          <tr>
+          <tr data-test-id="combobox-aria-autocomplete">
             <td></td>
             <th scope="row">
               <code>aria-autocomplete="none"</code>
@@ -261,7 +261,7 @@
             <td><code>input[type="text"]</code></td>
             <td>Indicates that the suggestions in the combobox popup are not values that complete the current textbox input.</td>
           </tr>
-          <tr>
+          <tr data-test-id="combobox-aria-haspopup">
             <td></td>
             <th scope="row">
               <code>aria-haspopup="true"</code>
@@ -269,7 +269,7 @@
             <td><code>input[type="text"]</code></td>
             <td>Indicates that the combobox can popup another element to suggest values.</td>
           </tr>
-          <tr>
+          <tr data-test-id="combobox-aria-owns">
             <td></td>
             <th scope="row">
               <code>aria-owns="#IDREF"</code>
@@ -282,7 +282,7 @@
               </ul>
             </td>
           </tr>
-          <tr>
+          <tr data-test-id="combobox-aria-expanded">
             <td></td>
             <th scope="row">
               <code>aria-expanded="false"</code>
@@ -290,7 +290,7 @@
             <td><code>input[type="text"]</code></td>
             <td>Indicates that the popup element <strong>is not</strong> displayed.</td>
           </tr>
-          <tr>
+          <tr data-test-id="combobox-aria-expanded">
             <td></td>
             <th scope="row">
               <code>aria-expanded="true"</code>
@@ -298,7 +298,7 @@
             <td><code>input[type="text"]</code></td>
             <td>Indicates that the popup element <strong>is</strong> displayed.</td>
           </tr>
-          <tr>
+          <tr data-test-id="combobox-aria-activedescendant">
             <td></td>
             <th scope="row">
               <code>aria-activedescendant="IDREF"</code>
@@ -329,7 +329,7 @@
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr data-test-id="listbox-role">
             <th scope="row">
               <code>listbox</code>
             </th>
@@ -339,7 +339,7 @@
             </td>
             <td>Identifies the <code>ul</code> element as a <code>listbox</code>.</td>
           </tr>
-          <tr>
+          <tr data-test-id="listbox-aria-label">
             <td></td>
             <th scope="row">
               <code>aria-label="Previous Searches"</code>
@@ -347,7 +347,7 @@
             <td><code>ul</code></td>
             <td>Provides a label for the <code>listbox</code>.</td>
           </tr>
-          <tr>
+          <tr data-test-id="option-role">
             <th scope="row">
               <code>option</code>
             </th>
@@ -360,7 +360,7 @@
               </ul>
             </td>
           </tr>
-          <tr>
+          <tr data-test-id="option-aria-selected">
             <td></td>
             <th scope="row">
               <code>aria-selected="true"</code>

--- a/examples/combobox/aria1.1pattern/grid-combo.html
+++ b/examples/combobox/aria1.1pattern/grid-combo.html
@@ -94,15 +94,15 @@
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr data-test-id="textbox-key-down-arrow">
             <th><kbd>Down Arrow</kbd></th>
             <td>If the grid is displayed, moves focus to the first suggested value.</td>
           </tr>
-          <tr>
+          <tr data-test-id="textbox-key-up-arrow">
             <th><kbd>Up Arrow</kbd></th>
             <td>If the grid is displayed, moves focus to the last suggested value.</td>
           </tr>
-          <tr>
+          <tr data-test-id="textbox-key-escape">
             <th><kbd>Escape</kbd></th>
             <td>
               <ul>
@@ -137,7 +137,7 @@
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr data-test-id="popup-key-enter">
             <th><kbd>Enter</kbd></th>
             <td>
               <ul>
@@ -147,7 +147,7 @@
               </ul>
             </td>
           </tr>
-          <tr>
+          <tr data-test-id="popup-key-escape">
             <th><kbd>Escape</kbd></th>
             <td>
               <ul>
@@ -157,7 +157,7 @@
               </ul>
             </td>
           </tr>
-          <tr>
+          <tr data-test-id="popup-key-down-arrow">
             <th><kbd>Down Arrow</kbd></th>
             <td>
               <ul>
@@ -167,7 +167,7 @@
               </ul>
             </td>
           </tr>
-          <tr>
+          <tr data-test-id="popup-key-up-arrow">
             <th><kbd>Up Arrow</kbd></th>
             <td>
               <ul>
@@ -177,7 +177,7 @@
               </ul>
             </td>
           </tr>
-          <tr>
+          <tr data-test-id="popup-key-right-arrow">
             <th><kbd>Right Arrow</kbd></th>
             <td>
               <ul>
@@ -187,7 +187,7 @@
               </ul>
             </td>
           </tr>
-          <tr>
+          <tr data-test-id="popup-key-left-arrow">
             <th><kbd>Left Arrow</kbd></th>
             <td>
               <ul>
@@ -197,15 +197,15 @@
               </ul>
             </td>
           </tr>
-          <tr>
+          <tr data-test-id="popup-key-home">
             <th><kbd>Home</kbd></th>
             <td>Moves focus to the textbox and places the editing cursor at the beginning of the field.</td>
           </tr>
-          <tr>
+          <tr data-test-id="popup-key-end">
             <th><kbd>End</kbd></th>
             <td>Moves focus to the textbox and places the editing cursor at the end of the field.</td>
           </tr>
-          <tr>
+          <tr data-test-id="popup-key-char">
             <th>Printable Characters</th>
             <td>
               <ul>
@@ -236,7 +236,7 @@
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr data-test-id="combobox-role">
             <th scope="row">
               <code>combobox</code>
             </th>
@@ -254,7 +254,7 @@
               </ul>
             </td>
           </tr>
-          <tr>
+          <tr data-test-id="combobox-aria-haspopup">
             <td></td>
             <th scope="row">
               <code>aria-haspopup=<q>grid</q></code>
@@ -262,7 +262,7 @@
             <td><code>div</code></td>
             <td>Indicates that the combobox can popup a <code>grid</code> to suggest values.</td>
           </tr>
-          <tr>
+          <tr data-test-id="combobox-aria-owns">
             <td></td>
             <th scope="row">
               <code>aria-owns=<q>IDREF</q></code>
@@ -275,7 +275,7 @@
               </ul>
             </td>
           </tr>
-          <tr>
+          <tr data-test-id="combobox-aria-expanded">
             <td></td>
             <th scope="row">
               <code>aria-expanded=<q>false</q></code>
@@ -283,7 +283,7 @@
             <td><code>div</code></td>
             <td>Indicates that the popup element <strong>is not</strong> displayed.</td>
           </tr>
-          <tr>
+          <tr data-test-id="combobox-aria-expanded">
             <td></td>
             <th scope="row">
               <code>aria-expanded=<q>true</q></code>
@@ -304,7 +304,7 @@
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr data-test-id="textbox-id">
             <td></td>
             <th scope="row">
               <code>id="string"</code>
@@ -317,7 +317,7 @@
               </ul>
             </td>
           </tr>
-          <tr>
+          <tr data-test-id="textbox-aria-autocomplete">
             <td></td>
             <th scope="row">
               <code>aria-autocomplete=<q>list</q></code>
@@ -325,7 +325,7 @@
             <td><code>input[type="text"]</code></td>
             <td>Indicates that the autocomplete behavior of the text input is to suggest a list of possible values in a popup.</td>
           </tr>
-          <tr>
+          <tr data-test-id="textbox-aria-controls">
             <td></td>
             <th scope="row">
               <code>aria-controls=<q>IDREF</q></code>
@@ -343,7 +343,7 @@
               </ul>
             </td>
           </tr>
-          <tr>
+          <tr data-test-id="textbox-aria-activedescendant">
             <td></td>
             <th scope="row">
               <code>aria-activedescendant=<q>IDREF</q></code>
@@ -374,7 +374,7 @@
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr data-test-id="grid-role">
             <th scope="row">
               <code>grid</code>
             </th>
@@ -384,7 +384,7 @@
             </td>
             <td>Identifies the element as a <code>grid</code>.</td>
           </tr>
-          <tr>
+          <tr data-test-id="grid-aria-labelledby">
             <td></td>
             <th scope="row">
               <code>aria-labelledby=<q>IDREF</q></code>
@@ -392,7 +392,7 @@
             <td><code>div</code></td>
             <td>Provides a label for the <code>grid</code> element of the combobox.</td>
           </tr>
-          <tr>
+          <tr data-test-id="row-role">
             <th scope="row">
               <code>row</code>
             </th>
@@ -400,7 +400,7 @@
             <td><code>div</code></td>
             <td>Identifies the element containing all the cells for a row.</td>
           </tr>
-          <tr>
+          <tr data-test-id="row-aria-selected">
             <td></td>
             <th scope="row">
               <code>aria-selected=<q>true</q></code>
@@ -413,7 +413,7 @@
               </ul>
             </td>
           </tr>
-          <tr>
+          <tr data-test-id="gridcell-role">
             <th scope="row"><code>gridcell</code></th>
             <td></td>
             <td><code>div</code></td>


### PR DESCRIPTION
Add data-test-id attributes to documentation tables for combobox examples. @mcking65, can you approve this PR?