### PR TITLE
Add data-test-id attribute to remaining examples

### DIFF
--- a/examples/disclosure/disclosure-img-long-description.html
+++ b/examples/disclosure/disclosure-img-long-description.html
@@ -261,7 +261,7 @@
         </tr>
       </thead>
       <tbody>
-        <tr>
+        <tr data-test-id="key-tab">
           <th>
             <kbd>Tab</kbd>
           </th>
@@ -269,7 +269,7 @@
               Moves keyboard focus to the disclosure button.
           </td>
         </tr>
-        <tr>
+        <tr data-test-id="key-space-or-enter">
           <th>
             <kbd>Space</kbd> or <br />
             <kbd>Enter</kbd>
@@ -295,7 +295,7 @@
         </tr>
       </thead>
       <tbody>
-        <tr>
+        <tr data-test-id="aria-controls">
           <td></td>
           <th scope="row">
             <code>aria-controls=&quot;IDREF&quot;</code>
@@ -309,7 +309,7 @@
             </ul>
           </td>
         </tr>
-        <tr>
+        <tr data-test-id="aria-expanded-false">
           <td></td>
           <th scope="row">
             <code>aria-expanded=&quot;false&quot;</code>
@@ -334,7 +334,7 @@
             </ul>
           </td>
         </tr>
-        <tr>
+        <tr data-test-id="aria-expanded-true">
           <td></td>
           <th scope="row">
             <code>aria-expanded=&quot;true&quot;</code>

--- a/examples/feed/feed.html
+++ b/examples/feed/feed.html
@@ -61,19 +61,19 @@
         </tr>
       </thead>
       <tbody>
-        <tr>
+        <tr data-test-id="key-page-down">
           <th><kbd>Page Down</kbd></th>
           <td>Move focus to next article.</td>
         </tr>
-        <tr>
+        <tr data-test-id="key-page-up">
           <th><kbd>Page Up</kbd></th>
           <td>Move focus to previous article.</td>
         </tr>
-        <tr>
+        <tr data-test-id="key-control-end">
           <th><kbd>Control + End</kbd></th>
           <td>Move focus to the first focusable element after the feed.</td>
         </tr>
-        <tr>
+        <tr data-test-id="hey-control-home">
           <th><kbd>Control + Home</kbd></th>
           <td>Move focus to the first focusable element before the feed.</td>
         </tr>
@@ -93,7 +93,7 @@
         </tr>
       </thead>
       <tbody>
-        <tr>
+        <tr data-test-id="feed-role">
           <th scope="row"><code>feed</code></th>
           <td></td>
           <td><code>div</code></td>
@@ -104,13 +104,13 @@
             </ul>
           </td>
         </tr>
-        <tr>
+        <tr data-test-id="feed-aria-labelledby">
           <td></td>
           <th scope="row"><code>aria-labelledby="IDREF"</code></th>
           <td><code>div</code></td>
           <td>Provides an accessible name for the feed element.</td>
         </tr>
-        <tr>
+        <tr data-test-id="feed-aria-busy">
           <td></td>
           <th scope="row"><code>aria-busy="true"</code></th>
           <td><code>div</code></td>
@@ -122,7 +122,7 @@
             </ul>
           </td>
         </tr>
-        <tr>
+        <tr data-test-id="article-role">
           <th scope="row"><code>article</code></th>
           <td></td>
           <td><code>div</code></td>
@@ -133,7 +133,7 @@
             </ul>
           </td>
         </tr>
-        <tr>
+        <tr data-test-id="article-tabindex">
           <td></td>
           <th scope="row"><code>tabindex="0"</code></th>
           <td><code>div</code></td>
@@ -145,7 +145,7 @@
             </ul>
           </td>
         </tr>
-        <tr>
+        <tr data-test-id="article-labelledby">
           <td> </td>
           <th scope="row"><code>aria-labelledby="IDREF_LIST"</code></th>
           <td><code>div</code></td>
@@ -157,7 +157,7 @@
             </ul>
           </td>
         </tr>
-        <tr>
+        <tr data-test-id="article-describedby">
           <td> </td>
           <th scope="row"><code>aria-describedby="IDREF_LIST"</code></th>
           <td><code>div</code></td>
@@ -169,7 +169,7 @@
             </ul>
           </td>
         </tr>
-        <tr>
+        <tr data-test-id="article-aria-posinset">
           <td> </td>
           <th scope="row"><code>aria-posinset="INTEGER"</code></th>
           <td><code>div</code></td>
