### PR TITLE
Slider patterns: Provide warning about inability to operate with touch-based assistive technologies due to lack of needed APIs

### DIFF
--- a/aria-practices.html
+++ b/aria-practices.html
@@ -2346,7 +2346,7 @@
       </p>
       <p class="warning">
         Users of touch-based assistive technologies may not be able to fully operate widgets that implement this pattern because APIs for capturing the necessary gestures and commands from assistive technologies are not yet available.
-        Authors should fully test widgets using this pattern with assistive technoligies before considering incorporation into production systems.
+        Authors should fully test widgets using this pattern with assistive technologies before considering incorporation into production systems.
       </p>
       <section class="notoc">
         <h4>Examples</h4>

--- a/aria-practices.html
+++ b/aria-practices.html
@@ -2345,7 +2345,7 @@
         Sliders typically have a slider thumb that can be moved along a bar or track to change the value of the slider.
       </p>
       <p class="warning">
-      Widgets implemented using this pattern may not currently be fully supported by assisitive technologies operated based on touch interaction. Authors should fully test this widget before using it for a production ready project.
+      Interaction with widgets implemented using this pattern may not be fully supported by touch based assistive technologies. Authors should fully test this widget before using it for a production ready project.
       </p>
       <section class="notoc">
         <h4>Examples</h4>

--- a/aria-practices.html
+++ b/aria-practices.html
@@ -2344,7 +2344,9 @@
         A slider is an input where the user selects a value from within a given range.
         Sliders typically have a slider thumb that can be moved along a bar or track to change the value of the slider.
       </p>
-
+      <p class="note">
+      This widget may not be have support gaps that can only be filled by the development of new technologies. Likewise, it may be poorly supported by certain browsers or assistive technologies. For information on that, please refer to the forthcoming ARIA-AT Project. Authors should fully  before using them for a production ready project
+      </p>
       <section class="notoc">
         <h4>Examples</h4>
         <ul>
@@ -2394,13 +2396,6 @@
           </li>
         </ul>
       </section>
-      <section>
-        <h4>Potential Support Gap</h4>
-        <p class="warning">
-          This widget may not be have support gaps that can only be filled by the development of new technologies. Likewise, it may be poorly supported by certain browsers or assistive technologies. For information on that, please refer to the forthcoming ARIA-AT Project. Authors should fully  before using them for a production ready project
-        </p>
-      </section>
-
     </section>
 
     <section class="widget" id="slidertwothumb">

--- a/aria-practices.html
+++ b/aria-practices.html
@@ -2344,7 +2344,7 @@
         A slider is an input where the user selects a value from within a given range.
         Sliders typically have a slider thumb that can be moved along a bar or track to change the value of the slider.
       </p>
-      <p class="note">
+      <p class="warning">
       This widget may not be have support gaps that can only be filled by the development of new technologies. Likewise, it may be poorly supported by certain browsers or assistive technologies. For information on that, please refer to the forthcoming ARIA-AT Project. Authors should fully  before using them for a production ready project
       </p>
       <section class="notoc">

--- a/aria-practices.html
+++ b/aria-practices.html
@@ -2395,8 +2395,9 @@
         </ul>
       </section>
       <section>
+        <h4>Potential Support Gap</h4>
         <p class="warning">
-          This widget may not be have support gaps that can only be filled by the development of new technologies. Likewise, it may be poorly supported by certain browsers or assistive technologies. For information on that, please refer to the forthcoming ARIA-AT Project. Authors should fully  before using them for a production ready project 
+          This widget may not be have support gaps that can only be filled by the development of new technologies. Likewise, it may be poorly supported by certain browsers or assistive technologies. For information on that, please refer to the forthcoming ARIA-AT Project. Authors should fully  before using them for a production ready project
         </p>
       </section>
 

--- a/aria-practices.html
+++ b/aria-practices.html
@@ -2394,6 +2394,12 @@
           </li>
         </ul>
       </section>
+      <section>
+        <p class="warning">
+          This widget may not be have support gaps that can only be filled by the development of new technologies. Likewise, it may be poorly supported by certain browsers or assistive technologies. For information on that, please refer to the forthcoming ARIA-AT Project. Authors should fully  before using them for a production ready project 
+        </p>
+      </section>
+
     </section>
 
     <section class="widget" id="slidertwothumb">

--- a/aria-practices.html
+++ b/aria-practices.html
@@ -2345,7 +2345,7 @@
         Sliders typically have a slider thumb that can be moved along a bar or track to change the value of the slider.
       </p>
       <p class="warning">
-      This widget may not be have support gaps that can only be filled by the development of new technologies. Likewise, it may be poorly supported by certain browsers or assistive technologies. For information on that, please refer to the forthcoming ARIA-AT Project. Authors should fully  before using them for a production ready project
+      This widget may have support gaps that can only be filled by the development of new technologies. Authors should fully test this widget before using it for a production ready project. Likewise, it may be poorly supported by certain browsers or assistive technologies. 
       </p>
       <section class="notoc">
         <h4>Examples</h4>

--- a/aria-practices.html
+++ b/aria-practices.html
@@ -2410,6 +2410,10 @@
         Conversely, the minimum value of the upper end thumb is limited by the current value of the lower end thumb.
         However, in some multi-thumb sliders, each thumb sets a value that does not depend on the other thumb values.
       </p>
+      <p class="warning">
+        Users of touch-based assistive technologies may not be able to fully operate widgets that implement this pattern because APIs for capturing the necessary gestures and commands from assistive technologies are not yet available.
+        Authors should fully test widgets using this pattern with assistive technologies before considering incorporation into production systems.
+      </p>
 
       <section class="notoc">
         <h4>Example</h4>

--- a/aria-practices.html
+++ b/aria-practices.html
@@ -2345,7 +2345,8 @@
         Sliders typically have a slider thumb that can be moved along a bar or track to change the value of the slider.
       </p>
       <p class="warning">
-      Interaction with widgets implemented using this pattern may not be fully supported by touch based assistive technologies. Authors should fully test this widget before using it for a production ready project.
+        Users of touch-based assistive technologies may not be able to fully operate widgets that implement this pattern because APIs for capturing the necessary gestures and commands from assistive technologies are not yet available.
+        Authors should fully test widgets using this pattern with assistive technoligies before considering incorporation into production systems.
       </p>
       <section class="notoc">
         <h4>Examples</h4>

--- a/aria-practices.html
+++ b/aria-practices.html
@@ -2345,7 +2345,7 @@
         Sliders typically have a slider thumb that can be moved along a bar or track to change the value of the slider.
       </p>
       <p class="warning">
-      This widget may have support gaps that can only be filled by the development of new technologies. Authors should fully test this widget before using it for a production ready project. Likewise, it may be poorly supported by certain browsers or assistive technologies. 
+      Widgets implemented using this pattern may not currently be fully supported by assisitive technologies operated based on touch interaction. Authors should fully test this widget before using it for a production ready project.
       </p>
       <section class="notoc">
         <h4>Examples</h4>


### PR DESCRIPTION
Partially resolves issue #1150 by adding a warning to the slider patterns.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria-practices/pull/1186.html" title="Last updated on Jan 27, 2020, 6:30 AM UTC (766ce61)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria-practices/1186/1a1ba9f...766ce61.html" title="Last updated on Jan 27, 2020, 6:30 AM UTC (766ce61)">Diff</a>