### PR TITLE
Add regression test run to travis CI build stages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ stages:
 jobs:
   include:
     - stage: Test
+      script: ava -c 1 test/tests
+    - stage: Test
       name: JS Linting
       script: npm run lint
     - stage: Test


### PR DESCRIPTION
Before #851, travis.ci ran "npm test", which runs the linters and the regression tests all in one. Now the tests are separated out and the regression tests needed to be added explicitly back in.

This PR also sets "concurrency=1" for the ava tests. This will element the bug which causes firefox to crash at least once (sometimes twice) during the regression test. We reported the crashing of firefox to geckodriver in this [bug](https://github.com/mozilla/geckodriver/issues/1135#issuecomment-417337821).
