### PR TITLE
Changed HTML5 references to HTML

### DIFF
--- a/aria-practices.html
+++ b/aria-practices.html
@@ -3285,22 +3285,22 @@
       Landmark regions can also be used as targets for &quot;skip links&quot; and by browser extensions to enhanced keyboard navigation.
     </p>
     <p>
-      This section explains how HTML5 sectioning elements and ARIA landmark roles
+      This section explains how HTML sectioning elements and ARIA landmark roles
       are used to make it easy for assistive technology users to understand the meaning of the layout of a page.
     </p>
     <section>
-      <h3>HTML5 Sectioning Elements</h3>
+      <h3>HTML Sectioning Elements</h3>
       <p>
-        Several HTML5 sectioning elements automatically create ARIA landmark regions.
+        Several HTML sectioning elements automatically create ARIA landmark regions.
         So, in order to provide assistive technology users with a logical view of a page,
-        it is important to understand the effects of using HTML5 sectioning elements.
-        <a href="https://www.w3.org/TR/html-aria/">More information on HTML5 element role mapping</a>.
+        it is important to understand the effects of using HTML sectioning elements.
+        [[HTML-ARIA]] contains more information on HTML element role mapping</a>.
       </p>
       <table class="widget-features">
-        <caption>Default landmark roles for HTML5 sectioning elements</caption>
+        <caption>Default landmark roles for HTML sectioning elements</caption>
         <thead>
           <tr>
-            <th>HTML5 Element</th>
+            <th>HTML Element</th>
 
             <th>Default Landmark Role</th>
           </tr>
@@ -3419,12 +3419,12 @@
         </ul>
 
         <section class="notoc">
-          <h5>HTML5 Techniques</h5>
+          <h5>HTML Techniques</h5>
           <ul>
-            <li>The HTML5 <code>header</code> element defines a <code>banner</code> landmark when its context is the <code>body</code> element.</li>
+            <li>The HTML <code>header</code> element defines a <code>banner</code> landmark when its context is the <code>body</code> element.</li>
 
             <li>
-              The HTML5 <code>header</code> element is not considered a <code>banner</code> landmark when it is descendant of any of following elements (see <a href="" class="html-mapping">HTML Accessibility Mappings</a> [[HTML-AAM]]):
+              The HTML <code>header</code> element is not considered a <code>banner</code> landmark when it is descendant of any of following elements (see <a href="" class="html-mapping">HTML Accessibility Mappings</a> [[HTML-AAM]]):
               <ul>
                 <li><code>article</code></li>
                 <li><code>aside</code></li>
@@ -3437,7 +3437,7 @@
 
           <h5>ARIA Techniques</h5>
 
-          <p>If the HTML5 <code>header</code> element technique is not being used, a <code>role=&quot;banner&quot;</code> attribute should be used to define a <code>banner</code> landmark.</p>
+          <p>If the HTML <code>header</code> element technique is not being used, a <code>role=&quot;banner&quot;</code> attribute should be used to define a <code>banner</code> landmark.</p>
         </section>
 
         <section class="notoc">
@@ -3463,13 +3463,13 @@
         </ul>
 
         <section class="notoc">
-          <h5>HTML5 Technique</h5>
+          <h5>HTML Technique</h5>
 
-          <p>Use the HTML5 <code>aside</code> element to define a <code>complementary</code> landmark.</p>
+          <p>Use the HTML <code>aside</code> element to define a <code>complementary</code> landmark.</p>
 
           <h5>ARIA Technique</h5>
 
-          <p>If the HTML5 <code>aside</code> element technique is not being used, use a <code>role=&quot;complementary&quot;</code> attribute to define a <code>complementary</code> landmark.</p>
+          <p>If the HTML <code>aside</code> element technique is not being used, use a <code>role=&quot;complementary&quot;</code> attribute to define a <code>complementary</code> landmark.</p>
         </section>
 
         <section class="notoc">
@@ -3498,13 +3498,13 @@
 
         <section class="notoc">
 
-          <h5>HTML5 Techniques</h5>
+          <h5>HTML Techniques</h5>
 
           <ul>
-            <li>The HTML5 <code>footer</code> element defines a <code>contentinfo</code> landmark when its context is the <code>body</code> element.</li>
+            <li>The HTML <code>footer</code> element defines a <code>contentinfo</code> landmark when its context is the <code>body</code> element.</li>
 
             <li>
-              The HTML5 <code>footer</code> element is not considered a <code>contentinfo</code> landmark when it is descendant of any of following elements (see <a href="" class="html-mapping">HTML Accessibility Mappings</a> [[HTML-AAM]]):
+              The HTML <code>footer</code> element is not considered a <code>contentinfo</code> landmark when it is descendant of any of following elements (see <a href="" class="html-mapping">HTML Accessibility Mappings</a> [[HTML-AAM]]):
               <ul>
                 <li><code>article</code></li>
                 <li><code>aside</code></li>
@@ -3517,7 +3517,7 @@
 
           <h5>ARIA Technique</h5>
 
-          <p>If the HTML5 <code>footer</code> element technique is not being used, a <code>role=&quot;contentinfo&quot;</code> attribute should be used to define a <code>contentinfo</code> landmark.</p>
+          <p>If the HTML <code>footer</code> element technique is not being used, a <code>role=&quot;contentinfo&quot;</code> attribute should be used to define a <code>contentinfo</code> landmark.</p>
         </section>
 
         <section class="notoc">
@@ -3556,9 +3556,9 @@
         </ul>
 
         <section class="notoc">
-          <h5>HTML5 Techniques</h5>
+          <h5>HTML Techniques</h5>
 
-          <p>The HTML5 <code>form</code> element defines a <code>form</code> landmark when it has an accessible name (e.g. <code>aria-labelledby</code>, <code>aria-label</code> or <code>title</code>).</p>
+          <p>The HTML <code>form</code> element defines a <code>form</code> landmark when it has an accessible name (e.g. <code>aria-labelledby</code>, <code>aria-label</code> or <code>title</code>).</p>
 
           <h5>ARIA Technique</h5>
 
@@ -3589,13 +3589,13 @@
         </ul>
 
         <section class="notoc">
-          <h5>HTML5 Technique</h5>
+          <h5>HTML Technique</h5>
 
-          <p>Use the HTML5 <code>main</code> element to define a <code>main</code> landmark.</p>
+          <p>Use the HTML <code>main</code> element to define a <code>main</code> landmark.</p>
 
           <h5>ARIA Technique</h5>
 
-          <p>If the HTML5 <code>main</code> element technique is not being used, use a <code>role=&quot;main&quot;</code> attribute to define a <code>main</code> landmark.</p>
+          <p>If the HTML <code>main</code> element technique is not being used, use a <code>role=&quot;main&quot;</code> attribute to define a <code>main</code> landmark.</p>
         </section>
 
         <section class="notoc">
@@ -3617,13 +3617,13 @@
         </ul>
 
         <section class="notoc">
-          <h5>HTML5 Technique</h5>
+          <h5>HTML Technique</h5>
 
