### PR TITLE
Fix bug in exampe: treeview/treeview-2/treeview-2b.html

### DIFF
--- a/examples/treeview/treeview-2/treeview-2b.html
+++ b/examples/treeview/treeview-2/treeview-2b.html
@@ -201,9 +201,9 @@
               <span>Vegetables</span>
               <ul role="group">
                 <li role="treeitem"
-                  aria-level="1"
+                  aria-level="2"
                   aria-setsize="3"
-                  aria-posinset="2"
+                  aria-posinset="1"
                   aria-expanded="false">
                   <span>Podded Vegetables</span>
                   <ul role="group">


### PR DESCRIPTION
The attributes aria-level and aria-posinset were incorrectly set on on treeitem.

This bug was caught by the tests written here:  #870