### PR TITLE
Use ava '.failing' to skip known failures

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -39,18 +39,35 @@ test.after.always(() => {
  * Declare a test for a behavior documented on and demonstrated by an
  * aria-practices examples page.
  *
+ * @param {String} desc - short description of the test
  * @param {String} page - path to the example file
  * @param {String} testId - unique identifier for the documented behavior
  *                          within the demonstration page
  * @param {Function} body - script which implements the test
  */
 const ariaTest = (desc, page, testId, body) => {
+  _ariaTest(desc, page, testId, body);
+};
+
+/**
+ * Mark a declared test as failing using ava's 'test.failing' functionality.
+ * If the test passes when it is expected to fail, a failure will be reported.
+ *
+ * See arguments for ariaTest.
+ */
+ariaTest.failing = (desc, page, testId, body) => {
+  _ariaTest(desc, page, testId, body, 'FAILING');
+};
+
+const _ariaTest = (desc, page, testId, body, failing) => {
   const absPath = path.resolve(__dirname, '..', 'examples', ...page.split('/'));
   const url = 'file://' + absPath;
   const selector = '[data-test-id="' + testId + '"]';
 
   const testName = page + ' ' + selector + ': ' + desc;
-  test.serial(testName, async function (t) {
+
+  let runTest = failing ? test.failing : test.serial;
+  runTest(testName, async function (t) {
     t.context.url = url;
     await t.context.session.get(url);
 

--- a/test/tests/combobox-autocomplete-both.js
+++ b/test/tests/combobox-autocomplete-both.js
@@ -232,36 +232,36 @@ ariaTest('Test up key press with focus on textbox',
     await assertAriaSelectedAndActivedescendant(t, ex.textboxSelector, ex.optionsSelector, numOptions - 1);
   });
 
+
 // This test fails due to bug: https://github.com/w3c/aria-practices/issues/821
-// Uncomment when the bug is fixed.
+ariaTest.failing('Test up key press with focus on listbox',
+  exampleFile, 'listbox-key-up-arrow', async (t) => {
 
-// ariaTest('Test up key press with focus on listbox',
-//   exampleFile, 'listbox-key-up-arrow', async (t) => {
+    t.plan(3);
 
-//     t.plan(3);
+    // Send 'a' to text box, then send ARROW_UP to textbox to textbox to put focus in textbox
+    // Up arrow should move selection to the last item in the list
+    await t.context.session
+      .findElement(By.css(ex.textboxSelector))
+      .sendKeys('a', Key.ARROW_UP);
 
-//     // Send 'a' to text box, then send ARROW_UP to textbox to textbox to put focus in textbox
-//     // Up arrow should move selection to the last item in the list
-//     await t.context.session
-//       .findElement(By.css(ex.textboxSelector))
-//       .sendKeys('a', Key.ARROW_UP);
+    // Test that ARROW_UP moves active descendant focus up one item in the listbox
+    for (let index = ex.numAOptions - 1; index > 0 ; index--) {
+      let oldfocus = await t.context.session
+        .findElement(By.css(ex.textboxSelector))
+        .getAttribute('aria-activedescendant');
 
-//     // Test that ARROW_UP moves active descendant focus up one item in the listbox
-//     for (let index = ex.numAOptions - 1; index > 0 ; index--) {
-//       let oldfocus = await t.context.session
-//         .findElement(By.css(ex.textboxSelector))
-//         .getAttribute('aria-activedescendant');
+      // Send Key
+      await t.context.session
+        .findElement(By.css(ex.textboxSelector))
+        .sendKeys(Key.ARROW_UP);
 
-//       // Send Key
-//       await t.context.session
-//         .findElement(By.css(ex.textboxSelector))
-//         .sendKeys(Key.ARROW_UP);
+      await waitForFocusChange(t, ex.textboxSelector, oldfocus);
 
-//       await waitForFocusChange(t, ex.textboxSelector, oldfocus);
+      await assertAriaSelectedAndActivedescendant(t, ex.textboxSelector, ex.optionsSelector, index);
+    }
+  });
 
-//       await assertAriaSelectedAndActivedescendant(t, ex.textboxSelector, ex.optionsSelector, index);
-//     }
-//   });
 
 ariaTest('Test enter key press with focus on textbox',
   exampleFile, 'textbox-key-enter', async (t) => {

--- a/test/tests/grid-combo.js
+++ b/test/tests/grid-combo.js
@@ -259,7 +259,7 @@ ariaTest('Test down key press with focus on textbox',
       .sendKeys('a', Key.ARROW_DOWN);
 
     // Account for race condition
-    await waitForFocusChange(t, ex.textboxSelector, null);
+    await waitForFocusChange(t, ex.textboxSelector, '');
 
     // Check that the grid is displayed
     t.true(
@@ -381,7 +381,7 @@ ariaTest('Test up key press with focus on textbox',
       .sendKeys('a', Key.ARROW_UP);
 
     // Account for race condition
-    await waitForFocusChange(t, ex.textboxSelector, null);
+    await waitForFocusChange(t, ex.textboxSelector, '');
 
     // Check that the grid is displayed
     t.true(
@@ -559,7 +559,13 @@ ariaTest.failing('Test escape key press with focus on popup',
 
     await t.context.session
       .findElement(By.css(ex.textboxSelector))
-      .sendKeys('a', Key.ARROW_DOWN, Key.ESCAPE);
+      .sendKeys('a', Key.ARROW_DOWN);
+
+    await waitForFocusChange(t, ex.textboxSelector, '');
+
+    await t.context.session
+      .findElement(By.css(ex.textboxSelector))
+      .sendKeys(Key.ESCAPE);
 
     // Wait for gridbox to close
     await t.context.session.wait(
@@ -572,6 +578,7 @@ ariaTest.failing('Test escape key press with focus on popup',
 
     // Confirm the grid is closed and the textboxed is cleared
     await assertAttributeValues(t, ex.comboboxSelector, 'aria-expanded', 'false');
+
     t.is(
       await t.context.session
         .findElement(By.css(ex.textboxSelector))
@@ -579,6 +586,7 @@ ariaTest.failing('Test escape key press with focus on popup',
       '',
       'In grid key press "ESCAPE" should result in clearing of the textbox'
     );
+
   });
 
 ariaTest('left arrow from focus on list puts focus on grid and moves cursor right',

--- a/test/tests/grid-combo.js
+++ b/test/tests/grid-combo.js
@@ -207,18 +207,17 @@ ariaTest('role "row" exists within grid element', exampleFile, 'row-role', async
 });
 
 // This test fails due to bug: https://github.com/w3c/aria-practices/issues/859
+ariaTest.failing('"aria-selected" attribute on row element', exampleFile, 'row-aria-selected', async (t) => {
+  t.plan(2);
 
-// ariaTest('"aria-selected" attribute on row element', exampleFile, 'row-aria-selected', async (t) => {
-//   t.plan(2);
+  // Send key "a"
+  await t.context.session.findElement(By.css(ex.textboxSelector)).sendKeys('a');
+  await assertAttributeDNE(t, ex.rowSelector + ':nth-of-type(1)', 'aria-selected');
 
-//   // Send key "a"
-//   await t.context.session.findElement(By.css(ex.textboxSelector)).sendKeys('a');
-//   await assertAttributeDNE(t, ex.rowSelector + ':nth-of-type(1)', 'aria-selected');
-
-//   // Send key ARROW_DOWN to selected first option
-//   await t.context.session.findElement(By.css(ex.textboxSelector)).sendKeys(Key.ARROW_DOWN);
-//   await assertAttributeValues(t, ex.rowSelector + ':nth-of-type(1)', 'aria-selected', 'true');
-// });
+  // Send key ARROW_DOWN to selected first option
+  await t.context.session.findElement(By.css(ex.textboxSelector)).sendKeys(Key.ARROW_DOWN);
+  await assertAttributeValues(t, ex.rowSelector + ':nth-of-type(1)', 'aria-selected', 'true');
+});
 
 ariaTest('role "gridcell" exists within row element', exampleFile, 'gridcell-role', async (t) => {
   t.plan(1);
@@ -551,38 +550,36 @@ ariaTest('Test escape key press with focus on textbox',
   });
 
 // This test fails due to bug: https://github.com/w3c/aria-practices/issues/860
+ariaTest.failing('Test escape key press with focus on popup',
+  exampleFile, 'popup-key-escape', async (t) => {
+    t.plan(2);
 
-// ariaTest('Test escape key press with focus on popup',
-//   exampleFile, 'popup-key-escape', async (t) => {
-//     t.plan(2);
+    // Send key "a" then key "ARROW_DOWN to put the focus on the grid,
+    // then key ESCAPE to the textbox
 
-//     // Send key "a" then key "ARROW_DOWN to put the focus on the grid,
-//     // then key ESCAPE to the textbox
+    await t.context.session
+      .findElement(By.css(ex.textboxSelector))
+      .sendKeys('a', Key.ARROW_DOWN, Key.ESCAPE);
 
-//     await t.context.session
-//       .findElement(By.css(ex.textboxSelector))
-//       .sendKeys('a', Key.ARROW_DOWN, Key.ESCAPE);
+    // Wait for gridbox to close
+    await t.context.session.wait(
+      async function () {
+        return !(await t.context.session.findElement(By.css(ex.gridSelector)).isDisplayed());
+      },
+      t.context.waitTime,
+      'Timeout waiting for gridbox to close afer escape'
+    );
 
-//     // Wait for gridbox to close
-//     await t.context.session.wait(
-//       async function () {
-//         return ! (await t.context.session.findElement(By.css(ex.gridSelector)).isDisplayed());
-//       },
-//       t.context.waitTime,
-//       'Timeout waiting for gridbox to close afer escape'
-//     );
-
-//     // Confirm the grid is closed and the textboxed is cleared
-//     await assertAttributeValues(t, ex.comboboxSelector, 'aria-expanded', 'false');
-//     t.is(
-//       await t.context.session
-//         .findElement(By.css(ex.textboxSelector))
-//         .getAttribute('value'),
-//       '',
-//       'In grid key press "ESCAPE" should result in clearing of the textbox'
-//     );
-
-//   });
+    // Confirm the grid is closed and the textboxed is cleared
+    await assertAttributeValues(t, ex.comboboxSelector, 'aria-expanded', 'false');
+    t.is(
+      await t.context.session
+        .findElement(By.css(ex.textboxSelector))
+        .getAttribute('value'),
+      '',
+      'In grid key press "ESCAPE" should result in clearing of the textbox'
+    );
+  });
 
 ariaTest('left arrow from focus on list puts focus on grid and moves cursor right',
   exampleFile, 'popup-key-left-arrow', async (t) => {

--- a/test/tests/listbox-combo.js
+++ b/test/tests/listbox-combo.js
@@ -177,35 +177,33 @@ ariaTest('Test aria-expanded on listbox correlates with listbox',
   });
 
 // This test fails due to bug: https://github.com/w3c/aria-practices/issues/785
-// Uncomment when the bug is fixed.
+ariaTest.failing('Test id attribute on textbox referred to by label element',
+  exampleFile, 'textbox-id', async (t) => {
 
-// ariaTest('Test id attribute on textbox referred to by label element',
-//   exampleFile, 'textbox-id', async (t) => {
+    t.plan(9);
 
-//     t.plan(9);
+    for (let exId in pageExamples) {
+      let ex =  pageExamples[exId];
 
-//     for (let exId in pageExamples) {
-//       let ex =  pageExamples[exId];
+      const labelEl = await t.context.session.findElement(By.css('#' + exId + ' label'));
+      const textboxEl = await t.context.session.findElement(By.css(ex.textboxSelector));
 
-//       const labelEl = await t.context.session.findElement(By.css('#' + exId + ' label'));
-//       const textboxEl = await t.context.session.findElement(By.css(ex.textboxSelector));
+      t.truthy(
+        await labelEl.getAttribute('for'),
+        'Attribute "for" should exist on label element in example: ' + exId
+      );
 
-//       t.truthy(
-//         await labelEl.getAttribute('for'),
-//         'Attribute "for" should exist on label element in example: ' + exId
-//       );
+      t.truthy(
+        await textboxEl.getAttribute('id'),
+        'Attribute "id" should exist on textbox element: ' + exId
+      );
 
-//       t.truthy(
-//         await textboxEl.getAttribute('id'),
-//         'Attribute "id" should exist on textbox element: ' + exId
-//       );
-
-//       t.true(
-//         await labelEl.getAttribute('for') === await textboxEl.getAttribute('id'),
-//         'Attribute "for" on label element should match the "id" on the textbox element in example:' + exId
-//       );
-//     }
-//   });
+      t.true(
+        await labelEl.getAttribute('for') === await textboxEl.getAttribute('id'),
+        'Attribute "for" on label element should match the "id" on the textbox element in example:' + exId
+      );
+    }
+  });
 
 ariaTest('Test aria-autocomplete="list" attribute on textbox',
   exampleFile, 'aria-autocomplete-list', async (t) => {

--- a/test/tests/toolbar.js
+++ b/test/tests/toolbar.js
@@ -74,11 +74,10 @@ ariaTest('role="toolbar" element', exampleFile, 'toolbar-role', async (t) => {
 });
 
 // Test fails from bug in example: fix in issue 847 on w3c/aria-practices
-
-// ariaTest('"aria-label" on toolbar element', exampleFile, 'toolbar-aria-label', async (t) => {
-//   t.plan(1);
-//   await assertAriaLabelExists(t, ex.toolbarSelector);
-// });
+ariaTest.failing('"aria-label" on toolbar element', exampleFile, 'toolbar-aria-label', async (t) => {
+  t.plan(1);
+  await assertAriaLabelExists(t, ex.toolbarSelector);
+});
 
 ariaTest('role="button elements', exampleFile, 'button-role', async (t) => {
   t.plan(1);
@@ -99,10 +98,9 @@ ariaTest('roving tabindex on button elements', exampleFile, 'button-tabindex', a
 });
 
 // Test pending fix bug in example: fix in issue 847 on w3c/aria-practices
-
-// ariaTest('"aria-disabled" on button elements', exampleFile, 'button-aria-disabled', async (t) => {
-//   t.pass();
-// });
+ariaTest.failing('"aria-disabled" on button elements', exampleFile, 'button-aria-disabled', async (t) => {
+  t.pass();
+});
 
 
 // Keys
@@ -129,153 +127,155 @@ ariaTest('key TAB moves focus', exampleFile, 'key-tab', async (t) => {
   }
 });
 
-// The following tests fail from bug in example: fix in issue 847 on w3c/aria-practices
+// This tests fail from bug in example: fix in issue 847 on w3c/aria-practices
+ariaTest.failing('key LEFT ARROW moves focus', exampleFile, 'key-left-arrow', async (t) => {
+  t.plan(12);
 
-// ariaTest('key LEFT ARROW moves focus', exampleFile, 'key-left-arrow', async (t) => {
-//   t.plan(12);
+  // Put focus on the first item in the list
+  await clickAndWait(t, ex.allToolSelectors[0]);
 
-//   // Put focus on the first item in the list
-//   await clickAndWait(t, ex.allToolSelectors[0]);
+  let numTools = ex.allToolSelectors.length;
+  let toolSelector = ex.allToolSelectors[0];
+  let nextToolSelector = ex.allToolSelectors[numTools - 1];
 
-//   let numTools = ex.allToolSelectors.length;
-//   let toolSelector = ex.allToolSelectors[0];
-//   let nextToolSelector = ex.allToolSelectors[numTools - 1];
+  // Send ARROW LEFT key to the first item
+  await t.context.session.findElement(By.css(toolSelector))
+    .sendKeys(Key.ARROW_LEFT);
 
-//   // Send ARROW LEFT key to the first item
-//   await t.context.session.findElement(By.css(toolSelector))
-//     .sendKeys(Key.ARROW_LEFT);
+  // Focus should now be on last item
+  t.true(
+    await waitAndCheckFocus(t, nextToolSelector),
+    'Sending ARROW_RIGHT to tool "' + toolSelector + '" should move focus to "' +
+      nextToolSelector + '"'
+  );
 
-//   // Focus should now be on last item
-//   t.true(
-//     await waitAndCheckFocus(t, nextToolSelector),
-//     'Sending ARROW_RIGHT to tool "' + toolSelector + '" should move focus to "' +
-//       nextToolSelector + '"'
-//   );
-
-//   t.true(
-//     await waitAndCheckTabindex(t, nextToolSelector),
-//     'Sending ARROW_RIGHT to tool "' + toolSelector + '" should set tabindex on "' +
-//       nextToolSelector + '"'
-//   );
+  t.true(
+    await waitAndCheckTabindex(t, nextToolSelector),
+    'Sending ARROW_RIGHT to tool "' + toolSelector + '" should set tabindex on "' +
+      nextToolSelector + '"'
+  );
 
 
-//   // Confirm right arrow moves focus to the previous item
-//   for (let index = numTools - 1; index > 0; index--) {
-//     let toolSelector = ex.allToolSelectors[index];
-//     let nextToolSelector = ex.allToolSelectors[index + 1];
+  // Confirm right arrow moves focus to the previous item
+  for (let index = numTools - 1; index > 0; index--) {
+    let toolSelector = ex.allToolSelectors[index];
+    let nextToolSelector = ex.allToolSelectors[index + 1];
 
-//     // Send ARROW LEFT key
-//     await t.context.session.findElement(By.css(toolSelector))
-//       .sendKeys(Key.ARROW_LEFT);
+    // Send ARROW LEFT key
+    await t.context.session.findElement(By.css(toolSelector))
+      .sendKeys(Key.ARROW_LEFT);
 
-//     t.true(
-//       await waitAndCheckFocus(t, nextToolSelector),
-//       'Sending ARROW_RIGHT to tool "' + toolSelector + '" should move focus to "' +
-//         nextToolSelector + '"'
-//     );
+    t.true(
+      await waitAndCheckFocus(t, nextToolSelector),
+      'Sending ARROW_RIGHT to tool "' + toolSelector + '" should move focus to "' +
+        nextToolSelector + '"'
+    );
 
-//     t.true(
-//       await waitAndCheckTabindex(t, nextToolSelector),
-//       'Sending ARROW_RIGHT to tool "' + toolSelector + '" should set tabindex on "' +
-//         nextToolSelector + '"'
-//     );
-//   }
+    t.true(
+      await waitAndCheckTabindex(t, nextToolSelector),
+      'Sending ARROW_RIGHT to tool "' + toolSelector + '" should set tabindex on "' +
+        nextToolSelector + '"'
+    );
+  }
 
-// });
+});
 
-// ariaTest('key RIGHT ARROW moves focus', exampleFile, 'key-right-arrow', async (t) => {
-//   t.plan(12);
+// This tests fail from bug in example: fix in issue 847 on w3c/aria-practices
+ariaTest.failing('key RIGHT ARROW moves focus', exampleFile, 'key-right-arrow', async (t) => {
+  t.plan(12);
 
-//   // Put focus on the first item in the list
-//   await clickAndWait(t, ex.allToolSelectors[0]);
+  // Put focus on the first item in the list
+  await clickAndWait(t, ex.allToolSelectors[0]);
 
-//   let numTools = ex.allToolSelectors.length;
+  let numTools = ex.allToolSelectors.length;
 
-//   // Confirm right arrow moves focus to the next item
-//   for (let index = 0; index < numTools - 1; index++) {
-//     let toolSelector = ex.allToolSelectors[index];
-//     let nextToolSelector = ex.allToolSelectors[index + 1];
+  // Confirm right arrow moves focus to the next item
+  for (let index = 0; index < numTools - 1; index++) {
+    let toolSelector = ex.allToolSelectors[index];
+    let nextToolSelector = ex.allToolSelectors[index + 1];
 
-//     // Send ARROW RIGHT key
-//     await t.context.session.findElement(By.css(toolSelector))
-//       .sendKeys(Key.ARROW_RIGHT);
+    // Send ARROW RIGHT key
+    await t.context.session.findElement(By.css(toolSelector))
+      .sendKeys(Key.ARROW_RIGHT);
 
-//     t.true(
-//       await waitAndCheckFocus(t, nextToolSelector),
-//       'Sending ARROW_RIGHT to tool "' + toolSelector + '" should move focus to "' +
-//         nextToolSelector + '"'
-//     );
+    t.true(
+      await waitAndCheckFocus(t, nextToolSelector),
+      'Sending ARROW_RIGHT to tool "' + toolSelector + '" should move focus to "' +
+        nextToolSelector + '"'
+    );
 
-//     t.true(
-//       await waitAndCheckTabindex(t, nextToolSelector),
-//       'Sending ARROW_RIGHT to tool "' + toolSelector + '" should set tabindex on "' +
-//         nextToolSelector + '"'
-//     );
-//   }
+    t.true(
+      await waitAndCheckTabindex(t, nextToolSelector),
+      'Sending ARROW_RIGHT to tool "' + toolSelector + '" should set tabindex on "' +
+        nextToolSelector + '"'
+    );
+  }
 
-//   let toolSelector = ex.allToolSelectors[numTools - 1];
-//   let nextToolSelector = ex.allToolSelectors[0];
+  let toolSelector = ex.allToolSelectors[numTools - 1];
+  let nextToolSelector = ex.allToolSelectors[0];
 
-//   // Send ARROW RIGHT key to the last item
-//   await t.context.session.findElement(By.css(toolSelector))
-//     .sendKeys(Key.ARROW_RIGHT);
+  // Send ARROW RIGHT key to the last item
+  await t.context.session.findElement(By.css(toolSelector))
+    .sendKeys(Key.ARROW_RIGHT);
 
-//   // Focus should now be on first item
-//   t.true(
-//     await waitAndCheckFocus(t, nextToolSelector),
-//     'Sending ARROW_RIGHT to tool "' + toolSelector + '" should move focus to "' +
-//       nextToolSelector + '"'
-//   );
+  // Focus should now be on first item
+  t.true(
+    await waitAndCheckFocus(t, nextToolSelector),
+    'Sending ARROW_RIGHT to tool "' + toolSelector + '" should move focus to "' +
+      nextToolSelector + '"'
+  );
 
-//   t.true(
-//     await waitAndCheckTabindex(t, nextToolSelector),
-//     'Sending ARROW_RIGHT to tool "' + toolSelector + '" should set tabindex on "' +
-//       nextToolSelector + '"'
-//   );
-// });
+  t.true(
+    await waitAndCheckTabindex(t, nextToolSelector),
+    'Sending ARROW_RIGHT to tool "' + toolSelector + '" should set tabindex on "' +
+      nextToolSelector + '"'
+  );
+});
 
-// ariaTest('key HOME moves focus', exampleFile, 'key-home', async (t) => {
-//   t.plan(6);
+// This tests fail from bug in example: fix in issue 847 on w3c/aria-practices
+ariaTest.failing('key HOME moves focus', exampleFile, 'key-home', async (t) => {
+  t.plan(6);
 
-//   let numTools = ex.allToolSelectors.length;
+  let numTools = ex.allToolSelectors.length;
 
-//   // Confirm right moves HOME focus to first item
-//   for (let index = 0; index < numTools - 1; index++) {
-//     let toolSelector = ex.allToolSelectors[index];
+  // Confirm right moves HOME focus to first item
+  for (let index = 0; index < numTools - 1; index++) {
+    let toolSelector = ex.allToolSelectors[index];
 
-//     // Click on element to focus
-//     await clickAndWait(t, toolSelector);
+    // Click on element to focus
+    await clickAndWait(t, toolSelector);
 
-//     // Send HOME key to the last item
-//     await t.context.session.findElement(By.css(toolSelector))
-//       .sendKeys(Key.HOME);
+    // Send HOME key to the last item
+    await t.context.session.findElement(By.css(toolSelector))
+      .sendKeys(Key.HOME);
 
-//     t.true(
-//       await waitAndCheckFocus(t, ex.allToolSelectors[0], index),
-//       'Sending HOME to tool "' + toolSelector + '" should move focus to first tool'
-//     );
-//   }
-// });
+    t.true(
+      await waitAndCheckFocus(t, ex.allToolSelectors[0], index),
+      'Sending HOME to tool "' + toolSelector + '" should move focus to first tool'
+    );
+  }
+});
 
-// ariaTest('key END moves focus', exampleFile, 'key-end', async (t) => {
-//   t.plan(6)
+// This tests fail from bug in example: fix in issue 847 on w3c/aria-practices
+ariaTest.failing('key END moves focus', exampleFile, 'key-end', async (t) => {
+  t.plan(6);
 
-//   let numTools = ex.allToolSelectors.length;
+  let numTools = ex.allToolSelectors.length;
 
-//   // Confirm right moves HOME focus to first item
-//   for (let index = 0; index < numTools - 1; index++) {
-//     let toolSelector = ex.allToolSelectors[index];
+  // Confirm right moves HOME focus to first item
+  for (let index = 0; index < numTools - 1; index++) {
+    let toolSelector = ex.allToolSelectors[index];
 
-//     // Click on element to focus
-//     await clickAndWait(t, toolSelector);
+    // Click on element to focus
+    await clickAndWait(t, toolSelector);
 
-//     // Send HOME key to the last item
-//     await t.context.session.findElement(By.css(toolSelector))
-//       .sendKeys(Key.HOME);
+    // Send HOME key to the last item
+    await t.context.session.findElement(By.css(toolSelector))
+      .sendKeys(Key.HOME);
 
-//     t.true(
-//       await waitAndCheckFocus(t, ex.allToolSelectors[0], index),
-//       'Sending HOME to tool "' + toolSelector + '" should move focus to first tool'
-//     );
-//   }
-// });
+    t.true(
+      await waitAndCheckFocus(t, ex.allToolSelectors[0], index),
+      'Sending HOME to tool "' + toolSelector + '" should move focus to first tool'
+    );
+  }
+});

--- a/test/tests/toolbar.js
+++ b/test/tests/toolbar.js
@@ -99,7 +99,7 @@ ariaTest('roving tabindex on button elements', exampleFile, 'button-tabindex', a
 
 // Test pending fix bug in example: fix in issue 847 on w3c/aria-practices
 ariaTest.failing('"aria-disabled" on button elements', exampleFile, 'button-aria-disabled', async (t) => {
-  t.pass();
+  t.fail();
 });
 
 

--- a/test/tests/treegrid-1.js
+++ b/test/tests/treegrid-1.js
@@ -678,49 +678,8 @@ ariaTest('CTRL+END moves focus', exampleFile, 'key-control-end', async (t) => {
   );
 });
 
-// This test fails due to: https://github.com/w3c/aria-practices/issues/790#issuecomment-422079276
-ariaTest.failing('ENTER actives interative items item', exampleFile, 'key-enter', async (t) => {
-  t.plan(16);
+// TODO: backlog issue 878
 
-
-  // INTERACTIVE ITEM 1: Enter sent while focus is on email row should open email altert
-  await openAllThreads(t);
-  const emailRows = await t.context.session.findElements(By.css(ex.emailRowSelector));
-
-  for (let email of emailRows) {
-    await email.sendKeys(Key.ENTER);
-
-    t.truthy(
-      await t.context.session.switchTo().alert().getText(),
-      'Sending "enter" to any email row should open alert with the test of the email'
-    );
-    await t.context.session.switchTo().alert().accept();
-  }
-
-
-  // INTERACTIVE ITEM 1: Enter sent while focus is email gridcell should trigger link
-  for (let index = 0; index <= ex.lastRowIndex; index++) {
-
-    // Reload the page and open all emails
-    await t.context.session.get(t.context.url);
-    await openAllThreads(t);
-
-    const selector = '#ex1 [role="row"]:nth-of-type(' + (index + 1) + ') a';
-    const newUrl = t.context.url + '#test-url-change';
-
-    // Reset the href to not be an email link in order to test
-    await t.context.session.executeScript(function () {
-      let [selector, newUrl] = arguments;
-      document.querySelector(selector).href = newUrl;
-    }, selector, newUrl);
-
-    await t.context.session.findElement(By.css(selector)).sendKeys(Key.ENTER);
-
-    // Test the the URL is updated.
-    t.is(
-      await t.context.session.getCurrentUrl(),
-      newUrl,
-      'Sending "enter" to a link within the gridcell should activate the link'
-    );
-  }
-});
+// ariaTest('ENTER actives item', exampleFile, 'key-enter', async (t) => {
+//   t.pass();
+// });

--- a/test/tests/treegrid-1.js
+++ b/test/tests/treegrid-1.js
@@ -678,8 +678,49 @@ ariaTest('CTRL+END moves focus', exampleFile, 'key-control-end', async (t) => {
   );
 });
 
-// TODO: backlog issue 878
+// This test fails due to: https://github.com/w3c/aria-practices/issues/790#issuecomment-422079276
+ariaTest.failing('ENTER actives interative items item', exampleFile, 'key-enter', async (t) => {
+  t.plan(16);
 
-// ariaTest('ENTER actives item', exampleFile, 'key-enter', async (t) => {
-//   t.pass();
-// });
+
+  // INTERACTIVE ITEM 1: Enter sent while focus is on email row should open email altert
+  await openAllThreads(t);
+  const emailRows = await t.context.session.findElements(By.css(ex.emailRowSelector));
+
+  for (let email of emailRows) {
+    await email.sendKeys(Key.ENTER);
+
+    t.truthy(
+      await t.context.session.switchTo().alert().getText(),
+      'Sending "enter" to any email row should open alert with the test of the email'
+    );
+    await t.context.session.switchTo().alert().accept();
+  }
+
+
+  // INTERACTIVE ITEM 1: Enter sent while focus is email gridcell should trigger link
+  for (let index = 0; index <= ex.lastRowIndex; index++) {
+
+    // Reload the page and open all emails
+    await t.context.session.get(t.context.url);
+    await openAllThreads(t);
+
+    const selector = '#ex1 [role="row"]:nth-of-type(' + (index+1) + ') a';
+    const newUrl = t.context.url + '#test-url-change'
+
+    // Reset the href to not be an email link in order to test
+    await t.context.session.executeScript(function () {
+      let [selector, newUrl] = arguments;
+      document.querySelector(selector).href = newUrl;
+    }, selector, newUrl);
+
+    await t.context.session.findElement(By.css(selector)).sendKeys(Key.ENTER);
+
+    // Test the the URL is updated.
+    t.is(
+      await t.context.session.getCurrentUrl(),
+      newUrl,
+      'Sending "enter" to a link within the gridcell should activate the link'
+    );
+  }
+});

--- a/test/tests/treegrid-1.js
+++ b/test/tests/treegrid-1.js
@@ -705,8 +705,8 @@ ariaTest.failing('ENTER actives interative items item', exampleFile, 'key-enter'
     await t.context.session.get(t.context.url);
     await openAllThreads(t);
 
-    const selector = '#ex1 [role="row"]:nth-of-type(' + (index+1) + ') a';
-    const newUrl = t.context.url + '#test-url-change'
+    const selector = '#ex1 [role="row"]:nth-of-type(' + (index + 1) + ') a';
+    const newUrl = t.context.url + '#test-url-change';
 
     // Reset the href to not be an email link in order to test
     await t.context.session.executeScript(function () {

--- a/test/tests/treeview-2b.js
+++ b/test/tests/treeview-2b.js
@@ -419,38 +419,37 @@ ariaTest('Key enter opens folder and activates link', exampleFile, 'key-enter-or
 
 });
 
-// This test fails due to bug #869. When the bug is fixed this test should be uncommented.
+// This test fails due to bug #869.
+ariaTest.failing('Key space opens folder and activates link', exampleFile, 'key-enter-or-space', async (t) => {
+  t.plan(2);
 
-// ariaTest('Key space opens folder and activates link', exampleFile, 'key-enter-or-space', async (t) => {
-//   t.plan(2);
+  let folders = await t.context.session.findElements(By.css(ex.folderSelector));
 
-//   let folders = await t.context.session.findElements(By.css(ex.folderSelector));
+  // Going through all closed folder elements in dom order will open parent
+  // folders first, therefore all child folders will be visible before sending "enter"
+  for (let folder of folders) {
+    await folder.sendKeys(Key.SPACE);
+  }
 
-//   // Going through all closed folder elements in dom order will open parent
-//   // folders first, therefore all child folders will be visible before sending "enter"
-//   for (let folder of folders) {
-//     await folder.sendKeys(Key.SPACE);
-//   }
+  // Assert that the attribute value "aria-expanded" on all folders is "true"
+  await assertAttributeValues(t, ex.folderSelector, 'aria-expanded', 'true');
 
-//   // Assert that the attribute value "aria-expanded" on all folders is "true"
-//   await assertAttributeValues(t, ex.folderSelector, 'aria-expanded', 'true');
+  // Test a leaf node
+  let leafnodes = await t.context.session.findElements(By.css(ex.linkSelector));
+  await leafnodes[0].sendKeys(Key.SPACE);
 
-//   // Test a leaf node
-//   let leafnodes = await t.context.session.findElements(By.css(ex.linkSelector));
-//   await leafnodes[0].sendKeys(Key.SPACE);
+  await t.context.session.wait(() => {
+    return t.context.session.getCurrentUrl().then(url => {
+      return url != t.context.url;
+    });
+  }, t.context.waitTime).catch(() => {});
 
-//   await t.context.session.wait(() => {
-//     return t.context.session.getCurrentUrl().then(url => {
-//       return url != t.context.url;
-//     });
-//   }, t.context.waitTime).catch(() => {});
-
-//   t.not(
-//     await t.context.session.getCurrentUrl(),
-//     t.context.url,
-//     'SPACE key on first element found by selector "' + ex.linkSelector + '" should activate link.'
-//   );
-// });
+  t.not(
+    await t.context.session.getCurrentUrl(),
+    t.context.url,
+    'SPACE key on first element found by selector "' + ex.linkSelector + '" should activate link.'
+  );
+});
 
 ariaTest('key down arrow moves focus', exampleFile, 'key-down-arrow', async (t) => {
   t.plan(51);
@@ -601,73 +600,72 @@ ariaTest('key right arrow opens folders and moves focus', exampleFile, 'key-righ
   }
 });
 
-// This test fails due to bug #866. When the bug is fix this test should be uncommented.
+// This test fails due to bug #866.
+ariaTest.failing('key left arrow closes folders and moves focus', exampleFile, 'key-left-arrow', async (t) => {
+  t.plan(106);
 
-// ariaTest('key left arrow closes folders and moves focus', exampleFile, 'key-left-arrow', async (t) => {
-//   t.plan(106);
+  // Open all folders
+  await openAllFolders(t);
 
-//   // Open all folders
-//   await openAllFolders(t);
+  const items = await t.context.session.findElements(By.css(ex.treeitemSelector));
 
-//   const items = await t.context.session.findElements(By.css(ex.treeitemSelector));
+  let i = items.length - 1;
+  while (i > 0) {
 
-//   let i = items.length - 1;
-//   while (i > 0) {
+    const isFolder = await isFolderTreeitem(items[i]);
+    const isOpened = await isOpenedFolderTreeitem(items[i]);
+    const isTopLevel = isFolder ?
+      await isTopLevelFolder(t, items[i]) :
+      false;
 
-//     const isFolder = await isFolderTreeitem(items[i]);
-//     const isOpened = await isOpenedFolderTreeitem(items[i]);
-//     const isTopLevel = isFolder ?
-//       await isTopLevelFolder(t, items[i]) :
-//       false;
+    await items[i].sendKeys(Key.ARROW_LEFT);
 
-//     await items[i].sendKeys(Key.ARROW_LEFT);
+    // If the item is a folder and the folder was opened, arrow will close folder
+    if (isFolder && isOpened) {
+      t.is(
+        await items[i].getAttribute('aria-expanded'),
+        'false',
+        'Sending key ARROW_LEFT to folder at treeitem index ' + i +
+          ' when the folder is opened should close the folder'
+      );
 
-//     // If the item is a folder and the folder was opened, arrow will close folder
-//     if (isFolder && isOpened) {
-//       t.is(
-//         await items[i].getAttribute('aria-expanded'),
-//         'false',
-//         'Sending key ARROW_LEFT to folder at treeitem index ' + i +
-//           ' when the folder is opened should close the folder'
-//       );
+      t.true(
+        await checkFocus(t,  ex.treeitemSelector, i),
+        'Sending key ARROW_LEFT to folder at treeitem index ' + i +
+          ' when the folder is opened should not move the focus'
+      );
+      // Send one more arrow key to the folder that is now closed
+      continue;
+    }
 
-//       t.true(
-//         await checkFocus(t,  ex.treeitemSelector, i),
-//         'Sending key ARROW_LEFT to folder at treeitem index ' + i +
-//           ' when the folder is opened should not move the focus'
-//       );
-//       // Send one more arrow key to the folder that is now closed
-//       continue;
-//     }
+    // If the item is a top level folder and closed, arrow will do nothing
+    else if (isTopLevel) {
+      t.true(
+        await checkFocus(t,  ex.treeitemSelector, i),
+        'Sending key ARROW_LEFT to link in top level folder at treeitem index ' + i +
+          ' should not move focu'
+      );
+    }
 
-//     // If the item is a top level folder and closed, arrow will do nothing
-//     else if (isTopLevel) {
-//       t.true(
-//         await checkFocus(t,  ex.treeitemSelector, i),
-//         'Sending key ARROW_LEFT to link in top level folder at treeitem index ' + i +
-//           ' should not move focu'
-//       );
-//     }
+    // If the item is a link in folder, or a closed folder, arrow will move up a folder
+    else {
+      t.true(
+        await checkFocusOnParentFolder(t, items[i]),
+        'Sending key ARROW_LEFT to link in folder at treeitem index ' + i +
+          ' should move focus to parent folder'
+      );
 
-//     // If the item is a link in folder, or a closed folder, arrow will move up a folder
-//     else {
-//       t.true(
-//         await checkFocusOnParentFolder(t, items[i]),
-//         'Sending key ARROW_LEFT to link in folder at treeitem index ' + i +
-//           ' should move focus to parent folder'
-//       );
+      t.is(
+        await items[i].isDisplayed(),
+        true,
+        'Sending key ARROW_LEFT to link in folder at treeitem index ' + i +
+          ' should not close the folder it is in'
+      );
+    }
 
-//       t.is(
-//         await items[i].isDisplayed(),
-//         true,
-//         'Sending key ARROW_LEFT to link in folder at treeitem index ' + i +
-//           ' should not close the folder it is in'
-//       );
-//     }
-
-//     i--;
-//   }
-// });
+    i--;
+  }
+});
 
 ariaTest('key home moves focus', exampleFile, 'key-home', async (t) => {
   t.plan(51);


### PR DESCRIPTION
This commit:
- adds the `.failing` option to the ariaTest wrapper around ava's test
- uses `.failing` in all places where failing tests were previously commented out