### PR TITLE
Proof of concept: Open example in JSFiddle

### DIFF
--- a/examples/js/examples.js
+++ b/examples/js/examples.js
@@ -33,6 +33,8 @@ var VOID_ELEMENTS = ['area', 'base', 'br', 'col', 'embed', 'hr', 'img', 'input',
 aria.widget.SourceCode = function () {
   this.location = new Array();
   this.code = new Array();
+  this.cssJsFiles = new Array();
+  this.fiddleForms = new Array();
 };
 
 /**
@@ -41,9 +43,11 @@ aria.widget.SourceCode = function () {
  * @method add
  * @memberof aria.widget.SourceCode
  */
-aria.widget.SourceCode.prototype.add = function (locationId, codeId) {
+aria.widget.SourceCode.prototype.add = function (locationId, codeId, cssJsFilesId, fiddleFormId) {
   this.location[this.location.length] = locationId;
   this.code[this.code.length] = codeId;
+  this.cssJsFiles[this.cssJsFiles.length] = cssJsFilesId;
+  this.fiddleForms[this.fiddleForms.length] = fiddleFormId;
 };
 
 /**
@@ -63,6 +67,28 @@ aria.widget.SourceCode.prototype.make = function () {
     // Remove unnecessary `<br>` element.
     if (sourceCodeNode.innerHTML.startsWith('<br>')) {
       sourceCodeNode.innerHTML = sourceCodeNode.innerHTML.replace('<br>', '');
+    }
+
+    if (this.cssJsFiles[i]) {
+      var cssJsFilesId = this.cssJsFiles[i];
+      var htmlInput = '#' + this.fiddleForms[i] + ' input[name="html"]';
+      var cssInput = '#' + this.fiddleForms[i] + ' input[name="css"]';
+      var jsInput = '#' + this.fiddleForms[i] + ' input[name="js"]';
+
+      document.querySelector(htmlInput).value = '<head><base href="' + location.href + '"></head>\n' + document.getElementById(this.code[i]).innerHTML;
+
+      // Get file content of the other files necessary for this particular example
+      $('#' + cssJsFilesId + ' a').each(function () {
+        var href = this.href;
+        $.get(href, function (fileContent) {
+          if (href.indexOf('css') != -1) {
+            document.querySelector(cssInput).value += fileContent;
+          }
+          if (href.indexOf('js') != -1) {
+            document.querySelector(jsInput).value += fileContent;
+          }
+        });
+      });
     }
   }
 };

--- a/examples/slider/multithumb-slider.html
+++ b/examples/slider/multithumb-slider.html
@@ -7,6 +7,7 @@
   <!--  Core js and css shared by all examples; do not modify when using this template. -->
   <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/base.css">
   <link rel="stylesheet" href="../css/core.css">
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
   <script src="../js/examples.js"></script>
   <script src="../js/highlight.pack.js"></script>
   <script src="../js/app.js"></script>
@@ -109,6 +110,16 @@
               </div>
           </div>
           <div role="separator" id="ex_end_sep" aria-labelledby="ex_end_sep ex_label" aria-label="End of"></div>
+    </section>
+
+    <section>
+      <h2>Open Example in JSFiddle</h2>
+      <form id="openFiddle" action="https://jsfiddle.net/api/post/library/pure/" method="POST" target="check/">
+        <input type="hidden" name="html" value="<div>Hello, World!</div>">
+        <input type="hidden" name="js" value="">
+        <input type="hidden" name="css" value="">
+        <input type="submit" value="Open this example in JSFiddle">
+      </form>
     </section>
 
     <section>
@@ -250,7 +261,7 @@
 
   <section>
         <h2>Javascript and CSS Source Code</h2>
-        <ul>
+        <ul id="cssJsFiles">
           <li>CSS: <a href="css/multithumb-slider.css" type="tex/css">multithumb-slider.css</a></li>
           <li>Javascript: <a href="js/multithumb-slider.js" type="text/javascript">multithumb-slider.js</a></li>
         </ul>
@@ -262,7 +273,7 @@
         <pre><code id="sc1"></code></pre>
         <div role="separator" id="sc1_end_sep" aria-labelledby="sc1_end_sep sc1_label" aria-label="End of"></div>
         <script>
-          sourceCode.add('sc1', 'ex1');
+          sourceCode.add('sc1', 'ex1', 'cssJsFiles', 'openFiddle');
           sourceCode.make();
         </script>
     </section>


### PR DESCRIPTION
This is a proof of concept for issue #1102.

JSFiddle has a POST API to prefill the HTML/CSS/JS inputs.  This PR adds a dynamically created form that can send a POST request with the appropriate data to JSFiddle (look for "Open this example in JSFiddle" button on the `slider/multithumb-slider.html` page).

I tried to do this in a generalized way -- the code is mostly in `examples/js/examples.js` -- so that each example page would only need a small amount of html/js added, most of which could be added/copied directly from the template file. This solution should also work for examples pages that contain multiple examples.

Here is a PR for doing the same thing but using Codepen: #1110

#### Preview WIP

[View the slider example with the JSFiddle button](https://raw.githack.com/w3c/aria-practices/issue1102-open-example-jsfiddle/examples/slider/multithumb-slider.html)