@@ -181,7 +181,7 @@
             </ul>
           </td>
         </tr>
-        <tr>
+        <tr data-test-id="article-aria-setsize">
           <td></td>
           <th scope="row"><code>aria-setsize="INTEGER"</code></th>
           <td><code>div</code></td>

--- a/examples/listbox/listbox-rearrangeable.html
+++ b/examples/listbox/listbox-rearrangeable.html
@@ -225,7 +225,7 @@ while in the second example, they may select multiple options before activating 
         </tr>
       </thead>
       <tbody>
-        <tr>
+        <tr data-test-id="key-down-arrow">
           <th><kbd>Down Arrow</kbd></th>
           <td>
           <ul>
@@ -234,7 +234,7 @@ while in the second example, they may select multiple options before activating 
           </ul>
           </td>
         </tr>
-        <tr>
+        <tr data-test-id="key-up-arrow">
           <th><kbd>Up Arrow</kbd></th>
           <td>
             <ul>
@@ -243,7 +243,7 @@ while in the second example, they may select multiple options before activating 
             </ul>
           </td>
         </tr>
-        <tr>
+        <tr data-test-id="key-home">
           <th><kbd>Home</kbd></th>
           <td>
             <ul>
@@ -252,7 +252,7 @@ while in the second example, they may select multiple options before activating 
           </ul>
           </td>
         </tr>
-        <tr>
+        <tr data-test-id="key-end">
           <th><kbd>End</kbd></th>
           <td>
             <ul>
@@ -272,27 +272,27 @@ while in the second example, they may select multiple options before activating 
         </tr>
       </thead>
       <tbody>
-        <tr>
+        <tr data-test-id="key-space">
           <th><kbd>Space</kbd></th>
           <td>changes the selection state of the focused option .</td>
         </tr>
-        <tr>
+        <tr data-test-id="key-shift-down-arrow">
           <th><kbd>Shift + Down Arrow</kbd></th>
           <td>Moves focus to and selects the next option.</td>
         </tr>
-        <tr>
+        <tr data-test-id="key-shift-up-arrow">
           <th><kbd>Shift + Up Arrow</kbd></th>
           <td>Moves focus to and selects the previous option.</td>
         </tr>
-        <tr>
+        <tr data-test-id="key-control-shift-home">
           <th><kbd>Control + Shift + Home</kbd></th>
           <td>Selects from the focused option to the beginning of the list.</td>
         </tr>
-        <tr>
+        <tr data-test-id="key-control-shift-end">
           <th><kbd>Control + Shift + End</kbd></th>
           <td>Selects from the focused option to the end of the list.</td>
         </tr>
-        <tr>
+        <tr data-test-id="key-control-a">
           <th><kbd>Control + A</kbd></th>
           <td>selects all options in the list. If all options are selected, unselects all options.</td>
         </tr>
@@ -317,25 +317,25 @@ while in the second example, they may select multiple options before activating 
         </tr>
       </thead>
       <tbody>
-        <tr>
+        <tr data-test-id="listbox-role">
           <th scope="row"><code>listbox</code></th>
           <td></td>
           <td><code>ul</code></td>
           <td>Identifies the focusable element that has listbox behaviors and contains the listbox options. </td>
         </tr>
-        <tr>
+        <tr data-test-id="listbox-aria-labelledby">
           <td></td>
           <th scope="row"><code>aria-labelledby=&quot;ID_REF&quot;</code></th>
           <td><code>ul</code></td>
           <td>Applied to the element with the listbox role, it refers to the span containing its label.</td>
         </tr>
-        <tr>
+        <tr data-test-id="listbox-tabindex">
           <td></td>
           <th scope="row"><code>tabindex=&quot;0&quot;</code></th>
           <td><code>ul</code></td>
           <td>Applied to the element with the listbox role, it puts the listbox in the tab sequence.</td>
         </tr>
-        <tr>
+        <tr data-test-id="listbox-aria-multiselectable">
           <td></td>
           <th scope="row"><code>aria-multiselectable=&quot;true&quot;</code></th>
           <td><code>ul</code></td>
@@ -347,7 +347,7 @@ while in the second example, they may select multiple options before activating 
             </ul>
           </td>
         </tr>
-        <tr>
+        <tr data-test-id="listbox-aria-activedescendant">
           <td></td>
           <th scope="row"><code>aria-activedescendant=&quot;ID_REF&quot;</code></th>
           <td><code>ul</code></td>
