### PR TITLE
Date picker dialog: fix bug when clicking on a disabled day

### DIFF
--- a/examples/dialog-modal/js/datepicker-day.js
+++ b/examples/dialog-modal/js/datepicker-day.js
@@ -161,7 +161,7 @@ DatePickerDay.prototype.handleKeyDown = function (event) {
 DatePickerDay.prototype.handleMouseDown = function (event) {
 
   if (this.isDisabled()) {
-    this.datepicker.moveFocusToDay(this.date);
+    this.datepicker.moveFocusToDay(this.day);
   }
   else {
     this.datepicker.setTextboxDate(this.day);


### PR DESCRIPTION
@mcking65 

This patch fixes a bug when clicking on a disabled date in the date picker grid with a pointing device.
It now updates the grid with the new month, before it generated a javascript error due to reference to an undefined value.
