### PR TITLE
fixed linting issues and the return key reference for radio 2 example

### DIFF
--- a/examples/radio/radio-2/js/radioButtonActiveDescendant.js
+++ b/examples/radio/radio-2/js/radioButtonActiveDescendant.js
@@ -13,35 +13,18 @@
 *
 */
 var RadioButtonActiveDescendant = function (domNode, groupObj) {
-
   this.domNode = domNode;
   this.radioGroup = groupObj;
-
-  this.keyCode = Object.freeze({
-    'TAB': 9,
-    'RETURN': 13,
-    'ESC': 27,
-    'SPACE': 32,
-    'PAGEUP': 33,
-    'PAGEDOWN': 34,
-    'END': 35,
-    'HOME': 36,
-    'LEFT': 37,
-    'UP': 38,
-    'RIGHT': 39,
-    'DOWN': 40
-  });
 };
 
 RadioButtonActiveDescendant.prototype.init = function () {
   this.domNode.setAttribute('aria-checked', 'false');
-  this.domNode.addEventListener('click',      this.handleClick.bind(this));
+  this.domNode.addEventListener('click', this.handleClick.bind(this));
 
 };
 
 /* EVENT HANDLERS */
 
-RadioButtonActiveDescendant.prototype.handleClick = function (event) {
-  console.log('click');
+RadioButtonActiveDescendant.prototype.handleClick = function () {
   this.radioGroup.setChecked(this);
 };

--- a/examples/radio/radio-2/js/radioGroupActiveDescendant.js
+++ b/examples/radio/radio-2/js/radioGroupActiveDescendant.js
@@ -52,9 +52,6 @@ RadioGroup.prototype.init = function () {
     var rb = new RadioButtonActiveDescendant(rbs[i], this);
     rb.init();
     this.radioButtons.push(rb);
-
-    console.log(rb);
-
     if (!this.firstRadioButton) {
       this.firstRadioButton = rb;
     }
@@ -118,14 +115,11 @@ RadioGroup.prototype.getCurrentRadioButton = function () {
 // Event Handlers
 
 RadioGroup.prototype.handleKeydown = function (event) {
-  var tgt = event.currentTarget,
-    flag = false,
-    clickEvent;
+  var flag = false;
 
   var currentItem = this.getCurrentRadioButton();
   switch (event.keyCode) {
     case this.keyCode.SPACE:
-    case this.keyCode.RETURN:
       this.setChecked(currentItem);
       flag = true;
       break;
@@ -160,12 +154,12 @@ RadioGroup.prototype.handleKeydown = function (event) {
   }
 };
 
-RadioGroup.prototype.handleFocus = function (event) {
+RadioGroup.prototype.handleFocus = function () {
   var currentItem = this.getCurrentRadioButton();
   currentItem.domNode.classList.add('focus');
 };
 
-RadioGroup.prototype.handleBlur = function (event) {
+RadioGroup.prototype.handleBlur = function () {
   var currentItem = this.getCurrentRadioButton();
   currentItem.domNode.classList.remove('focus');
 };


### PR DESCRIPTION
@mcking65 This pull request fixes a bunch of other linting issues with the JS file, including the RETURN key issue

[Preview of updated radio button 2 example](https://raw.githack.com/w3c/aria-practices/issue1037-remove-return-key-reference/examples/radio/radio-2/radio-2.html)