-          <p>Use the HTML5 <code>nav</code> element to define a <code>navigation</code> landmark.</p>
+          <p>Use the HTML <code>nav</code> element to define a <code>navigation</code> landmark.</p>
 
           <h5>ARIA Technique</h5>
 
-          <p>If the HTML5 <code>nav</code> element technique is not being used, use a <code>role=&quot;navigation&quot;</code> attribute to define a <code>navigation</code> landmark.</p>
+          <p>If the HTML <code>nav</code> element technique is not being used, use a <code>role=&quot;navigation&quot;</code> attribute to define a <code>navigation</code> landmark.</p>
 
         </section>
 
@@ -3648,13 +3648,13 @@
         </ul>
 
         <section class="notoc">
-          <h5>HTML5 Technique</h5>
+          <h5>HTML Technique</h5>
 
-          <p>The HTML5 <code>section</code> element defines a <code>region</code> landmark when it has an accessible name (e.g. <code>aria-labelledby</code>, <code>aria-label</code> or <code>title</code>).</p>
+          <p>The HTML <code>section</code> element defines a <code>region</code> landmark when it has an accessible name (e.g. <code>aria-labelledby</code>, <code>aria-label</code> or <code>title</code>).</p>
 
           <h5>ARIA Technique</h5>
 
-          <p>If the HTML5 <code>section</code> element technique is not being used, use a <code>role=&quot;region&quot;</code> attribute to define a <code>region</code> landmark.</p>
+          <p>If the HTML <code>section</code> element technique is not being used, use a <code>role=&quot;region&quot;</code> attribute to define a <code>region</code> landmark.</p>
         </section>
 
         <section class="notoc">
@@ -3676,8 +3676,8 @@
         </ul>
 
         <section class="notoc">
-          <h5>HTML5 Technique</h5>
-          <p>There is no HTML5 element that defines a <code>search</code> landmark.</p>
+          <h5>HTML Technique</h5>
+          <p>There is no HTML element that defines a <code>search</code> landmark.</p>
 
           <h5>ARIA Technique</h5>
 
@@ -5383,7 +5383,7 @@ However, most authors do not need detailed understanding of the algorithms since
       <p> As explained in section <a href="#kbd_generalnav"></a>, all interactive UI components need to be reachable via the keyboard. This is best achieved by either including them in the tab sequence or by making them accessible from a component that is in the tab sequence, e.g., as part of a composite component. This section addresses building and managing the tab sequence, and subsequent sections cover making focusable elements that are contained within components keyboard accessible. </p>
 
       <p>
-        The <a href="https://www.w3.org/TR/html5/editing.html#attr-tabindex">HTML tabindex</a> and <a href="https://www.w3.org/TR/SVG2/struct.html#tabindexattribute">SVG tabindex</a> attributes can be used to add and remove elements from the tab sequence.
+        The [[HTML]] <a href="https://html.spec.whatwg.org/multipage/interaction.html#the-tabindex-attribute">tabindex</a> and [[SVG2]] <a href="https://www.w3.org/TR/SVG2/struct.html#tabindexattribute">tabindex</a> attributes can be used to add and remove elements from the tab sequence.
         The value of tabindex can also influence the order of the tab sequence, although authors are strongly advised not to use tabindex for that purpose.
       </p>
 

--- a/aria-practices.html
+++ b/aria-practices.html
@@ -3294,7 +3294,7 @@
         Several HTML sectioning elements automatically create ARIA landmark regions.
         So, in order to provide assistive technology users with a logical view of a page,
         it is important to understand the effects of using HTML sectioning elements.
-        [[HTML-ARIA]] contains more information on HTML element role mapping</a>.
+        [[HTML-ARIA]] contains more information on HTML element role mapping.
       </p>
       <table class="widget-features">
         <caption>Default landmark roles for HTML sectioning elements</caption>

--- a/examples/grid/LayoutGrids.html
+++ b/examples/grid/LayoutGrids.html
@@ -65,7 +65,7 @@
             <span role="gridcell" class="list-link"><a tabindex="-1" href="https://www.w3.org/TR/core-aam-1.1/">Core Accessibility API Mappings 1.1</a></span>
             <span role="gridcell" class="list-link"><a tabindex="-1" href="https://www.w3.org/WAI/intro/aria.php">WAI-ARIA Overview</a></span>
             <span role="gridcell" class="list-link"><a tabindex="-1" href="https://www.w3.org/WAI/intro/wcag">WCAG Overview</a></span>
-            <span role="gridcell" class="list-link"><a tabindex="-1" href="https://www.w3.org/TR/html5/">HTML 5 Specification</a></span>
+            <span role="gridcell" class="list-link"><a tabindex="-1" href="https://html.spec.whatwg.org/">HTML Specification</a></span>
             <span role="gridcell" class="list-link"><a tabindex="-1" href="https://www.w3.org/TR/SVG2/">SVG 2 Specification</a></span>
           </div>
         </div>

--- a/examples/landmarks/HTML5.html
+++ b/examples/landmarks/HTML5.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html >
 <html lang="en">
   <head>
-    <title>HTML5 Sectioning Elements: ARIA Landmarks Example</title>
+    <title>HTML Sectioning Elements: ARIA Landmarks Example</title>
     <meta charset="utf-8">
     <link href="css/bootstrap.css" rel="stylesheet" media="screen"/>
     <link href="css/bootstrap-theme.css" rel="stylesheet" media="screen"/>
@@ -27,7 +27,7 @@
           <nav>
             <ul class="nav nav-pills nav-stacked">
               <li><a href="index.html">Principles</a></li>
-              <li class="active"><a href="HTML5.html" aria-current="page">HTML5</a></li>
+              <li class="active"><a href="HTML5.html" aria-current="page">HTML</a></li>
               <li><a href="banner.html">Banner</a></li>
               <li><a href="complementary.html">Complementary</a></li>
               <li><a href="contentinfo.html">Contentinfo</a></li>
@@ -43,14 +43,14 @@
         </div>
         <div class="col-xs-12 col-sm-9 col-md-6 col-lg-7">
           <main>
-            <h1 id="id1">HTML5 Sectioning Elements</h1>
-            <p>It is important to understand that many HTML5 sectioning (e.g. <code>main</code>, <code>nav</code>, <code>aside</code> ...) elements by default define ARIA landmarks. 
-              If HTML5 sectioning elements are used without understanding the associated landmark structure, assistive technology users will most likely be confused and less efficient in accessing content and interacting with web pages.
+            <h1 id="id1">HTML Sectioning Elements</h1>
+            <p>It is important to understand that many HTML sectioning (e.g. <code>main</code>, <code>nav</code>, <code>aside</code> ...) elements by default define ARIA landmarks. 
+              If HTML sectioning elements are used without understanding the associated landmark structure, assistive technology users will most likely be confused and less efficient in accessing content and interacting with web pages.
             </p>
-            <table class="table table-striped table-hover" aria-label="Default landmark roles for HTML5 sectioning elements">
+            <table class="table table-striped table-hover" aria-label="Default landmark roles for HTML sectioning elements">
               <thead>
                 <tr>
