### PR TITLE
Remove Math role from Children Presentational

### DIFF
--- a/aria-practices.html
+++ b/aria-practices.html
@@ -4938,7 +4938,6 @@
       <li>button</li>
       <li>checkbox</li>
       <li>img</li>
-      <li>math</li>
       <li>menuitemcheckbox</li>
       <li>menuitemradio</li>
       <li>option</li>


### PR DESCRIPTION
remove Math role from those which make their descendants presentational


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria-practices/pull/1112.html" title="Last updated on Aug 24, 2019, 11:44 PM UTC (836434d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria-practices/1112/4a29654...836434d.html" title="Last updated on Aug 24, 2019, 11:44 PM UTC (836434d)">Diff</a>