### PR TITLE
Spin Button Date Picker Example: Fix incrementing and decrementing past limits

### DIFF
--- a/examples/spinbutton/js/spinbutton-date.js
+++ b/examples/spinbutton/js/spinbutton-date.js
@@ -35,10 +35,10 @@ var SpinButtonDate = function (domNode, values, callback)  {
     }
   }
   else {
-    this.valueMin  = parseInt(domNode.getAttribute('aria-valuemin'));
-    this.valueMax  = parseInt(domNode.getAttribute('aria-valuemax'));
-    this.valueNow  = parseInt(domNode.getAttribute('aria-valuenow'));
-    this.valueText = domNode.getAttribute('aria-valuenow');
+    this.valueMin  = parseInt(this.spinbuttonNode.getAttribute('aria-valuemin'));
+    this.valueMax  = parseInt(this.spinbuttonNode.getAttribute('aria-valuemax'));
+    this.valueNow  = parseInt(this.spinbuttonNode.getAttribute('aria-valuenow'));
+    this.valueText = this.spinbuttonNode.getAttribute('aria-valuenow');
   }
 
   this.keyCode = Object.freeze({


### PR DESCRIPTION
The date picker spin button example would show NaN on all the dates if you tried to loop around to the first date. Also, despite there being a min and max year set, the year could be cycled through potentially infinitely beyond the min or max year.

This was due to the way the min and max values were being queried. The values are set on the DOM nodes for the node with the `spinbutton` role. However, the node that was being queried for those values was the parent node.

This change fixes the node used so that the initial values are set appropriately, and the spinners work as expected.

Before, once you tried to wrap around beyond the last day of the month, all the values would then be set to NaN, and there'd be no way to get it to go back to having real numbers without refreshing the page. Additionally, the years could be incremented (or decremented) as high as desired, even though the min year was set to 2019 and the max year is set to 2040. 
![Video of tabbing through date spinners and where NaN appears after going past 31 for August and the year is set up to 2117](https://user-images.githubusercontent.com/6530351/63980346-2193e800-ca70-11e9-8939-41fb403c7cbf.gif)

After, you can wrap around the days of the month. Also, 2019 shows up as the min year (with no previous year showing) and 2040 is the max year (with no next year showing). 
![Video of tabbing through date spinners and the date loops properly, with the year starting at 2019 and ending at 2040](https://user-images.githubusercontent.com/6530351/63980345-2193e800-ca70-11e9-88ec-ddc638221399.gif)
