### PR TITLE
Fix spinbutton example query selector

### DIFF
--- a/examples/spinbutton/js/spinbutton-date.js
+++ b/examples/spinbutton/js/spinbutton-date.js
@@ -14,7 +14,7 @@ var SpinButtonDate = function (domNode, values, callback)  {
 
   var initialValue = domNode.getAttribute('aria-valuetext');
 
-  this.spinbuttonNode = domNode.querySelector('[role="spinbutton');
+  this.spinbuttonNode = domNode.querySelector('[role="spinbutton"]');
 
   this.previousValueNode = domNode.querySelector('.previous');
   this.nextValueNode = domNode.querySelector('.next');


### PR DESCRIPTION
Fixes issue: https://github.com/w3c/aria-practices/issues/1151

The query selector for the `spinbutton` element was incomplete, which caused it to not query properly in Safari or IE. 

This fix adds in the missing characters to the query so that it queries properly.

Before, clicking on the arrows didn't do anything and the element couldn't be tabbed to:
![Video of clicking on arrows not changing the values in the datepicker](https://user-images.githubusercontent.com/6530351/63977020-86971000-ca67-11e9-9a19-4b6442864dff.gif)

After, clicking on the arrows updates the value up/down and when tabbing to the picker values, using the up/down arrow keys adjusts the values:
![Video of clicking on arrows updating values up or down, and then keyboard focus on values with the values changing in the datepicker](https://user-images.githubusercontent.com/6530351/63977019-85fe7980-ca67-11e9-92c4-5b029363202c.gif)