### PR TITLE
add example for meter

### DIFF
--- a/examples/google/meter.html
+++ b/examples/google/meter.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>Meter Blueprint</title>
+    <style>
+      [role=meter] {
+        position: relative;
+        border: 4px solid black;
+        height: 20px;
+        width: 200px;
+      }
+
+      #fill {
+        position: absolute;
+        height: 100%;
+        background-color: black;
+      }
+    </style>
+    <script>
+      /** @type {!Element} Meter element. */
+      let meterEl;
+
+      /** @type {!Element} Element visually filling the meter. */
+      let visualFillEl;
+
+      /** @type {number} Minimum value. */
+      let minUsage;
+
+      /** @type {number} Maximum value. */
+      let maxUsage;
+
+      /** @type {number} Current value. */
+      let usage;
+
+      /** Set the value randomly between the minimum and maximum. */
+      function randomizeUsage() {
+        const range = maxUsage - minUsage;
+        usage = Math.floor((Math.random() * range) + minUsage);
+        meterEl.setAttribute('aria-valuenow', usage);
+        render();
+      }
+
+      function render() {
+        const asPercentage = (100 * usage) / (maxUsage - minUsage);
+        visualFillEl.style.width = asPercentage + '%';
+      }
+
+      function init() {
+        meterEl = document.querySelector('[role=meter]');
+        visualFillEl = document.getElementById('fill');
+        minUsage = Number(meterEl.getAttribute('aria-valuemin'));
+        maxUsage = Number(meterEl.getAttribute('aria-valuemax'));
+        usage = Number(meterEl.getAttribute('aria-valuenow'));
+        render();
+        setInterval(randomizeUsage, 5000);
+      }
+
+      window.addEventListener('load', init, false);
+    </script>
+  </head>
+  <body>
+    <p>This meter changes its value randomly every 5 seconds.</p>
+    <div role="meter" aria-valuenow="90" aria-valuemin="0" aria-valuemax="128"
+         aria-label="Disk Usage">
+      <div id="fill" role="presentation"></div>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
Adds example implementation of the meter role, as described in this [draft specification](https://raw.githack.com/w3c/aria/b3aef2c3cf12c0a5d3bdb9098f2c73b7e0d5d860/index.html#meter)