### PR TITLE
Activate/toggle buttons with space on keyup

### DIFF
--- a/examples/button/js/button.js
+++ b/examples/button/js/button.js
@@ -40,13 +40,12 @@ function actionButtonKeydownHandler (event) {
 }
 
 /**
- * Activates the action button with the enter or space key.
+ * Activates the action button with the space key.
  *
  * @param {KeyboardEvent} event
  */
 function actionButtonKeyupHandler (event) {
-  // If either enter or space is pressed, activate the button
-  if (event.keyCode === 13 || event.keyCode === 32) {
+  if (event.keyCode === 32) {
     event.preventDefault();
     activateActionButton();
   }
@@ -87,12 +86,12 @@ function toggleButtonKeydownHandler (event) {
 }
 
 /**
- * Toggles the toggle button’s state with the enter or space key.
+ * Toggles the toggle button’s state with space key.
  *
  * @param {KeyboardEvent} event
  */
 function toggleButtonKeyupHandler (event) {
-  if (event.keyCode === 13 || event.keyCode === 32) {
+  if (event.keyCode === 32) {
     event.preventDefault();
     toggleButtonState(event.currentTarget);
   }

--- a/examples/button/js/button.js
+++ b/examples/button/js/button.js
@@ -2,84 +2,114 @@
 *   This content is licensed according to the W3C Software License at
 *   https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document
 *
-*   File:   button.js
-*
-*   Desc:   JS code for Button Design Pattersn
+*   JS code for the button design pattern
 */
 
-var ICON_MUTE_URL  = 'images/mute.svg#icon-mute';
+var ICON_MUTE_URL = 'images/mute.svg#icon-mute';
 var ICON_SOUND_URL = 'images/mute.svg#icon-sound';
 
 function init () {
-  // Create variables for the various buttons
   var actionButton = document.getElementById('action');
+  actionButton.addEventListener('click', activateActionButton);
+  actionButton.addEventListener('keydown', actionButtonKeydownHandler);
+  actionButton.addEventListener('keyup', actionButtonKeyupHandler);
+
   var toggleButton = document.getElementById('toggle');
-
-  // Add event listeners to the various buttons
-  actionButton.addEventListener('click', actionButtonEventHandler);
-  actionButton.addEventListener('keydown', actionButtonEventHandler);
-
-  toggleButton.addEventListener('click', toggleButtonEventHandler);
-  toggleButton.addEventListener('keydown', toggleButtonEventHandler);
-
+  toggleButton.addEventListener('click', toggleButtonClickHandler);
+  toggleButton.addEventListener('keydown', toggleButtonKeydownHandler);
+  toggleButton.addEventListener('keyup', toggleButtonKeyupHandler);
 }
 
-function actionButtonEventHandler (event) {
-  var type = event.type;
-
-  // Grab the keydown and click events
-  if (type === 'keydown') {
-    // If either enter or space is pressed, execute the funtion
-    if (event.keyCode === 13 || event.keyCode === 32) {
-      window.print();
-
-      event.preventDefault();
-    }
+/**
+ * Activates the action button with the enter key.
+ *
+ * @param {KeyboardEvent} event
+ */
+function actionButtonKeydownHandler (event) {
+  // The action button is activated by space on the keyup event, but the
+  // default action for space is already triggered on keydown. It needs to be
+  // prevented to stop scrolling the page before activating the button.
+  if (event.keyCode === 32) {
+    event.preventDefault();
   }
-  else if (type === 'click') {
-    window.print();
+  // If enter is pressed, activate the button
+  else if (event.keyCode === 13) {
+    event.preventDefault();
+    activateActionButton();
   }
 }
 
-function toggleButtonEventHandler (event) {
-  var type = event.type;
-
-  // Grab the keydown and click events
-  if (type === 'keydown') {
-    // If either enter or space is pressed, execute the funtion
-    if (event.keyCode === 13 || event.keyCode === 32) {
-      toggleButtonState(event);
-
-      event.preventDefault();
-    }
-  }
-  else if (type === 'click') {
-    // Only allow this event if either role is correctly set
-    // or a correct element is used.
-    if (event.target.getAttribute('role') === 'button' || event.target.tagName === 'button') {
-      toggleButtonState(event);
-    }
+/**
+ * Activates the action button with the enter or space key.
+ *
+ * @param {KeyboardEvent} event
+ */
+function actionButtonKeyupHandler (event) {
+  // If either enter or space is pressed, activate the button
+  if (event.keyCode === 13 || event.keyCode === 32) {
+    event.preventDefault();
+    activateActionButton();
   }
 }
 
-function toggleButtonState (event) {
-  var button = event.target;
-  var currentState = button.getAttribute('aria-pressed');
-  var newState = 'true';
+function activateActionButton () {
+  window.print();
+}
 
-  var icon = button.getElementsByTagName('use')[0];
-  var currentIconState = icon.getAttribute('xlink:href');
-  var newIconState = ICON_MUTE_URL;
-
-  // If aria-pressed is set to true, set newState to false
-  if (currentState === 'true') {
-    newState = 'false';
-    newIconState = ICON_SOUND_URL;
+/**
+ * Toggles the toggle button’s state if it’s actually a button element or has
+ * the `role` attribute set to `button`.
+ *
+ * @param {MouseEvent} event
+ */
+function toggleButtonClickHandler (event) {
+  if (
+    event.currentTarget.tagName === 'button' ||
+    event.currentTarget.getAttribute('role') === 'button'
+  ) {
+    toggleButtonState(event.currentTarget);
   }
+}
 
-  // Set the new aria-pressed state on the button
-  button.setAttribute('aria-pressed', newState);
-  icon.setAttribute('xlink:href', newIconState);
+/**
+ * Toggles the toggle button’s state with the enter key.
+ *
+ * @param {KeyboardEvent} event
+ */
+function toggleButtonKeydownHandler (event) {
+  if (event.keyCode === 32) {
+    event.preventDefault();
+  }
+  else if (event.keyCode === 13) {
+    event.preventDefault();
+    toggleButtonState(event.currentTarget);
+  }
+}
+
+/**
+ * Toggles the toggle button’s state with the enter or space key.
+ *
+ * @param {KeyboardEvent} event
+ */
+function toggleButtonKeyupHandler (event) {
+  if (event.keyCode === 13 || event.keyCode === 32) {
+    event.preventDefault();
+    toggleButtonState(event.currentTarget);
+  }
+}
+
+/**
+ * Toggles the toggle button’s state between *pressed* and *not pressed*.
+ *
+ * @param {HTMLElement} button
+ */
+function toggleButtonState (button) {
+  var isAriaPressed = button.getAttribute('aria-pressed') === 'true';
+
+  button.setAttribute('aria-pressed', isAriaPressed ? 'false' : 'true');
+
+  var icon = button.querySelector('use');
+  icon.setAttribute('xlink:href', isAriaPressed ? ICON_SOUND_URL : ICON_MUTE_URL);
 }
 
 window.onload = init;


### PR DESCRIPTION
Implements #610.

Both action and toggle buttons are now activated with space on the keyup event and no longer on the keydown event. The behavior for pressing enter has not changed.

As brought up in #610, I would like to remove the safety check on lines 66 to 69 (in the new file). What are your thoughts on that?

Also, do you want me to expand the description in the design pattern to reflect this behavior?