### PR TITLE
typos: Double words

### DIFF
--- a/aria-practices-DeletedSectionsArchive.html
+++ b/aria-practices-DeletedSectionsArchive.html
@@ -3305,7 +3305,7 @@ field. </p>
       extensions for Mozilla/Firefox</a> from the University of Illinois at
       Urbana-Champaign to render the document landmarks. This picture
       shows the Firefox browser rendering the University of Illinois
-      Career Career Center home page. In this example. The "List of Navigation Bars" viewer is shown, launched from the extension on the
+      Career Center home page. In this example. The "List of Navigation Bars" viewer is shown, launched from the extension on the
       toolbar. The viewer shows that the secondary "Career Center Services" is selected resulting
       in that section of the document being highlighted in yellow. The
       Navigation Bar Lists Viewer  lists the following list of titles corresponding to the navigation sections:</p>

--- a/aria-practices-DeletedSectionsArchive.html
+++ b/aria-practices-DeletedSectionsArchive.html
@@ -1890,7 +1890,7 @@ excommunication&lt;/dd&gt;
           If the keypress is a <kbd>Shift + Tab</kbd> key and the target == the first tab navigable object, then set focus to the last tab-navigable object and stop the key press event. If there is only a single tab focusable item, then focus does not have to be set, but the key press event must be stopped.
         </li>
         <li>
-          If the keypress is a <kbd>Tab</kbd> key and the target == the last tab navigable object, then set focus to the first tab-navigable object and stop the keypress event. If there is only a single tab-focusable item, then focus does not have to be set but the keypress event must must be stopped.
+          If the keypress is a <kbd>Tab</kbd> key and the target == the last tab navigable object, then set focus to the first tab-navigable object and stop the keypress event. If there is only a single tab-focusable item, then focus does not have to be set but the keypress event must be stopped.
         </li>
         <li>
           If the keypress is an <kbd>Escape</kbd> key and the target node is the container node for the dialog box, then close the dialog box and hide or destroy the dialog underlay.

--- a/aria-practices-DeletedSectionsArchive.html
+++ b/aria-practices-DeletedSectionsArchive.html
@@ -568,7 +568,7 @@
               <li>
                 <kbd>Enter</kbd> -
                 <ul>
-                  <li>If the the calendar is a popup attached to some other widget (e.g., a text field), then <kbd>Enter</kbd> dismisses the popup, and the selected date(s) are shown in the associated widget.</li>
+                  <li>If the calendar is a popup attached to some other widget (e.g., a text field), then <kbd>Enter</kbd> dismisses the popup, and the selected date(s) are shown in the associated widget.</li>
                   <li>If the calendar is a static region on the page, then <kbd>Enter</kbd> confirms the selected date(s).</li>
                 </ul>
               </li>
@@ -942,7 +942,7 @@
             </ol>
           </li>
           <li>
-            Navigation region: Each navigation widget should be wrapped in a container with role <a class="role-reference" href="#navigation">navigation</a> and have a label that is the same as the label on the the widget.
+            Navigation region: Each navigation widget should be wrapped in a container with role <a class="role-reference" href="#navigation">navigation</a> and have a label that is the same as the label on the widget.
             If multiple widgets are used to support a hierarchy and if the widgets are sequential in the <kbd>Tab</kbd> order, then the navigation regions for child widgets should be nested inside the navigation region of the parent.
           </li>
         </ol>
@@ -1005,7 +1005,7 @@
 
         <p>Option 1: Listbox containing links</p>
         <ul>