-                  <th>HTML5 Element</th>
+                  <th>HTML Element</th>
                   <th>Default Landmark Role</th>
                 </tr>
               </thead>
@@ -62,7 +62,7 @@
                 <tr>
                   <td><code>footer</code></td>
                   <td><code>contentinfo</code> when in context of the <code>body</code> element.  
-                    The <code>footer</code> element is <strong>not</strong> a <code>contentinfo</code> landmark when it is a descendant of the following HTML5 sectioning elements: 
+                    The <code>footer</code> element is <strong>not</strong> a <code>contentinfo</code> landmark when it is a descendant of the following HTML sectioning elements: 
                     <ul>
                       <li><code>article</code></li>
                       <li><code>aside</code></li>
@@ -79,7 +79,7 @@
                 <tr>
                   <td><code>header</code></td>
                   <td><code>banner</code> when in context of the <code>body</code> element.
-                    The <code>header</code> element is <strong>not</strong> a <code>banner</code> landmark when it is a descendant of the following HTML5 sectioning elements:  
+                    The <code>header</code> element is <strong>not</strong> a <code>banner</code> landmark when it is a descendant of the following HTML sectioning elements:  
                     <ul>
                       <li><code>article</code></li>
                       <li><code>aside</code></li>
@@ -118,7 +118,7 @@
             </ul>
           </aside>
           <aside aria-labelledby="id3">
-            <h2 id="id3">Related W3C Documents</h2>
+            <h2 id="id3">Related Documents</h2>
             <ul>
               <li><a href="https://www.w3.org/TR/wai-aria-practices-1.1/">WAI-ARIA Authoring Practices 1.1</a></li>
               <li><a href="http://www.w3.org/TR/2014/REC-wai-aria-20140320/">WAI-ARIA 1.0 Specification</a></li>
@@ -126,7 +126,7 @@
               <li><a href="https://www.w3.org/TR/accname-aam-1.1/">Accessible Name and Description: Computation and API Mappings 1.1</a></li>
               <li><a href="http://www.w3.org/TR/core-aam-1.1/">Core Accessibility API Mappings 1.1</a></li>
               <li><a href="https://www.w3.org/TR/html-aam-1.0/">HTML Accessibility API Mappings 1.0</a></li>
-              <li><a href="http://www.w3.org/TR/html5/">HTML5 Specification</a></li>
+              <li><a href="https://html.spec.whatwg.org/">HTML Specification</a></li>
               <li><a href="https://www.w3.org/TR/html-aria/">ARIA in HTML</a>
               <li><a href="https://www.w3.org/TR/using-aria/">Using ARIA in HTML</a></li>
               <li><a href="http://www.w3.org/TR/WCAG/">WCAG Specification</a></li>

--- a/examples/landmarks/at.html
+++ b/examples/landmarks/at.html
@@ -27,7 +27,7 @@
           <nav>
             <ul class="nav nav-pills nav-stacked">
               <li><a href="index.html">Principles</a></li>
-              <li><a href="HTML5.html">HTML5</a></li>
+              <li><a href="HTML5.html">HTML</a></li>
               <li><a href="banner.html">Banner</a></li>
               <li><a href="complementary.html">Complementary</a></li>
               <li><a href="contentinfo.html">Contentinfo</a></li>
@@ -233,7 +233,7 @@
             </ul>
           </aside>
           <aside aria-labelledby="id3">
-            <h2 id="id3">Related W3C Documents</h2>
+            <h2 id="id3">Related Documents</h2>
             <ul>
               <li><a href="https://www.w3.org/TR/wai-aria-practices-1.1/">WAI-ARIA Authoring Practices 1.1</a></li>
               <li><a href="http://www.w3.org/TR/2014/REC-wai-aria-20140320/">WAI-ARIA 1.0 Specification</a></li>
@@ -241,7 +241,7 @@
               <li><a href="https://www.w3.org/TR/accname-aam-1.1/">Accessible Name and Description: Computation and API Mappings 1.1</a></li>
               <li><a href="http://www.w3.org/TR/core-aam-1.1/">Core Accessibility API Mappings 1.1</a></li>
               <li><a href="https://www.w3.org/TR/html-aam-1.0/">HTML Accessibility API Mappings 1.0</a></li>
-              <li><a href="http://www.w3.org/TR/html5/">HTML5 Specification</a></li>
+              <li><a href="https://html.spec.whatwg.org/">HTML Specification</a></li>
               <li><a href="https://www.w3.org/TR/html-aria/">ARIA in HTML</a>
               <li><a href="https://www.w3.org/TR/using-aria/">Using ARIA in HTML</a></li>
               <li><a href="http://www.w3.org/TR/WCAG/">WCAG Specification</a></li>

--- a/examples/landmarks/banner.html
+++ b/examples/landmarks/banner.html
@@ -27,7 +27,7 @@
           <nav>
             <ul class="nav nav-pills nav-stacked">
               <li><a href="index.html">Principles</a></li>
-              <li><a href="HTML5.html">HTML5</a></li>
+              <li><a href="HTML5.html">HTML</a></li>
               <li class="active"><a href="banner.html" aria-current="page">Banner</a></li>
               <li><a href="complementary.html">Complementary</a></li>
               <li><a href="contentinfo.html">Contentinfo</a></li>
@@ -59,7 +59,7 @@
             <section aria-label="Coding Techniques">
               <ul id="myTabs" class="nav nav-tabs" role="tablist">
                 <li class="active"><a id="tab1" href="#tabpanel1" aria-controls="tabpanel1" role="tab" data-toggle="tab">ARIA Techniques</a></li>
-                <li><a id="tab2" href="#tabpanel2" aria-controls="tabpanel2" role="tab" data-toggle="tab">HTML5 Techniques</a></li>
+                <li><a id="tab2" href="#tabpanel2" aria-controls="tabpanel2" role="tab" data-toggle="tab">HTML Techniques</a></li>
               </ul>
               <div class="tab-content">
                 <div id="tabpanel1" aria-labelledby="tab1" role="tabpanel" class="tab-pane active" >
@@ -74,9 +74,9 @@
                 </div>
                 <div id="tabpanel2" aria-labelledby="tab2"  role="tabpanel" class="tab-pane">
                   <ul>
-                    <li>The HTML5 <code>header</code> element defines a <code>banner</code> landmark when its context is the <code>body</code> element.</li>
+                    <li>The HTML <code>header</code> element defines a <code>banner</code> landmark when its context is the <code>body</code> element.</li>
                     <li>
-                      The HTML5 <code>header</code> element is not considered a <code>banner</code> landmark when it is descendant of any of following elements:
+                      The HTML <code>header</code> element is not considered a <code>banner</code> landmark when it is descendant of any of following elements:
                       <ul>
                         <li><code>article</code></li>
                         <li><code>aside</code></li>
@@ -86,7 +86,7 @@
                       </ul>
                     </li>
                   </ul>
-                  <h3>HTML5 Example</h3>
+                  <h3>HTML Example</h3>
                   <div class="code">
                             <strong>&lt;header&gt;</strong>
                     <br>
