### PR TITLE
fixed bug with rendering the grid of dates for a year and month

### DIFF
--- a/examples/dialog-modal/js/datepicker.js
+++ b/examples/dialog-modal/js/datepicker.js
@@ -121,7 +121,9 @@ DatePicker.prototype.updateGrid = function () {
   var daysInMonth = new Date(fd.getFullYear(), fd.getMonth() + 1, 0).getDate();
   var dayOfWeek = firstDayOfMonth.getDay();
 
-  var d = new Date(firstDayOfMonth - dayOfWeek);
+  firstDayOfMonth.setDate(firstDayOfMonth.getDate() - dayOfWeek);
+
+  var d = new Date(firstDayOfMonth);
 
   for (i = 0; i < this.days.length; i++) {
     flag = d.getMonth() != fd.getMonth();
@@ -134,8 +136,11 @@ DatePicker.prototype.updateGrid = function () {
     d.setDate(d.getDate() + 1);
   }
 
-  if (dayOfWeek + daysInMonth < 35) {
+  if ((dayOfWeek + daysInMonth) < 36) {
     this.hideLastRow();
+  }
+  else {
+    this.showLastRow();
   }
 
 };


### PR DESCRIPTION
@mcking65 

This patch fixed a bug with the layout of dates for the calendar grid, based on a month and year.
As you change the month or year the first day of the week is in the wrong day in the grid this patch fixes this bug.

[Preview link of date picker dialog patch](https://raw.githack.com/w3c/aria-practices/datepicker-dialog-calendar-computation-patch/examples/dialog-modal/datepicker-dialog.html)