### PR TITLE
Regression test: expanded error messages, rare race condition fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,3 +33,6 @@ jobs:
         script: /tmp/deploy/travis-deploy.sh
         on:
           branch: master
+
+env:
+  - TEST_WAIT_TIME=1000

--- a/test/index.js
+++ b/test/index.js
@@ -9,6 +9,7 @@ const startGeckodriver = require('./util/start-geckodriver');
 
 let session, geckodriver;
 const firefoxArgs = process.env.CI ? [ '-headless' ] : [];
+const testWaitTime = process.env.TEST_WAIT_TIME || 500;
 
 test.before(async (t) => {
   geckodriver = await startGeckodriver(1022, 12 * 1000);
@@ -26,6 +27,7 @@ test.before(async (t) => {
 
 test.beforeEach((t) => {
   t.context.session = session;
+  t.context.waitTime = testWaitTime;
 });
 
 test.after.always(() => {

--- a/test/index.js
+++ b/test/index.js
@@ -9,7 +9,7 @@ const startGeckodriver = require('./util/start-geckodriver');
 
 let session, geckodriver;
 const firefoxArgs = process.env.CI ? [ '-headless' ] : [];
-const testWaitTime = process.env.TEST_WAIT_TIME || 500;
+const testWaitTime = parseInt(process.env.TEST_WAIT_TIME) || 500;
 
 test.before(async (t) => {
   geckodriver = await startGeckodriver(1022, 12 * 1000);

--- a/test/tests/LayoutGrids.js
+++ b/test/tests/LayoutGrids.js
@@ -5,8 +5,8 @@ const { By, Key } = require('selenium-webdriver');
 
 const assertAriaLabelledby = require('../util/assertAriaLabelledby');
 
-const reload = async (session) => {
-  return session.get(await session.getCurrentUrl());
+const reload = async (t) => {
+  return t.context.session.get(t.context.url);
 };
 
 const clickUntilDisabled = async (session, selector) => {
@@ -507,7 +507,7 @@ ariaTest('PageDown key moves focus', 'grid/LayoutGrids.html', 'key-page-down', a
 
   for (let [initialCell, selector, focusableElement] of cellSelectors) {
 
-    await reload(t.context.session);
+    await reload(t);
 
     let finalIndex;
     const gridcellElements = (await t.context.session.findElements(
@@ -565,7 +565,7 @@ ariaTest('PageUp key moves focus', 'grid/LayoutGrids.html', 'key-page-up', async
 
   for (let [initialCell, selector, focusableElement] of cellSelectors) {
 
-    await reload(t.context.session);
+    await reload(t);
     // This test depends on the "page down" button which is not specified by
     // the widget's description. It does this to avoid relying on behaviors
     // that are tested elsewhere.

--- a/test/tests/LayoutGrids.js
+++ b/test/tests/LayoutGrids.js
@@ -108,7 +108,7 @@ const exampleInitialized = async function (t, exId) {
   await t.context.session.wait(async function () {
     const els = await t.context.session.findElements(By.css(initializedSelector));
     return els.length === 1;
-  }, 500);
+  }, 500, 'Timeout waiting for widget to initialize before running tests.');
 };
 
 // Attributes

--- a/test/tests/LayoutGrids.js
+++ b/test/tests/LayoutGrids.js
@@ -108,7 +108,7 @@ const exampleInitialized = async function (t, exId) {
   await t.context.session.wait(async function () {
     const els = await t.context.session.findElements(By.css(initializedSelector));
     return els.length === 1;
-  }, 500, 'Timeout waiting for widget to initialize before running tests.');
+  }, t.context.waitTime, 'Timeout waiting for widget to initialize before running tests.');
 };
 
 // Attributes

--- a/test/tests/button.js
+++ b/test/tests/button.js
@@ -83,7 +83,7 @@ ariaTest('"aria-pressed" reflects button state', exampleFile, 'button-aria-press
   await toggleButtonEl.click();
   await t.context.session.wait(async function () {
     return toggleButtonEl.getAttribute('aria-pressed') !== 'true';
-  }, 500, 'Timeout waiting for aria-pressed to change from "true"');
+  }, t.context.waitTime, 'Timeout waiting for aria-pressed to change from "true"');
 
   t.is(
     await toggleButtonEl.getAttribute('aria-pressed'),
@@ -102,7 +102,7 @@ ariaTest('key ENTER activates button', exampleFile, 'key-enter', async (t) => {
   await toggleButtonEl.sendKeys(Key.ENTER);
   await t.context.session.wait(async function () {
     return toggleButtonEl.getAttribute('aria-pressed') !== 'true';
-  }, 500, 'Timeout waiting for aria-pressed to change from "true"');
+  }, t.context.waitTime, 'Timeout waiting for aria-pressed to change from "true"');
 
   t.is(
     await toggleButtonEl.getAttribute('aria-pressed'),
@@ -114,7 +114,7 @@ ariaTest('key ENTER activates button', exampleFile, 'key-enter', async (t) => {
   await toggleButtonEl.sendKeys(Key.ENTER);
   await t.context.session.wait(async function () {
     return toggleButtonEl.getAttribute('aria-pressed') !== 'false';
-  }, 500, 'Timeout waiting for aria-pressed to change from "false"');
+  }, t.context.waitTime, 'Timeout waiting for aria-pressed to change from "false"');
 
   t.is(
     await toggleButtonEl.getAttribute('aria-pressed'),
@@ -139,7 +139,7 @@ ariaTest('key ENTER activates button', exampleFile, 'key-enter', async (t) => {
 
   await t.context.session.wait(async function () {
     return actionButtonEl.getText('') !== oldText;
-  }, 500, 'window.print was not executed');
+  }, t.context.waitTime, 'window.print was not executed');
 
   t.is(
     await actionButtonEl.getText(),
@@ -158,7 +158,7 @@ ariaTest('key SPACE activates button', exampleFile, 'key-space', async (t) => {
   await toggleButtonEl.sendKeys(Key.SPACE);
   await t.context.session.wait(async function () {
     return toggleButtonEl.getAttribute('aria-pressed') !== 'true';
-  }, 500, 'Timeout waiting for aria-pressed to change from "true"');
+  }, t.context.waitTime, 'Timeout waiting for aria-pressed to change from "true"');
 
   t.is(
     await toggleButtonEl.getAttribute('aria-pressed'),
@@ -170,7 +170,7 @@ ariaTest('key SPACE activates button', exampleFile, 'key-space', async (t) => {
   await toggleButtonEl.sendKeys(Key.SPACE);
   await t.context.session.wait(async function () {
     return toggleButtonEl.getAttribute('aria-pressed') !== 'false';
-  }, 500, 'Timeout waiting for aria-pressed to change from "false"');
+  }, t.context.waitTime, 'Timeout waiting for aria-pressed to change from "false"');
 
   t.is(
     await toggleButtonEl.getAttribute('aria-pressed'),
@@ -195,7 +195,7 @@ ariaTest('key SPACE activates button', exampleFile, 'key-space', async (t) => {
 
   await t.context.session.wait(async function () {
     return actionButtonEl.getText('') !== oldText;
-  }, 500, 'window.print was not executed');
+  }, t.context.waitTime, 'window.print was not executed');
 
   t.is(
     await actionButtonEl.getText(),

--- a/test/tests/button.js
+++ b/test/tests/button.js
@@ -83,7 +83,7 @@ ariaTest('"aria-pressed" reflects button state', exampleFile, 'button-aria-press
   await toggleButtonEl.click();
   await t.context.session.wait(async function () {
     return toggleButtonEl.getAttribute('aria-pressed') !== 'true';
-  }, 500);
+  }, 500, 'Timeout waiting for aria-pressed to change from "true"');
 
   t.is(
     await toggleButtonEl.getAttribute('aria-pressed'),
@@ -102,7 +102,7 @@ ariaTest('key ENTER activates button', exampleFile, 'key-enter', async (t) => {
   await toggleButtonEl.sendKeys(Key.ENTER);
   await t.context.session.wait(async function () {
     return toggleButtonEl.getAttribute('aria-pressed') !== 'true';
-  }, 500);
+  }, 500, 'Timeout waiting for aria-pressed to change from "true"');
 
   t.is(
     await toggleButtonEl.getAttribute('aria-pressed'),
@@ -114,7 +114,7 @@ ariaTest('key ENTER activates button', exampleFile, 'key-enter', async (t) => {
   await toggleButtonEl.sendKeys(Key.ENTER);
   await t.context.session.wait(async function () {
     return toggleButtonEl.getAttribute('aria-pressed') !== 'false';
-  }, 500);
+  }, 500, 'Timeout waiting for aria-pressed to change from "false"');
 
   t.is(
     await toggleButtonEl.getAttribute('aria-pressed'),
@@ -158,7 +158,7 @@ ariaTest('key SPACE activates button', exampleFile, 'key-space', async (t) => {
   await toggleButtonEl.sendKeys(Key.SPACE);
   await t.context.session.wait(async function () {
     return toggleButtonEl.getAttribute('aria-pressed') !== 'true';
-  }, 500);
+  }, 500, 'Timeout waiting for aria-pressed to change from "true"');
 
   t.is(
     await toggleButtonEl.getAttribute('aria-pressed'),
@@ -170,7 +170,7 @@ ariaTest('key SPACE activates button', exampleFile, 'key-space', async (t) => {
   await toggleButtonEl.sendKeys(Key.SPACE);
   await t.context.session.wait(async function () {
     return toggleButtonEl.getAttribute('aria-pressed') !== 'false';
-  }, 500);
+  }, 500, 'Timeout waiting for aria-pressed to change from "false"');
 
   t.is(
     await toggleButtonEl.getAttribute('aria-pressed'),

--- a/test/tests/checkbox-1.js
+++ b/test/tests/checkbox-1.js
@@ -29,7 +29,7 @@ const waitAndCheckAriaChecked = async function (t, selector, value) {
       let checkbox = await t.context.session.findElement(By.css(selector));
       return (await checkbox.getAttribute('aria-checked')) === value;
     },
-    500,
+    t.context.waitTime,
     'Timeout: aria-checked is not set to "' + value + '" for: ' + selector,
   ).catch((err) => { return err; });
 };

--- a/test/tests/checkbox-1.js
+++ b/test/tests/checkbox-1.js
@@ -30,7 +30,7 @@ const waitAndCheckAriaChecked = async function (t, selector, value) {
       return (await checkbox.getAttribute('aria-checked')) === value;
     },
     500,
-    'aria-checked is not set to "' + value + '" for: ' + selector,
+    'Timeout: aria-checked is not set to "' + value + '" for: ' + selector,
   ).catch((err) => { return err; });
 };
 

--- a/test/tests/combobox-autocomplete-both.js
+++ b/test/tests/combobox-autocomplete-both.js
@@ -18,7 +18,7 @@ const ex = {
 };
 
 const reload = async (session) => {
-  return session.get(await session.getCurrentUrl());
+  return session.get(t.context.url);
 };
 
 const waitForFocusChange = async (t, textboxSelector, originalFocus) => {

--- a/test/tests/combobox-autocomplete-both.js
+++ b/test/tests/combobox-autocomplete-both.js
@@ -17,10 +17,6 @@ const ex = {
 
 };
 
-const reload = async (session) => {
-  return session.get(t.context.url);
-};
-
 const waitForFocusChange = async (t, textboxSelector, originalFocus) => {
   await t.context.session.wait(async function () {
     let newfocus = await t.context.session
@@ -174,6 +170,9 @@ ariaTest('Test down key press with focus on textbox',
       'In example ex3 listbox should display after ARROW_DOWN keypress'
     );
 
+    // Account for race condition
+    await waitForFocusChange(t, ex.textboxSelector, null);
+
     // Check that the active descendent focus is correct
     await assertAriaSelectedAndActivedescendant(t, ex.textboxSelector, ex.optionsSelector, 0);
 
@@ -223,6 +222,9 @@ ariaTest('Test up key press with focus on textbox',
       await t.context.session.findElement(By.css(ex.listboxSelector)).isDisplayed(),
       'In example ex3 listbox should display after ARROW_UP keypress'
     );
+
+    // Account for race condition
+    await waitForFocusChange(t, ex.textboxSelector, null);
 
     // Check that the active descendent focus is correct
     let numOptions = (await t.context.session.findElements(By.css(ex.optionsSelector))).length;

--- a/test/tests/combobox-autocomplete-both.js
+++ b/test/tests/combobox-autocomplete-both.js
@@ -23,7 +23,7 @@ const waitForFocusChange = async (t, textboxSelector, originalFocus) => {
       .findElement(By.css(textboxSelector))
       .getAttribute('aria-activedescendant');
     return newfocus != originalFocus;
-  }, 500, 'Timeout waiting for "aria-activedescendant" value to change from: ' + originalFocus);
+  }, t.context.waitTime, 'Timeout waiting for "aria-activedescendant" value to change from: ' + originalFocus);
 };
 
 const confirmCursorIndex = async (t, selector, cursorIndex) => {

--- a/test/tests/combobox-autocomplete-both.js
+++ b/test/tests/combobox-autocomplete-both.js
@@ -22,18 +22,12 @@ const reload = async (session) => {
 };
 
 const waitForFocusChange = async (t, textboxSelector, originalFocus) => {
-  try {
-    await t.context.session.wait(async function () {
-      let newfocus = await t.context.session
-        .findElement(By.css(textboxSelector))
-        .getAttribute('aria-activedescendant');
-      return newfocus != originalFocus;
-    }, 500);
-  }
-  catch (e) {
-    throw new Error('Error waiting for "aria-activedescendant" value to change from "' +
-                    originalFocus + '". ' + e.message);
-  }
+  await t.context.session.wait(async function () {
+    let newfocus = await t.context.session
+      .findElement(By.css(textboxSelector))
+      .getAttribute('aria-activedescendant');
+    return newfocus != originalFocus;
+  }, 500, 'Timeout waiting for "aria-activedescendant" value to change from: ' + originalFocus);
 };
 
 const confirmCursorIndex = async (t, selector, cursorIndex) => {

--- a/test/tests/combobox-autocomplete-list.js
+++ b/test/tests/combobox-autocomplete-list.js
@@ -24,7 +24,7 @@ const waitForFocusChange = async (t, textboxSelector, originalFocus) => {
         .getAttribute('aria-activedescendant');
       return newfocus != originalFocus;
     },
-    500,
+    t.context.waitTime,
     'Error waiting for "aria-activedescendant" value to change from "' + originalFocus + '". '
   );
 };

--- a/test/tests/combobox-autocomplete-list.js
+++ b/test/tests/combobox-autocomplete-list.js
@@ -17,7 +17,7 @@ const ex = {
 };
 
 const reload = async (session) => {
-  return session.get(await session.getCurrentUrl());
+  return session.get(t.context.url);
 };
 
 const waitForFocusChange = async (t, textboxSelector, originalFocus) => {

--- a/test/tests/combobox-autocomplete-list.js
+++ b/test/tests/combobox-autocomplete-list.js
@@ -16,10 +16,6 @@ const ex = {
   numAOptions: 5
 };
 
-const reload = async (session) => {
-  return session.get(t.context.url);
-};
-
 const waitForFocusChange = async (t, textboxSelector, originalFocus) => {
   await t.context.session.wait(
     async function () {
@@ -181,6 +177,8 @@ ariaTest('Test down key press with focus on textbox',
       'In example ex3 listbox should display after ARROW_DOWN keypress'
     );
 
+    await waitForFocusChange(t, ex.textboxSelector, null);
+
     // Check that the active descendent focus is correct
     await assertAriaSelectedAndActivedescendant(t, ex.textboxSelector, ex.optionsSelector, 0);
 
@@ -244,6 +242,8 @@ ariaTest('Test up key press with focus on textbox',
       await t.context.session.findElement(By.css(ex.listboxSelector)).isDisplayed(),
       'In example ex3 listbox should display after ARROW_UP keypress'
     );
+
+    await waitForFocusChange(t, ex.textboxSelector, null);
 
     // Check that the active descendent focus is correct
     let numOptions = (await t.context.session.findElements(By.css(ex.optionsSelector))).length;

--- a/test/tests/combobox-autocomplete-none.js
+++ b/test/tests/combobox-autocomplete-none.js
@@ -17,7 +17,7 @@ const ex = {
 };
 
 const reload = async (session) => {
-  return session.get(await session.getCurrentUrl());
+  return session.get(t.context.url);
 };
 
 const waitForFocusChange = async (t, textboxSelector, originalFocus) => {

--- a/test/tests/combobox-autocomplete-none.js
+++ b/test/tests/combobox-autocomplete-none.js
@@ -29,7 +29,7 @@ const waitForFocusChange = async (t, textboxSelector, originalFocus) => {
       return newfocus != originalFocus;
     },
     500,
-    'Error waiting for "aria-activedescendant" value to change from "' + originalFocus + '". '
+    'Timeout waiting for "aria-activedescendant" value to change from "' + originalFocus + '". '
   );
 };
 

--- a/test/tests/combobox-autocomplete-none.js
+++ b/test/tests/combobox-autocomplete-none.js
@@ -24,7 +24,7 @@ const waitForFocusChange = async (t, textboxSelector, originalFocus) => {
         .getAttribute('aria-activedescendant');
       return newfocus != originalFocus;
     },
-    500,
+    t.context.waitTime,
     'Timeout waiting for "aria-activedescendant" value to change from "' + originalFocus + '". '
   );
 };

--- a/test/tests/combobox-autocomplete-none.js
+++ b/test/tests/combobox-autocomplete-none.js
@@ -16,10 +16,6 @@ const ex = {
   numOptions: 11
 };
 
-const reload = async (session) => {
-  return session.get(t.context.url);
-};
-
 const waitForFocusChange = async (t, textboxSelector, originalFocus) => {
   await t.context.session.wait(
     async function () {
@@ -181,6 +177,8 @@ ariaTest('Test down key press with focus on textbox',
       'In example ex3 listbox should display after ARROW_DOWN keypress'
     );
 
+    await waitForFocusChange(t, ex.textboxSelector, null);
+
     // Check that the active descendent focus is correct
     await assertAriaSelectedAndActivedescendant(t, ex.textboxSelector, ex.optionsSelector, 0);
 
@@ -244,6 +242,8 @@ ariaTest('Test up key press with focus on textbox',
       await t.context.session.findElement(By.css(ex.listboxSelector)).isDisplayed(),
       'In example ex3 listbox should display after ARROW_UP keypress'
     );
+
+    await waitForFocusChange(t, ex.textboxSelector, null);
 
     // Check that the active descendent focus is correct
     let numOptions = (await t.context.session.findElements(By.css(ex.optionsSelector))).length;

--- a/test/tests/dialog.js
+++ b/test/tests/dialog.js
@@ -144,7 +144,7 @@ const sendTabToSelector = async function (t, selector) {
       let selector = arguments[0];
       return document.activeElement !== document.querySelector(selector);
     }, selector);
-  }, 500);
+  }, 500, 'Timeout waiting for focus to move after TAB sent to: ' + selector);
 };
 
 const sendShiftTabToSelector = async function (t, selector) {
@@ -157,7 +157,7 @@ const sendShiftTabToSelector = async function (t, selector) {
       let selector = arguments[0];
       return document.activeElement !== document.querySelector(selector);
     }, selector);
-  }, 500);
+  }, 500, 'Timeout waiting for focus to move after SHIFT TAB sent to: ' + selector);
 };
 
 const sendEscapeTo = async function (t, selector) {

--- a/test/tests/dialog.js
+++ b/test/tests/dialog.js
@@ -144,7 +144,7 @@ const sendTabToSelector = async function (t, selector) {
       let selector = arguments[0];
       return document.activeElement !== document.querySelector(selector);
     }, selector);
-  }, 500, 'Timeout waiting for focus to move after TAB sent to: ' + selector);
+  }, t.context.waitTime, 'Timeout waiting for focus to move after TAB sent to: ' + selector);
 };
 
 const sendShiftTabToSelector = async function (t, selector) {
@@ -157,7 +157,7 @@ const sendShiftTabToSelector = async function (t, selector) {
       let selector = arguments[0];
       return document.activeElement !== document.querySelector(selector);
     }, selector);
-  }, 500, 'Timeout waiting for focus to move after SHIFT TAB sent to: ' + selector);
+  }, t.context.waitTime, 'Timeout waiting for focus to move after SHIFT TAB sent to: ' + selector);
 };
 
 const sendEscapeTo = async function (t, selector) {

--- a/test/tests/dialog.js
+++ b/test/tests/dialog.js
@@ -123,7 +123,7 @@ const openDialog4 = async function (t) {
 };
 
 const reload = async (t) => {
-  return t.context.session.get(await t.context.session.getCurrentUrl());
+  return t.context.session.get(t.context.url);
 };
 
 const checkFocus = async function (t, selector) {

--- a/test/tests/disclosure-faq.js
+++ b/test/tests/disclosure-faq.js
@@ -26,16 +26,18 @@ const ex = {
 };
 
 
-const waitAndCheckExpandedTrue = async function (t, element) {
+const waitAndCheckExpandedTrue = async function (t, selector) {
   return t.context.session.wait(async function () {
+    const element = t.context.session.findElement(By.css(selector));
     return (await element.getAttribute('aria-expanded')) === 'true';
-  }, 500);
+  }, 500, 'Timeout waiting for aria-expanded to change to true on element: ' + selector);
 };
 
-const waitAndCheckExpandedFalse = async function (t, element) {
+const waitAndCheckExpandedFalse = async function (t, selector) {
   return t.context.session.wait(async function () {
+    const element = t.context.session.findElement(By.css(selector));
     return (await element.getAttribute('aria-expanded')) === 'false';
-  }, 500);
+  }, 500, 'Timeout waiting for aria-expanded to change to false on element: ' + selector);
 };
 
 
@@ -93,7 +95,7 @@ ariaTest('key ENTER expands details', exampleFile, 'key-enter-or-space', async (
     await button.sendKeys(Key.ENTER);
 
     t.true(
-      await waitAndCheckExpandedTrue(t, button),
+      await waitAndCheckExpandedTrue(t, buttonSelector),
       'Question should have aria-expanded true after sending ENTER: ' + buttonSelector
     );
 
@@ -105,7 +107,7 @@ ariaTest('key ENTER expands details', exampleFile, 'key-enter-or-space', async (
     await button.sendKeys(Key.ENTER);
 
     t.true(
-      await waitAndCheckExpandedFalse(t, button),
+      await waitAndCheckExpandedFalse(t, buttonSelector),
       'Question should have aria-expanded false after sending ENTER twice: ' + buttonSelector
     );
 
@@ -127,7 +129,7 @@ ariaTest('key SPACE expands details', exampleFile, 'key-enter-or-space', async (
     await button.sendKeys(Key.SPACE);
 
     t.true(
-      await waitAndCheckExpandedTrue(t, button),
+      await waitAndCheckExpandedTrue(t, buttonSelector),
       'Question should have aria-expanded true after sending SPACE: ' + buttonSelector
     );
 
@@ -139,7 +141,7 @@ ariaTest('key SPACE expands details', exampleFile, 'key-enter-or-space', async (
     await button.sendKeys(Key.SPACE);
 
     t.true(
-      await waitAndCheckExpandedFalse(t, button),
+      await waitAndCheckExpandedFalse(t, buttonSelector),
       'Question should have aria-expanded false after sending SPACE twice: ' + buttonSelector
     );
 

--- a/test/tests/disclosure-faq.js
+++ b/test/tests/disclosure-faq.js
@@ -30,14 +30,14 @@ const waitAndCheckExpandedTrue = async function (t, selector) {
   return t.context.session.wait(async function () {
     const element = t.context.session.findElement(By.css(selector));
     return (await element.getAttribute('aria-expanded')) === 'true';
-  }, 500, 'Timeout waiting for aria-expanded to change to true on element: ' + selector);
+  }, t.context.waitTime, 'Timeout waiting for aria-expanded to change to true on element: ' + selector);
 };
 
 const waitAndCheckExpandedFalse = async function (t, selector) {
   return t.context.session.wait(async function () {
     const element = t.context.session.findElement(By.css(selector));
     return (await element.getAttribute('aria-expanded')) === 'false';
-  }, 500, 'Timeout waiting for aria-expanded to change to false on element: ' + selector);
+  }, t.context.waitTime, 'Timeout waiting for aria-expanded to change to false on element: ' + selector);
 };
 
 

--- a/test/tests/grid-combo.js
+++ b/test/tests/grid-combo.js
@@ -23,7 +23,7 @@ const ex = {
 };
 
 const reload = async (session) => {
-  return session.get(await session.getCurrentUrl());
+  return session.get(t.context.url);
 };
 
 const waitForFocusChange = async (t, textboxSelector, originalFocus) => {

--- a/test/tests/grid-combo.js
+++ b/test/tests/grid-combo.js
@@ -35,7 +35,7 @@ const waitForFocusChange = async (t, textboxSelector, originalFocus) => {
       return newfocus != originalFocus;
     },
     500,
-    'Error waiting for "aria-activedescendant" value to change from "' + originalFocus + '". '
+    'Timeout waiting for "aria-activedescendant" value to change from "' + originalFocus + '". '
   );
 };
 
@@ -534,7 +534,7 @@ ariaTest('Test escape key press with focus on textbox',
         return !(await t.context.session.findElement(By.css(ex.gridSelector)).isDisplayed());
       },
       500,
-      'Error waiting for gridbox to close afer escape'
+      'Timeout waiting for gridbox to close afer escape'
     );
 
     // Confirm the grid is closed and the textboxed is cleared
@@ -568,7 +568,7 @@ ariaTest('Test escape key press with focus on textbox',
 //         return ! (await t.context.session.findElement(By.css(ex.gridSelector)).isDisplayed());
 //       },
 //       500,
-//       'Error waiting for gridbox to close afer escape'
+//       'Timeout waiting for gridbox to close afer escape'
 //     );
 
 //     // Confirm the grid is closed and the textboxed is cleared

--- a/test/tests/grid-combo.js
+++ b/test/tests/grid-combo.js
@@ -29,7 +29,7 @@ const waitForFocusChange = async (t, textboxSelector, originalFocus) => {
         .getAttribute('aria-activedescendant');
       return newfocus != originalFocus;
     },
-    500,
+    t.context.waitTime,
     'Timeout waiting for "aria-activedescendant" value to change from "' + originalFocus + '". '
   );
 };
@@ -534,7 +534,7 @@ ariaTest('Test escape key press with focus on textbox',
       async function () {
         return !(await t.context.session.findElement(By.css(ex.gridSelector)).isDisplayed());
       },
-      500,
+      t.context.waitTime,
       'Timeout waiting for gridbox to close afer escape'
     );
 
@@ -568,7 +568,7 @@ ariaTest('Test escape key press with focus on textbox',
 //       async function () {
 //         return ! (await t.context.session.findElement(By.css(ex.gridSelector)).isDisplayed());
 //       },
-//       500,
+//       t.context.waitTime,
 //       'Timeout waiting for gridbox to close afer escape'
 //     );
 

--- a/test/tests/grid-combo.js
+++ b/test/tests/grid-combo.js
@@ -6,7 +6,6 @@ const assertAriaLabelledby = require('../util/assertAriaLabelledby');
 const assertAttributeValues = require('../util/assertAttributeValues');
 const assertAttributeDNE = require('../util/assertAttributeDNE');
 const assertAriaRoles = require('../util/assertAriaRoles');
-const assertAriaSelectedAndActivedescendant = require('../util/assertAriaSelectedAndActivedescendant');
 
 const exampleFile = 'combobox/aria1.1pattern/grid-combo.html';
 
@@ -20,10 +19,6 @@ const ex = {
   gridcellSelector: '#ex1 [role="gridcell"]',
   gridcellFocusedClass: 'focused-cell',
   numAOptions: 3
-};
-
-const reload = async (session) => {
-  return session.get(t.context.url);
 };
 
 const waitForFocusChange = async (t, textboxSelector, originalFocus) => {
@@ -264,6 +259,9 @@ ariaTest('Test down key press with focus on textbox',
       .findElement(By.css(ex.textboxSelector))
       .sendKeys('a', Key.ARROW_DOWN);
 
+    // Account for race condition
+    await waitForFocusChange(t, ex.textboxSelector, null);
+
     // Check that the grid is displayed
     t.true(
       await t.context.session.findElement(By.css(ex.gridSelector)).isDisplayed(),
@@ -382,6 +380,9 @@ ariaTest('Test up key press with focus on textbox',
     await t.context.session
       .findElement(By.css(ex.textboxSelector))
       .sendKeys('a', Key.ARROW_UP);
+
+    // Account for race condition
+    await waitForFocusChange(t, ex.textboxSelector, null);
 
     // Check that the grid is displayed
     t.true(

--- a/test/tests/link.js
+++ b/test/tests/link.js
@@ -104,7 +104,7 @@ ariaTest('Test "ENTER" key behavior',
         return t.context.session.getCurrentUrl().then(url => {
           return url != t.context.url;
         });
-      }, 500).catch(() => {});
+      }, t.context.waitTime).catch(() => {});
 
       t.not(
         await t.context.session.getCurrentUrl(),

--- a/test/tests/listbox-combo.js
+++ b/test/tests/listbox-combo.js
@@ -43,7 +43,7 @@ const waitForFocusChange = async (t, textboxSelector, originalFocus) => {
       .findElement(By.css(textboxSelector))
       .getAttribute('aria-activedescendant');
     return newfocus != originalFocus;
-  }, 500, 'Timeout waiting for "aria-activedescendant" value to change from: ' + originalFocus);
+  }, t.context.waitTime, 'Timeout waiting for "aria-activedescendant" value to change from: ' + originalFocus);
 };
 
 const confirmCursorIndex = async (t, selector, cursorIndex) => {

--- a/test/tests/listbox-combo.js
+++ b/test/tests/listbox-combo.js
@@ -32,13 +32,14 @@ const pageExamples = {
   }
 };
 
-const reload = async (session) => {
-  return session.get(t.context.url);
+const reload = async (t) => {
+  return t.context.session.get(t.context.url);
 };
 
 const waitForFocusChange = async (t, textboxSelector, originalFocus) => {
+
   await t.context.session.wait(async function () {
-    let newfocus = await t.context.session
+    const newfocus = await t.context.session
       .findElement(By.css(textboxSelector))
       .getAttribute('aria-activedescendant');
     return newfocus != originalFocus;
@@ -437,7 +438,10 @@ ariaTest('Test for aria-selected on option element',
 
     /* Example 2 and 3 */
 
+    await reload(t);
+
     for (let exId of ['ex2', 'ex3']) {
+      await reload(t);
       ex = pageExamples[exId];
 
       // Send key "a" to textbox
@@ -490,6 +494,7 @@ ariaTest('Test down key press with focus on textbox',
 
     /* Example 2 */
 
+    await reload(t);
     ex = pageExamples.ex2;
 
     // Send ARROW_DOWN to the textbox
@@ -505,6 +510,7 @@ ariaTest('Test down key press with focus on textbox',
 
     /* Example 3 */
 
+    await reload(t);
     ex = pageExamples.ex3;
 
     // Send ARROW_DOWN to the textbox
@@ -513,10 +519,13 @@ ariaTest('Test down key press with focus on textbox',
       .sendKeys(Key.ARROW_DOWN);
 
     // Check that the listbox is displayed
-    t.truthy(
+    t.true(
       await t.context.session.findElement(By.css(ex.listboxSelector)).isDisplayed(),
       'In example ex3 listbox should display after ARROW_DOWN keypress'
     );
+
+    // Wait for focus to change
+    await waitForFocusChange(t, ex.textboxSelector, null);
 
     // Check that the active descendent focus is correct
     await assertAriaSelectedAndActivedescendant(t, ex.textboxSelector, ex.optionsSelector, 0);
@@ -530,6 +539,7 @@ ariaTest('Test down key press with focus on list',
 
     // Test assumptions: the number of options in the listbox after typing "a"
     const numOptions = 3;
+
 
     /* Example 1 */
 
@@ -556,8 +566,10 @@ ariaTest('Test down key press with focus on list',
       await assertAriaSelectedAndActivedescendant(t, ex.textboxSelector, ex.optionsSelector, i % numOptions);
     }
 
+
     /* Example 2 */
 
+    await reload(t);
     ex = pageExamples.ex2;
 
     // Send 'a' to text box, then send ARROW_DOWN to textbox to set focus on listbox
@@ -583,6 +595,7 @@ ariaTest('Test down key press with focus on list',
 
     /* Example 3 */
 
+    await reload(t);
     ex = pageExamples.ex3;
 
     // Send 'a' to text box, then send ARROW_DOWN to textbox to set focus on listbox
@@ -631,6 +644,7 @@ ariaTest('Test up key press with focus on textbox',
 
     /* Example 2 */
 
+    await reload(t);
     ex = pageExamples.ex2;
 
     // Send ARROW_UP to the textbox
@@ -646,6 +660,7 @@ ariaTest('Test up key press with focus on textbox',
 
     /* Example 3 */
 
+    await reload(t);
     ex = pageExamples.ex3;
 
     // Send ARROW_UP to the textbox
@@ -653,8 +668,11 @@ ariaTest('Test up key press with focus on textbox',
       .findElement(By.css(ex.textboxSelector))
       .sendKeys(Key.ARROW_UP);
 
+    // Wait for focus to change
+    await waitForFocusChange(t, ex.textboxSelector, null);
+
     // Check that the listbox is displayed
-    t.truthy(
+    t.true(
       await t.context.session.findElement(By.css(ex.listboxSelector)).isDisplayed(),
       'In example ex3 listbox should display after ARROW_UP keypress'
     );
@@ -700,6 +718,7 @@ ariaTest('Test up key press with focus on listbox',
 
     /* Example 2 */
 
+    await reload(t);
     ex = pageExamples.ex2;
 
     // Send 'a' to text box, then send ARROW_UP to textbox to textbox to put focus in textbox
@@ -728,6 +747,7 @@ ariaTest('Test up key press with focus on listbox',
 
     /* Example 3 */
 
+    await reload(t);
     ex = pageExamples.ex3;
 
     // Send 'a' to text box, then send ARROW_UP to textbox to textbox to put focus in textbox
@@ -787,6 +807,7 @@ ariaTest('Test enter key press with focus on textbox',
     /* Example 2 and 3 */
 
     for (let exId of ['ex2', 'ex3']) {
+      await reload(t);
       ex = pageExamples[exId];
 
       // Send key "a" to the textbox

--- a/test/tests/listbox-combo.js
+++ b/test/tests/listbox-combo.js
@@ -33,7 +33,7 @@ const pageExamples = {
 };
 
 const reload = async (session) => {
-  return session.get(await session.getCurrentUrl());
+  return session.get(t.context.url);
 };
 
 const waitForFocusChange = async (t, textboxSelector, originalFocus) => {

--- a/test/tests/listbox-combo.js
+++ b/test/tests/listbox-combo.js
@@ -37,20 +37,13 @@ const reload = async (session) => {
 };
 
 const waitForFocusChange = async (t, textboxSelector, originalFocus) => {
-  try {
-    await t.context.session.wait(async function () {
-      let newfocus = await t.context.session
-        .findElement(By.css(textboxSelector))
-        .getAttribute('aria-activedescendant');
-      return newfocus != originalFocus;
-    }, 500);
-  }
-  catch (e) {
-    throw new Error('Error waiting for "aria-activedescendant" value to change from "' +
-                    originalFocus + '". ' + e.message);
-  }
+  await t.context.session.wait(async function () {
+    let newfocus = await t.context.session
+      .findElement(By.css(textboxSelector))
+      .getAttribute('aria-activedescendant');
+    return newfocus != originalFocus;
+  }, 500, 'Timeout waiting for "aria-activedescendant" value to change from: ' + originalFocus);
 };
-
 
 const confirmCursorIndex = async (t, selector, cursorIndex) => {
   return t.context.session.executeScript(function () {

--- a/test/tests/listbox-scrollable.js
+++ b/test/tests/listbox-scrollable.js
@@ -13,7 +13,8 @@ const exampleFile = 'listbox/listbox-scrollable.html';
 const ex = {
   listboxSelector: '#ex [role="listbox"]',
   optionSelector: '#ex [role="option"]',
-  numOptions: 26
+  numOptions: 26,
+  firstOptionSelector: '#ex #ss_elem_Np'
 };
 
 // Attributes
@@ -38,7 +39,7 @@ ariaTest('aria-activedescendant on listbox element', exampleFile, 'listbox-aria-
 
   // Put the focus on the listbox. In this example, focusing on the listbox
   // will automatically select the first option.
-  await t.context.session.findElement(By.css(ex.listboxSelector)).sendKeys(Key.TAB);
+  await t.context.session.findElement(By.css(ex.firstOptionSelector)).click();
 
   let options = await t.context.session.findElements(By.css(ex.optionSelector));
   let optionId = await options[0].getAttribute('id');
@@ -64,8 +65,7 @@ ariaTest('"aria-selected" on option elements', exampleFile, 'option-aria-selecte
 
   // Put the focus on the listbox. In this example, focusing on the listbox
   // will automatically select the first option.
-  const listbox = await t.context.session.findElement(By.css(ex.listboxSelector));
-  await listbox.sendKeys(Key.TAB);
+  await t.context.session.findElement(By.css(ex.firstOptionSelector)).click();
 
   await assertAttributeValues(t, ex.optionSelector + ':nth-child(1)', 'aria-selected', 'true');
 });
@@ -77,11 +77,12 @@ ariaTest('DOWN ARROW moves focus', exampleFile, 'key-down-arrow', async (t) => {
 
   // Put the focus on the listbox. In this example, focusing on the listbox
   // will automatically select the first option.
-  const listbox = await t.context.session.findElement(By.css(ex.listboxSelector));
-  await listbox.sendKeys(Key.TAB);
+  await t.context.session.findElement(By.css(ex.firstOptionSelector)).click();
 
   // Sending the key down arrow will put focus on the item at index 1
+  const listbox = await t.context.session.findElement(By.css(ex.listboxSelector));
   await listbox.sendKeys(Key.ARROW_DOWN);
+
   await assertAriaSelectedAndActivedescendant(t, ex.listboxSelector, ex.optionSelector, 1);
 
   // The selection does not wrap to beginning of list if keydown arrow is sent more times
@@ -95,6 +96,10 @@ ariaTest('DOWN ARROW moves focus', exampleFile, 'key-down-arrow', async (t) => {
 
 ariaTest('END moves focus', exampleFile, 'key-end', async (t) => {
   t.pass(2);
+
+  // Put the focus on the listbox. In this example, focusing on the listbox
+  // will automatically select the first option.
+  await t.context.session.findElement(By.css(ex.firstOptionSelector)).click();
 
   const listbox = await t.context.session.findElement(By.css(ex.listboxSelector));
 
@@ -111,6 +116,10 @@ ariaTest('END moves focus', exampleFile, 'key-end', async (t) => {
 
 ariaTest('UP ARROW moves focus', exampleFile, 'key-up-arrow', async (t) => {
   t.plan(2);
+
+  // Put the focus on the listbox. In this example, focusing on the listbox
+  // will automatically select the first option.
+  await t.context.session.findElement(By.css(ex.firstOptionSelector)).click();
 
   const listbox = await t.context.session.findElement(By.css(ex.listboxSelector));
 
@@ -132,6 +141,10 @@ ariaTest('UP ARROW moves focus', exampleFile, 'key-up-arrow', async (t) => {
 
 ariaTest('HOME moves focus', exampleFile, 'key-home', async (t) => {
   t.plan(2);
+
+  // Put the focus on the listbox. In this example, focusing on the listbox
+  // will automatically select the first option.
+  await t.context.session.findElement(By.css(ex.firstOptionSelector)).click();
 
   const listbox = await t.context.session.findElement(By.css(ex.listboxSelector));
   await listbox.sendKeys(Key.ARROW_DOWN, Key.ARROW_DOWN);

--- a/test/tests/menubar-2.js
+++ b/test/tests/menubar-2.js
@@ -58,7 +58,7 @@ const exampleInitialized = async function (t) {
   await t.context.session.wait(async function () {
     const els = await t.context.session.findElements(By.css(initializedSelector));
     return els.length === 1;
-  }, 500, 'Timeout waiting for example to initialize');
+  }, t.context.waitTime, 'Timeout waiting for example to initialize');
 };
 
 const checkmarkVisible = async function (t, selector, index) {
@@ -295,7 +295,7 @@ ariaTest('Test aria-disabled="false" for all submenu role="menuitem"s',
       await menuitem[0].sendKeys(Key.ENTER);
 
       return await menuitem[0].getAttribute('aria-disabled') === 'true';
-    }, 500, 'Timeout trying to disable the first item in the last menu by sending multiple clicks');
+    }, t.context.waitTime, 'Timeout trying to disable the first item in the last menu by sending multiple clicks');
 
     // Test that the item was successfully disabled
     t.true(
@@ -310,7 +310,7 @@ ariaTest('Test aria-disabled="false" for all submenu role="menuitem"s',
       await menuitem[1].sendKeys(Key.ENTER);
 
       return await menuitem[1].getAttribute('aria-disabled') === 'true';
-    }, 500, 'Timeout trying to disable the second item in the last menu by sending multiple clicks');
+    }, t.context.waitTime, 'Timeout trying to disable the second item in the last menu by sending multiple clicks');
 
     // Test that the item was successfully disabled
     t.true(

--- a/test/tests/menubar-2.js
+++ b/test/tests/menubar-2.js
@@ -58,7 +58,7 @@ const exampleInitialized = async function (t) {
   await t.context.session.wait(async function () {
     const els = await t.context.session.findElements(By.css(initializedSelector));
     return els.length === 1;
-  }, 500);
+  }, 500, 'Timeout waiting for example to initialize');
 };
 
 const checkmarkVisible = async function (t, selector, index) {
@@ -295,7 +295,7 @@ ariaTest('Test aria-disabled="false" for all submenu role="menuitem"s',
       await menuitem[0].sendKeys(Key.ENTER);
 
       return await menuitem[0].getAttribute('aria-disabled') === 'true';
-    }, 500);
+    }, 500, 'Timeout trying to disable the first item in the last menu by sending multiple clicks');
 
     // Test that the item was successfully disabled
     t.true(
@@ -310,7 +310,7 @@ ariaTest('Test aria-disabled="false" for all submenu role="menuitem"s',
       await menuitem[1].sendKeys(Key.ENTER);
 
       return await menuitem[1].getAttribute('aria-disabled') === 'true';
-    }, 500);
+    }, 500, 'Timeout trying to disable the second item in the last menu by sending multiple clicks');
 
     // Test that the item was successfully disabled
     t.true(

--- a/test/tests/tabs.js
+++ b/test/tests/tabs.js
@@ -37,13 +37,13 @@ const waitAndCheckFocus = async function (t, selector, index) {
       let items = document.querySelectorAll(selector);
       return items[index] === document.activeElement;
     }, selector, index);
-  }, 500, 'Timeout waiting for document.activeElement to become item at index ' + index + ' of elements selected by: ' + selector);
+  }, t.context.waitTime, 'Timeout waiting for document.activeElement to become item at index ' + index + ' of elements selected by: ' + selector);
 };
 
 const waitAndCheckAriaSelected = async function (t, element) {
   return t.context.session.wait(async function () {
     return (await element.getAttribute('aria-selected')) === 'true';
-  }, 500, 'Timeout waiting for aria-selected to be set to true.');
+  }, t.context.waitTime, 'Timeout waiting for aria-selected to be set to true.');
 };
 
 // Attributes

--- a/test/tests/tabs.js
+++ b/test/tests/tabs.js
@@ -37,13 +37,13 @@ const waitAndCheckFocus = async function (t, selector, index) {
       let items = document.querySelectorAll(selector);
       return items[index] === document.activeElement;
     }, selector, index);
-  }, 500);
+  }, 500, 'Timeout waiting for document.activeElement to become item at index ' + index + ' of elements selected by: ' + selector);
 };
 
 const waitAndCheckAriaSelected = async function (t, element) {
   return t.context.session.wait(async function () {
     return (await element.getAttribute('aria-selected')) === 'true';
-  }, 500);
+  }, 500, 'Timeout waiting for aria-selected to be set to true.');
 };
 
 // Attributes

--- a/test/tests/toolbar.js
+++ b/test/tests/toolbar.js
@@ -35,7 +35,7 @@ const clickAndWait = async function (t, selector) {
       let tabindex = await element.getAttribute('tabindex');
       return tabindex === '0';
     },
-    500,
+    t.context.waitTime,
     'Timeout waiting for click to set tabindex="0" on: ' + selector
   ).catch((err) => { return err; });
 };
@@ -49,7 +49,7 @@ const waitAndCheckFocus = async function (t, selector) {
         return item === document.activeElement;
       }, selector);
     },
-    500,
+    t.context.waitTime,
     'Timeout waiting for activeElement to become: ' + selector,
   ).catch((err) => { return err; });
 };

--- a/test/tests/toolbar.js
+++ b/test/tests/toolbar.js
@@ -36,7 +36,7 @@ const clickAndWait = async function (t, selector) {
       return tabindex === '0';
     },
     500,
-    'click did not set tabindex="0" on: ' + selector
+    'Timeout waiting for click to set tabindex="0" on: ' + selector
   ).catch((err) => { return err; });
 };
 
@@ -50,7 +50,7 @@ const waitAndCheckFocus = async function (t, selector) {
       }, selector);
     },
     500,
-    'activeElement is not: ' + selector,
+    'Timeout waiting for activeElement to become: ' + selector,
   ).catch((err) => { return err; });
 };
 
@@ -61,7 +61,7 @@ const waitAndCheckTabindex = async function (t, selector) {
       return (await item.getAttribute('tabindex')) === '0';
     },
     600,
-    'tabindex is not "0" for: ' + selector
+    'Timeout waiting for tabindex to set to "0" for: ' + selector
   ).catch((err) => { return err; });
 };
 

