### PR TITLE
Add carousel pattern

### DIFF
--- a/aria-practices.html
+++ b/aria-practices.html
@@ -545,8 +545,8 @@
         <p>This section describes the element composition for three styles of carousels:</p>
         <ul>
           <li>Basic: Has rotation , previous slide, and next slide controls but no slide selection controls.</li>
-          <li>Tabbed: Has basic controls plus a single tab stop for slide selection controls implemented using the tabs pattern.</li>
-          <li>Grouped: Has basic controls plus a group of tab stops for slide selection controls implemented using the button pattern. Because each slide adds an element to the page tab sequence, this is the least friendly style for keyboard users.</li>
+          <li>Tabbed: Has basic controls plus a single tab stop for slide selection controls implemented using the <a href="#tabpanel">tabs pattern.</a></li>
+          <li>Grouped: Has basic controls plus a series of tab stops in a group of slide selection controls where each control implements the <a href="#button">button pattern.</a> Because each slide selector button adds an element to the page tab sequence, this style is the least friendly for keyboard users.</li>
         </ul>
         <h5>Basic carousel elements</h5>
         <ul>
@@ -581,17 +581,15 @@
         <p>The structure of a tabbed carousel is the same as a basic carousel except that:</p>
         <ul>
           <li>
-            Each slide container has role
-            <a href="#tabpanel" class="role-reference">tabpanel</a>
+            Each slide container has role <a href="#tabpanel" class="role-reference">tabpanel,</a>
             and it does not have the <code>aria-roledescription</code> property.
           </li>
-          <li>
-            It has slide selection controls implemented using the
-            <a href="#tabpanel">tabs pattern</a>
-            where each control is a <code>tab</code> element and the set of controls is grouped in a <code>tablist</code>
-            element. See the
-            <a href="#tabpanel">tabs pattern</a>
-            for the complete list of implementation details.
+          <li>It has slide selection controls implemented using the <a href="#tabpanel">tabs pattern</a> where:
+            <ul>
+              <li>Each control is a <code>tab</code> element; activating the tab displays the slide associated with that tab.</li>
+              <li>the set of controls is grouped in a <code>tablist</code> element.</li>
+              <li>The <code>tab</code>, <code>tablist</code>, and <code>tabpanel</code> implement the properties specified in the <a href="#tabpanel">tabs pattern</a>.</li>
+            </ul>
           </li>
         </ul>
         <h5>Grouped Carousel</h5>

--- a/aria-practices.html
+++ b/aria-practices.html
@@ -492,34 +492,17 @@
         While a slide may contain any type of content, image carousels where each slide contains nothing more than a single image are common.
       </p>
       <p>
-          Ensuring all users, especially screen reader users, can control slide rotation is an essential accessibility feature of carousels.
-          If a slide is hidden while a screen reader user is reading it, the screen reader will lose its point of regard, typically forcing the screen reader's reading cursor to the top of the page.
-          this is particularly disorienting if the user is not aware of the automatic rotation.
-        </p>
-      <p>
-        The requirements for controlling the slide rotation include pausing rotation on keyboard focus and pointer hover, an explicit pause button, previous button and a next slide buttons.  Optionally a <code>tablist</code> can be used to provide additional control over the navigation of the slides.
+        Ensuring all users, especially screen reader users, can control slide rotation is an essential accessibility feature of carousels.
+        If content is hidden and replaced while a screen reader user is reading it, the experience can be confusing and disorienting, especially  if the user is not aware of the automatic slide rotation.
       </p>
-        <dl>
-          <dt>Pause Rotation</dt>
-          <dd>The auto-rotation must stop when keyboard focus is on a slide in the carousel.  Keyboard only and screen reader users will be disoriented if keyboard focus disappears when the slides change.</dd>
-          <dd>The auto-rotation must stop when the pointer hovers over an image in the carousel.</dd>
-
-          <dt>Pause Button</dt>
-          <dd>Used to stop the auto-rotation of slides, and can optionally be a toggle to restart the rotation of slides</dd>
-          <dd>This is important to inform screen reader users using virtual reading modes to switch to application mode to stop the rotation of slides.</dd>
-
-          <dt>Previous Slide Button</dt>
-          <dd>Used to move to the previous slide in the set of slides.</dd>
-          <dd>The label for the previous button should contain information on the slide position of the previous slide in the sequence of slides and the total number of slides (e.g. Slide 3 of 6).</dd>
-
-          <dt>Next Slide Button</dt>
-          <dd>Used to move to the next slide in the set of slides.</dd>
-          <dd>The label for the next button should contain information on the slide position of the previous slide in the sequence of slides and the total number of slides (e.g. Slide 5 of 6).</dd>
-
-          <dt><code>tablist</code> Widget (optional)</dt>
-          <dd>Used to provide direct navigation to individual slides when a carousel provides visual controls indicating number of slides and direct navigation to a slide.</dd>
-          <dd>The set of controls for navigating slides can be modelled using the <code>tablist</code> pattern.</dd>
-        </dl>
+      <p>Features needed to provide sufficient rotation control include:</p>
+      <ol>
+        <li>Rotation pauses when keyboard focus enters the carousel.</li>
+        <li>Rotation pauses when the mouse hovers over the carousel.</li>
+        <li>A button for pausing and restarting rotation. This is particularly important for supporting assistive technologies operating in a mode that does not move either keyboard focus or the mouse.</li>
+        <li>Buttons for displaying the previous and next slides.</li>
+        <li>Optionally, a control, or group of controls, for choosing a specific slide to display. For example, the selection controls can be marked up as tabs in a tablist with the slide represented by a tabpanel element.</li>
+      </ol>
 
       <section class="notoc">
         <h4>Example</h4>

--- a/aria-practices.html
+++ b/aria-practices.html
@@ -522,8 +522,8 @@
           <dd>An interactive element, often styled as an arrow,  that displays the next slide in the rotation sequence.</dd>
           <dt>Previous Slide Control</dt>
           <dd>An interactive element, often styled as an arrow,  that displays the previous slide in the rotation sequence.</dd>
-          <dt>Slide Selection Controls</dt>
-          <dd>A group of elements, often styled as small dots, that enable the user to display a specific slide in the rotation sequence.</dd>
+          <dt>Slide Picker Controls</dt>
+          <dd>A group of elements, often styled as small dots, that enable the user to pick a specific slide in the rotation sequence to display.</dd>
         </dl>
       </section>
 
