### PR TITLE
added missing roles to reference table script'

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -36,6 +36,14 @@
         </thead>
         <tbody id="examples_by_role_tbody">
           <tr>
+            <td><code>alert</code></td>
+            <td><a href="alert/alert.html">Alert</a></td>
+          </tr>
+          <tr>
+            <td><code>alertdialog</code></td>
+            <td><a href="dialog-modal/alertdialog.html">Alert Dialog</a></td>
+          </tr>
+          <tr>
             <td><code>article</code></td>
             <td><a href="feed/feed.html">Feed</a></td>
           </tr>
@@ -79,6 +87,15 @@
           <tr>
             <td><code>contentinfo</code></td>
             <td><a href="landmarks/contentinfo.html">Contentinfo Landmark</a></td>
+          </tr>
+          <tr>
+            <td><code>dialog</code></td>
+            <td>
+              <ul>
+                <li><a href="dialog-modal/datepicker-dialog.html">Date Picker Dialog</a></li>
+                <li><a href="dialog-modal/dialog.html">Modal Dialog</a></li>
+              </ul>
+            </td>
           </tr>
           <tr>
             <td><code>feed</code></td>

--- a/scripts/reference-tables.js
+++ b/scripts/reference-tables.js
@@ -21,6 +21,8 @@ let output = fs.readFileSync(exampleTemplatePath, function (err) {
 const $ = cheerio.load(output);
 
 const ariaRoles = [
+  'alert',
+  'alertdialog',
   'application',
   'article',
   'banner',
@@ -32,6 +34,7 @@ const ariaRoles = [
   'complementary',
   'contentinfo',
   'definition',
+  'dialog',
   'directory',
   'document',
   'feed',
@@ -46,7 +49,9 @@ const ariaRoles = [
   'list',
   'listbox',
   'listitem',
+  'log',
   'main',
+  'marquee',
   'math',
   'menu',
   'menubar',
@@ -70,6 +75,7 @@ const ariaRoles = [
   'separator',
   'slider',
   'spinbutton',
+  'satus',
   'switch',
   'tab',
   'table',
@@ -77,6 +83,7 @@ const ariaRoles = [
   'tabpanel',
   'term',
   'textbox',
+  'timer',
   'toolbar',
   'tooltip',
   'tree',

--- a/scripts/reference-tables.js
+++ b/scripts/reference-tables.js
@@ -75,7 +75,7 @@ const ariaRoles = [
   'separator',
   'slider',
   'spinbutton',
-  'satus',
+  'status',
   'switch',
   'tab',
   'table',


### PR DESCRIPTION
@mcking65 

I added the following missing roles to the `reference-table.js` script:

* alert
* alertdialog
* dialog
* log
* marquee
* status
*timer

