### PR TITLE
Add remaining test for treegrid/treegrid-1.html

### DIFF
--- a/test/tests/treegrid-1.js
+++ b/test/tests/treegrid-1.js
@@ -678,8 +678,52 @@ ariaTest('CTRL+END moves focus', exampleFile, 'key-control-end', async (t) => {
   );
 });
 
-// TODO: backlog issue 878
+// This test fails due to: https://github.com/w3c/aria-practices/issues/790#issuecomment-422079276
+// When the bug is fixed this test should be uncommented.
 
-// ariaTest('ENTER actives item', exampleFile, 'key-enter', async (t) => {
-//   t.pass();
+// ariaTest('ENTER actives interative items item', exampleFile, 'key-enter', async (t) => {
+//   t.plan(16);
+
+
+//   // INTERACTIVE ITEM 1: Enter sent while focus is on email row should open email altert
+//   await openAllThreads(t);
+//   const emailRows = await t.context.session.findElements(By.css(ex.emailRowSelector));
+
+//   for (let email of emailRows) {
+//     await email.sendKeys(Key.ENTER);
+
+//     t.truthy(
+//       await t.context.session.switchTo().alert().getText(),
+//       'Sending "enter" to any email row should open alert with the test of the email'
+//     );
+//     await t.context.session.switchTo().alert().accept();
+//   }
+
+
+//   // INTERACTIVE ITEM 1: Enter sent while focus is email gridcell should trigger link
+//   for (let index = 0; index <= ex.lastRowIndex; index++) {
+
+//     // Reload the page and open all emails
+//     await t.context.session.get(t.context.url);
+//     await openAllThreads(t);
+
+//     const selector = '#ex1 [role="row"]:nth-of-type(' + (index+1) + ') a';
+//     const newUrl = t.context.url + '#test-url-change'
+
+//     // Reset the href to not be an email link in order to test
+//     await t.context.session.executeScript(function () {
+//       let [selector, newUrl] = arguments;
+//       document.querySelector(selector).href = newUrl;
+//     }, selector, newUrl);
+
+//     await t.context.session.findElement(By.css(selector)).sendKeys(Key.ENTER);
+
+//     // Test the the URL is updated.
+//     t.is(
+//       await t.context.session.getCurrentUrl(),
+//       newUrl,
+//       'Sending "enter" to a link within the gridcell should activate the link'
+//     );
+//   }
 // });
+


### PR DESCRIPTION
This completes all tests for the treegrid example. This is an odd PR, because the only test added is also commented out due to a bug. This is our convention for handling bugs in the examples so far.

You can read about the bug in the open issue on treegrid [here](https://github.com/w3c/aria-practices/issues/790#issuecomment-422079276).

