### PR TITLE
Naming and describing section: Remove bibliography reference

### DIFF
--- a/aria-practices.html
+++ b/aria-practices.html
@@ -4060,7 +4060,7 @@ However, most authors do not need detailed understanding of the algorithms since
  &lt;tr>&lt;td>30 May &lt;td>Closed
  &lt;tr>&lt;td>6 June &lt;td>11:00-16:00
 &lt;/table></code></pre>
-          <p>The following example gives the table a number ("Table 1") so it can be referenced. [[?CALORIC-RESTRICTION]]</p>
+          <p>The following example gives the table a number (<q>Table 1</q>) so it can be referenced. </p>
           <pre><code>&lt;table>
  &lt;caption>Table 1. Traditional dietary intake of Okinawans and other Japanese circa 1950&lt;/caption>
  &lt;thead>
@@ -4077,6 +4077,7 @@ However, most authors do not need detailed understanding of the algorithms since
   [...]
 
 &lt;/table></code></pre>
+          <p>Note: Above table content is from <a href="https://www.ncbi.nlm.nih.gov/pubmed/17986602">Caloric restriction, the traditional Okinawan diet, and healthy aging: the diet of the world's longest-lived people and its potential impact on morbidity and life span</a>.</p>
           <p>Similarly, the HTML <code>figure</code> element can be given a caption using the <code>figcaption</code> element. The caption can appear before or after the figure, but it is more common for figures to have the caption after.</p>
           <pre><code>&lt;figure>
  &lt;img alt="Painting of a person walking in a desert." src="Hole_JesusalDesierto.jpg">

--- a/common/biblio.js
+++ b/common/biblio.js
@@ -34,10 +34,5 @@ var biblio = {
 	},
 	"WAI-ARIA": {
 		"aliasOf": "WAI-ARIA-1.1",
-	},
-  "CALORIC-RESTRICTION": {
-    "href": "https://www.ncbi.nlm.nih.gov/pubmed/17986602",
-    "title": "Caloric restriction, the traditional Okinawan diet, and healthy aging: the diet of the world's longest-lived people and its potential impact on morbidity and life span",
-    "publisher": "The National Center for Biotechnology Information"
-  }
+	}
 };


### PR DESCRIPTION
PR #994 included changes to common/biblio.js that should not have been merged
because that file is maintained outside the aria-practices repository.
The change was addition of a reference to an external site.
This commit removes the common/biblio.js changes and the reference to them.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria-practices/pull/1059.html" title="Last updated on Jun 28, 2019, 8:04 PM UTC (d1fa8bc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria-practices/1059/745105f...d1fa8bc.html" title="Last updated on Jun 28, 2019, 8:04 PM UTC (d1fa8bc)">Diff</a>