@@ -536,7 +536,7 @@
           </li>
           <li><kbd>Tab</kbd> and <kbd>Shift + Tab</kbd>: Move focus through the interactive elements of the carousel as specified by the page tab sequence; no special scripting is necessary.</li>
           <li>Button elements implement the keyboard interaction defined in the <a href="#button">button pattern</a>.</li>
-          <li>If tab elements are used for slide selection controls, they implement the keyboard interaction defined in the <a href="#tabpanel">Tabs Pattern.</a></li>
+          <li>If tab elements are used for slide picker controls, they implement the keyboard interaction defined in the <a href="#tabpanel">Tabs Pattern.</a></li>
         </ul>
       </section>
 
@@ -544,9 +544,9 @@
         <h4>WAI-ARIA Roles, States, and Properties</h4>
         <p>This section describes the element composition for three styles of carousels:</p>
         <ul>
-          <li>Basic: Has rotation , previous slide, and next slide controls but no slide selection controls.</li>
-          <li>Tabbed: Has basic controls plus a single tab stop for slide selection controls implemented using the <a href="#tabpanel">tabs pattern.</a></li>
-          <li>Grouped: Has basic controls plus a series of tab stops in a group of slide selection controls where each control implements the <a href="#button">button pattern.</a> Because each slide selector button adds an element to the page tab sequence, this style is the least friendly for keyboard users.</li>
+          <li>Basic: Has rotation , previous slide, and next slide controls but no slide picker controls.</li>
+          <li>Tabbed: Has basic controls plus a single tab stop for slide picker controls implemented using the <a href="#tabpanel">tabs pattern.</a></li>
+          <li>Grouped: Has basic controls plus a series of tab stops in a group of slide picker controls where each control implements the <a href="#button">button pattern.</a> Because each slide selector button adds an element to the page tab sequence, this style is the least friendly for keyboard users.</li>
         </ul>
         <h5>Basic carousel elements</h5>
         <ul>
@@ -584,7 +584,7 @@
             Each slide container has role <a href="#tabpanel" class="role-reference">tabpanel,</a>
             and it does not have the <code>aria-roledescription</code> property.
           </li>
-          <li>It has slide selection controls implemented using the <a href="#tabpanel">tabs pattern</a> where:
+          <li>It has slide picker controls implemented using the <a href="#tabpanel">tabs pattern</a> where:
             <ul>
               <li>Each control is a <code>tab</code> element, so activating a tab displays the slide associated with that tab.</li>
               <li>The set of controls is grouped in a <code>tablist</code> element.</li>
@@ -593,12 +593,12 @@
           </li>
         </ul>
         <h5>Grouped Carousel</h5>
-        <p>A grouped carousel has the same structure as a basic carousel, but it also includes slide selection controls where:</p>
+        <p>A grouped carousel has the same structure as a basic carousel, but it also includes slide picker controls where:</p>
         <ul>
-          <li>The set of slide selection controls is contained in an element with role <a href="#group" class="role-reference">group</a>.</li>
-          <li>The group containing the controls has an accessible label provided by the value of <a href="#aria-label" class="property-reference">aria-label</a> that identifies the purpose of the controls, e.g., &quot;Choose slide to display&quot;.</li>
-          <li>Each control is a native button element (recommended) or implements the <a href="#button">button pattern.</a></li>
-          <li>The button representing the currently displayed slide has the property <a href="#aria-disabled" class="property-reference">aria-disabled</a> set to <code>true</code>. Note: <code>aria-disabled</code> is preferable to the HTML <code>disabled</code> attribute because it helpful for the disabled button to be included in the page tab sequence in this circumstance.</li>
+          <li>The set of slide picker controls is contained in an element with role <a href="#group" class="role-reference">group</a>.</li>
+          <li>The group containing the picker controls has an accessible label provided by the value of <a href="#aria-label" class="property-reference">aria-label</a> that identifies the purpose of the controls, e.g., &quot;Choose slide to display&quot;.</li>
+          <li>Each picker control is a native button element (recommended) or implements the <a href="#button">button pattern.</a></li>
+          <li>The button representing the currently displayed slide has the property <a href="#aria-disabled" class="property-reference">aria-disabled</a> set to <code>true</code>. Note: <code>aria-disabled</code> is preferable to the HTML <code>disabled</code> attribute because this is a circumstance where screen reader users benefit from the disabled button being included in the page <kbd>Tab</kbd> sequence.</li>
         </ul>
       </section>
     </section>

--- a/aria-practices.html
+++ b/aria-practices.html
@@ -554,7 +554,7 @@
         <h4>WAI-ARIA Roles, States, and Properties</h4>
         <p>This section describes the element composition for three styles of carousels:</p>
         <ul>
-          <li>Basic: Has rotation , previous slide, and next slide controls but no slide picker controls.</li>
+          <li>Basic: Has rotation, previous slide, and next slide controls but no slide picker controls.</li>
           <li>Tabbed: Has basic controls plus a single tab stop for slide picker controls implemented using the <a href="#tabpanel">tabs pattern.</a></li>
           <li>Grouped: Has basic controls plus a series of tab stops in a group of slide picker controls where each control implements the <a href="#button">button pattern.</a> Because each slide selector button adds an element to the page tab sequence, this style is the least friendly for keyboard users.</li>
         </ul>
@@ -600,7 +600,7 @@
                 An exception is helpful in this implementation because group elements do not support <a href="#aria-setsize" class="property-reference">aria-setsize</a> or <a href="#aria-posinset" class="property-reference">aria-posinset</a>.
                 The tabbed carousel implementation pattern does not have this limitation.
               </li>
-              <li>Note that since the <code>aria-roledescription</code> is set to &quot;slide&quot;, the label does not contain the word &quot;slide&quot;.</li>
+              <li>Note that since the <code>aria-roledescription</code> is set to &quot;slide&quot;, the label does not contain the word &quot;slide.&quot;</li>
             </ul>
           </li>
           <li>
@@ -623,7 +623,7 @@
             <ul>
               <li>Each control is a <code>tab</code> element, so activating a tab displays the slide associated with that tab.</li>
               <li>The accessible name of each <code>tab</code> indicates which slide it will display by including the name or number of the slide, e.g., &quot;Slide 3&quot;. Slide names are preferable if each slide has a unique name.</li>
