### PR TITLE
Accessible Name Guidance by Role Table: Advise that empty cells are represented by empty names

### DIFF
--- a/aria-practices.html
+++ b/aria-practices.html
@@ -4189,12 +4189,15 @@ So, As advised by <a href="#naming_rule_avoid_fallback">Rule 4: Avoid Browser Fa
           </dd>
         </dl>
         <table aria-labelledby="naming_role_guidance_heading">
-          <tr>
-            <th>role</th>
-            <th>Necessity of Naming</th>
-            <th>Guidance</th>
-          </tr>
-          <tr>
+          <thead>
+            <tr>
+              <th>role</th>
+              <th>Necessity of Naming</th>
+              <th>Guidance</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
               <td><a href="#alert" class="role-reference"><code>alert</code></a></td>
               <td>Discretionary</td>
               <td>
@@ -4874,6 +4877,7 @@ So, As advised by <a href="#naming_rule_avoid_fallback">Rule 4: Avoid Browser Fa
                 </ul>
               </td>
             </tr>
+          </tbody>
         </table>
       </section>
 

--- a/aria-practices.html
+++ b/aria-practices.html
@@ -4251,7 +4251,8 @@ So, As advised by <a href="#naming_rule_avoid_fallback">Rule 4: Avoid Browser Fa
                 <ul>
                   <li>Warning! Using <code>aria-label</code> or <code>aria-labelledby</code> will hide descendant content from assistive technologies.</li>
                   <li>Ideally named by visible, descendant content.</li>
-                  <li>Note that associated row or column headers do not name a cell; a cell's name is its content. Headers are complementary information.</li>
+                  <li>Note that a name is not required; assistive technologies expect an empty cell in a table to be represented by an empty name.</li>
+                  <li>Note that associated row or column headers do not name a <code>cell</code>; the name of a cell in a table is its content. Headers are complementary information.</li>
                 </ul>
               </td>
             </tr>
@@ -4389,7 +4390,8 @@ So, As advised by <a href="#naming_rule_avoid_fallback">Rule 4: Avoid Browser Fa
                 <ul>
                   <li>Warning! Using <code>aria-label</code> or <code>aria-labelledby</code> will hide descendant content from assistive technologies.</li>
                   <li>Ideally named by visible, descendant content.</li>
-                  <li>Note that associated row or column headers do not name a cell; a cell's name is its content. Headers are complementary information.</li>
+                  <li>Note that a name is not required; assistive technologies expect an empty cell in a grid to be represented by an empty name.</li>
+                  <li>Note that associated row or column headers do not name a <code>gridcell</code>; the name of a cell in a grid is its content. Headers are complementary information.</li>
                 </ul>
               </td>
             </tr>


### PR DESCRIPTION
Revise table of name guidance by role for cell and gridcell; supports change made for ARIA issue w3c/aria#993.

#### Preview Link

[View aria-practices.html in this branch using raw.githack](https://raw.githack.com/w3c/aria-practices/empty-cell-naming-guidance/aria-practices.html)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria-practices/pull/1081.html" title="Last updated on Jul 13, 2019, 7:23 AM UTC (ff19718)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria-practices/1081/ea5f0c1...ff19718.html" title="Last updated on Jul 13, 2019, 7:23 AM UTC (ff19718)">Diff</a>