@@ -113,7 +113,7 @@
             </ul>
           </aside>
           <aside aria-labelledby="id3">
-            <h2 id="id3">Related W3C Documents</h2>
+            <h2 id="id3">Related Documents</h2>
             <ul>
               <li><a href="https://www.w3.org/TR/wai-aria-practices-1.1/">WAI-ARIA Authoring Practices 1.1</a></li>
               <li><a href="http://www.w3.org/TR/2014/REC-wai-aria-20140320/">WAI-ARIA 1.0 Specification</a></li>
@@ -121,7 +121,7 @@
               <li><a href="https://www.w3.org/TR/accname-aam-1.1/">Accessible Name and Description: Computation and API Mappings 1.1</a></li>
               <li><a href="http://www.w3.org/TR/core-aam-1.1/">Core Accessibility API Mappings 1.1</a></li>
               <li><a href="https://www.w3.org/TR/html-aam-1.0/">HTML Accessibility API Mappings 1.0</a></li>
-              <li><a href="http://www.w3.org/TR/html5/">HTML5 Specification</a></li>
+              <li><a href="https://html.spec.whatwg.org/">HTML Specification</a></li>
               <li><a href="https://www.w3.org/TR/html-aria/">ARIA in HTML</a>
               <li><a href="https://www.w3.org/TR/using-aria/">Using ARIA in HTML</a></li>
               <li><a href="http://www.w3.org/TR/WCAG/">WCAG Specification</a></li>

--- a/examples/landmarks/complementary.html
+++ b/examples/landmarks/complementary.html
@@ -27,7 +27,7 @@
           <nav>
             <ul class="nav nav-pills nav-stacked">
               <li><a href="index.html">Principles</a></li>
-              <li><a href="HTML5.html">HTML5</a></li>
+              <li><a href="HTML5.html">HTML</a></li>
               <li><a href="banner.html">Banner</a></li>
               <li class="active"><a href="complementary.html" aria-current="page">Complementary</a></li>
               <li><a href="contentinfo.html">Contentinfo</a></li>
@@ -59,7 +59,7 @@
                   <a id="tab1" href="#tabpanel1" aria-controls="tabpanel1" role="tab" data-toggle="tab">ARIA Techniques</a>
                 </li>
                 <li>
-                  <a id="tab2" href="#tabpanel2" aria-controls="tabpanel2" role="tab" data-toggle="tab">HTML5 Techniques</a>
+                  <a id="tab2" href="#tabpanel2" aria-controls="tabpanel2" role="tab" data-toggle="tab">HTML Techniques</a>
                 </li>
               </ul>
               <div class="tab-content">
@@ -111,9 +111,9 @@
 
                 </div>
                 <div role="tabpanel" class="tab-pane" id="tabpanel2" aria-labelledby="tab2">
-                  <p>Use the HTML5 <code>aside</code> element to define a <code>complementary</code> landmark.</p>
+                  <p>Use the HTML <code>aside</code> element to define a <code>complementary</code> landmark.</p>
 
-                  <h3>HTML5 Example: One Complementary Landmark on Page</h3>
+                  <h3>HTML Example: One Complementary Landmark on Page</h3>
                   <p>When only one complementary landmark on a page, a label is optional.</p>
                   <div class="code">
                           <strong>&lt;aside&gt;</strong>
@@ -127,7 +127,7 @@
                   <br>
                   </div>
 
-                  <h3>HTML5 Example: Multiple Complementary Landmarks</h3>
+                  <h3>HTML Example: Multiple Complementary Landmarks</h3>
                   <p>When there is more than one complementary landmark on a page, each should have a unique label.</p>
                   <div class="code">
                     <strong>&lt;aside aria-labelledby="comp1"&gt;</strong>
@@ -174,7 +174,7 @@
             </ul>
           </aside>
           <aside aria-labelledby="id3">
-            <h2 id="id3">Related W3C Documents</h2>
+            <h2 id="id3">Related Documents</h2>
             <ul>
               <li><a href="https://www.w3.org/TR/wai-aria-practices-1.1/">WAI-ARIA Authoring Practices 1.1</a></li>
               <li><a href="http://www.w3.org/TR/2014/REC-wai-aria-20140320/">WAI-ARIA 1.0 Specification</a></li>
@@ -182,7 +182,7 @@
               <li><a href="https://www.w3.org/TR/accname-aam-1.1/">Accessible Name and Description: Computation and API Mappings 1.1</a></li>
               <li><a href="http://www.w3.org/TR/core-aam-1.1/">Core Accessibility API Mappings 1.1</a></li>
               <li><a href="https://www.w3.org/TR/html-aam-1.0/">HTML Accessibility API Mappings 1.0</a></li>
-              <li><a href="http://www.w3.org/TR/html5/">HTML5 Specification</a></li>
+              <li><a href="https://html.spec.whatwg.org/">HTML Specification</a></li>
               <li><a href="https://www.w3.org/TR/html-aria/">ARIA in HTML</a>
               <li><a href="https://www.w3.org/TR/using-aria/">Using ARIA in HTML</a></li>
               <li><a href="http://www.w3.org/TR/WCAG/">WCAG Specification</a></li>

--- a/examples/landmarks/contentinfo.html
+++ b/examples/landmarks/contentinfo.html
@@ -27,7 +27,7 @@
           <nav>
             <ul class="nav nav-pills nav-stacked">
               <li><a href="index.html">Principles</a></li>
-              <li><a href="HTML5.html">HTML5</a></li>
+              <li><a href="HTML5.html">HTML</a></li>
               <li><a href="banner.html">Banner</a></li>
               <li><a href="complementary.html">Complementary</a></li>
               <li class="active"><a href="contentinfo.html" aria-current="page">Contentinfo</a></li>
@@ -58,7 +58,7 @@
             <section aria-label="Coding Techniques">
               <ul id="myTabs" class="nav nav-tabs" role="tablist">
                 <li class="active"><a id="tab1" href="#tabpanel1" aria-controls="tabpanel1" role="tab" data-toggle="tab">ARIA Techniques</a></li>
-                <li><a id="tab2" href="#tabpanel2" aria-controls="tabpanel2"  role="tab" data-toggle="tab">HTML5 Techniques</a></li>
+                <li><a id="tab2" href="#tabpanel2" aria-controls="tabpanel2"  role="tab" data-toggle="tab">HTML Techniques</a></li>
               </ul>
               <div class="tab-content">
                 <div id="tabpanel1" aria-labelledby="tab1" role="tabpanel" class="tab-pane active">
@@ -76,9 +76,9 @@
                 </div>
                 <div id="tabpanel2" aria-labelledby="tab2" role="tabpanel" class="tab-pane">
                   <ul>
-                    <li>The HTML5 <code>footer</code> element defines a <code>contentinfo</code> landmark when its context is the <code>body</code> element.</li>
+                    <li>The HTML <code>footer</code> element defines a <code>contentinfo</code> landmark when its context is the <code>body</code> element.</li>
                     <li>