-          <li>The listbox should implement keyboard navigation consistent with the <a href="#Listbox">Listbox design pattern</a>. In addition, when <kbd>Enter</kbd> is pressed, the default action associated with the the currently focused option will be executed. Note that selection keys should not be implemented unless <a class="property-reference" href="#aria-multiselectable">aria-multiselectable</a> is <code>true</code>. If aria-multi-selectable is <code>false</code>, the default action should be to display the content specified by the link contained in that option, and if possible, move the focus to the beginning of the controlled region. If aria-multiselectable is <code>true</code> and <a href="#aria-haspopup" class="property-reference">aria-haspopup</a> is <code>true</code> for the currently focused option, then <kbd>Enter</kbd> should open a pop-up menu that provides items for navigating to the target specified by the currently focused option and for performing supported non-navigation operations on the currently selected options.</li>
+          <li>The listbox should implement keyboard navigation consistent with the <a href="#Listbox">Listbox design pattern</a>. In addition, when <kbd>Enter</kbd> is pressed, the default action associated with the currently focused option will be executed. Note that selection keys should not be implemented unless <a class="property-reference" href="#aria-multiselectable">aria-multiselectable</a> is <code>true</code>. If aria-multi-selectable is <code>false</code>, the default action should be to display the content specified by the link contained in that option, and if possible, move the focus to the beginning of the controlled region. If aria-multiselectable is <code>true</code> and <a href="#aria-haspopup" class="property-reference">aria-haspopup</a> is <code>true</code> for the currently focused option, then <kbd>Enter</kbd> should open a pop-up menu that provides items for navigating to the target specified by the currently focused option and for performing supported non-navigation operations on the currently selected options.</li>
           <li>Focus: When the listbox receives focus, the option in the listbox that is marked as currently displayed should receive focus.</li>
         </ul>
         <p>Option 2:  Toolbar containing toggle buttons</p>