-              <li>The set of controls is grouped in a <code>tablist</code> element with an accessible name provided by the value of <a href="#aria-label" class="property-reference">aria-label</a> that identifies the purpose of the tabs, e.g., &quot;Choose slide to display&quot;.</li>
+              <li>The set of controls is grouped in a <code>tablist</code> element with an accessible name provided by the value of <a href="#aria-label" class="property-reference">aria-label</a> that identifies the purpose of the tabs, e.g., &quot;Choose slide to display.&quot;</li>
               <li>The <code>tab</code>, <code>tablist</code>, and <code>tabpanel</code> implement the properties specified in the <a href="#tabpanel">tabs pattern</a>.</li>
             </ul>
           </li>
@@ -632,7 +632,7 @@
         <p>A grouped carousel has the same structure as a basic carousel, but it also includes slide picker controls where:</p>
         <ul>
           <li>The set of slide picker controls is contained in an element with role <a href="#group" class="role-reference">group</a>.</li>
-          <li>The group containing the picker controls has an accessible label provided by the value of <a href="#aria-label" class="property-reference">aria-label</a> that identifies the purpose of the controls, e.g., &quot;Choose slide to display&quot;.</li>
+          <li>The group containing the picker controls has an accessible label provided by the value of <a href="#aria-label" class="property-reference">aria-label</a> that identifies the purpose of the controls, e.g., &quot;Choose slide to display.&quot;</li>
           <li>Each picker control is a native button element (recommended) or implements the <a href="#button">button pattern.</a></li>
           <li>
             The accessible name of each picker button matches the name of the slide it displays.

--- a/aria-practices.html
+++ b/aria-practices.html
@@ -486,23 +486,28 @@
         <a href="https://github.com/w3c/aria-practices/issues/43">issue 43.</a>
       </p>
       <p>
-        A carousel presents a set of items, referred to as slides, by rotating, i.e., horizontally scrolling,  a subset of the slides into view at a time.
-        Typically, one slide is made visible at a time, and rotation automatically starts when the page loads.
-        In some implementations, rotation automatically stops once all the slides have been displayed.
+        A carousel presents a set of items, referred to as slides, by rotating one or more of the slides into view.
+        Typically, only one slide is displayed at a time.
         While a slide may contain any type of content, image carousels where each slide contains nothing more than a single image are common.
+        In some implementations, rotation automatically starts when the page loads, and it may also automatically stop once all the slides have been displayed.
       </p>
       <p>
-        Ensuring all users, especially screen reader users, can control slide rotation is an essential accessibility feature of carousels.
-        If content is hidden and replaced while a screen reader user is reading it, the experience can be confusing and disorienting, especially  if the user is not aware of the automatic slide rotation.
+        Ensuring all users can easily control and are not adversely effected by slide rotation is an essential aspect of making carousels accessible.
+        For instance, the screen reader experience can be confusing and disorienting if slides that are not visible on screen are incorrectly hidden, e.g., displayed off-screen.
+        Similarly, if slides rotate automatically and a screen reader user is not aware of the rotation, the user may read an element on slide one, execute the screen reader command for next element, and, instead of hearing the next element on slide one,  hear an element from slide 2 without any knowledge that the element just announced is from an entirely new context.
       </p>
       <p>Features needed to provide sufficient rotation control include:</p>
-      <ol>
-        <li>Rotation stops when keyboard focus enters the carousel. It does not restart unless the user explicitly requests it to do so.</li>
-        <li>Rotation is stopped whenever the mouse is hovering over the carousel.</li>
-        <li>A button for stopping and restarting rotation. This is particularly important for supporting assistive technologies operating in a mode that does not move either keyboard focus or the mouse.</li>
+      <ul>
         <li>Buttons for displaying the previous and next slides.</li>
-        <li>Optionally, a control, or group of controls, for choosing a specific slide to display. For example, the selection controls can be marked up as tabs in a tablist with the slide represented by a tabpanel element.</li>
-      </ol>
+        <li>Optionally, a control, or group of controls, for choosing a specific slide to display. For example, slide picker controls can be marked up as tabs in a tablist with the slide represented by a tabpanel element.</li>
+        <li>If the carousel can automatically rotate, it also:
+          <ul>
+            <li>Has a button for stopping and restarting rotation. This is particularly important for supporting assistive technologies operating in a mode that does not move either keyboard focus or the mouse.</li>
+            <li>Stops rotating when keyboard focus enters the carousel. It does not restart unless the user explicitly requests it to do so.</li>
+            <li>Stops rotating whenever the mouse is hovering over the carousel.</li>
+          </ul>
+        </li>
+      </ul>
 
       <section class="notoc">
         <h4>Example</h4>
@@ -516,6 +521,8 @@
         <h4>Terms</h4>
         <p>The following terms are used to describe components of a carousel.</p>
         <dl>
+          <dt>Slide</dt>
+          <dd>A single content container within a set of content containers that hold the content to be presented by the carousel.</dd>
           <dt>Rotation Control</dt>
           <dd>An interactive element that stops and starts automatic slide rotation.</dd>
           <dt>Next Slide Control</dt>
@@ -531,11 +538,14 @@
         <h4>Keyboard Interaction</h4>
         <ul>
           <li>
-            Automatic slide rotation stops when any element in the carousel receives keyboard focus.
+            If the carousel has an auto-rotate feature, automatic slide rotation stops when any element in the carousel receives keyboard focus.
             It does not resume unless the user activates the rotation control.
           </li>
-          <li><kbd>Tab</kbd> and <kbd>Shift + Tab</kbd>: Move focus through the interactive elements of the carousel as specified by the page tab sequence; no special scripting is necessary.</li>
-          <li>Button elements implement the keyboard interaction defined in the <a href="#button">button pattern</a>.</li>
+          <li><kbd>Tab</kbd> and <kbd>Shift + Tab</kbd>: Move focus through the interactive elements of the carousel as specified by the page tab sequence -- scripting for <kbd>Tab</kbd> is not necessary.</li>
+          <li>
+            Button elements implement the keyboard interaction defined in the <a href="#button">button pattern</a>.
+            Note: Activating the rotation control, next slide, and previous slide do not move focus, so users may easily repetitively activate them as many times as desired.
+          </li>
           <li>If tab elements are used for slide picker controls, they implement the keyboard interaction defined in the <a href="#tabpanel">Tabs Pattern.</a></li>
         </ul>
       </section>
@@ -591,6 +601,14 @@
                 The tabbed carousel implementation pattern does not have this limitation.
               </li>
               <li>Note that since the <code>aria-roledescription</code> is set to &quot;slide&quot;, the label does not contain the word &quot;slide&quot;.</li>