-                      The HTML5 <code>footer</code> element is not considered a <code>contentinfo</code> landmark when it is descendant of any of following elements:
+                      The HTML <code>footer</code> element is not considered a <code>contentinfo</code> landmark when it is descendant of any of following elements:
                       <ul>
                         <li><code>article</code></li>
                         <li><code>aside</code></li>
@@ -88,7 +88,7 @@
                       </ul>
                     </li>
                   </ul>
-                  <h3>HTML5 Example</h3>
+                  <h3>HTML Example</h3>
                     <div class="code">
                             <strong>&lt;footer&gt;</strong>
                     <br>
@@ -118,7 +118,7 @@
             </ul>
           </aside>
           <aside aria-labelledby="id3">
-            <h2 id="id3">Related W3C Documents</h2>
+            <h2 id="id3">Related Documents</h2>
             <ul>
               <li><a href="https://www.w3.org/TR/wai-aria-practices-1.1/">WAI-ARIA Authoring Practices 1.1</a></li>
               <li><a href="http://www.w3.org/TR/2014/REC-wai-aria-20140320/">WAI-ARIA 1.0 Specification</a></li>
@@ -126,7 +126,7 @@
               <li><a href="https://www.w3.org/TR/accname-aam-1.1/">Accessible Name and Description: Computation and API Mappings 1.1</a></li>
               <li><a href="http://www.w3.org/TR/core-aam-1.1/">Core Accessibility API Mappings 1.1</a></li>
               <li><a href="https://www.w3.org/TR/html-aam-1.0/">HTML Accessibility API Mappings 1.0</a></li>
-              <li><a href="http://www.w3.org/TR/html5/">HTML5 Specification</a></li>
+              <li><a href="https://html.spec.whatwg.org/">HTML Specification</a></li>
               <li><a href="https://www.w3.org/TR/html-aria/">ARIA in HTML</a>
               <li><a href="https://www.w3.org/TR/using-aria/">Using ARIA in HTML</a></li>
               <li><a href="http://www.w3.org/TR/WCAG/">WCAG Specification</a></li>

--- a/examples/landmarks/form.html
+++ b/examples/landmarks/form.html
@@ -59,7 +59,7 @@
           <nav>
             <ul class="nav nav-pills nav-stacked">
               <li><a href="index.html">Principles</a></li>
-              <li><a href="HTML5.html">HTML5</a></li>
+              <li><a href="HTML5.html">HTML</a></li>
               <li><a href="banner.html">Banner</a></li>
               <li><a href="complementary.html">Complementary</a></li>
               <li><a href="contentinfo.html">Contentinfo</a></li>
@@ -97,7 +97,7 @@
             <section aria-label="Coding Techniques">
               <ul id="myTabs" class="nav nav-tabs" role="tablist">
                 <li class="active"><a  id="tab1" href="#tabpanel1" aria-controls="tabpanel1"  role="tab" data-toggle="tab">ARIA Techniques</a></li>
-                <li><a  id="tab2" href="#tabpanel2" aria-controls="tabpanel2"  role="tab" data-toggle="tab">HTML5 Techniques</a></li>
+                <li><a  id="tab2" href="#tabpanel2" aria-controls="tabpanel2"  role="tab" data-toggle="tab">HTML Techniques</a></li>
               </ul>
               <div class="tab-content">
                 <div id="tabpanel1" aria-labelledby="tab1" role="tabpanel" class="tab-pane active">
@@ -184,7 +184,7 @@
                 <div id="tabpanel2" aria-labelledby="tab2" role="tabpanel" class="tab-pane">
                   <p>If a <code>form</code> element has an accessible name it is considered <code>form</code> landmark.</p>
 
-                  <h3>HTML5 Form Landmark Example</h3>
+                  <h3>HTML Form Landmark Example</h3>
 
                   <p>Assume the following two forms (e.g. add contact and add organization) can be independently submitted from the same web page.</p>
 
@@ -275,7 +275,7 @@
             </ul>
           </aside>
           <aside aria-labelledby="id3">
-            <h2 id="id3">Related W3C Documents</h2>
+            <h2 id="id3">Related Documents</h2>
             <ul>
               <li><a href="https://www.w3.org/TR/wai-aria-practices-1.1/">WAI-ARIA Authoring Practices 1.1</a></li>
               <li><a href="http://www.w3.org/TR/2014/REC-wai-aria-20140320/">WAI-ARIA 1.0 Specification</a></li>
@@ -283,7 +283,7 @@
               <li><a href="https://www.w3.org/TR/accname-aam-1.1/">Accessible Name and Description: Computation and API Mappings 1.1</a></li>
               <li><a href="http://www.w3.org/TR/core-aam-1.1/">Core Accessibility API Mappings 1.1</a></li>
               <li><a href="https://www.w3.org/TR/html-aam-1.0/">HTML Accessibility API Mappings 1.0</a></li>
-              <li><a href="http://www.w3.org/TR/html5/">HTML5 Specification</a></li>
+              <li><a href="https://html.spec.whatwg.org/">HTML Specification</a></li>
               <li><a href="https://www.w3.org/TR/html-aria/">ARIA in HTML</a>
               <li><a href="https://www.w3.org/TR/using-aria/">Using ARIA in HTML</a></li>
               <li><a href="http://www.w3.org/TR/WCAG/">WCAG Specification</a></li>

--- a/examples/landmarks/index.html
+++ b/examples/landmarks/index.html
@@ -27,7 +27,7 @@
           <nav>
             <ul class="nav nav-pills nav-stacked">
               <li class="active"><a href="index.html" aria-current="page">Principles</a></li>
-              <li><a href="HTML5.html">HTML5</a></li>
+              <li><a href="HTML5.html">HTML</a></li>
               <li><a href="banner.html">Banner</a></li>
               <li><a href="complementary.html">Complementary</a></li>
               <li><a href="contentinfo.html">Contentinfo</a></li>
@@ -49,7 +49,7 @@
               The use of landmarks roles support keyboard navigation to the structure of a web page for screen reader users, and can be used as targets for author supplied "skip links" and browser extensions for enhanced keyboard navigation.
             </p>
             <p>This section is intended to assist designers, developers and quality assurance staff in defining and understanding the importance of logical, usable, and accessible layout for assistive technologies 
-              using HTML5 sectioning elements and ARIA landmark roles.
+              using HTML sectioning elements and ARIA landmark roles.
             </p>
             <p>Due to the complexity of today's web content, if using landmarks, <strong>all perceivable content</strong> should reside in a semantically meaningful landmark in order that content is not missed by the user.</p>
 
@@ -114,7 +114,7 @@
             </ul>
           </aside>
           <aside aria-labelledby="id3">
-            <h2 id="id3">Related W3C Documents</h2>
+            <h2 id="id3">Related Documents</h2>
             <ul>
               <li><a href="https://www.w3.org/TR/wai-aria-practices-1.1/">WAI-ARIA Authoring Practices 1.1</a></li>
               <li><a href="http://www.w3.org/TR/2014/REC-wai-aria-20140320/">WAI-ARIA 1.0 Specification</a></li>
