### PR TITLE
Ignore examples/index.html in regression report

### DIFF
--- a/test/util/report_files/ignore_html_files
+++ b/test/util/report_files/ignore_html_files
@@ -3,3 +3,4 @@ menubar/menubar-1/mb-about.html
 menubar/menubar-1/mb-academics.html
 feed/feedDisplay.html
 menubar/menubar-1/mb-admissions.html
+index.html


### PR DESCRIPTION
When running the regression report, it looks at the new index.html file for `data-test-id` meta date. We have an ignore file for this report, so I updated it.