### PR TITLE
Conditionally skip regression tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,13 +31,19 @@ jobs:
 
     - stage: Test
       name: AVA Regression Tests
+      before_install:
+      - |
+        if ! git diff --name-only $TRAVIS_COMMIT_RANGE | grep -qE '(test/|examples/)'
+        then
+          echo "Examples files were not updated, not running example regression tests."
+          exit
+        fi
       script: ava -c 1 test/tests
       env: TEST_WAIT_TIME=1000
     - stage: Test
       name: Regression Tests Coverage Report
       script: node test/util/report.js
       env: ALLOW_FAILURE=true
-
     - stage: Deploy
       if: branch = master AND type != pull_request
       script: skip


### PR DESCRIPTION
travisCI will now check to make sure that a file in the `examples/` folder or `tests/` folder has been edited in a PR before running the example regression tests. If you look at the CI results, it will look as if the regression test pass, but if you look at the results it says "Examples files were not updated, not running example regression tests.".