@@ -122,7 +122,7 @@
               <li><a href="https://www.w3.org/TR/accname-aam-1.1/">Accessible Name and Description: Computation and API Mappings 1.1</a></li>
               <li><a href="http://www.w3.org/TR/core-aam-1.1/">Core Accessibility API Mappings 1.1</a></li>
               <li><a href="https://www.w3.org/TR/html-aam-1.0/">HTML Accessibility API Mappings 1.0</a></li>
-              <li><a href="http://www.w3.org/TR/html5/">HTML5 Specification</a></li>
+              <li><a href="https://html.spec.whatwg.org/">HTML Specification</a></li>
               <li><a href="https://www.w3.org/TR/html-aria/">ARIA in HTML</a>
               <li><a href="https://www.w3.org/TR/using-aria/">Using ARIA in HTML</a></li>
               <li><a href="http://www.w3.org/TR/WCAG/">WCAG Specification</a></li>

--- a/examples/landmarks/main.html
+++ b/examples/landmarks/main.html
@@ -28,7 +28,7 @@
           <nav>
             <ul class="nav nav-pills nav-stacked">
               <li><a href="index.html">Principles</a></li>
-              <li><a href="HTML5.html">HTML5</a></li>
+              <li><a href="HTML5.html">HTML</a></li>
               <li><a href="banner.html">Banner</a></li>
               <li><a href="complementary.html">Complementary</a></li>
               <li><a href="contentinfo.html">Contentinfo</a></li>
@@ -59,7 +59,7 @@
             <section aria-label="Coding Techniques">
               <ul id="myTabs" class="nav nav-tabs" role="tablist">
                 <li role="presentation" class="active"><a id="tab1" href="#tabpanel1" aria-controls="tabpanel1" role="tab" data-toggle="tab">ARIA Techniques</a></li>
-                <li role="presentation"><a id="tab2" href="#tabpanel2" aria-controls="tabpanel2" role="tab" data-toggle="tab">HTML5 Techniques</a></li>
+                <li role="presentation"><a id="tab2" href="#tabpanel2" aria-controls="tabpanel2" role="tab" data-toggle="tab">HTML Techniques</a></li>
               </ul>
               <div class="tab-content">
                 <div id="tabpanel1" aria-labelledby="tab1" role="tabpanel" class="tab-pane active">
@@ -112,9 +112,9 @@
                 </div>
                 <div id="tabpanel2" aria-labelledby="tab2" role="tabpanel" class="tab-pane">
 
-                  <p>Use the HTML5 <code>main</code> element to define a <code>main</code> landmark.</p>
+                  <p>Use the HTML <code>main</code> element to define a <code>main</code> landmark.</p>
 
-                  <h3>HTML5 Example: One Main Landmark</h3>
+                  <h3>HTML Example: One Main Landmark</h3>
 
                   <p>When only one main landmark on a page, a label is optional.</p>
 
@@ -129,7 +129,7 @@
                     <strong>&lt;/main&gt;</strong>
                   </div>
                   
-                  <h3>HTML5 Example: Multiple Main Landmarks</h3>
+                  <h3>HTML Example: Multiple Main Landmarks</h3>
 
                   <p>When there is more than one main landmark on a page, each should have a unique label.</p>
 
@@ -175,7 +175,7 @@
             </ul>
           </aside>
           <aside aria-labelledby="id3">
-            <h2 id="id3">Related W3C Documents</h2>
+            <h2 id="id3">Related Documents</h2>
             <ul>
               <li><a href="https://www.w3.org/TR/wai-aria-practices-1.1/">WAI-ARIA Authoring Practices 1.1</a></li>
               <li><a href="http://www.w3.org/TR/2014/REC-wai-aria-20140320/">WAI-ARIA 1.0 Specification</a></li>
@@ -183,7 +183,7 @@
               <li><a href="https://www.w3.org/TR/accname-aam-1.1/">Accessible Name and Description: Computation and API Mappings 1.1</a></li>
               <li><a href="http://www.w3.org/TR/core-aam-1.1/">Core Accessibility API Mappings 1.1</a></li>
               <li><a href="https://www.w3.org/TR/html-aam-1.0/">HTML Accessibility API Mappings 1.0</a></li>
-              <li><a href="http://www.w3.org/TR/html5/">HTML5 Specification</a></li>
+              <li><a href="https://html.spec.whatwg.org/">HTML Specification</a></li>
               <li><a href="https://www.w3.org/TR/html-aria/">ARIA in HTML</a>
               <li><a href="https://www.w3.org/TR/aria-in-html/">Using ARIA in HTML</a></li>
               <li><a href="http://www.w3.org/TR/WCAG/">WCAG Specification</a></li>

--- a/examples/landmarks/navigation.html
+++ b/examples/landmarks/navigation.html
@@ -27,7 +27,7 @@
           <nav>
             <ul class="nav nav-pills nav-stacked">
               <li><a href="index.html">Principles</a></li>
-              <li><a href="HTML5.html">HTML5</a></li>
+              <li><a href="HTML5.html">HTML</a></li>
               <li><a href="banner.html">Banner</a></li>
               <li><a href="complementary.html">Complementary</a></li>
               <li><a href="contentinfo.html">Contentinfo</a></li>
@@ -54,7 +54,7 @@
             <section aria-label="Coding Techniques">
               <ul id="myTabs" class="nav nav-tabs" role="tablist">
                 <li class="active"><a id="tab1" href="#tabpanel1" aria-controls="tabpanel1" role="tab" data-toggle="tab">ARIA Techniques</a></li>
-                <li><a id="tab2" href="#tabpanel2" aria-controls="tabpanel2" role="tab" data-toggle="tab">HTML5 Techniques</a></li>
+                <li><a id="tab2" href="#tabpanel2" aria-controls="tabpanel2" role="tab" data-toggle="tab">HTML Techniques</a></li>
               </ul>
               <div class="tab-content">
                 <div  id="tabpanel1" aria-labelledby="tab1" role="tabpanel" class="tab-pane active">
@@ -114,9 +114,9 @@
                 </div>
 
                 <div id="tabpanel2" aria-labelledby="tab2" role="tabpanel" class="tab-pane">
-                  <p>Use the HTML5 <code>nav</code> element to define a <code>navigation</code> landmark.</p>
+                  <p>Use the HTML <code>nav</code> element to define a <code>navigation</code> landmark.</p>
 
-                  <h3>HTML5 Example: One Navigation Landmark</h3>
+                  <h3>HTML Example: One Navigation Landmark</h3>
                   <p>When only one navigation landmark on a page, a label is optional.</p>
 
                   <div class="code">
@@ -135,7 +135,7 @@
                     <strong>&lt;/nav&gt;</strong>
                   </div>
 
-                  <h3>HTML5 Example: More Than One Navigation Landmark Example</h3>
+                  <h3>HTML Example: More Than One Navigation Landmark Example</h3>
                   <p>When there is more than one navigation landmark on a page, each should have a unique label.</p>
                   <div class="code">
                     <strong>&lt;nav aria-labelledby="<em>nav1</em>"&gt;</strong>
@@ -187,7 +187,7 @@
             </ul>
           </aside>
           <aside aria-labelledby="id3">