--- a/test/tests/treegrid-1.js~
+++ b/test/tests/treegrid-1.js~
@@ -1,0 +1,162 @@
+'use strict';
+
+const { ariaTest } = require('..');
+const { By, Key } = require('selenium-webdriver');
+const assertAriaRoles = require('../util/assertAriaRoles');
+const assertAttributeValues = require('../util/assertAttributeValues');
+const assertAriaLabelExists = require('../util/assertAriaLabelExists');
+const assertRovingTabindex = require('../util/assertRovingTabindex');
+
+const exampleFile = 'treegrid/treegrid-1.html';
+
+const ex = {
+  treegridSelector: '#ex1 [role="treegrid"]',
+  rowSelector: '#ex1 [role="row"]',
+  gridcellSelector: '#ex1 [role="gridcell"]',
+  parentEmailSelector: '#ex1 [role="row"][aria-expanded]'
+};
+
+const openAllThreads = async function (t) {
+  let closedThreads = await t.context.session.findElements(By.css(ex.parentEmailSelector));
+
+  // Going through all closed email thread elements in dom order will open parent
+  // threads first, therefore all child threads will be visible before openning
+  for (let thread of closedThreads) {
+    await thread.sendKeys(Key.ENTER);
+  }
+};
+
+const checkFocus = async function (t, selector, index) {
+  return t.context.session.executeScript(function (/* selector, index*/) {
+    const [selector, index] = arguments;
+    const items = document.querySelectorAll(selector);
+    return items[index] === document.activeElement;
+  }, selector, index);
+};
+
+const checkFocusOnParentFolder = async function (t, el) {
+  return t.context.session.executeScript(function () {
+    const el = arguments[0];
+
+    // the element is a folder
+    if (el.hasAttribute('aria-expanded')) {
+      return document.activeElement === el.parentElement.closest('[role="treeitem"][aria-expanded]');
+    }
+    // the element is a folder
+    else {
+      return document.activeElement === el.closest('[role="treeitem"][aria-expanded]');
+    }
+  }, el);
+};
+
+const isTopLevelFolder = async function (t, el) {
+  return t.context.session.executeScript(function () {
+    const el = arguments[0];
+    return el.parentElement.getAttribute('role') === 'tree';
+  }, el);
+};
+
+const isFolderTreeitem = async function (el) {
+  return !(await el.getAttribute('class')).includes('doc');
+};
+
+const isOpenedFolderTreeitem =  async function (el) {
+  return await el.getAttribute('aria-expanded') === 'true';
+};
+
+const isClosedFolderTreeitem =  async function (el) {
+  return await el.getAttribute('aria-expanded') === 'false';
+};
+
+// Attributes
+
+ariaTest('', exampleFile, 'treegrid-role', async (t) => {
+  t.plan(1);
+  await assertAriaRoles(t, 'ex1', 'treegrid', 1, 'table');
+});
+
+ariaTest('', exampleFile, 'treegrid-aria-label', async (t) => {
+  t.plan(1);
+  await assertAriaLabelExists(t, ex.treegridSelector);
+});
+
+ariaTest('', exampleFile, 'row-role', async (t) => {
+  t.plan(1);
+  await assertAriaRoles(t, 'ex1', 'row', 8, 'tr');
+});
+
+ariaTest('', exampleFile, 'row-tabindex', async (t) => {
+  t.pass();
+});
+
+
+ariaTest('', exampleFile, 'row-aria-expanded', async (t) => {
+  t.pass();
+});
+
+
+ariaTest('', exampleFile, 'row-aria-level', async (t) => {
+  t.pass();
+});
+
+ariaTest('', exampleFile, 'row-aria-setsize', async (t) => {
+  t.pass();
+});
+
+
+ariaTest('', exampleFile, 'row-aria-posinset', async (t) => {
+  t.pass();
+});
+
+
+ariaTest('', exampleFile, 'gridcell-role', async (t) => {
+  t.plan(1);
+  await assertAriaRoles(t, 'ex1', 'gridcell', 24, 'td');
+});
+
+// Keys
+
+ariaTest('', exampleFile, 'key-right-arrow', async (t) => {
+  t.pass();
+});
+
+
+ariaTest('', exampleFile, 'key-left-arrow', async (t) => {
+  t.pass();
+});
+
+ariaTest('', exampleFile, 'key-down-arrow', async (t) => {
+  t.pass();
+});
+
+ariaTest('', exampleFile, 'key-up-arrow', async (t) => {
+  t.pass();
+});
+
+ariaTest('', exampleFile, 'key-tab', async (t) => {
+  t.pass();
+});
+
+ariaTest('', exampleFile, 'key-shift-tab', async (t) => {
+  t.pass();
+});
+
+ariaTest('', exampleFile, 'key-home', async (t) => {
+  t.pass();
+});
+
+ariaTest('', exampleFile, 'key-end', async (t) => {
+  t.pass();
+});
+
+ariaTest('', exampleFile, 'key-control-home', async (t) => {
+  t.pass();
+});
+
+ariaTest('', exampleFile, 'key-control-end', async (t) => {
+  t.pass();
+});
+
+ariaTest('', exampleFile, 'key-enter', async (t) => {
+  t.pass();
+});