+            </ul>
+          </li>
+          <li>
+            Optionally, an element wrapping the set of slide elements has <a href="#aria-atomic" class="property-reference">aria-atomic</a> set to <code>false</code>
+            and <a href="#aria-live" class="property-reference">aria-live</a> set to:
+            <ul>
+              <li><code>off</code>: ifthe the carousel is automatically rotating.
+              <li><code>polite</code>: if the carousel is <strong>NOT</strong> automatically rotating.
             </ul>
           </li>
         </ul>

--- a/aria-practices.html
+++ b/aria-practices.html
@@ -541,6 +541,7 @@
             Button elements implement the keyboard interaction defined in the <a href="#button">button pattern</a>.
             Note: Activating the rotation control, next slide, and previous slide do not move focus, so users may easily repetitively activate them as many times as desired.
           </li>
+          <li>If present, the rotation control is the first element in the <kbd>Tab</kbd> sequence inside the carousel. It is essential that it precede the rotating content so it can be easily located.</li>
           <li>If tab elements are used for slide picker controls, they implement the keyboard interaction defined in the <a href="#tabpanel">Tabs Pattern.</a></li>
         </ul>
       </section>

--- a/aria-practices.html
+++ b/aria-practices.html
@@ -562,13 +562,9 @@
             If the carousel has a visible label, its accessible label is provided by the property
             <a href="#aria-labelledby" class="property-reference" >aria-labelledby</a> on the carousel container set to the ID of the element containing the visible label.
             Otherwise, an accessible label is provided by the property <a href="#aria-label" class="property-reference">aria-label</a> set on the carousel container.
-            Note that since the <code>aria-roledescription</code> is set to &quot;carousel&quot;, the label should not contain the word &quot;carousel&quot;.
+            Note that since the <code>aria-roledescription</code> is set to &quot;carousel&quot;, the label does not contain the word &quot;carousel&quot;.
           </li>
-          <li>
-            The rotation control, next slide control, and previous slide control are
-            either native button elements with an implicit role of <a href="#button" class="role-reference">button</a> (recommended)
-            or implement the <a href="#button">button pattern</a>.
-          </li>
+          <li>The rotation control, next slide control, and previous slide control are either native button elements (recommended) or implement the <a href="#button">button pattern</a>.</li>
           <li>
             The rotation control has an accessible label provided by either its inner text or <a href="#aria-label" class="property-reference">aria-label</a>.
             The label changes to match the action the button will perform, e.g., &quot;Stop slide rotation&quot; or &quot;Start slide rotation&quot;.
@@ -576,29 +572,58 @@
             Note that since the label changes, the rotation control does not have any states, e.g., <code>aria-pressed</code>, specified.
           </li>
           <li>Each slide container has role <a href="#group" class="role-reference">group</a> with the property <a href="aria-roledescription" class="property-reference">aria-roledescription</a> set to <code>slide</code>.</li>
+          <li>Each slide has an accessible name:
+            <ul>
+              <li>
+                If a slide has a visible label, its accessible label is provided by the property
+                <a href="#aria-labelledby" class="property-reference" >aria-labelledby</a>
+                on the slide container set to the ID of the element containing the visible label.
+              </li>
+              <li>
+                Otherwise, an accessible label is provided by the property
+                <a href="#aria-label" class="property-reference">aria-label</a>
+                set on the slide container.
+              </li>
+              <li>
+                If unique names that identify the slide content are not available, a number and set size can serve as a meaningful alternative, e.g., &quot;3 of 10&quot;.
+                Note: Normally, including set position and size information in an accessible name is not appropriate.
+                An exception is helpful in this implementation because group elements do not support <a href="#aria-setsize" class="property-reference">aria-setsize</a> or <a href="#aria-posinset" class="property-reference">aria-posinset</a>.
+                The tabbed carousel implementation pattern does not have this limitation.
+              </li>
+              <li>Note that since the <code>aria-roledescription</code> is set to &quot;slide&quot;, the label does not contain the word &quot;slide&quot;.</li>
+            </ul>
+          </li>
         </ul>
         <h5>Tabbed Carousel Elements</h5>
         <p>The structure of a tabbed carousel is the same as a basic carousel except that:</p>
         <ul>
           <li>
-            Each slide container has role <a href="#tabpanel" class="role-reference">tabpanel,</a>
+            Each slide container has role <a href="#tabpanel" class="role-reference">tabpanel</a> in lieu of <code>group</code>,
             and it does not have the <code>aria-roledescription</code> property.
           </li>
           <li>It has slide picker controls implemented using the <a href="#tabpanel">tabs pattern</a> where:
             <ul>
               <li>Each control is a <code>tab</code> element, so activating a tab displays the slide associated with that tab.</li>
-              <li>The set of controls is grouped in a <code>tablist</code> element.</li>
+              <li>The accessible name of each <code>tab</code> indicates which slide it will display by including the name or number of the slide, e.g., &quot;Slide 3&quot;. Slide names are preferable if each slide has a unique name.</li>
+              <li>The set of controls is grouped in a <code>tablist</code> element with an accessible name provided by the value of <a href="#aria-label" class="property-reference">aria-label</a> that identifies the purpose of the tabs, e.g., &quot;Choose slide to display&quot;.</li>
               <li>The <code>tab</code>, <code>tablist</code>, and <code>tabpanel</code> implement the properties specified in the <a href="#tabpanel">tabs pattern</a>.</li>
             </ul>
           </li>
         </ul>
-        <h5>Grouped Carousel</h5>
+        <h5>Grouped Carousel Elements</h5>
         <p>A grouped carousel has the same structure as a basic carousel, but it also includes slide picker controls where:</p>
         <ul>
           <li>The set of slide picker controls is contained in an element with role <a href="#group" class="role-reference">group</a>.</li>
           <li>The group containing the picker controls has an accessible label provided by the value of <a href="#aria-label" class="property-reference">aria-label</a> that identifies the purpose of the controls, e.g., &quot;Choose slide to display&quot;.</li>
           <li>Each picker control is a native button element (recommended) or implements the <a href="#button">button pattern.</a></li>