-            <h2 id="id3">Related W3C Documents</h2>
+            <h2 id="id3">Related Documents</h2>
             <ul>
               <li><a href="https://www.w3.org/TR/wai-aria-practices-1.1/">WAI-ARIA Authoring Practices 1.1</a></li>
               <li><a href="http://www.w3.org/TR/2014/REC-wai-aria-20140320/">WAI-ARIA 1.0 Specification</a></li>
@@ -195,7 +195,7 @@
               <li><a href="https://www.w3.org/TR/accname-aam-1.1/">Accessible Name and Description: Computation and API Mappings 1.1</a></li>
               <li><a href="http://www.w3.org/TR/core-aam-1.1/">Core Accessibility API Mappings 1.1</a></li>
               <li><a href="https://www.w3.org/TR/html-aam-1.0/">HTML Accessibility API Mappings 1.0</a></li>
-              <li><a href="http://www.w3.org/TR/html5/">HTML5 Specification</a></li>
+              <li><a href="https://html.spec.whatwg.org/">HTML Specification</a></li>
               <li><a href="https://www.w3.org/TR/html-aria/">ARIA in HTML</a>
               <li><a href="https://www.w3.org/TR/using-aria/">Using ARIA in HTML</a></li>
               <li><a href="http://www.w3.org/TR/WCAG/">WCAG Specification</a></li>

--- a/examples/landmarks/region.html
+++ b/examples/landmarks/region.html
@@ -27,7 +27,7 @@
           <nav>
             <ul class="nav nav-pills nav-stacked">
               <li><a href="index.html">Principles</a></li>
-              <li><a href="HTML5.html">HTML5</a></li>
+              <li><a href="HTML5.html">HTML</a></li>
               <li><a href="banner.html">Banner</a></li>
               <li><a href="complementary.html">Complementary</a></li>
               <li><a href="contentinfo.html">Contentinfo</a></li>
@@ -57,7 +57,7 @@
             <section aria-label="Coding Techniques">
               <ul id="myTabs" class="nav nav-tabs" role="tablist">
                 <li class="active"><a id="tab1" href="#tabpanel1" aria-controls="tabpanel1" role="tab" data-toggle="tab">ARIA Techniques</a></li>
-                <li><a id="tab2" href="#tabpanel2" aria-controls="tabpanel2"  role="tab" data-toggle="tab">HTML5 Techniques</a></li>
+                <li><a id="tab2" href="#tabpanel2" aria-controls="tabpanel2"  role="tab" data-toggle="tab">HTML Techniques</a></li>
               </ul>
 
               <section aria-label="Coding Techniques">
@@ -100,9 +100,9 @@
                 </div>
 
                 <div  id="tabpanel2" aria-labelledby="tab2" role="tabpanel" class="tab-pane">
-                  <p>Use the HTML5 <code>section</code> element to define a <code>region</code> landmark.</p>
+                  <p>Use the HTML <code>section</code> element to define a <code>region</code> landmark.</p>
 
-                  <h3>HTML5 Example: Using <code>section[aria-labelledby]</code> attribute</h3>
+                  <h3>HTML Example: Using <code>section[aria-labelledby]</code> attribute</h3>
                   <p>Defines a label for each region using existing content on the page.</p>
                   <div class="code">
                     &lt;main&gt;
@@ -137,7 +137,7 @@
                     &lt;/main&gt;
                   </div>
 
-                   <h3>HTML5 Example: Using <code>section[aria-label]</code> attribute</h3>
+                   <h3>HTML Example: Using <code>section[aria-label]</code> attribute</h3>
                   <p>Defines a label for each region using attribute value that is only visible to assistive technologies.</p>
                   <div class="code">
                     &lt;main&gt;
@@ -172,7 +172,7 @@
                     &lt;/main&gt;
                   </div>
 
-                  <h3>HTML5 Example: Using <code>section[title]</code> attribute</h3>
+                  <h3>HTML Example: Using <code>section[title]</code> attribute</h3>
                   <p>Defines a label for each region using attribute value that maybe available as a tooltip on some browsers.</p>
                   <br>
                   <div class="code">
@@ -226,7 +226,7 @@
             </ul>
           </aside>
           <aside aria-labelledby="id3">
-            <h2 id="id3">Related W3C Documents</h2>
+            <h2 id="id3">Related Documents</h2>
             <ul>
               <li><a href="https://www.w3.org/TR/wai-aria-practices-1.1/">WAI-ARIA Authoring Practices 1.1</a></li>
               <li><a href="http://www.w3.org/TR/2014/REC-wai-aria-20140320/">WAI-ARIA 1.0 Specification</a></li>
@@ -234,7 +234,7 @@
               <li><a href="https://www.w3.org/TR/accname-aam-1.1/">Accessible Name and Description: Computation and API Mappings 1.1</a></li>
               <li><a href="http://www.w3.org/TR/core-aam-1.1/">Core Accessibility API Mappings 1.1</a></li>
               <li><a href="https://www.w3.org/TR/html-aam-1.0/">HTML Accessibility API Mappings 1.0</a></li>
-              <li><a href="http://www.w3.org/TR/html5/">HTML5 Specification</a></li>
+              <li><a href="https://html.spec.whatwg.org/">HTML Specification</a></li>
               <li><a href="https://www.w3.org/TR/html-aria/">ARIA in HTML</a>
               <li><a href="https://www.w3.org/TR/using-aria/">Using ARIA in HTML</a></li>
               <li><a href="http://www.w3.org/TR/WCAG/">WCAG Specification</a></li>

--- a/examples/landmarks/resources.html
+++ b/examples/landmarks/resources.html
@@ -28,7 +28,7 @@
                     <nav>
                         <ul class="nav nav-pills nav-stacked">
                             <li><a href="index.html">Principles</a></li>
-                            <li><a href="HTML5.html">HTML5</a></li>
+                            <li><a href="HTML5.html">HTML</a></li>
                             <li><a href="banner.html">Banner</a></li>
                             <li><a href="complementary.html">Complementary</a></li>
                             <li><a href="contentinfo.html">Contentinfo</a></li>
@@ -54,7 +54,7 @@
                             <li><a href="https://www.w3.org/TR/WCAG20-TECHS/aria#ARIA20">ARIA20: Using the region role to identify a region of the page</a> (WCAG 2.0 Technique)</li>
                             <li><a href="https://alistapart.com/column/wai-finding-with-aria-landmark-roles">WAI-finding with ARIA Landmark Roles</a> (A List Apart)</li>
                             <li><a href="https://www.paciellogroup.com/blog/2013/02/using-wai-aria-landmarks-2013/">Using WAI-ARIA Landmarks – 2013</a> (Paciello Group)</li>
