### PR TITLE
Editor Menubar Example: add group around font style menu item checkboxes

### DIFF
--- a/examples/menubar/menubar-2/menubar-2.html
+++ b/examples/menubar/menubar-2/menubar-2.html
@@ -62,8 +62,8 @@
           <ul role="menu" aria-label="Style/Color">
             <li role="none">
               <ul role="group" rel="font-style" aria-label="Font Style">
-                <li role="menuitemcheckbox" rel="font-bold" aria-checked="false">Bold</li>
-                <li role="menuitemcheckbox" rel="font-italic" aria-checked="false">Italic</li>
+                <li role="menuitemcheckbox" data-option="font-bold" aria-checked="false">Bold</li>
+                <li role="menuitemcheckbox" data-option="font-italic" aria-checked="false">Italic</li>
               </ul>
             </li>
             <li role="separator"></li>

--- a/examples/menubar/menubar-2/menubar-2.html
+++ b/examples/menubar/menubar-2/menubar-2.html
@@ -60,10 +60,14 @@
         <li role="none">
           <a role="menuitem" aria-haspopup="true" aria-expanded="false" href="#">Style/Color</a>
           <ul role="menu" aria-label="Style/Color">
-            <li role="menuitemcheckbox" data-option="font-bold" aria-checked="false">Bold</li>
-            <li role="menuitemcheckbox" data-option="font-italic" aria-checked="false">Italic</li>
+            <li role="none">
+              <ul role="group" rel="font-style" aria-label="Font Style">
+                <li role="menuitemcheckbox" rel="font-bold" aria-checked="false">Bold</li>
+                <li role="menuitemcheckbox" rel="font-italic" aria-checked="false">Italic</li>
+              </ul>
+            </li>
             <li role="separator"></li>
-            <li>
+            <li role="none">
               <ul role="group" data-option="font-color" aria-label="Text Color">
                 <li role="menuitemradio" aria-checked="true">Black</li>
                 <li role="menuitemradio" aria-checked="false">Blue</li>
@@ -71,7 +75,7 @@
                 <li role="menuitemradio" aria-checked="false">Green</li>
               </ul>
             <li role="separator"></li>
-            <li>
+            <li role="none">
               <ul role="group" data-option="text-decoration" aria-label="Text Decoration">
                 <li role="menuitemradio" aria-checked="true">None</li>
                 <li role="menuitemradio" aria-checked="false">Overline</li>

--- a/examples/menubar/menubar-2/menubar-2.html
+++ b/examples/menubar/menubar-2/menubar-2.html
@@ -61,7 +61,7 @@
           <a role="menuitem" aria-haspopup="true" aria-expanded="false" href="#">Style/Color</a>
           <ul role="menu" aria-label="Style/Color">
             <li role="none">
-              <ul role="group" rel="font-style" aria-label="Font Style">
+              <ul role="group" data-option="font-style" aria-label="Font Style">
                 <li role="menuitemcheckbox" data-option="font-bold" aria-checked="false">Bold</li>
                 <li role="menuitemcheckbox" data-option="font-italic" aria-checked="false">Italic</li>
               </ul>