-          <li>The button representing the currently displayed slide has the property <a href="#aria-disabled" class="property-reference">aria-disabled</a> set to <code>true</code>. Note: <code>aria-disabled</code> is preferable to the HTML <code>disabled</code> attribute because this is a circumstance where screen reader users benefit from the disabled button being included in the page <kbd>Tab</kbd> sequence.</li>
+          <li>
+            The accessible name of each picker button matches the name of the slide it displays.
+            One technique for accomplishing this is to set <a href="#aria-labelledby" class="property-reference">aria-labelledby</a> to a value that references the slide <code>group</code> element.
+          </li>
+          <li>
+            The picker button representing the currently displayed slide has the property <a href="#aria-disabled" class="property-reference">aria-disabled</a> set to <code>true</code>.
+            Note: <code>aria-disabled</code> is preferable to the HTML <code>disabled</code> attribute because this is a circumstance where screen reader users benefit from the disabled button being included in the page <kbd>Tab</kbd> sequence.
+          </li>
         </ul>
       </section>
     </section>

--- a/aria-practices.html
+++ b/aria-practices.html
@@ -542,6 +542,13 @@
 
       <section class="notoc">
         <h4>WAI-ARIA Roles, States, and Properties</h4>
+        <p>This section describes the element composition for three styles of carousels:</p>
+        <ul>
+          <li>Basic: Has rotation , previous slide, and next slide controls but no slide selection controls.</li>
+          <li>Tabbed: Has basic controls plus a single tab stop for slide selection controls implemented using the tabs pattern.</li>
+          <li>Grouped: Has basic controls plus a group of tab stops for slide selection controls implemented using the button pattern. Because each slide adds an element to the page tab sequence, this is the least friendly style for keyboard users.</li>
+        </ul>
+        <h5>Basic carousel elements</h5>
         <ul>
           <li>
             A carousel container element that encompasses all components of the carousel,  including both carousel controls and slides,
@@ -568,27 +575,31 @@
             A label that changes when the button is activated clearly communicates both that slide content can change automatically and when it is doing so. 
             Note that since the label changes, the rotation control does not have any states, e.g., <code>aria-pressed</code>, specified.
           </li>
+          <li>Each slide container has role <a href="#group" class="role-reference">group</a> with the property <a href="aria-roledescription" class="property-reference">aria-roledescription</a> set to <code>slide</code>.</li>
+        </ul>
+        <h5>Tabbed Carousel Elements</h5>
+        <p>The structure of a tabbed carousel is the same as a basic carousel except that:</p>
+        <ul>
           <li>
-            If slide selection controls are present and are implemented as <a href="#tab" class="role-reference">tab</a> elements,
-            each slide container has the role <a href="#tabpanel" class="role-reference">tabpanel</a>.
-            Otherwise, each slide container has the role <a href="#group" class="role-reference">group</a>
-            and the property <a href="aria-roledescription" class="property-reference">aria-roledescription</a> set to <code>slide</code>.
+            Each slide container has role
+            <a href="#tabpanel" class="role-reference">tabpanel</a>
+            and it does not have the <code>aria-roledescription</code> property.
           </li>
-          <li>If slide selection controls are included, they are either:
-            <ul>
-              <li>
-                <strong>(Recommended)</strong> Implemented using the <a href="#tabpanel">tabs pattern</a> where each control is a <code>tab</code> element and the set of controls is grouped in a <code>tablist</code> element.
-                See the <a href="#tabpanel">tabs pattern</a> for the complete list of implementation details.
-              </li>
-              <li>Implemented as a group of buttons where:
-                <ul>
-                  <li>The set of controls is contained in an element with role group and has a label.</li>
-                  <li>Each selection control is a native button or implements the button pattern.</li>
-                  <li>The button representing the currently display slide has aria-disabled.</li> 
-                </ul>
-              </li>
-            </ul>
+          <li>
+            It has slide selection controls implemented using the
+            <a href="#tabpanel">tabs pattern</a>
+            where each control is a <code>tab</code> element and the set of controls is grouped in a <code>tablist</code>
+            element. See the
+            <a href="#tabpanel">tabs pattern</a>
+            for the complete list of implementation details.
           </li>
+        </ul>
+        <h5>Grouped Carousel</h5>
+        <p>A grouped carousel has the same structure as a basic carousel, but it also includes slide selection controls where:</p>
+        <ul>
+          <li>The set of controls is contained in an element with role group and has a label.</li>
+          <li>Each selection control is a native button or implements the button pattern.</li>
+          <li>The button representing the currently display slide has aria-disabled.</li>
         </ul>
       </section>
     </section>

--- a/aria-practices.html
+++ b/aria-practices.html
@@ -603,7 +603,7 @@
             Optionally, an element wrapping the set of slide elements has <a href="#aria-atomic" class="property-reference">aria-atomic</a> set to <code>false</code>
             and <a href="#aria-live" class="property-reference">aria-live</a> set to:
             <ul>
-              <li><code>off</code>: ifthe the carousel is automatically rotating.
+              <li><code>off</code>: if the carousel is automatically rotating.
               <li><code>polite</code>: if the carousel is <strong>NOT</strong> automatically rotating.
             </ul>
           </li>

--- a/aria-practices.html
+++ b/aria-practices.html
@@ -586,8 +586,8 @@
           </li>
           <li>It has slide selection controls implemented using the <a href="#tabpanel">tabs pattern</a> where:
             <ul>
-              <li>Each control is a <code>tab</code> element; activating the tab displays the slide associated with that tab.</li>
-              <li>the set of controls is grouped in a <code>tablist</code> element.</li>
+              <li>Each control is a <code>tab</code> element, so activating a tab displays the slide associated with that tab.</li>
+              <li>The set of controls is grouped in a <code>tablist</code> element.</li>
               <li>The <code>tab</code>, <code>tablist</code>, and <code>tabpanel</code> implement the properties specified in the <a href="#tabpanel">tabs pattern</a>.</li>
             </ul>
           </li>
@@ -595,9 +595,10 @@
         <h5>Grouped Carousel</h5>
         <p>A grouped carousel has the same structure as a basic carousel, but it also includes slide selection controls where:</p>
         <ul>
-          <li>The set of controls is contained in an element with role group and has a label.</li>
-          <li>Each selection control is a native button or implements the button pattern.</li>
-          <li>The button representing the currently display slide has aria-disabled.</li>
+          <li>The set of slide selection controls is contained in an element with role <a href="#group" class="role-reference">group</a>.</li>
+          <li>The group containing the controls has an accessible label provided by the value of <a href="#aria-label" class="property-reference">aria-label</a> that identifies the purpose of the controls, e.g., &quot;Choose slide to display&quot;.</li>
+          <li>Each control is a native button element (recommended) or implements the <a href="#button">button pattern.</a></li>
+          <li>The button representing the currently displayed slide has the property <a href="#aria-disabled" class="property-reference">aria-disabled</a> set to <code>true</code>. Note: <code>aria-disabled</code> is preferable to the HTML <code>disabled</code> attribute because it helpful for the disabled button to be included in the page tab sequence in this circumstance.</li>
         </ul>
       </section>
     </section>