@@ -360,13 +360,13 @@ while in the second example, they may select multiple options before activating 
             </ul>
           </td>
         </tr>
-        <tr>
+        <tr data-test-id="option-role">
           <th scope="row"><code>role=&quot;option&quot;</code></th>
           <td></td>
           <td><code>li</code></td>
           <td>Identifies each selectable element containing the name of an option.</td>
         </tr>
-        <tr>
+        <tr data-test-id="option-aria-selected">
           <td></td>
           <th scope="row"><code>aria-selected=&quot;true&quot;</code></th>
           <td><code>li</code></td>
@@ -379,7 +379,7 @@ while in the second example, they may select multiple options before activating 
             </ul>
           </td>
         </tr>
-        <tr>
+        <tr data-test-id="option-aria-selected">
           <td></td>
           <th><code>aria-selected=&quot;false&quot;</code></th>
           <td><code>li</code></td>

--- a/examples/menu-button/menu-button-actions-active-descendant.html
+++ b/examples/menu-button/menu-button-actions-active-descendant.html
@@ -96,11 +96,11 @@
             </tr>
           </thead>
           <tbody>
-            <tr>
+            <tr data-test-id="button-down-arrow-or-space-or-enter">
               <th><kbd>Down Arrow</kbd><br><kbd>Space</kbd><br><kbd>Enter</kbd></th>
               <td>Opens <code>menu</code> and moves focus to first <code>menuitem</code></td>
             </tr>
-            <tr>
+            <tr data-test-id="button-up-arrow">
               <th><kbd>Up Arrow</kbd></th>
               <td>Opens <code>menu</code> and moves focus to last <code>menuitem</code></td>
             </tr>
@@ -115,7 +115,7 @@
             </tr>
           </thead>
           <tbody>
-            <tr>
+            <tr data-test-id="menu-enter">
               <th><kbd>Enter</kbd></th>
               <td>
                 <ul>
@@ -125,7 +125,7 @@
                 </ul>
               </td>
             </tr>
-            <tr>
+            <tr data-test-id="menu-escape">
               <th><kbd>Escape</kbd></th>
               <td>
                 <ul>
@@ -134,7 +134,7 @@
                 </ul>
               </td>
             </tr>
-            <tr>
+            <tr data-test-id="menu-up-arrow">
               <th><kbd>Up Arrow</kbd></th>
               <td>
                 <ul>
@@ -143,7 +143,7 @@
                 </ul>
               </td>
             </tr>
-             <tr>
+             <tr data-test-id="menu-down-arrow">
               <th><kbd>Down Arrow</kbd></th>
               <td>
                 <ul>
@@ -152,15 +152,15 @@
                 </ul>
               </td>
             </tr>
-            <tr>
+            <tr data-test-id="menu-home">
               <th><kbd>Home</kbd></th>
               <td>Moves focus to the first menu item.</td>
             </tr>
-            <tr>
+            <tr data-test-id="menu-end">
               <th><kbd>End</kbd></th>
               <td>Moves focus to the last menu item.</td>
             </tr>
-            <tr>
+            <tr data-test-id="menu-character">
               <th><kbd>A-Z</kbd><br><kbd>a-z</kbd></th>
               <td>
                 <ul>
@@ -186,7 +186,7 @@
             </tr>
           </thead>
           <tbody>
-            <tr>
+            <tr data-test-id="button-aria-haspopup">
               <td></td>
               <th scope="row"><code>aria-haspopup=&quot;true&quot;</code></th>
               <td>
@@ -202,7 +202,7 @@
                 </ul>
               </td>
             </tr>
-            <tr>
+            <tr data-test-id="button-aria-controls">
               <td></td>
               <th scope="row"><code>aria-controls=&quot;IDREF&quot;</code></th>
               <td>
@@ -215,7 +215,7 @@
                 </ul>
               </td>
             </tr>
-            <tr>
+            <tr data-test-id="button-aria-expanded">
                 <td></td>
                 <th scope="row"><code>aria-expanded=&quot;true&quot;</code></th>
                 <td><code>button</code></td>
@@ -241,7 +241,7 @@
             </tr>
           </thead>
           <tbody>
-            <tr>
+            <tr data-test-id="menu-role">
               <th scope="row">
                 <code>menu</code>
               </th>
@@ -251,7 +251,7 @@
               </td>
               <td>Identifies the <code>ul</code> element as a <code>menu</code>.</td>
             </tr>
-            <tr>
+            <tr data-test-id="menu-aria-labelledby">
               <td>
                 <code></code>
               </td>