@@ -1921,7 +1921,7 @@ if(evt.charOrCode){
 var node = evt.target; // get the target node of the keypress event
 if (evt.charOrCode === keys.TAB){
 // find the first and last tab focusable items in the hierarchy of the dialog container node
-// do this every time if the items may be added / removed from the the dialog may change visibility or state
+// do this every time if the items may be added / removed from the dialog may change visibility or state
 var focusItemsArray = helper.getFocusItems(dialogContainerNode);
 dialog.firstFocusItem = focusItemsArray[0];
 dialog.lastFocusItem = focusItemsArray[focusItemsArray.length-1];

--- a/aria-practices-DeletedSectionsArchive.html
+++ b/aria-practices-DeletedSectionsArchive.html
@@ -389,7 +389,7 @@
                         tab order. If you create a text field without using a standard HTML text
                         field form control then ensure that it is in the tab order.
                     </li>
-                    <li>If the text field is not editable it must have have <a
+                    <li>If the text field is not editable it must have <a
                         href="#aria-readonly" class="property-reference">aria-readonly</a> = <code>true</code>.
                     </li>
                     <li>The combobox must have <a href="#aria-expanded"
@@ -422,7 +422,7 @@
                         field is in the tab order. If you create a text field without using a
                         standard HTML text field form control then ensure that it is in the tab
                         order.</li>
-                    <li>If the combobox is not editable it must have have <a
+                    <li>If the combobox is not editable it must have <a
                         href="#aria-readonly" class="property-reference">aria-readonly</a> = <code>true</code>.
                     </li>
                     <li>The combobox must have <a href="#aria-expanded"
@@ -2284,7 +2284,7 @@ consistent with their visual rendering. Rather than setting  size only on a cont
 &lt;img src="foo.jpg" id="333" title="Finance Manager Approval"&gt;
 &lt;img src="foo.jpg" id="334" title="Sales Manager Approval"&gt;
 &#8230;  </pre>
-<p>Each element referenced by the flowto must have have a unique id. The combination of the unique id and the name allow the assistive technology  to adequately assist the user in retracing their steps backward through a flow to reference or moving forward to it. Since the author sets only the target the user agent is responsible for mapping the backward reference relationship. Therefore, neither the user agent nor the user can get lost. The host user agent does not provide an alternative navigation order; this is an assistive technology function.</p>
+<p>Each element referenced by the flowto must have a unique id. The combination of the unique id and the name allow the assistive technology  to adequately assist the user in retracing their steps backward through a flow to reference or moving forward to it. Since the author sets only the target the user agent is responsible for mapping the backward reference relationship. Therefore, neither the user agent nor the user can get lost. The host user agent does not provide an alternative navigation order; this is an assistive technology function.</p>
       </li>
       <li id="step3_keyboard">Make sure visual objects are keyboard accessible
         <p>Use tabindex to enable objects to receive focus. Actually setting focus to them may be performed by an assistive technology, such as an alternative input device. This example places each drawing object in  document order with respect to the tab sequence. </p>

--- a/aria-practices-DeletedSectionsArchive.html
+++ b/aria-practices-DeletedSectionsArchive.html
@@ -3122,7 +3122,7 @@ field. </p>
         analysis of the accessibility properties defined in <abbr title="Microsoft Active Accessibility">MSAA</abbr> and <abbr title="Accessibility Toolkit">ATK</abbr>.
         The following example extends the previous approach by adding the <a class="property-reference" href="#aria-haspopup">aria-haspopup</a> accessibility property.</p>
       <div class="example">
-        <p>Example: Use of WAI-ARIA to incorporate accessible state information information into XHTML 1.x</p>
+        <p>Example: Use of WAI-ARIA to incorporate accessible state information into XHTML 1.x</p>
         <pre class="highlight">
 <span class="pi">&lt;?xml version="1.1" encoding="us-ascii"?&gt;</span>
 <span class="doctype">&lt;!DOCTYPE html PUBLIC "Accessible Adaptive Applications//EN"

--- a/aria-practices.html
+++ b/aria-practices.html
@@ -4200,7 +4200,7 @@
         For example, specifying an invalid value for <code>aria-rowindex</code> or setting it on some but not all rows in a table, could cause screen reader table reading functions to skip rows or simply stop functioning.
       </p>
       <p>
-        The following code demonstrates the use of <code>aria-rowcount</code> and <code>aria-rowindex</code> properties on a table containing a a hypothetical class list.
+        The following code demonstrates the use of <code>aria-rowcount</code> and <code>aria-rowindex</code> properties on a table containing a hypothetical class list.
       </p>
       <pre>
         <code>

--- a/aria-practices.html
+++ b/aria-practices.html
@@ -1986,9 +1986,9 @@
     <section class="widget" id="radiobutton">
       <h3>Radio Group</h3>
       <p>
-        A radio group is a set of checkable buttons, known as radio buttons, where no more than one of 
+        A radio group is a set of checkable buttons, known as radio buttons, where no more than one of
         the buttons can be checked at a time.
-        Some implementations may initialize the set with all buttons in the unchecked state in order to 
+        Some implementations may initialize the set with all buttons in the unchecked state in order to
         force the user to check one of the buttons before moving past a certain point in the workflow.
       </p>
 
@@ -2399,7 +2399,7 @@
               <li><kbd>End</kbd> (Optional): Moves focus to the last tab. Optionally, activates the newly focused tab (See note below).</li>
               <li><kbd>Shift + F10</kbd>: If the tab has an associated pop-up menu, opens the menu. </li>
               <li>
-                <kbd>Delete</kbd> (Optional): If deletion is allowed, deletes (closes) the current tab element and its associated tab panel, 
+                <kbd>Delete</kbd> (Optional): If deletion is allowed, deletes (closes) the current tab element and its associated tab panel,
                 sets focus on the tab following the tab that was closed, and optionally activates the newly focused tab. If there is not a tab that followed the tab that was deleted,
                 e.g., the deleted tab was the right-most tab in a left-to-right horizontal tab list,
                 sets focus on and optionally activates the tab that preceded the deleted tab.
@@ -2930,7 +2930,7 @@
         </ul>
         <p class="note">See <a href="#kbd_common_conventions"></a> for cut, copy, and paste key assignments.</p>
       </section>
-        
+
       <section id="treegrid_roles_states_props" class="notoc">
         <h4>WAI-ARIA Roles, States, and Properties</h4>
         <ul>
@@ -4294,7 +4294,7 @@
         <h4>Using <code>aria-colindex</code> When Column Indicies Are Contiguous</h4>
         <p>
           When all the cells in a row have column index numbers that are consecutive integers,
-          <code>aria-colindex</code> can be set on the row element with a value equal to the the index number of the first column in the set.
+          <code>aria-colindex</code> can be set on the row element with a value equal to the index number of the first column in the set.
           Browsers will then compute a column number for each cell in the row.
         </p>
         <p>
@@ -4532,7 +4532,7 @@
       <p>The following example grid uses <code>aria-sort</code> to indicate the rows are sorted from the highest "Quiz 2" score to the lowest "Quiz 2" score.</p>
       <pre>
         <code>
-          &lt;table role=&quot;grid&quot; aria-rowcount=&quot;463&quot; aria-colcount=&quot;13&quot; 
+          &lt;table role=&quot;grid&quot; aria-rowcount=&quot;463&quot; aria-colcount=&quot;13&quot;
             aria-label=&quot;Student grades for history 101&quot;&gt;
             &lt;thead&gt;
               &lt;tr aria-colindex=&quot;10&quot; aria-rowindex=&quot;1&quot;&gt;
@@ -4781,7 +4781,7 @@
               <li>Menu button example bug fixes</li>
               <li>Navigation menubar example bug fixes</li>
               <li>Radio group example styling</li>
-              <li>Tabs pattern, including labeling guidance</li> 
+              <li>Tabs pattern, including labeling guidance</li>
               <li>Tree view pattern, including multi-select guidance</li>
               <li>Tree view example bug fixes</li>
             </ul>

--- a/examples/dialog-modal/dialog.html
+++ b/examples/dialog-modal/dialog.html
@@ -65,7 +65,7 @@
                 <li>When the dialog closes as a result of the <q>Cancel</q> action, the user's point of regard is maintained by returning focus to the <q>Add Delivery Address</q> button.
                 <li>
                   When the dialog closes as a result of the <q>Add</q> action and the <q>Address Added</q> dialog replaces the <q>Add Delivery Address</q> dialog,
-                  the <q>Add Delivery Address</q> dialog passes a reference to the <q>Add Delivery Address</q> button to the the <q>Address Added</q> dialog
+                  the <q>Add Delivery Address</q> dialog passes a reference to the <q>Add Delivery Address</q> button to the <q>Address Added</q> dialog
                   so that it can maintain the user's point of regard when it closes.
                 </li>
               </ul>

--- a/examples/listbox/listbox-collapsible.html
+++ b/examples/listbox/listbox-collapsible.html
@@ -35,7 +35,7 @@
   <p>
     The following example implementation of the
     <a href="../../#Listbox">design pattern for listbox</a>
-    demonstrates a collapsible single-select listbox widget that is functionally similar to an HTML <code>select</code> input with the the attribute <code>size=&quot;1&quot;</code>.
+    demonstrates a collapsible single-select listbox widget that is functionally similar to an HTML <code>select</code> input with the attribute <code>size=&quot;1&quot;</code>.
     The widget consists of a button that triggers the display of a listbox.
     In its default state, the widget is collapsed (the listbox is not visible)  and the button label shows the currently selected option from the listbox.
     When the button is activated, the listbox is displayed and the current option is focused and selected.
@@ -216,7 +216,7 @@
           <td>
             <ul>
               <li>Set by the JavaScript when the listbox is displayed.</li>
-              <li>Otherwise, is not present.</li> 
+              <li>Otherwise, is not present.</li>
             </ul>
           </td>
         </tr>
@@ -254,7 +254,7 @@
               <li>When navigation keys, such as <kbd>Down Arrow</kbd>, are pressed, the JavaScript changes the value.</li>
               <li>Enables assistive technologies to know which element the application regards as focused while DOM focus remains on the <code>ul</code> element.</li>
               <li>
-                For more information about this focus management technique, see 
+                For more information about this focus management technique, see
                 <a href="../../../#kbd_focus_activedescendant">Using aria-activedescendant to Manage Focus.</a>
               </li>
             </ul>


### PR DESCRIPTION
Just ran Vale to find duplicate words. There were a few others, but they seemed intentional


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/nschonni/aria-practices/pull/867.html" title="Last updated on Aug 30, 2018, 5:35 AM GMT (48966e8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria-practices/867/1379511...nschonni:48966e8.html" title="Last updated on Aug 30, 2018, 5:35 AM GMT (48966e8)">Diff</a>