--- a/test/tests/menubar_menubar-2.js
+++ b/test/tests/menubar_menubar-2.js
@@ -397,7 +397,7 @@ ariaTest('Test role="separator" exists', exampleFile, 'separator-role', async (t
 
 ariaTest('Test role="group" exists', exampleFile, 'group-role', async (t) => {
   t.plan(1);
-  await assertAriaRoles(t, 'ex1', 'group', 3, 'ul');
+  await assertAriaRoles(t, 'ex1', 'group', 4, 'ul');
 });
 
 ariaTest('Test aria-label on group', exampleFile, 'group-aria-label', async (t) => {

--- a/test/tests/menubar_menubar-2.js
+++ b/test/tests/menubar_menubar-2.js
@@ -275,8 +275,8 @@ ariaTest('Test tabindex="-1" for all submenu role="menuitem"s',
   });
 
 
-/*
-ariaTest.failing('Test aria-disabled="false" for all submenu role="menuitem"s',
+
+ariaTest('Test aria-disabled="false" for all submenu role="menuitem"s',
   exampleFile, 'submenu-menuitem-aria-disabled', async (t) => {
     t.plan(3);
 
@@ -288,6 +288,21 @@ ariaTest.failing('Test aria-disabled="false" for all submenu role="menuitem"s',
 
     // Select the first item in the list until it is disabled
     const disabledFirstItem = await t.context.session.wait(async function () {
+      await menus[3].sendKeys(Key.ARROW_DOWN);
+      await menuitem[0].sendKeys(Key.ENTER);
+
+      await menus[3].sendKeys(Key.ARROW_DOWN);
+      await menuitem[0].sendKeys(Key.ENTER);
+
+      await menus[3].sendKeys(Key.ARROW_DOWN);
+      await menuitem[0].sendKeys(Key.ENTER);
+
+      await menus[3].sendKeys(Key.ARROW_DOWN);
+      await menuitem[0].sendKeys(Key.ENTER);
+
+      await menus[3].sendKeys(Key.ARROW_DOWN);
+      await menuitem[0].sendKeys(Key.ENTER);
+
       await menus[3].sendKeys(Key.ARROW_DOWN);
       await menuitem[0].sendKeys(Key.ENTER);
 
@@ -306,6 +321,26 @@ ariaTest.failing('Test aria-disabled="false" for all submenu role="menuitem"s',
       await menuitem[0].sendKeys(Key.ARROW_DOWN);
       await menuitem[1].sendKeys(Key.ENTER);
 
+      await menus[3].sendKeys(Key.ARROW_DOWN);
+      await menuitem[0].sendKeys(Key.ARROW_DOWN);
+      await menuitem[1].sendKeys(Key.ENTER);
+
+      await menus[3].sendKeys(Key.ARROW_DOWN);
+      await menuitem[0].sendKeys(Key.ARROW_DOWN);
+      await menuitem[1].sendKeys(Key.ENTER);
+
+      await menus[3].sendKeys(Key.ARROW_DOWN);
+      await menuitem[0].sendKeys(Key.ARROW_DOWN);
+      await menuitem[1].sendKeys(Key.ENTER);
+
+      await menus[3].sendKeys(Key.ARROW_DOWN);
+      await menuitem[0].sendKeys(Key.ARROW_DOWN);
+      await menuitem[1].sendKeys(Key.ENTER);
+
+      await menus[3].sendKeys(Key.ARROW_DOWN);
+      await menuitem[0].sendKeys(Key.ARROW_DOWN);
+      await menuitem[1].sendKeys(Key.ENTER);
+
       return await menuitem[1].getAttribute('aria-disabled') === 'true';
     }, t.context.waitTime, 'Timeout trying to disable the second item in the last menu by sending multiple clicks');
 
@@ -315,7 +350,6 @@ ariaTest.failing('Test aria-disabled="false" for all submenu role="menuitem"s',
       'The second menuitem in the last dropdown should become disabled after multiple \'ENTER\' keys sent'
     );
   });
-*/
 
 ariaTest('Test for role="menuitemcheckbox" on li', exampleFile, 'menuitemcheckbox-role', async (t) => {
   t.plan(3);

--- a/test/tests/menubar_menubar-2.js
+++ b/test/tests/menubar_menubar-2.js
@@ -275,6 +275,7 @@ ariaTest('Test tabindex="-1" for all submenu role="menuitem"s',
   });
 
 
+/*
 ariaTest.failing('Test aria-disabled="false" for all submenu role="menuitem"s',
   exampleFile, 'submenu-menuitem-aria-disabled', async (t) => {
     t.plan(3);
@@ -314,6 +315,7 @@ ariaTest.failing('Test aria-disabled="false" for all submenu role="menuitem"s',
       'The second menuitem in the last dropdown should become disabled after multiple \'ENTER\' keys sent'
     );
   });
+*/
 
 ariaTest('Test for role="menuitemcheckbox" on li', exampleFile, 'menuitemcheckbox-role', async (t) => {
   t.plan(3);

--- a/test/tests/menubar_menubar-2.js
+++ b/test/tests/menubar_menubar-2.js
@@ -274,8 +274,6 @@ ariaTest('Test tabindex="-1" for all submenu role="menuitem"s',
     await assertAttributeValues(t, ex.submenuMenuitemSelector, 'tabindex', '-1');
   });
 
-
-
 ariaTest('Test aria-disabled="false" for all submenu role="menuitem"s',
   exampleFile, 'submenu-menuitem-aria-disabled', async (t) => {
     t.plan(3);

--- a/test/tests/menubar_menubar-2.js
+++ b/test/tests/menubar_menubar-2.js
@@ -275,7 +275,7 @@ ariaTest('Test tabindex="-1" for all submenu role="menuitem"s',
   });
 
 
-ariaTest('Test aria-disabled="false" for all submenu role="menuitem"s',
+ariaTest.failing('Test aria-disabled="false" for all submenu role="menuitem"s',
   exampleFile, 'submenu-menuitem-aria-disabled', async (t) => {
     t.plan(3);
 

--- a/test/tests/menubar_menubar-2.js
+++ b/test/tests/menubar_menubar-2.js
@@ -282,71 +282,35 @@ ariaTest('Test aria-disabled="false" for all submenu role="menuitem"s',
     await assertAttributeValues(t, ex.submenuMenuitemSelector, 'aria-disabled', 'false');
 
     const menus = await t.context.session.findElements(By.css(ex.menubarMenuitemSelector));
-    const menuitem = await t.context.session.findElements(By.css(ex.submenuMenuitemSelector));
+    const sizeMenu = await t.context.session.findElement(By.css('[aria-label="Size"]'));
+    const menuitems = await sizeMenu.findElements(By.css('[role="menuitem"]'));
+    const menuItemRadios = await sizeMenu.findElements(By.css('[role="menuitemradio"]'));
 
-    // Select the first item in the list until it is disabled
-    const disabledFirstItem = await t.context.session.wait(async function () {
-      await menus[3].sendKeys(Key.ARROW_DOWN);
-      await menuitem[0].sendKeys(Key.ENTER);
+    // select X-Small size
+    await menus[3].sendKeys(Key.ARROW_DOWN);
+    await menuItemRadios[0].sendKeys(Key.ENTER);
 
-      await menus[3].sendKeys(Key.ARROW_DOWN);
-      await menuitem[0].sendKeys(Key.ENTER);
-
-      await menus[3].sendKeys(Key.ARROW_DOWN);
-      await menuitem[0].sendKeys(Key.ENTER);
-
-      await menus[3].sendKeys(Key.ARROW_DOWN);
-      await menuitem[0].sendKeys(Key.ENTER);
-
-      await menus[3].sendKeys(Key.ARROW_DOWN);
-      await menuitem[0].sendKeys(Key.ENTER);
-
-      await menus[3].sendKeys(Key.ARROW_DOWN);
-      await menuitem[0].sendKeys(Key.ENTER);
-
-      return await menuitem[0].getAttribute('aria-disabled') === 'true';
-    }, t.context.waitTime, 'Timeout trying to disable the first item in the last menu by sending multiple clicks');
+    const disabledFirstItem = await menuitems[0].getAttribute('aria-disabled');
 
     // Test that the item was successfully disabled
     t.true(
-      disabledFirstItem,
-      'The first menuitem in the last dropdown should become disabled after multiple \'ENTER\' keys sent'
+      disabledFirstItem === 'true',
+      'The first menuitem in the last dropdown should become disabled after X-Small is selected'
     );
 
-    // Select the second item in the list until it is disabled
-    const disabledSecondItem = await t.context.session.wait(async function () {
-      await menus[3].sendKeys(Key.ARROW_DOWN);
-      await menuitem[0].sendKeys(Key.ARROW_DOWN);
-      await menuitem[1].sendKeys(Key.ENTER);
+    // Select the X-Large size
+    await menus[3].sendKeys(Key.ARROW_DOWN);
+    await menuItemRadios[menuItemRadios.length - 1].sendKeys(Key.ENTER);
 
-      await menus[3].sendKeys(Key.ARROW_DOWN);
-      await menuitem[0].sendKeys(Key.ARROW_DOWN);
-      await menuitem[1].sendKeys(Key.ENTER);
-
-      await menus[3].sendKeys(Key.ARROW_DOWN);
-      await menuitem[0].sendKeys(Key.ARROW_DOWN);
-      await menuitem[1].sendKeys(Key.ENTER);
-
-      await menus[3].sendKeys(Key.ARROW_DOWN);
-      await menuitem[0].sendKeys(Key.ARROW_DOWN);
-      await menuitem[1].sendKeys(Key.ENTER);
-
-      await menus[3].sendKeys(Key.ARROW_DOWN);
-      await menuitem[0].sendKeys(Key.ARROW_DOWN);
-      await menuitem[1].sendKeys(Key.ENTER);
-
-      await menus[3].sendKeys(Key.ARROW_DOWN);
-      await menuitem[0].sendKeys(Key.ARROW_DOWN);
-      await menuitem[1].sendKeys(Key.ENTER);
-
-      return await menuitem[1].getAttribute('aria-disabled') === 'true';
-    }, t.context.waitTime, 'Timeout trying to disable the second item in the last menu by sending multiple clicks');
+    const disabledSecondItem = await menuitems[1].getAttribute('aria-disabled');
 
     // Test that the item was successfully disabled
     t.true(
-      disabledSecondItem,
-      'The second menuitem in the last dropdown should become disabled after multiple \'ENTER\' keys sent'
+      disabledSecondItem === 'true',
+      'The second menuitem in the last dropdown should become disabled after X-Large is selected'
     );
+
+
   });
 
 ariaTest('Test for role="menuitemcheckbox" on li', exampleFile, 'menuitemcheckbox-role', async (t) => {


### PR DESCRIPTION
To resolve issue #914, adds role group around the menuitemcheckbox elements for font style.
Also updates applicable regression test for the group role.
Also adds missing role="none" on `<li>` elements.

Uses commits from #1144 by @jnurthen, but merges to master instead of apg-1.2.

#### Preview Link

[View the editor menubar in the compare branch for this PR](https://raw.githack.com/w3c/aria-practices/issue914-menubar2-add-fontstyle-group/examples/menubar/menubar-2/menubar-2.html)