@@ -266,7 +266,7 @@
                 </ul>
               </td>
             </tr>
-            <tr>
+            <tr data-test-id="menu-tabindex">
               <td></td>
               <th scope="row"><code>tabindex=&quot;-1&quot;</code></th>
               <td>
@@ -280,7 +280,7 @@
                 </ul>
               </td>
             </tr>
-            <tr>
+            <tr data-test-id="menu-aria-activedescendant">
               <td></td>
               <th scope="row"><code>aria-activedescendant=&quot;IDREF&quot;</code></th>
               <td>
@@ -298,7 +298,7 @@
                 </ul>
               </td>
             </tr>
-            <tr>
+            <tr data-test-id="menuitem-role">
               <th scope="row">
                 <code>menuitem</code>
               </th>

--- a/examples/menubar/menubar-1/menubar-1.html
+++ b/examples/menubar/menubar-1/menubar-1.html
@@ -186,13 +186,13 @@
         </tr>
       </thead>
       <tbody>
-        <tr>
+        <tr data-test-id="menubar-space-or-enter">
           <th>
             <kbd>Space</kbd><br><kbd>Enter</kbd>
           </th>
           <td>Opens submenu and moves focus to first item in the submenu.</td>
         </tr>
-        <tr>
+        <tr data-test-id="menubar-right-arrow">
           <th>
             <kbd>Right Arrow</kbd>
           </th>
@@ -203,7 +203,7 @@
             </ul>
           </td>
         </tr>
-        <tr>
+        <tr data-test-id="menubar-left-arrow">
           <th>
             <kbd>Left Arrow</kbd>
           </th>
@@ -214,31 +214,31 @@
             </ul>
           </td>
         </tr>
-        <tr>
+        <tr data-test-id="menubar-down-arrow">
           <th>
             <kbd>Down Arrow</kbd>
           </th>
           <td>Opens submenu and moves focus to first item in the submenu.</td>
         </tr>
-        <tr>
+        <tr data-test-id="menubar-up-arrow">
           <th>
             <kbd>Up Arrow</kbd>
           </th>
           <td>Opens submenu and moves focus to last item in the submenu.</td>
         </tr>
-        <tr>
+        <tr data-test-id="menubar-home">
           <th>
             <kbd>Home</kbd>
           </th>
           <td>Moves focus to first item in the menubar.</td>
         </tr>
-        <tr>
+        <tr data-test-id="menubar-end">
           <th>
             <kbd>End</kbd>
           </th>
           <td>Moves focus to last item in the menubar.</td>
         </tr>
-        <tr>
+        <tr data-test-id="menubar-character">
           <th>
             <kbd>Character</kbd>
           </th>
@@ -260,7 +260,7 @@
         </tr>
       </thead>
       <tbody>
-        <tr>
+        <tr data-test-id="submenu-space-or-enter">
           <th>
             <kbd>Space</kbd><br><kbd>Enter</kbd>
           </th>
@@ -271,7 +271,7 @@
             </ul>
           </td>
         </tr>
-        <tr>
+        <tr data-test-id="submenu-escape">
           <th>
             <kbd>Escape</kbd>
           </th>
@@ -282,7 +282,7 @@
             </ul>
           </td>
         </tr>
-        <tr>
+        <tr data-test-id="submenu-right-arrow">
           <th>
             <kbd>Right Arrow</kbd>
           </th>
@@ -299,7 +299,7 @@
             </ul>
           </td>
         </tr>
-        <tr>
+        <tr data-test-id="submenu-left-arrow">
           <th>
             <kbd>Left Arrow</kbd>
           </th>
@@ -315,7 +315,7 @@
             </ul>
           </td>
         </tr>
-        <tr>
+        <tr data-test-id="submenu-down-arrow">
           <th>
             <kbd>Down Arrow</kbd>
           </th>
@@ -326,7 +326,7 @@
             </ul>
           </td>
         </tr>
-        <tr>
+        <tr data-test-id="submenu-up-arrow">
           <th>
             <kbd>Up Arrow</kbd>
           </th>
@@ -337,19 +337,19 @@
             </ul>
           </td>
         </tr>
-        <tr>
+        <tr data-test-id="submenu-home">
           <th>
             <kbd>Home</kbd>
           </th>
           <td>Moves focus to the first item in the submenu.</td>
         </tr>
-        <tr>
+        <tr data-test-id="submenu-end">
           <th>
             <kbd>End</kbd>
           </th>
           <td>Moves focus to the last item in the submenu.</td>
         </tr>