--- a/aria-practices.html
+++ b/aria-practices.html
@@ -497,9 +497,9 @@
       </p>
       <p>Features needed to provide sufficient rotation control include:</p>
       <ol>
-        <li>Rotation pauses when keyboard focus enters the carousel.</li>
-        <li>Rotation pauses when the mouse hovers over the carousel.</li>
-        <li>A button for pausing and restarting rotation. This is particularly important for supporting assistive technologies operating in a mode that does not move either keyboard focus or the mouse.</li>
+        <li>Rotation stops when keyboard focus enters the carousel. It does not restart unless the user explicitly requests it to do so.</li>
+        <li>Rotation is stopped whenever the mouse is hovering over the carousel.</li>
+        <li>A button for stopping and restarting rotation. This is particularly important for supporting assistive technologies operating in a mode that does not move either keyboard focus or the mouse.</li>
         <li>Buttons for displaying the previous and next slides.</li>
         <li>Optionally, a control, or group of controls, for choosing a specific slide to display. For example, the selection controls can be marked up as tabs in a tablist with the slide represented by a tabpanel element.</li>
       </ol>
@@ -514,38 +514,15 @@
 
       <section class="notoc">
         <h4>Keyboard Interaction</h4>
-
-        <p>Moving keyboard focus to any interactive element immediately stops slide rotation.  Automated slide rotation should not resume unless explicitly requested by the user (e.g. through an optional resume rotation button)</p>
-
-        <p>For the pause, previous and next buttons:</p>
         <ul>
           <li>
-            <kbd>Tab</kbd>: The tab sequence begins with the pause button, next the previous slide button, then to interactive content in the slide and then to the next slide button.
+            Automatic slide rotation stops when any element in the carousel receives keyboard focus.
+            It does not resume unless the user activates the control for starting and stopping rotation.
           </li>
-          <li>
-            <kbd>Enter or Space</kbd>: Activates the previous or next button rotating in new slide content or pauses the rotation of the slides.
-          </li>
+          <li><kbd>Tab</kbd> and <kbd>Shift + Tab</kbd>: Move focus through the carousel as specified by the page tab sequence; no special scripting is necessary.</li>
+          <li>Button elements implement the keyboard interaction defined in the <a href="#button">button pattern</a>.</li>
+          <li>If tabs are used for slide selection, they implement the keyboard interaction defined in the <a href="#tabpanel">Tabs Pattern.</a></li>
         </ul>
-        <p>
-
-        <p>For the optional <code>tablist</code>:</p>
-        <ul>
-          <li>
-            <kbd>Tab</kbd>: The tab sequence begins with the pause button, next the tablist, the interactive slide content, previous slide button, and then to the next slide button.  Keyboard focus moves to the <code>tab</code> element representing the current slide.
-            When the tablist has keyboard focus, moves focus to the interactive slide content.
-          </li>
-          <li>
-            <kbd>Left Arrow</kbd>: moves focus to the previous tab (i.e. slide).
-            If focus is on the first tab, moves focus to the last tab.
-          </li>
-          <li>
-            <kbd>Right Arrow</kbd>: Moves focus to the next tab (i.e. slide).
-            If focus is on the last tab element, moves focus to the first tab.
-          </li>
-          <li><kbd>Home</kbd> (Optional): Moves focus to the first tab (i.e. slide).</li>
-          <li><kbd>End</kbd> (Optional): Moves focus to the last tab (i.e. slide).</li>
-        </ul>
-        <p>
       </section>
 
       <section class="notoc">

--- a/aria-practices.html
+++ b/aria-practices.html
@@ -480,16 +480,11 @@
     
     <section class="widget" id="carousel">
       <h3>Carousel (Slide Show or Image Rotator)</h3>
-      <p class="ednote">
-        This is a draft pattern that is being actively revised.
-        Please provide feedback in
-        <a href="https://github.com/w3c/aria-practices/issues/43">issue 43.</a>
-      </p>
       <p>
-        A carousel presents a set of items, referred to as slides, by rotating one or more of the slides into view.
-        Typically, only one slide is displayed at a time.
-        While a slide may contain any type of content, image carousels where each slide contains nothing more than a single image are common.
+        A carousel presents a set of items, referred to as slides, by sequentially displaying a subset of one or more slides.
+        Typically, one slide is displayed at a time, and users can activate a next or previous slide control that hides the current slide and &quot;rotates&quot; the next or previous slide into view.
         In some implementations, rotation automatically starts when the page loads, and it may also automatically stop once all the slides have been displayed.
+        While a slide may contain any type of content, image carousels where each slide contains nothing more than a single image are common.
       </p>
       <p>
         Ensuring all users can easily control and are not adversely effected by slide rotation is an essential aspect of making carousels accessible.

--- a/aria-practices.html
+++ b/aria-practices.html
@@ -479,7 +479,7 @@
     </section>
     
     <section class="widget" id="carousel">
-      <h3>Carousel (Image or Slide Rotator)</h3>
+      <h3>Carousel (Slide Show or Image Rotator)</h3>
       <p class="ednote">
         This is a draft pattern that is being actively revised.
         Please provide feedback in

--- a/aria-practices.html
+++ b/aria-practices.html
@@ -477,7 +477,111 @@
         </ul>
       </section>
     </section>
+    
+    <section class="widget" id="carousel">
+      <h3>Carousel (Image or Slide Rotator)</h3>
+      <p class="ednote">
+        This is a draft pattern that is being actively revised.
+        Please provide feedback in
+        <a href="https://github.com/w3c/aria-practices/issues/43">issue 43.</a>
+      </p>
+      <p>
+        A carousel presents a set of items, referred to as slides, by rotating, i.e., horizontally scrolling,  a subset of the slides into view at a time.
+        Typically, one slide is made visible at a time, and rotation automatically starts when the page loads.
+        In some implementations, rotation automatically stops once all the slides have been displayed.
+        While a slide may contain any type of content, image carousels where each slide contains nothing more than a single image are common.
+      </p>
+      <p>
+          Ensuring all users, especially screen reader users, can control slide rotation is an essential accessibility feature of carousels.
+          If a slide is hidden while a screen reader user is reading it, the screen reader will lose its point of regard, typically forcing the screen reader's reading cursor to the top of the page.
+          this is particularly disorienting if the user is not aware of the automatic rotation.
+        </p>
+      <p>
+        The requirements for controlling the slide rotation include pausing rotation on keyboard focus and pointer hover, an explicit pause button, previous button and a next slide buttons.  Optionally a <code>tablist</code> can be used to provide additional control over the navigation of the slides.
+      </p>
+        <dl>
+          <dt>Pause Rotation</dt>
+          <dd>The auto-rotation must stop when keyboard focus is on a slide in the carousel.  Keyboard only and screen reader users will be disoriented if keyboard focus disappears when the slides change.</dd>
+          <dd>The auto-rotation must stop when the pointer hovers over an image in the carousel.</dd>
 