--- a/test/tests/treeview-1a.js
+++ b/test/tests/treeview-1a.js
@@ -286,7 +286,7 @@ ariaTest('key down arrow moves focus', exampleFile, 'key-down-arrow', async (t) 
   }
 
   // Reload page
-  await t.context.session.get(await t.context.session.getCurrentUrl());
+  await t.context.session.get(t.context.url);
 
   // Open all folders
   await openAllFolders(t);
@@ -335,7 +335,7 @@ ariaTest('key up arrow moves focus', exampleFile, 'key-up-arrow', async (t) => {
   }
 
   // Reload page
-  await t.context.session.get(await t.context.session.getCurrentUrl());
+  await t.context.session.get(t.context.url);
 
   // Open all folders
   await openAllFolders(t);
@@ -497,7 +497,7 @@ ariaTest('key home moves focus', exampleFile, 'key-home', async (t) => {
 
 
   // Reload page
-  await t.context.session.get(await t.context.session.getCurrentUrl());
+  await t.context.session.get(t.context.url);
 
   // Open all folders
   await openAllFolders(t);
@@ -537,7 +537,7 @@ ariaTest('key end moves focus', exampleFile, 'key-end', async (t) => {
 
 
   // Reload page
-  await t.context.session.get(await t.context.session.getCurrentUrl());
+  await t.context.session.get(t.context.url);
 
   // Open all folders
   await openAllFolders(t);
@@ -593,7 +593,7 @@ ariaTest('characters move focus', exampleFile, 'key-character', async (t) => {
   }
 
   // Reload page
-  await t.context.session.get(await t.context.session.getCurrentUrl());
+  await t.context.session.get(t.context.url);
 
   // Open all folders
   await openAllFolders(t);

--- a/test/tests/treeview-2a.js
+++ b/test/tests/treeview-2a.js
@@ -272,7 +272,7 @@ ariaTest('Key enter opens folder and activates link', exampleFile, 'key-enter-or
     return t.context.session.getCurrentUrl().then(url => {
       return url != t.context.url;
     });
-  }, 500).catch(() => {});
+  }, t.context.waitTime).catch(() => {});
 
   t.not(
     await t.context.session.getCurrentUrl(),
@@ -306,7 +306,7 @@ ariaTest('Key enter opens folder and activates link', exampleFile, 'key-enter-or
 //     return t.context.session.getCurrentUrl().then(url => {
 //       return url != t.context.url;
 //     });
-//   }, 500).catch(() => {});
+//   }, t.context.waitTime).catch(() => {});
 
 //   t.not(
 //     await t.context.session.getCurrentUrl(),

--- a/test/tests/treeview-2b.js
+++ b/test/tests/treeview-2b.js
@@ -409,7 +409,7 @@ ariaTest('Key enter opens folder and activates link', exampleFile, 'key-enter-or
     return t.context.session.getCurrentUrl().then(url => {
       return url != t.context.url;
     });
-  }, 500).catch(() => {});
+  }, t.context.waitTime).catch(() => {});
 
   t.not(
     await t.context.session.getCurrentUrl(),
@@ -443,7 +443,7 @@ ariaTest('Key enter opens folder and activates link', exampleFile, 'key-enter-or
 //     return t.context.session.getCurrentUrl().then(url => {
 //       return url != t.context.url;
 //     });
-//   }, 500).catch(() => {});
+//   }, t.context.waitTime).catch(() => {});
 
 //   t.not(
 //     await t.context.session.getCurrentUrl(),


### PR DESCRIPTION
I was reviewing some old code and found a few things to fix:
- add useful timeout error messages to all "wait" calls (waiting for state to change after sending interaction to browser)
- use "t.context.url" (set during test set up) instead of getting the url from the browsers
- while testing I found I could regularly locally reproduce some race conditions in the combobox tests, so I fixed those as well