-        <tr>
+        <tr data-test-id="submenu-character">
           <th>
             <kbd>Character</kbd>
           </th>
@@ -377,7 +377,7 @@
         </tr>
       </thead>
       <tbody>
-        <tr>
+        <tr data-test-id="menubar-role">
           <th>
             <code>menubar</code>
           </th>
@@ -392,7 +392,7 @@
             </ul>
           </td>
         </tr>
-        <tr>
+        <tr data-test-id="menubar-aria-label">
           <td></td>
           <th>
             <code>aria-label=&quot;<em>string</em>&quot;
@@ -411,7 +411,7 @@
             </ul>
           </td>
         </tr>
-        <tr>
+        <tr data-test-id="menuitem-role">
           <th>
             <code>menuitem</code>
           </th>
@@ -426,7 +426,7 @@
             </ul>
           </td>
         </tr>
-        <tr>
+        <tr data-test-id="menuitem-tabindex">
           <td></td>
           <th>
             <code>tabindex=&quot;-1&quot;</code>
@@ -438,7 +438,7 @@
             Makes the <code>a</code> element keyboard focusable, but <strong>not</strong> part of the tab sequence.
           </td>
         </tr>
-        <tr>
+        <tr data-test-id="menuitem-tabindex">
           <td></td>
           <th>
             <code>tabindex=&quot;0&quot;</code>
@@ -455,7 +455,7 @@
             </ul>
           </td>
         </tr>
-        <tr>
+        <tr data-test-id="menuitem-aria-haspopup">
           <td></td>
           <th>
             <code>aria-haspopup=&quot;true&quot;</code>
@@ -465,7 +465,7 @@
           </td>
           <td>Indicates the menuitem has a submenu.</td>
         </tr>
-        <tr>
+        <tr data-test-id="menuitem-aria-expanded">
           <td></td>
           <th>
             <code>aria-expanded=&quot;true&quot;</code>
@@ -475,7 +475,7 @@
           </td>
           <td>Indicates the submenu is open.</td>
         </tr>
-        <tr>
+        <tr data-test-id="menuitem-aria-expanded">
           <td></td>
           <th>
             <code>aria-expanded=&quot;false&quot;</code>
@@ -485,7 +485,7 @@
           </td>
           <td>Indicates the submenu is closed.</td>
         </tr>
-        <tr>
+        <tr data-test-id="none-role">
           <th>
             <code>none</code>
           </th>
@@ -513,7 +513,7 @@
         </tr>
       </thead>
       <tbody>
-        <tr>
+        <tr data-test-id="menu-role">
           <th>
             <code>menu</code>
           </th>
@@ -523,7 +523,7 @@
           </td>
           <td>Identifies the element as a menu container for a set of menu items.</td>
         </tr>
-        <tr>
+        <tr data-test-id="menu-aria-label">
           <td></td>
           <th>
             <code>aria-label=&quot;<em>string</em>&quot;
@@ -542,7 +542,7 @@
             </ul>
           </td>
         </tr>
-        <tr>
+        <tr data-test-id="sub-menuitem-role">
           <th>
             <code>menuitem</code>
           </th>
@@ -557,7 +557,7 @@
             </ul>
           </td>
         </tr>
-        <tr>
+        <tr data-test-id="sub-menuitem-tabindex">
           <td></td>
           <th>
             <code>tabindex=&quot;-1&quot;</code>
@@ -567,7 +567,7 @@
           </td>
           <td>Keeps the <code>a</code> element focusable but removes it from the <kbd>Tab</kbd> sequence.</td>
         </tr>
-        <tr>
+        <tr data-test-id="sub-menuitem-aria-haspopup">
           <td></td>
           <th>
             <code>aria-haspopup=&quot;true&quot;</code>
@@ -577,7 +577,7 @@
           </td>
           <td>Indicates the menu item has a submenu.</td>
         </tr>
-        <tr>
+        <tr data-test-id="sub-menuitem-aria-expanded">
           <td></td>
           <th>
             <code>aria-expanded=&quot;true&quot;</code>
@@ -587,7 +587,7 @@
           </td>
           <td>Indicates the submenu is open.</td>
         </tr>
-        <tr>
+        <tr data-test-id="sub-menuitem-aria-expanded">
           <td></td>
           <th>
             <code>aria-expanded=&quot;false&quot;</code>
@@ -597,7 +597,7 @@
           </td>
           <td>Indicates the submenu is closed.</td>
         </tr>
