### PR TITLE
Mark previously failing test as passing

### DIFF
--- a/test/tests/menubar-1.js
+++ b/test/tests/menubar-1.js
@@ -201,8 +201,7 @@ ariaTest('"aria-expanded" attribute on menubar menuitem', exampleFile, 'menuitem
   }
 });
 
-// This test is failing due to a bug reported in issue: https://github.com/w3c/aria-practices/issues/906
-ariaTest.failing('Test for role="none" on menubar li', exampleFile, 'none-role', async (t) => {
+ariaTest('Test for role="none" on menubar li', exampleFile, 'none-role', async (t) => {
   t.plan(3);
 
   const liElements = await t.context.session.findElements(By.css(ex.menubarSelector + '>li'));


### PR DESCRIPTION
A test was marked as failing and a bug reported for it (https://github.com/w3c/aria-practices/issues/906) -- but that issue was closed with a PR that fixed the bug (https://github.com/w3c/aria-practices/pull/931). The test now passed but it was still marked as "failing", thus the CI errors.

What I'm confused about is why this wasn't caught earlier?

Fixes https://github.com/w3c/aria-practices/issues/1055