### PR TITLE
chore: Try Headless Firefox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,6 @@ language: node_js
 node_js:
   - "node"
 
-addons:
-  firefox: "60.0.2"
-
 git:
   depth: 3
 
@@ -31,6 +28,8 @@ jobs:
 
     - stage: Test
       name: AVA Regression Tests
+      addons:
+        firefox: latest
       before_install:
       - |
         if ! git diff --name-only $TRAVIS_COMMIT_RANGE | grep -qE '(test/|examples/)'
@@ -39,7 +38,9 @@ jobs:
           exit
         fi
       script: ava -c 1 test/tests
-      env: TEST_WAIT_TIME=1000
+      env:
+      - TEST_WAIT_TIME=1000
+      - MOZ_HEADLESS=1
     - stage: Test
       name: Regression Tests Coverage Report
       script: node test/util/report.js


### PR DESCRIPTION
Trying the config from https://docs.travis-ci.com/user/gui-and-headless-browsers/#using-the-firefox-addon-in-headless-mode
Probably don't need "latest", but 60.0.2 is behind the latest ESR now, and is also about to bump https://www.mozilla.org/en-US/firefox/organizations/
Edit: Looks like this probably overlaps with https://github.com/w3c/aria-practices/blob/ecdb87a55dceed94ce0460bafc80d99c96757f3a/test/index.js#L11