-        <tr>
+        <tr data-test-id="sub-none-role">
           <th>
             <code>none</code>
           </th>

--- a/examples/slider/multithumb-slider.html
+++ b/examples/slider/multithumb-slider.html
@@ -121,35 +121,35 @@
             </tr>
           </thead>
           <tbody>
-            <tr>
+            <tr data-test-id="key-right-arow">
               <th><kbd>Right Arrow</kbd></th>
               <td>Increases slider value one step.</td>
             </tr>
-            <tr>
+            <tr data-test-id="key-up-arrow">
               <th><kbd>Up Arrow</kbd></th>
               <td>Increases slider value one step.</td>
             </tr>
-            <tr>
+            <tr data-test-id="key-left-arrow">
               <th><kbd>Left Arrow</kbd></th>
               <td>Decreases slider value one step.</td>
             </tr>
-            <tr>
+            <tr data-test-id="key-down-arrow">
               <th><kbd>Down Arrow</kbd></th>
               <td>Decreases slider value one step.</td>
             </tr>
-            <tr>
+            <tr data-test-id="key-page-up">
               <th><kbd>Page Up</kbd></th>
               <td>Increases slider value multiple steps. In this slider, jumps ten steps.</td>
             </tr>
-            <tr>
+            <tr data-test-id="key-page-down">
               <th><kbd>Page Down</kbd></th>
               <td>Decreases slider value multiple steps. In this slider, jumps ten steps.</td>
             </tr>
-            <tr>
+            <tr data-test-id="key-home">
               <th><kbd>Home</kbd></th>
               <td>Sets slider to its minimum value.</td>
             </tr>
-            <tr>
+            <tr data-test-id="key-end">
               <th><kbd>End</kbd></th>
               <td>Sets slider to its maximum value.</td>
             </tr>
@@ -169,7 +169,7 @@
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr data-test-id="slider-role">
             <th scope="row">
               <code>slider</code>
             </th>
@@ -184,7 +184,7 @@
               </ul>
             </td>
           </tr>
-          <tr>
+          <tr data-test-id="tabindex">
             <td></td>
             <th scope="row">
               <code>tabindex=<q>0</q></code>
@@ -194,7 +194,7 @@
             </td>
             <td>Includes the slider thumb in the page tab sequence.</td>
           </tr>
-          <tr>
+          <tr data-test-id="aria-valuemax">
             <td></td>
             <th scope="row">
               <code>aria-valuemax=<q>NUMBER</q></code>
@@ -204,7 +204,7 @@
             </td>
             <td>Specifies the maximum value of the slider.</td>
           </tr>
-          <tr>
+          <tr data-test-id="aria-valuemin">
             <td></td>
             <th scope="row">
               <code>aria-valuemin=<q>NUMBER</q></code>
@@ -214,7 +214,7 @@
             </td>
             <td>Specifies the minimum value of the slider.</td>
           </tr>
-          <tr>
+          <tr data-test-id="aria-valuenow">
             <td></td>
             <th scope="row">
               <code>aria-valuenow=<q>NUMBER</q></code>
@@ -224,7 +224,7 @@
             </td>
             <td>Indicates the current value of the slider.</td>
           </tr>
-          <tr>
+          <tr data-test-id="aria-valuetext">
             <td></td>
             <th scope="row">
               <code>aria-valuetext=<q>DOLLAR AMOUNT</q></code>
@@ -234,7 +234,7 @@
             </td>
             <td>Indicates the current value of the slider in dollars using the <q>$</q> character as a prefix.</td>
           </tr>
-          <tr>
+          <tr data-test-id="aria-label">
             <td></td>
             <th scope="row">
               <code>aria-label=<q>text</q></code>


### PR DESCRIPTION
Add data-test-ids to:
- [multithumb-slider](https://w3c.github.io/aria-practices/examples/slider/multithumb-slider.html)
- [menubar-1](https://w3c.github.io/aria-practices/examples/menubar/menubar-1/menubar-1.html)
- [feed](https://w3c.github.io/aria-practices/examples/feed/feed.html)
- [disclosure-img-long-description](https://w3c.github.io/aria-practices/examples/disclosure/disclosure-img-long-description.html)
- [listbox-rearrangeable](https://w3c.github.io/aria-practices/examples/listbox/listbox-rearrangeable.html)
- [menu-button-actions-active-descendant](https://w3c.github.io/aria-practices/examples/menu-button/menu-button-actions-active-descendant.html)