### PR TITLE
Use TAP format for travis run of regression tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ jobs:
   include:
     - stage: Test
       name: AVA Regression Tests
-      script: ava -c 1 test/tests
+      script: ava --tap -c 1 test/tests
     - stage: Test
       name: JS Linting
       script: npm run lint


### PR DESCRIPTION
[TAP](https://testanything.org/): "The Test Anything Protocol" 

Set the output to TAP for the .travis.ci runs because the ava default uses symbols and poor formatting to differentiate between failures and successes.