-                            <li><a href="https://dequeuniversity.com/assets/html/jquery-summit/html5/slides/landmarks.html">HTML 5 and ARIA Landmarks</a> (Deque University)</li>
+                            <li><a href="https://dequeuniversity.com/assets/html/jquery-summit/html5/slides/landmarks.html">HTML and ARIA Landmarks</a> (Deque University)</li>
                             <li><a href="https://www.paciellogroup.com/blog/2015/01/basic-screen-reader-commands-for-accessibility-testing/">Basic screen reader commands for accessibility testing</a>  (Paciello Group)</li>
                             <li><a href="http://webaim.org/projects/screenreadersurvey6/#landmarks">Screen Reader User Survey #6 Results: Landmarks/Regions</a> (WebAIM)</li>
                           </ul>
@@ -93,7 +93,7 @@
                     </aside>
 
                     <aside aria-labelledby="id3">
-            <h2 id="id3">Related W3C Documents</h2>
+            <h2 id="id3">Related Documents</h2>
             <ul>
               <li><a href="https://www.w3.org/TR/wai-aria-practices-1.1/">WAI-ARIA Authoring Practices 1.1</a></li>
               <li><a href="http://www.w3.org/TR/2014/REC-wai-aria-20140320/">WAI-ARIA 1.0 Specification</a></li>
@@ -101,7 +101,7 @@
               <li><a href="https://www.w3.org/TR/accname-aam-1.1/">Accessible Name and Description: Computation and API Mappings 1.1</a></li>
               <li><a href="http://www.w3.org/TR/core-aam-1.1/">Core Accessibility API Mappings 1.1</a></li>
               <li><a href="https://www.w3.org/TR/html-aam-1.0/">HTML Accessibility API Mappings 1.0</a></li>
-              <li><a href="http://www.w3.org/TR/html5/">HTML5 Specification</a></li>
+              <li><a href="https://html.spec.whatwg.org/">HTML Specification</a></li>
               <li><a href="https://www.w3.org/TR/html-aria/">ARIA in HTML</a>
               <li><a href="https://www.w3.org/TR/using-aria/">Using ARIA in HTML</a></li>
               <li><a href="http://www.w3.org/TR/WCAG/">WCAG Specification</a></li>

--- a/examples/landmarks/resources.html
+++ b/examples/landmarks/resources.html
@@ -54,7 +54,7 @@
                             <li><a href="https://www.w3.org/TR/WCAG20-TECHS/aria#ARIA20">ARIA20: Using the region role to identify a region of the page</a> (WCAG 2.0 Technique)</li>
                             <li><a href="https://alistapart.com/column/wai-finding-with-aria-landmark-roles">WAI-finding with ARIA Landmark Roles</a> (A List Apart)</li>
                             <li><a href="https://www.paciellogroup.com/blog/2013/02/using-wai-aria-landmarks-2013/">Using WAI-ARIA Landmarks – 2013</a> (Paciello Group)</li>
-                            <li><a href="https://dequeuniversity.com/assets/html/jquery-summit/html5/slides/landmarks.html">HTML and ARIA Landmarks</a> (Deque University)</li>
+                            <li><a href="https://dequeuniversity.com/assets/html/jquery-summit/html5/slides/landmarks.html">HTML 5 and ARIA Landmarks</a> (Deque University)</li>
                             <li><a href="https://www.paciellogroup.com/blog/2015/01/basic-screen-reader-commands-for-accessibility-testing/">Basic screen reader commands for accessibility testing</a>  (Paciello Group)</li>
                             <li><a href="http://webaim.org/projects/screenreadersurvey6/#landmarks">Screen Reader User Survey #6 Results: Landmarks/Regions</a> (WebAIM)</li>
                           </ul>

--- a/examples/landmarks/search.html
+++ b/examples/landmarks/search.html
@@ -27,7 +27,7 @@
           <nav>
             <ul class="nav nav-pills nav-stacked">
               <li><a href="index.html">Principles</a></li>
-              <li><a href="HTML5.html">HTML5</a></li>
+              <li><a href="HTML5.html">HTML</a></li>
               <li><a href="banner.html">Banner</a></li>
               <li><a href="complementary.html">Complementary</a></li>
               <li><a href="contentinfo.html">Contentinfo</a></li>
@@ -57,7 +57,7 @@
             <section aria-label="Coding Techniques">
               <ul id="myTabs" class="nav nav-tabs" role="tablist">
                 <li class="active"><a id="tab1" href="#tabpanel1" aria-controls="tabpanel1" role="tab" data-toggle="tab">ARIA Techniques</a></li>
-                <li><a id="tab2" href="#tabpanel2" aria-controls="tabpanel2" role="tab" data-toggle="tab">HTML5 Techniques</a></li>
+                <li><a id="tab2" href="#tabpanel2" aria-controls="tabpanel2" role="tab" data-toggle="tab">HTML Techniques</a></li>
               </ul>
               <div class="tab-content">
                 <div id="tabpanel1" aria-labelledby="tab1" role="tabpanel" class="tab-pane active">
@@ -85,7 +85,7 @@
                   </div>
                </div>
                 <div id="tabpanel2" aria-labelledby="tab2" role="tabpanel" class="tab-pane">
-                  <p>There is no HTML5 element that defines a <code>search</code> landmark.</p>
+                  <p>There is no HTML element that defines a <code>search</code> landmark.</p>
                 </div>
               </div>
             </section>
@@ -106,7 +106,7 @@
             </ul>
           </aside>
           <aside aria-labelledby="id3">
-            <h2 id="id3">Related W3C Documents</h2>
+            <h2 id="id3">Related Documents</h2>
             <ul>
               <li><a href="https://www.w3.org/TR/wai-aria-practices-1.1/">WAI-ARIA Authoring Practices 1.1</a></li>
               <li><a href="http://www.w3.org/TR/2014/REC-wai-aria-20140320/">WAI-ARIA 1.0 Specification</a></li>
@@ -114,7 +114,7 @@
               <li><a href="https://www.w3.org/TR/accname-aam-1.1/">Accessible Name and Description: Computation and API Mappings 1.1</a></li>
               <li><a href="http://www.w3.org/TR/core-aam-1.1/">Core Accessibility API Mappings 1.1</a></li>
               <li><a href="https://www.w3.org/TR/html-aam-1.0/">HTML Accessibility API Mappings 1.0</a></li>
-              <li><a href="http://www.w3.org/TR/html5/">HTML5 Specification</a></li>
+              <li><a href="https://html.spec.whatwg.org/">HTML Specification</a></li>
               <li><a href="https://www.w3.org/TR/html-aria/">ARIA in HTML</a>
               <li><a href="https://www.w3.org/TR/using-aria/">Using ARIA in HTML</a></li>
               <li><a href="http://www.w3.org/TR/WCAG/">WCAG Specification</a></li>


### PR DESCRIPTION
- Changes all HTML5 References to HTML
- Changes reference in Landmark examples to WHATWG HTML spec
- Modify Header of references section from "Related W3C Documents" to "Related Documents"
- Adds References to [[SVG2]], [[HTML]] and [[HTML-ARIA]] so these appear correctly in the references section

Resolves #1020


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria-practices/pull/1058.html" title="Last updated on Jun 28, 2019, 11:50 PM UTC (fdfce8c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria-practices/1058/37da361...fdfce8c.html" title="Last updated on Jun 28, 2019, 11:50 PM UTC (fdfce8c)">Diff</a>