+          <dt>Pause Button</dt>
+          <dd>Used to stop the auto-rotation of slides, and can optionally be a toggle to restart the rotation of slides</dd>
+          <dd>This is important to inform screen reader users using virtual reading modes to switch to application mode to stop the rotation of slides.</dd>
+
+          <dt>Previous Slide Button</dt>
+          <dd>Used to move to the previous slide in the set of slides.</dd>
+          <dd>The label for the previous button should contain information on the slide position of the previous slide in the sequence of slides and the total number of slides (e.g. Slide 3 of 6).</dd>
+
+          <dt>Next Slide Button</dt>
+          <dd>Used to move to the next slide in the set of slides.</dd>
+          <dd>The label for the next button should contain information on the slide position of the previous slide in the sequence of slides and the total number of slides (e.g. Slide 5 of 6).</dd>
+
+          <dt><code>tablist</code> Widget (optional)</dt>
+          <dd>Used to provide direct navigation to individual slides when a carousel provides visual controls indicating number of slides and direct navigation to a slide.</dd>
+          <dd>The set of controls for navigating slides can be modelled using the <code>tablist</code> pattern.</dd>
+        </dl>
+
+      <section class="notoc">
+        <h4>Example</h4>
+        <p>
+          Development of an example for this pattern is tracked by 
+          <a href="https://github.com/w3c/aria-practices/issues/458">issue 458.</a>
+        </p>
+      </section>
+
+      <section class="notoc">
+        <h4>Keyboard Interaction</h4>
+
+        <p>Moving keyboard focus to any interactive element immediately stops slide rotation.  Automated slide rotation should not resume unless explicitly requested by the user (e.g. through an optional resume rotation button)</p>
+
+        <p>For the pause, previous and next buttons:</p>
+        <ul>
+          <li>
+            <kbd>Tab</kbd>: The tab sequence begins with the pause button, next the previous slide button, then to interactive content in the slide and then to the next slide button.
+          </li>
+          <li>
+            <kbd>Enter or Space</kbd>: Activates the previous or next button rotating in new slide content or pauses the rotation of the slides.
+          </li>
+        </ul>
+        <p>
+
+        <p>For the optional <code>tablist</code>:</p>
+        <ul>
+          <li>
+            <kbd>Tab</kbd>: The tab sequence begins with the pause button, next the tablist, the interactive slide content, previous slide button, and then to the next slide button.  Keyboard focus moves to the <code>tab</code> element representing the current slide.
+            When the tablist has keyboard focus, moves focus to the interactive slide content.
+          </li>
+          <li>
+            <kbd>Left Arrow</kbd>: moves focus to the previous tab (i.e. slide).
+            If focus is on the first tab, moves focus to the last tab.
+          </li>
+          <li>
+            <kbd>Right Arrow</kbd>: Moves focus to the next tab (i.e. slide).
+            If focus is on the last tab element, moves focus to the first tab.
+          </li>
+          <li><kbd>Home</kbd> (Optional): Moves focus to the first tab (i.e. slide).</li>
+          <li><kbd>End</kbd> (Optional): Moves focus to the last tab (i.e. slide).</li>
+        </ul>
+        <p>
+      </section>
+
+      <section class="notoc">
+        <h4>WAI-ARIA Roles, States, and Properties</h4>
+        <ul>
+          <li>The <code>complementary</code> or <code>region</code> landmark used to identify the carousel should have an accessible name (e.g. "Image Carousel") indicating it contains auto-rotating slides using <code>aria-label</code>.</li>
+          <li>The pause button uses <code>aria-pressed="true"</code> to indicate the rotator is paused.</li>
+          <li>The pause button uses <code>aria-pressed="false"</code> to indicate the rotator is automatically rotating.</li>
+          <li>The element that serves as the container the for the set of tabs has role  <a class="role-reference" href="#tablist">tablist</a>. </li>
+          <li>Each element that serves as a tab has role <a class="role-reference" href="#tab">tab</a> and is contained within the element with role <code>tablist</code>.</li>
+          <li>Each element that contains slide content for a <code>tab</code> has role <a class="role-reference" href="#tabpanel">tabpanel</a>.</li>
+          <li>Each element with role <code>tab</code> has the property <a href="#aria-controls" class="property-reference">aria-controls</a> referring to its associated <code>tabpanel</code> element.</li>
+          <li>The active <code>tab</code> element has the state <a href="#aria-selected" class="state-reference">aria-selected</a> set to <code>true</code> and all other <code>tab</code> elements have it set to <code>false</code>.</li>
+          <li>Each element with role <code>tabpanel</code> has the property <a href="#aria-labelledby" class="property-reference">aria-labelledby</a> referring to its associated <code>tab</code> element. </li>
+        </ul>
+      </section>
+
+    </section>
+    
     <section class="widget" id="checkbox">
       <h3>Checkbox</h3>
       <p>WAI-ARIA supports two types of <a href="#checkbox" class="role-reference">checkbox</a> widgets:</p>

--- a/aria-practices.html
+++ b/aria-practices.html
@@ -511,35 +511,86 @@
           <a href="https://github.com/w3c/aria-practices/issues/458">issue 458.</a>
         </p>
       </section>
+      
+      <section class="notoc">
+        <h4>Terms</h4>
+        <p>The following terms are used to describe components of a carousel.</p>
+        <dl>
+          <dt>Rotation Control</dt>
+          <dd>An interactive element that stops and starts automatic slide rotation.</dd>
+          <dt>Next Slide Control</dt>
+          <dd>An interactive element, often styled as an arrow,  that displays the next slide in the rotation sequence.</dd>
+          <dt>Previous Slide Control</dt>
+          <dd>An interactive element, often styled as an arrow,  that displays the previous slide in the rotation sequence.</dd>
+          <dt>Slide Selection Controls</dt>
+          <dd>A group of elements, often styled as small dots, that enable the user to display a specific slide in the rotation sequence.</dd>
+        </dl>
+      </section>
 
       <section class="notoc">
         <h4>Keyboard Interaction</h4>
         <ul>
           <li>
             Automatic slide rotation stops when any element in the carousel receives keyboard focus.
-            It does not resume unless the user activates the control for starting and stopping rotation.
+            It does not resume unless the user activates the rotation control.
           </li>
-          <li><kbd>Tab</kbd> and <kbd>Shift + Tab</kbd>: Move focus through the carousel as specified by the page tab sequence; no special scripting is necessary.</li>
+          <li><kbd>Tab</kbd> and <kbd>Shift + Tab</kbd>: Move focus through the interactive elements of the carousel as specified by the page tab sequence; no special scripting is necessary.</li>
           <li>Button elements implement the keyboard interaction defined in the <a href="#button">button pattern</a>.</li>
-          <li>If tabs are used for slide selection, they implement the keyboard interaction defined in the <a href="#tabpanel">Tabs Pattern.</a></li>
+          <li>If tab elements are used for slide selection controls, they implement the keyboard interaction defined in the <a href="#tabpanel">Tabs Pattern.</a></li>
         </ul>
       </section>
 
       <section class="notoc">
         <h4>WAI-ARIA Roles, States, and Properties</h4>
         <ul>
-          <li>The <code>complementary</code> or <code>region</code> landmark used to identify the carousel should have an accessible name (e.g. "Image Carousel") indicating it contains auto-rotating slides using <code>aria-label</code>.</li>
-          <li>The pause button uses <code>aria-pressed="true"</code> to indicate the rotator is paused.</li>
-          <li>The pause button uses <code>aria-pressed="false"</code> to indicate the rotator is automatically rotating.</li>
-          <li>The element that serves as the container the for the set of tabs has role  <a class="role-reference" href="#tablist">tablist</a>. </li>
-          <li>Each element that serves as a tab has role <a class="role-reference" href="#tab">tab</a> and is contained within the element with role <code>tablist</code>.</li>
-          <li>Each element that contains slide content for a <code>tab</code> has role <a class="role-reference" href="#tabpanel">tabpanel</a>.</li>
-          <li>Each element with role <code>tab</code> has the property <a href="#aria-controls" class="property-reference">aria-controls</a> referring to its associated <code>tabpanel</code> element.</li>
-          <li>The active <code>tab</code> element has the state <a href="#aria-selected" class="state-reference">aria-selected</a> set to <code>true</code> and all other <code>tab</code> elements have it set to <code>false</code>.</li>
-          <li>Each element with role <code>tabpanel</code> has the property <a href="#aria-labelledby" class="property-reference">aria-labelledby</a> referring to its associated <code>tab</code> element. </li>
+          <li>
+            A carousel container element that encompasses all components of the carousel,  including both carousel controls and slides,
+            has either role <a href="#region" class="role-reference">region</a>
+            or role <a href="#group" class="role-reference">group.</a>
+            The most appropriate role for the carousel container depends on the information architecture of the page.
+            See the <a href="#aria_landmark">landmark regions guidance</a> to determine whether the carousel warrants being designated as a landmark region.
+          </li>
+          <li>The carousel container has the <a href="#aria-roledescription" class="property-reference">aria-roledescription</a> property set to <code>carousel</code>.</li>
+          <li>
+            If the carousel has a visible label, its accessible label is provided by the property
+            <a href="#aria-labelledby" class="property-reference" >aria-labelledby</a> on the carousel container set to the ID of the element containing the visible label.
+            Otherwise, an accessible label is provided by the property <a href="#aria-label" class="property-reference">aria-label</a> set on the carousel container.
+            Note that since the <code>aria-roledescription</code> is set to &quot;carousel&quot;, the label should not contain the word &quot;carousel&quot;.
+          </li>
+          <li>
+            The rotation control, next slide control, and previous slide control are
+            either native button elements with an implicit role of <a href="#button" class="role-reference">button</a> (recommended)
+            or implement the <a href="#button">button pattern</a>.
+          </li>
+          <li>
+            The rotation control has an accessible label provided by either its inner text or <a href="#aria-label" class="property-reference">aria-label</a>.
+            The label changes to match the action the button will perform, e.g., &quot;Stop slide rotation&quot; or &quot;Start slide rotation&quot;.
+            A label that changes when the button is activated clearly communicates both that slide content can change automatically and when it is doing so. 
+            Note that since the label changes, the rotation control does not have any states, e.g., <code>aria-pressed</code>, specified.
+          </li>
+          <li>
+            If slide selection controls are present and are implemented as <a href="#tab" class="role-reference">tab</a> elements,
+            each slide container has the role <a href="#tabpanel" class="role-reference">tabpanel</a>.
+            Otherwise, each slide container has the role <a href="#group" class="role-reference">group</a>
+            and the property <a href="aria-roledescription" class="property-reference">aria-roledescription</a> set to <code>slide</code>.
+          </li>
+          <li>If slide selection controls are included, they are either:
+            <ul>
+              <li>
+                <strong>(Recommended)</strong> Implemented using the <a href="#tabpanel">tabs pattern</a> where each control is a <code>tab</code> element and the set of controls is grouped in a <code>tablist</code> element.
+                See the <a href="#tabpanel">tabs pattern</a> for the complete list of implementation details.
+              </li>
+              <li>Implemented as a group of buttons where:
+                <ul>
+                  <li>The set of controls is contained in an element with role group and has a label.</li>
+                  <li>Each selection control is a native button or implements the button pattern.</li>
+                  <li>The button representing the currently display slide has aria-disabled.</li> 
+                </ul>
+              </li>
+            </ul>
+          </li>
         </ul>
       </section>
-
     </section>
     
     <section class="widget" id="checkbox">


### PR DESCRIPTION
Adds a design pattern section for carousels to resolve issue #43.

#### Preview Pattern in Feature Branch

[Carousel pattern in issue43-add-carousel-pattern branch](https://raw.githack.com/w3c/aria-practices/issue43-add-carousel-pattern/aria-practices.html#carousel)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria-practices/pull/957.html" title="Last updated on Jan 15, 2019, 12:54 AM UTC (6f2f95e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria-practices/957/08e5fe0...6f2f95e.html" title="Last updated on Jan 15, 2019, 12:54 AM UTC (6f2f95e)">Diff</a>