### PR TITLE
Add grouped listbox example

### DIFF
--- a/examples/listbox/css/listbox.css
+++ b/examples/listbox/css/listbox.css
@@ -34,6 +34,13 @@
   border: 1px solid #aaa;
 }
 
+[role="group"] > [role="presentation"] {
+  background-color: #ccc;
+  font-weight: bold;
+  padding: 0 0.5em;
+  line-height: 2;
+}
+
 [role="option"] {
   display: block;
   padding: 0 1em 0 1.5em;

--- a/examples/listbox/css/listbox.css
+++ b/examples/listbox/css/listbox.css
@@ -34,10 +34,17 @@
   border: 1px solid #aaa;
 }
 
+[role="group"] {
+  padding: 0;
+  margin: 0;
+}
+
 [role="group"] > [role="presentation"] {
   background-color: #ccc;
-  font-weight: bold;
+  display: block;
   padding: 0 0.5em;
+  margin: 0;
+  font-weight: bold;
   line-height: 2;
 }
 

--- a/examples/listbox/css/listbox.css
+++ b/examples/listbox/css/listbox.css
@@ -1,33 +1,15 @@
-.annotate {
-  color: #366ed4;
-  font-style: italic;
-}
-
 .listbox-area {
+  display: grid;
+  grid-gap: 2em;
+  grid-template-columns: repeat(2, 1fr);
   padding: 20px;
   border: 1px solid #aaa;
-  font-size: 0;
+  border-radius: 4px;
   background: #eee;
 }
 
-.left-area,
-.right-area {
-  display: inline-block;
-  width: 50%;
-  box-sizing: border-box;
-  font-size: 14px;
-  vertical-align: top;
-}
-
-.left-area {
-  padding-right: 10px;
-}
-
-.right-area {
-  padding-left: 10px;
-}
-
 [role="listbox"] {
+  margin: 1em 0;
   padding: 0;
   min-height: 18em;
   border: 1px solid #aaa;
@@ -66,7 +48,7 @@
 }
 
 button {
-  font-size: 16px;
+  font-size: inherit;
 }
 
 button[aria-disabled="true"] {
@@ -154,21 +136,26 @@ button[aria-disabled="true"] {
   overflow-y: auto;
 }
 
-.hidden {
-  display: none;
+[role="toolbar"] {
+  display: flex;
 }
 
-.toolbar {
-  font-size: 0;
-}
-
-.toolbar-item {
+[role="toolbar"] > * {
   border: 1px solid #aaa;
   background: #ccc;
 }
 
-.toolbar-item[aria-disabled="false"]:focus {
+[role="toolbar"] > [aria-disabled="false"]:focus {
   background-color: #eee;
+}
+
+.annotate {
+  color: #366ed4;
+  font-style: italic;
+}
+
+.hidden {
+  display: none;
 }
 
 .offscreen {

--- a/examples/listbox/css/listbox.css
+++ b/examples/listbox/css/listbox.css
@@ -9,11 +9,16 @@
 }
 
 [role="listbox"] {
-  margin: 1em 0;
+  margin: 1em 0 0;
   padding: 0;
   min-height: 18em;
   border: 1px solid #aaa;
   background: white;
+}
+
+[role="listbox"] + *,
+.listbox-label + * {
+  margin-top: 1em;
 }
 
 [role="group"] {
@@ -55,36 +60,12 @@ button[aria-disabled="true"] {
   opacity: 0.5;
 }
 
-.move-right-btn {
-  position: relative;
-  padding-right: 20px;
-}
-
 .move-right-btn::after {
-  position: absolute;
-  top: 6px;
-  right: 2px;
-  width: 12px;
-  height: 10px;
-  content: "";
-  background-image: url("../imgs/Arrows-Right-icon.png");
-  background-position: center right;
+  content: " →";
 }
 
-.move-left-btn {
-  position: relative;
-  padding-left: 20px;
-}
-
-.move-left-btn::after {
-  position: absolute;
-  left: 2px;
-  top: 6px;
-  width: 12px;
-  height: 10px;
-  content: "";
-  background-image: url("../imgs/Arrows-Left-icon.png");
-  background-position: center left;
+.move-left-btn::before {
+  content: "← ";
 }
 
 #ss_elem_list {
@@ -93,7 +74,7 @@ button[aria-disabled="true"] {
   overflow-y: auto;
 }
 
-#exp_button {
+button[aria-haspopup="listbox"] {
   position: relative;
   padding: 5px 10px;
   width: 150px;
@@ -102,35 +83,34 @@ button[aria-disabled="true"] {
   text-align: left;
 }
 
-#exp_button::after {
+button[aria-haspopup="listbox"]::after {
   position: absolute;
   right: 5px;
   top: 10px;
   width: 0;
   height: 0;
-  border-top: 8px solid #aaa;
-  border-right: 8px solid transparent;
-  border-left: 8px solid transparent;
+  border: 8px solid transparent;
+  border-top-color: currentColor;
+  border-bottom: 0;
   content: "";
 }
 
-#exp_button[aria-expanded="true"]::after {
+button[aria-haspopup="listbox"][aria-expanded="true"]::after {
   position: absolute;
   right: 5px;
   top: 10px;
   width: 0;
   height: 0;
+  border: 8px solid transparent;
   border-top: 0;
-  border-right: 8px solid transparent;
-  border-bottom: 8px solid #aaa;
-  border-left: 8px solid transparent;
-  content: " ";
+  border-bottom-color: currentColor;
+  content: "";
 }
 
-#exp_elem_list {
+button[aria-haspopup="listbox"] + [role="listbox"] {
   position: absolute;
   margin: 0;
-  width: 148px;
+  width: 9.5em;
   max-height: 10em;
   border-top: 0;
   overflow-y: auto;

--- a/examples/listbox/css/listbox.css
+++ b/examples/listbox/css/listbox.css
@@ -1,22 +1,22 @@
 .annotate {
-  font-style: italic;
   color: #366ed4;
+  font-style: italic;
 }
 
 .listbox-area {
   padding: 20px;
-  background: #eee;
   border: 1px solid #aaa;
   font-size: 0;
+  background: #eee;
 }
 
 .left-area,
 .right-area {
-  box-sizing: border-box;
   display: inline-block;
+  width: 50%;
+  box-sizing: border-box;
   font-size: 14px;
   vertical-align: top;
-  width: 50%;
 }
 
 .left-area {
@@ -28,30 +28,30 @@
 }
 
 [role="listbox"] {
-  min-height: 18em;
   padding: 0;
-  background: white;
+  min-height: 18em;
   border: 1px solid #aaa;
+  background: white;
 }
 
 [role="group"] {
-  padding: 0;
   margin: 0;
+  padding: 0;
 }
 
 [role="group"] > [role="presentation"] {
-  background-color: #ccc;
   display: block;
-  padding: 0 0.5em;
   margin: 0;
+  padding: 0 0.5em;
   font-weight: bold;
   line-height: 2;
+  background-color: #ccc;
 }
 
 [role="option"] {
+  position: relative;
   display: block;
   padding: 0 1em 0 1.5em;
-  position: relative;
   line-height: 1.8em;
 }
 
@@ -60,9 +60,9 @@
 }
 
 [role="option"][aria-selected="true"]::before {
-  content: '✓';
   position: absolute;
   left: 0.5em;
+  content: "✓";
 }
 
 button {
@@ -74,84 +74,84 @@ button[aria-disabled="true"] {
 }
 
 .move-right-btn {
-  padding-right: 20px;
   position: relative;
+  padding-right: 20px;
 }
 
 .move-right-btn::after {
-  content: ' ';
-  height: 10px;
-  width: 12px;
-  background-image: url('../imgs/Arrows-Right-icon.png');
-  background-position: center right;
   position: absolute;
-  right: 2px;
   top: 6px;
+  right: 2px;
+  width: 12px;
+  height: 10px;
+  content: "";
+  background-image: url("../imgs/Arrows-Right-icon.png");
+  background-position: center right;
 }
 
 .move-left-btn {
-  padding-left: 20px;
   position: relative;
+  padding-left: 20px;
 }
 
 .move-left-btn::after {
-  content: ' ';
-  height: 10px;
-  width: 12px;
-  background-image: url('../imgs/Arrows-Left-icon.png');
-  background-position: center left;
   position: absolute;
   left: 2px;
   top: 6px;
+  width: 12px;
+  height: 10px;
+  content: "";
+  background-image: url("../imgs/Arrows-Left-icon.png");
+  background-position: center left;
 }
 
 #ss_elem_list {
+  position: relative;
   max-height: 18em;
   overflow-y: auto;
-  position: relative;
 }
 
 #exp_button {
+  position: relative;
+  padding: 5px 10px;
+  width: 150px;
   border-radius: 0;
   font-size: 16px;
   text-align: left;
-  padding: 5px 10px;
-  width: 150px;
-  position: relative;
 }
 
 #exp_button::after {
-  width: 0;
-  height: 0;
-  border-left: 8px solid transparent;
-  border-right: 8px solid transparent;
-  border-top: 8px solid #aaa;
-  content: " ";
   position: absolute;
   right: 5px;
   top: 10px;
+  width: 0;
+  height: 0;
+  border-top: 8px solid #aaa;
+  border-right: 8px solid transparent;
+  border-left: 8px solid transparent;
+  content: "";
 }
 
 #exp_button[aria-expanded="true"]::after {
-  width: 0;
-  height: 0;
-  border-left: 8px solid transparent;
-  border-right: 8px solid transparent;
-  border-top: 0;
-  border-bottom: 8px solid #aaa;
-  content: " ";
   position: absolute;
   right: 5px;
   top: 10px;
+  width: 0;
+  height: 0;
+  border-top: 0;
+  border-right: 8px solid transparent;
+  border-bottom: 8px solid #aaa;
+  border-left: 8px solid transparent;
+  content: " ";
 }
 
 #exp_elem_list {
-  border-top: 0;
-  max-height: 10em;
-  overflow-y: auto;
   position: absolute;
   margin: 0;
   width: 148px;
+  max-height: 10em;
+  border-top: 0;
+  overflow-y: auto;
 }
 
 .hidden {
@@ -172,12 +172,12 @@ button[aria-disabled="true"] {
 }
 
 .offscreen {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
   clip: rect(1px 1px 1px 1px);
   clip: rect(1px, 1px, 1px, 1px);
   font-size: 14px;
-  height: 1px;
-  overflow: hidden;
-  position: absolute;
   white-space: nowrap;
-  width: 1px;
 }

--- a/examples/listbox/css/listbox.css
+++ b/examples/listbox/css/listbox.css
@@ -16,6 +16,12 @@
   background: white;
 }
 
+[role="listbox"]#ss_elem_list {
+  position: relative;
+  max-height: 18em;
+  overflow-y: auto;
+}
+
 [role="listbox"] + *,
 .listbox-label + * {
   margin-top: 1em;
@@ -52,34 +58,11 @@
   content: "✓";
 }
 
-button {
-  font-size: inherit;
-}
-
-button[aria-disabled="true"] {
-  opacity: 0.5;
-}
-
-.move-right-btn::after {
-  content: " →";
-}
-
-.move-left-btn::before {
-  content: "← ";
-}
-
-#ss_elem_list {
-  position: relative;
-  max-height: 18em;
-  overflow-y: auto;
-}
-
 button[aria-haspopup="listbox"] {
   position: relative;
   padding: 5px 10px;
   width: 150px;
   border-radius: 0;
-  font-size: 16px;
   text-align: left;
 }
 
@@ -127,6 +110,22 @@ button[aria-haspopup="listbox"] + [role="listbox"] {
 
 [role="toolbar"] > [aria-disabled="false"]:focus {
   background-color: #eee;
+}
+
+button {
+  font-size: inherit;
+}
+
+button[aria-disabled="true"] {
+  opacity: 0.5;
+}
+
+.move-right-btn::after {
+  content: " →";
+}
+
+.move-left-btn::before {
+  content: "← ";
 }
 
 .annotate {

--- a/examples/listbox/js/listbox.js
+++ b/examples/listbox/js/listbox.js
@@ -49,8 +49,6 @@ aria.Listbox.prototype.setupFocus = function () {
   if (this.activeDescendant) {
     return;
   }
-
-  // this.focusFirstItem();
 };
 
 /**

--- a/examples/listbox/js/listbox.js
+++ b/examples/listbox/js/listbox.js
@@ -211,11 +211,12 @@ aria.Listbox.prototype.checkKeyPress = function (evt) {
 aria.Listbox.prototype.findItemToFocus = function (key) {
   var itemList = this.listboxNode.querySelectorAll('[role="option"]');
   var character = String.fromCharCode(key);
+  var searchIndex = 0;
 
   if (!this.keysSoFar) {
     for (var i = 0; i < itemList.length; i++) {
       if (itemList[i].getAttribute('id') == this.activeDescendant) {
-        this.searchIndex = i;
+        searchIndex = i;
       }
     }
   }
@@ -224,14 +225,14 @@ aria.Listbox.prototype.findItemToFocus = function (key) {
 
   var nextMatch = this.findMatchInRange(
     itemList,
-    this.searchIndex + 1,
+    searchIndex + 1,
     itemList.length
   );
   if (!nextMatch) {
     nextMatch = this.findMatchInRange(
       itemList,
       0,
-      this.searchIndex
+      searchIndex
     );
   }
   return nextMatch;

--- a/examples/listbox/js/listbox.js
+++ b/examples/listbox/js/listbox.js
@@ -125,10 +125,10 @@ aria.Listbox.prototype.checkKeyPress = function (evt) {
       }
 
       if (key === aria.KeyCode.UP) {
-        nextItem = nextItem.previousElementSibling;
+        nextItem = this.findPreviousOption(nextItem);
       }
       else {
-        nextItem = nextItem.nextElementSibling;
+        nextItem = this.findNextOption(nextItem);
       }
 
       if (nextItem) {
@@ -227,6 +227,32 @@ aria.Listbox.prototype.findItemToFocus = function (key) {
     );
   }
   return nextMatch;
+};
+
+/* Return the next listbox option, if it exists; otherwise, returns null */
+aria.Listbox.prototype.findNextOption = function (currentOption) {
+  var allOptions = Array.prototype.slice.call(this.listboxNode.querySelectorAll('[role="option"]')); // get options array
+  var currentOptionIndex = allOptions.indexOf(currentOption);
+  var nextOption = null;
+
+  if (currentOptionIndex > -1 && currentOptionIndex < allOptions.length - 1) {
+    nextOption = allOptions[currentOptionIndex + 1];
+  }
+
+  return nextOption;
+};
+
+/* Return the previous listbox option, if it exists; otherwise, returns null */
+aria.Listbox.prototype.findPreviousOption = function (currentOption) {
+  var allOptions = Array.prototype.slice.call(this.listboxNode.querySelectorAll('[role="option"]')); // get options array
+  var currentOptionIndex = allOptions.indexOf(currentOption);
+  var previousOption = null;
+
+  if (currentOptionIndex > -1 && currentOptionIndex > 0) {
+    previousOption = allOptions[currentOptionIndex - 1];
+  }
+
+  return previousOption;
 };
 
 aria.Listbox.prototype.clearKeysSoFarAfterDelay = function () {
@@ -457,14 +483,12 @@ aria.Listbox.prototype.clearActiveDescendant = function () {
  *  item is already at the top of the list.
  */
 aria.Listbox.prototype.moveUpItems = function () {
-  var previousItem;
-
   if (!this.activeDescendant) {
     return;
   }
 
-  currentItem = document.getElementById(this.activeDescendant);
-  previousItem = currentItem.previousElementSibling;
+  var currentItem = document.getElementById(this.activeDescendant);
+  var previousItem = currentItem.previousElementSibling;
 
   if (previousItem) {
     this.listboxNode.insertBefore(currentItem, previousItem);
@@ -480,14 +504,12 @@ aria.Listbox.prototype.moveUpItems = function () {
  *  the item is already at the end of the list.
  */
 aria.Listbox.prototype.moveDownItems = function () {
-  var nextItem;
-
   if (!this.activeDescendant) {
     return;
   }
 
-  currentItem = document.getElementById(this.activeDescendant);
-  nextItem = currentItem.nextElementSibling;
+  var currentItem = document.getElementById(this.activeDescendant);
+  var nextItem = currentItem.nextElementSibling;
 
   if (nextItem) {
     this.listboxNode.insertBefore(nextItem, currentItem);

--- a/examples/listbox/js/listbox.js
+++ b/examples/listbox/js/listbox.js
@@ -369,8 +369,8 @@ aria.Listbox.prototype.focusItem = function (element) {
 /**
  * Check if the selected option is in view, and scroll if not
  */
-aria.Listbox.prototype.updateScroll = function() {
-  const selectedOption = document.getElementById(this.activeDescendant);
+aria.Listbox.prototype.updateScroll = function () {
+  var selectedOption = document.getElementById(this.activeDescendant);
   if (selectedOption && this.listboxNode.scrollHeight > this.listboxNode.clientHeight) {
     var scrollBottom = this.listboxNode.clientHeight + this.listboxNode.scrollTop;
     var elementBottom = selectedOption.offsetTop + selectedOption.offsetHeight;
@@ -381,7 +381,7 @@ aria.Listbox.prototype.updateScroll = function() {
       this.listboxNode.scrollTop = selectedOption.offsetTop;
     }
   }
-}
+};
 
 /**
  * @desc

--- a/examples/listbox/js/listbox.js
+++ b/examples/listbox/js/listbox.js
@@ -298,6 +298,7 @@ aria.Listbox.prototype.checkClickItem = function (evt) {
   if (evt.target.getAttribute('role') === 'option') {
     this.focusItem(evt.target);
     this.toggleSelectItem(evt.target);
+    this.updateScroll();
   }
 };
 

--- a/examples/listbox/listbox-collapsible.html
+++ b/examples/listbox/listbox-collapsible.html
@@ -40,6 +40,7 @@
   <ul>
     <li><a href="listbox-scrollable.html">Scrollable Listbox Example</a>: Single-select listbox that scrolls to reveal more options, similar to HTML <code>select</code> with <code>size</code> attribute greater than one.</li>
     <li><a href="listbox-rearrangeable.html">Example Listboxes with Rearrangeable Options</a>: Examples of both single-select and multi-select listboxes with accompanying toolbars where options can be added, moved, and removed.</li>
+    <li><a href="listbox-grouped.html">Listbox Example with Grouped Options</a>: Single-select listbox with grouped options, similar to an HTML <code>select</code> with <code>optgroup</code> children.</li>
   </ul>
   <section>
     <h2 id="ex_label">Example</h2>

--- a/examples/listbox/listbox-collapsible.html
+++ b/examples/listbox/listbox-collapsible.html
@@ -49,7 +49,7 @@
       <p>Choose your favorite transuranic element (actinide or transactinide).</p>
       <div class="listbox-area">
         <div class="left-area">
-          <span id="exp_elem">Choose an element:</span>
+          <span id="exp_elem" class="listbox-label">Choose an element:</span>
           <div id="exp_wrapper">
             <button type="button" aria-haspopup="listbox" aria-labelledby="exp_elem exp_button" id="exp_button">Neptunium</button>
             <ul id="exp_elem_list" tabindex="-1" role="listbox" aria-labelledby="exp_elem" class="hidden">

--- a/examples/listbox/listbox-grouped.html
+++ b/examples/listbox/listbox-grouped.html
@@ -175,6 +175,18 @@
             </ul>
           </td>
         </tr>
+        <tr data-test-id="group-role">
+          <th scope="row"><code>role=&quot;group&quot;</code></th>
+          <td></td>
+          <td><code>div</code></td>
+          <td>Identifies a group of related options</td>
+        </tr>
+        <tr data-test-id="group-aria-labelledby">
+          <td></td>
+          <th scope="row"><code>aria-labelledby=&quot;ID_REF&quot;</code></th>
+          <td><code>div</code></td>
+          <td>Refers to the element containing the option group label.</td>
+        </tr>
         <tr data-test-id="option-role">
           <th scope="row"><code>role=&quot;option&quot;</code></th>
           <td></td>

--- a/examples/listbox/listbox-grouped.html
+++ b/examples/listbox/listbox-grouped.html
@@ -44,28 +44,28 @@
       <div class="listbox-area">
         <div class="left-area">
           <span id="ss_elem">Choose your animal sidekick</span>
-          <ul id="ss_elem_list" tabindex="0" role="listbox" aria-labelledby="ss_elem">
-            <div role="group" aria-labelledby="cat1">
-              <div role="presentation" id="cat1">Land</div>
+          <div id="ss_elem_list" tabindex="0" role="listbox" aria-labelledby="ss_elem">
+            <ul role="group" aria-labelledby="cat1">
+              <li role="presentation" id="cat1">Land</li>
               <li id="ss_elem_1" role="option">Cat</li>
               <li id="ss_elem_2" role="option">Dog</li>
               <li id="ss_elem_3" role="option">Tiger</li>
               <li id="ss_elem_4" role="option">Reindeer</li>
               <li id="ss_elem_5" role="option">Raccoon</li>
-            </div>
-            <div role="group" aria-labelledby="cat2">
-              <div role="presentation" id="cat2">Water</div>
+            </ul>
+            <ul role="group" aria-labelledby="cat2">
+              <li role="presentation" id="cat2">Water</li>
               <li id="ss_elem_6" role="option">Dolphin</li>
               <li id="ss_elem_7" role="option">Flounder</li>
               <li id="ss_elem_8" role="option">Eel</li>
-            </div>
-            <div role="group" aria-labelledby="cat3">
-              <div role="presentation" id="cat3">Air</div>
+            </ul>
+            <ul role="group" aria-labelledby="cat3">
+              <li role="presentation" id="cat3">Air</li>
               <li id="ss_elem_9" role="option">Falcon</li>
               <li id="ss_elem_10" role="option">Winged Horse</li>
               <li id="ss_elem_11" role="option">Owl</li>
-            </div>
-          </ul>
+            </ul>
+          </div>
         </div>
       </div>
     </div>
@@ -148,25 +148,25 @@
         <tr data-test-id="listbox-role">
           <th scope="row"><code>listbox</code></th>
           <td></td>
-          <td><code>ul</code></td>
+          <td><code>div</code></td>
           <td>Identifies the focusable element that has listbox behaviors and contains the listbox options. </td>
         </tr>
         <tr data-test-id="listbox-aria-labelledby">
           <td></td>
           <th scope="row"><code>aria-labelledby=&quot;ID_REF&quot;</code></th>
-          <td><code>ul</code></td>
+          <td><code>div</code></td>
           <td>Refers to the element containing the listbox label.</td>
         </tr>
         <tr data-test-id="listbox-tabindex">
           <td></td>
           <th scope="row"><code>tabindex=&quot;0&quot;</code></th>
-          <td><code>ul</code></td>
+          <td><code>div</code></td>
           <td>Includes the listbox in the page tab sequence.</td>
         </tr>
         <tr data-test-id="listbox-aria-activedescendant">
           <td></td>
           <th scope="row"><code>aria-activedescendant=&quot;ID_REF&quot;</code></th>
-          <td><code>ul</code></td>
+          <td><code>div</code></td>
           <td>
             <ul>
               <li>Tells assistive technologies which of the options, if any, is visually indicated as having keyboard focus.</li>
@@ -178,13 +178,13 @@
         <tr data-test-id="group-role">
           <th scope="row"><code>role=&quot;group&quot;</code></th>
           <td></td>
-          <td><code>div</code></td>
+          <td><code>ul</code></td>
           <td>Identifies a group of related options</td>
         </tr>
         <tr data-test-id="group-aria-labelledby">
           <td></td>
           <th scope="row"><code>aria-labelledby=&quot;ID_REF&quot;</code></th>
-          <td><code>div</code></td>
+          <td><code>ul</code></td>
           <td>Refers to the element containing the option group label.</td>
         </tr>
         <tr data-test-id="option-role">

--- a/examples/listbox/listbox-grouped.html
+++ b/examples/listbox/listbox-grouped.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8" />
-<title>Scrollable Listbox Example | WAI-ARIA Authoring Practices 1.1</title>
+<title>Grouped Option Listbox Example | WAI-ARIA Authoring Practices 1.1</title>
 
 <!--  Core js and css shared by all examples; do not modify when using this template. -->
 <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/base.css">
@@ -26,54 +26,45 @@
     </ul>
   </nav>
   <main>
-  <h1>Scrollable Listbox Example</h1>
+  <h1>Listbox Example with Grouped Options</h1>
   <p>
-    The following example implementation of the
-    <a href="../../#Listbox">design pattern for listbox</a>
-    demonstrates a scrollable single-select listbox widget.
-    This widget is functionally similar to an HTML <code>select</code> input where the <code>size</code> attribute has a value greater than one.
+    The following example implementation of the <a href="../../#Listbox">design pattern for listbox</a> demonstrates a single-select listbox widget with grouped options.
+    This widget is functionally similar to an HTML <code>select</code> element with labelled <code>optgroup</code> elements used to group options.
   </p>
   <p>Similar examples include:</p>
   <ul>
+    <li><a href="listbox-scrollable.html">Scrollable Listbox Example</a>: Single-select listbox that scrolls to reveal more options, similar to HTML <code>select</code> with <code>size</code> attribute greater than one.</li>
     <li><a href="listbox-rearrangeable.html">Example Listboxes with Rearrangeable Options</a>: Examples of both single-select and multi-select listboxes with accompanying toolbars where options can be added, moved, and removed.</li>
     <li><a href="listbox-collapsible.html">Collapsible Dropdown Listbox Example</a>: Single-select collapsible listbox that expands when activated, similar to HTML <code>select</code> with the attribute <code>size=&quot;1&quot;</code>.</li>
-    <li><a href="listbox-grouped.html">Listbox Example with Grouped Options</a>: Single-select listbox with grouped options, similar to an HTML <code>select</code> with <code>optgroup</code> children.</li>
   </ul>
   <section>
     <h2 id="ex_label">Example</h2>
     <div role="separator" id="ex_start_sep" aria-labelledby="ex_start_sep ex_label" aria-label="Start of"></div>
     <div id="ex">
-      <p>Choose your favorite transuranic element (actinide or transactinide).</p>
       <div class="listbox-area">
         <div class="left-area">
-          <span id="ss_elem">Transuranium elements:</span>
+          <span id="ss_elem">Choose your animal sidekick</span>
           <ul id="ss_elem_list" tabindex="0" role="listbox" aria-labelledby="ss_elem">
-            <li id="ss_elem_Np" role="option">Neptunium</li>
-            <li id="ss_elem_Pu" role="option">Plutonium</li>
-            <li id="ss_elem_Am" role="option">Americium</li>
-            <li id="ss_elem_Cm" role="option">Curium</li>
-            <li id="ss_elem_Bk" role="option">Berkelium</li>
-            <li id="ss_elem_Cf" role="option">Californium</li>
-            <li id="ss_elem_Es" role="option">Einsteinium</li>
-            <li id="ss_elem_Fm" role="option">Fermium</li>
-            <li id="ss_elem_Md" role="option">Mendelevium</li>
-            <li id="ss_elem_No" role="option">Nobelium</li>
-            <li id="ss_elem_Lr" role="option">Lawrencium</li>
-            <li id="ss_elem_Rf" role="option">Rutherfordium</li>
-            <li id="ss_elem_Db" role="option">Dubnium</li>
-            <li id="ss_elem_Sg" role="option">Seaborgium</li>
-            <li id="ss_elem_Bh" role="option">Bohrium</li>
-            <li id="ss_elem_Hs" role="option">Hassium</li>
-            <li id="ss_elem_Mt" role="option">Meitnerium</li>
-            <li id="ss_elem_Ds" role="option">Darmstadtium</li>
-            <li id="ss_elem_Rg" role="option">Roentgenium</li>
-            <li id="ss_elem_Cn" role="option">Copernicium</li>
-            <li id="ss_elem_Nh" role="option">Nihonium</li>
-            <li id="ss_elem_Fl" role="option">Flerovium</li>
-            <li id="ss_elem_Mc" role="option">Moscovium</li>
-            <li id="ss_elem_Lv" role="option">Livermorium</li>
-            <li id="ss_elem_Ts" role="option">Tennessine</li>
-            <li id="ss_elem_Og" role="option">Oganesson</li>
+            <div role="group" aria-labelledby="cat1">
+              <div role="presentation" id="cat1">Land</div>
+              <li id="ss_elem_1" role="option">Cat</li>
+              <li id="ss_elem_2" role="option">Dog</li>
+              <li id="ss_elem_3" role="option">Tiger</li>
+              <li id="ss_elem_4" role="option">Reindeer</li>
+              <li id="ss_elem_5" role="option">Raccoon</li>
+            </div>
+            <div role="group" aria-labelledby="cat2">
+              <div role="presentation" id="cat2">Water</div>
+              <li id="ss_elem_6" role="option">Dolphin</li>
+              <li id="ss_elem_7" role="option">Flounder</li>
+              <li id="ss_elem_8" role="option">Eel</li>
+            </div>
+            <div role="group" aria-labelledby="cat3">
+              <div role="presentation" id="cat3">Air</div>
+              <li id="ss_elem_9" role="option">Falcon</li>
+              <li id="ss_elem_10" role="option">Winged Horse</li>
+              <li id="ss_elem_11" role="option">Owl</li>
+            </div>
           </ul>
         </div>
       </div>
@@ -95,8 +86,10 @@
         </ol>
       </li>
       <li>When a fully visible option is focused in any way, no scrolling occurs.</li>
-      <li>Normal scrolling through any scrolling mechanism (including <kbd>Page Up</kbd> and <kbd>Page Down</kbd>) works as expected.
-        The scroll position will jump as described for <code>focusItem</code> if a means other than a mouse click is used to change focus after scrolling.</li>
+      <li>
+        Normal scrolling through any scrolling mechanism (including <kbd>Page Up</kbd> and <kbd>Page Down</kbd>) works as expected.
+        The scroll position will jump as described for <code>focusItem</code> if a means other than a mouse click is used to change focus after scrolling.
+      </li>
     </ol>
   </section>
 

--- a/examples/listbox/listbox-grouped.html
+++ b/examples/listbox/listbox-grouped.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8" />
-<title>Listbox Example with Grouped Options | WAI-ARIA Authoring Practices 1.1</title>
+<title>Listbox Example with Grouped Options | WAI-ARIA Authoring Practices 1.2</title>
 
 <!--  Core js and css shared by all examples; do not modify when using this template. -->
 <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/base.css">
@@ -237,7 +237,7 @@
   </section>
   </main>
   <nav>
-    <a href="../../#Listbox">Listbox Design Pattern in WAI-ARIA Authoring Practices 1.1</a>
+    <a href="../../#Listbox">Listbox Design Pattern in WAI-ARIA Authoring Practices 1.2</a>
   </nav>
 </body>
 </html>

--- a/examples/listbox/listbox-grouped.html
+++ b/examples/listbox/listbox-grouped.html
@@ -29,7 +29,7 @@
   <h1>Listbox Example with Grouped Options</h1>
   <p>
     The following example implementation of the <a href="../../#Listbox">design pattern for listbox</a> demonstrates a single-select listbox widget with grouped options.
-    This widget is functionally similar to an HTML <code>select</code> element with labelled <code>optgroup</code> elements used to group options.
+    This widget is functionally similar to an HTML <code>select</code> element with <code>size</code> greater than 1 and labelled <code>optgroup</code> elements used to group options.
   </p>
   <p>Similar examples include:</p>
   <ul>

--- a/examples/listbox/listbox-grouped.html
+++ b/examples/listbox/listbox-grouped.html
@@ -70,7 +70,7 @@
       </div>
     </div>
     <div role="separator" id="ex_end_sep" aria-labelledby="ex_end_sep ex_label" aria-label="End of"></div>
-    <h4>Notes</h4>
+    <h3>Notes</h3>
     <p>This listbox is scrollable; it has more options than its height can accommodate.</p>
     <ol>
       <li>

--- a/examples/listbox/listbox-grouped.html
+++ b/examples/listbox/listbox-grouped.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8" />
-<title>Grouped Option Listbox Example | WAI-ARIA Authoring Practices 1.1</title>
+<title>Listbox Example with Grouped Options | WAI-ARIA Authoring Practices 1.1</title>
 
 <!--  Core js and css shared by all examples; do not modify when using this template. -->
 <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/base.css">

--- a/examples/listbox/listbox-grouped.html
+++ b/examples/listbox/listbox-grouped.html
@@ -42,7 +42,7 @@
     <div role="separator" id="ex_start_sep" aria-labelledby="ex_start_sep ex_label" aria-label="Start of"></div>
     <div id="ex">
       <div class="listbox-area">
-        <div class="left-area">
+        <div>
           <span id="ss_elem">Choose your animal sidekick</span>
           <div id="ss_elem_list" tabindex="0" role="listbox" aria-labelledby="ss_elem">
             <ul role="group" aria-labelledby="cat1">
@@ -96,8 +96,8 @@
   <section>
     <h2 id="kbd_label">Keyboard Support</h2>
     <p>
-      The example listboxes on this page implement the following keyboard interface. 
-      Other variations and options for the keyboard interface are described in the  
+      The example listboxes on this page implement the following keyboard interface.
+      Other variations and options for the keyboard interface are described in the
       <a href="../../#listbox_kbd_interaction">Keyboard Interaction section of the Listbox Design Pattern.</a>
     </p>
     <table aria-labelledby="kbd_label" class="def">
@@ -131,8 +131,8 @@
   <section>
     <h2 id="rps_label">Role, Property, State, and Tabindex  Attributes</h2>
     <p>
-      The example listboxes on this page implement the following ARIA roles, states, and properties. 
-      Information about other ways of applying ARIA roles, states, and properties is available in the    
+      The example listboxes on this page implement the following ARIA roles, states, and properties.
+      Information about other ways of applying ARIA roles, states, and properties is available in the
       <a href="../../#listbox_roles_states_props">Roles, States, and Properties section of the Listbox Design Pattern.</a>
     </p>
     <table aria-labelledby="rps_label" class="data attributes">

--- a/examples/listbox/listbox-grouped.html
+++ b/examples/listbox/listbox-grouped.html
@@ -43,7 +43,7 @@
     <div id="ex">
       <div class="listbox-area">
         <div>
-          <span id="ss_elem">Choose your animal sidekick</span>
+          <span id="ss_elem" class="listbox-label">Choose your animal sidekick</span>
           <div id="ss_elem_list" tabindex="0" role="listbox" aria-labelledby="ss_elem">
             <ul role="group" aria-labelledby="cat1">
               <li role="presentation" id="cat1">Land</li>

--- a/examples/listbox/listbox-grouped.html
+++ b/examples/listbox/listbox-grouped.html
@@ -29,7 +29,7 @@
   <h1>Listbox Example with Grouped Options</h1>
   <p>
     The following example implementation of the <a href="../../#Listbox">design pattern for listbox</a> demonstrates a single-select listbox widget with grouped options.
-    This widget is functionally similar to an HTML <code>select</code> element with <code>size</code> greater than 1 and labelled <code>optgroup</code> elements used to group options.
+    This widget is functionally similar to an HTML <code>select</code> element with <code>size</code> greater than 1 and options grouped into categories with labeled <code>optgroup</code> elements.
   </p>
   <p>Similar examples include:</p>
   <ul>

--- a/examples/listbox/listbox-rearrangeable.html
+++ b/examples/listbox/listbox-rearrangeable.html
@@ -40,6 +40,7 @@ while in the second example, they may select multiple options before activating 
   <ul>
     <li><a href="listbox-scrollable.html">Scrollable Listbox Example</a>: Single-select listbox that scrolls to reveal more options, similar to HTML <code>select</code> with <code>size</code> attribute greater than one.</li>
     <li><a href="listbox-collapsible.html">Collapsible Dropdown Listbox Example</a>: Single-select collapsible listbox that expands when activated, similar to HTML <code>select</code> with the attribute <code>size=&quot;1&quot;</code>.</li>
+    <li><a href="listbox-grouped.html">Listbox Example with Grouped Options</a>: Single-select listbox with grouped options, similar to an HTML <code>select</code> with <code>optgroup</code> children.</li>
   </ul>
   <section>
     <h2>Examples</h2>

--- a/examples/listbox/listbox-rearrangeable.html
+++ b/examples/listbox/listbox-rearrangeable.html
@@ -51,7 +51,7 @@ while in the second example, they may select multiple options before activating 
         <p>Rank features important to you when choosing where to live. If a feature is unimportant, move it to the unimportant features list.</p>
         <div class="listbox-area">
           <div class="left-area">
-            <span id="ss_imp_l">Important Features:</span>
+            <span id="ss_imp_l" class="listbox-label">Important Features:</span>
             <ul id="ss_imp_list" tabindex="0" role="listbox" aria-labelledby="ss_imp_l">
               <li id="ss_opt1" role="option">Proximity of public K-12 schools</li>
               <li id="ss_opt2" role="option">Proximity of child-friendly parks</li>
@@ -71,7 +71,7 @@ while in the second example, they may select multiple options before activating 
             </div>
           </div>
           <div class="right-area">
-            <span id="ss_unimp_l">Unimportant Features:</span>
+            <span id="ss_unimp_l" class="listbox-label">Unimportant Features:</span>
             <ul id="ss_unimp_list" tabindex="0" role="listbox" aria-labelledby="ss_unimp_l" aria-activedescendant="">
             </ul>
             <button type="button" id="ex1-add" class="move-left-btn" aria-keyshortcuts="Alt+ArrowLeft Enter" aria-disabled="true">Important</button>
@@ -110,7 +110,7 @@ while in the second example, they may select multiple options before activating 
         <p>Choose upgrades for your transport capsule.</p>
         <div class="listbox-area">
           <div class="left-area">
-            <span id="ms_av_l">Available upgrades:</span>
+            <span id="ms_av_l" class="listbox-label">Available upgrades:</span>
             <ul
               id="ms_imp_list"
               tabindex="0"
@@ -131,7 +131,7 @@ while in the second example, they may select multiple options before activating 
             <button type="button" id="ex2-add" class="move-right-btn" aria-keyshortcuts="Alt+ArrowRight Enter" aria-disabled="true">Add</button>
           </div>
           <div class="right-area">
-            <span id="ms_ch_l">Upgrades you have chosen:</span>
+            <span id="ms_ch_l" class="listbox-label">Upgrades you have chosen:</span>
             <ul
               id="ms_unimp_list"
               tabindex="0"

--- a/examples/listbox/listbox-scrollable.html
+++ b/examples/listbox/listbox-scrollable.html
@@ -45,7 +45,7 @@
     <div id="ex">
       <p>Choose your favorite transuranic element (actinide or transactinide).</p>
       <div class="listbox-area">
-        <div class="left-area">
+        <div>
           <span id="ss_elem">Transuranium elements:</span>
           <ul id="ss_elem_list" tabindex="0" role="listbox" aria-labelledby="ss_elem">
             <li id="ss_elem_Np" role="option">Neptunium</li>
@@ -103,8 +103,8 @@
   <section>
     <h2 id="kbd_label">Keyboard Support</h2>
     <p>
-      The example listboxes on this page implement the following keyboard interface. 
-      Other variations and options for the keyboard interface are described in the  
+      The example listboxes on this page implement the following keyboard interface.
+      Other variations and options for the keyboard interface are described in the
       <a href="../../#listbox_kbd_interaction">Keyboard Interaction section of the Listbox Design Pattern.</a>
     </p>
     <table aria-labelledby="kbd_label" class="def">
@@ -138,8 +138,8 @@
   <section>
     <h2 id="rps_label">Role, Property, State, and Tabindex  Attributes</h2>
     <p>
-      The example listboxes on this page implement the following ARIA roles, states, and properties. 
-      Information about other ways of applying ARIA roles, states, and properties is available in the    
+      The example listboxes on this page implement the following ARIA roles, states, and properties.
+      Information about other ways of applying ARIA roles, states, and properties is available in the
       <a href="../../#listbox_roles_states_props">Roles, States, and Properties section of the Listbox Design Pattern.</a>
     </p>
     <table aria-labelledby="rps_label" class="data attributes">

--- a/examples/listbox/listbox-scrollable.html
+++ b/examples/listbox/listbox-scrollable.html
@@ -46,7 +46,7 @@
       <p>Choose your favorite transuranic element (actinide or transactinide).</p>
       <div class="listbox-area">
         <div>
-          <span id="ss_elem">Transuranium elements:</span>
+          <span id="ss_elem" class="listbox-label">Transuranium elements:</span>
           <ul id="ss_elem_list" tabindex="0" role="listbox" aria-labelledby="ss_elem">
             <li id="ss_elem_Np" role="option">Neptunium</li>
             <li id="ss_elem_Pu" role="option">Plutonium</li>

--- a/test/tests/listbox_grouped.js
+++ b/test/tests/listbox_grouped.js
@@ -19,7 +19,7 @@ const ex = {
 // Attributes
 
 ariaTest('role="listbox" on ul element', exampleFile, 'listbox-role', async (t) => {
-  await assertAriaRoles(t, 'ex', 'listbox', 1, 'ul');
+  await assertAriaRoles(t, 'ex', 'listbox', 1, 'div');
 });
 
 ariaTest('"aria-labelledby" on listbox element', exampleFile, 'listbox-aria-labelledby', async (t) => {
@@ -47,8 +47,8 @@ ariaTest('aria-activedescendant on listbox element', exampleFile, 'listbox-aria-
   );
 });
 
-ariaTest('role="group" on div elements', exampleFile, 'group-role', async (t) => {
-  await assertAriaRoles(t, 'ex', 'group', 3, 'div');
+ariaTest('role="group" on ul elements', exampleFile, 'group-role', async (t) => {
+  await assertAriaRoles(t, 'ex', 'group', 3, 'ul');
 });
 
 ariaTest('"aria-labelledby" on group elements', exampleFile, 'group-aria-labelledby', async (t) => {
@@ -82,7 +82,7 @@ ariaTest('DOWN ARROW moves focus', exampleFile, 'key-down-arrow', async (t) => {
   await assertAriaSelectedAndActivedescendant(t, ex.listboxSelector, ex.optionSelector, 2);
 });
 
-ariaTest('DOWN ARROW does not wrap to top of listbox', exampleFile, 'key-down-arrow', async(t) => {
+ariaTest('DOWN ARROW does not wrap to top of listbox', exampleFile, 'key-down-arrow', async (t) => {
   const listbox = await t.context.session.findElement(By.css(ex.listboxSelector));
   const options = await t.context.session.findElements(By.css(ex.optionSelector));
 
@@ -152,7 +152,7 @@ ariaTest('UP ARROW moves focus', exampleFile, 'key-up-arrow', async (t) => {
   await assertAriaSelectedAndActivedescendant(t, ex.listboxSelector, ex.optionSelector, 0);
 });
 
-ariaTest('UP ARROW does not wrap to bottom of listbox', exampleFile, 'key-up-arrow', async(t) => {
+ariaTest('UP ARROW does not wrap to bottom of listbox', exampleFile, 'key-up-arrow', async (t) => {
   const listbox = await t.context.session.findElement(By.css(ex.listboxSelector));
 
   // click the first option

--- a/test/tests/listbox_grouped.js
+++ b/test/tests/listbox_grouped.js
@@ -1,0 +1,193 @@
+'use strict';
+
+const { ariaTest } = require('..');
+const { By, Key } = require('selenium-webdriver');
+const assertAttributeValues = require('../util/assertAttributeValues');
+const assertAriaLabelledby = require('../util/assertAriaLabelledby');
+const assertAriaRoles = require('../util/assertAriaRoles');
+const assertAriaSelectedAndActivedescendant = require('../util/assertAriaSelectedAndActivedescendant');
+const assertAttributeDNE = require('../util/assertAttributeDNE');
+
+const exampleFile = 'listbox/listbox-grouped.html';
+
+const ex = {
+  listboxSelector: '#ex [role="listbox"]',
+  optionSelector: '#ex [role="option"]',
+  optionIdBase: '#ss_elem_'
+};
+
+// Attributes
+
+ariaTest('role="listbox" on ul element', exampleFile, 'listbox-role', async (t) => {
+  await assertAriaRoles(t, 'ex', 'listbox', 1, 'ul');
+});
+
+ariaTest('"aria-labelledby" on listbox element', exampleFile, 'listbox-aria-labelledby', async (t) => {
+  await assertAriaLabelledby(t, ex.listboxSelector);
+});
+
+ariaTest('tabindex="0" on listbox element', exampleFile, 'listbox-tabindex', async (t) => {
+  await assertAttributeValues(t, ex.listboxSelector, 'tabindex', '0');
+});
+
+ariaTest('aria-activedescendant on listbox element', exampleFile, 'listbox-aria-activedescendant', async (t) => {
+  // Put the focus on the listbox. In this example, focusing on the listbox
+  // will automatically select the first option.
+  await t.context.session.findElement(By.css(`${ex.optionIdBase}1`)).click();
+
+  let options = await t.context.session.findElements(By.css(ex.optionSelector));
+  let optionId = await options[0].getAttribute('id');
+
+  t.is(
+    await t.context.session
+      .findElement(By.css(ex.listboxSelector))
+      .getAttribute('aria-activedescendant'),
+    optionId,
+    'aria-activedescendant should be set to ' + optionId + ' for items: ' + ex.listboxSelector
+  );
+});
+
+ariaTest('role="group" on div elements', exampleFile, 'group-role', async (t) => {
+  await assertAriaRoles(t, 'ex', 'group', 3, 'div');
+});
+
+ariaTest('"aria-labelledby" on group elements', exampleFile, 'group-aria-labelledby', async (t) => {
+  await assertAriaLabelledby(t, `${ex.listboxSelector} [role="group"]`);
+});
+
+ariaTest('role="option" on li elements', exampleFile, 'option-role', async (t) => {
+  await assertAriaRoles(t, 'ex', 'option', 11, 'li');
+});
+
+ariaTest('"aria-selected" on option elements', exampleFile, 'option-aria-selected', async (t) => {
+  await assertAttributeDNE(t, ex.optionSelector, 'aria-selected');
+
+  // Put the focus on the listbox. In this example, focusing on the listbox
+  // will automatically select the first option.
+  await t.context.session.findElement(By.css(`${ex.optionIdBase}1`)).click();
+
+  await assertAttributeValues(t, `${ex.optionIdBase}1`, 'aria-selected', 'true');
+});
+
+// Keys
+
+ariaTest('DOWN ARROW moves focus', exampleFile, 'key-down-arrow', async (t) => {
+  // Click the second option
+  await t.context.session.findElement(By.css(`${ex.optionIdBase}2`)).click();
+
+  // Sending the key down arrow will put focus on the item at index 2 (the third option)
+  const listbox = await t.context.session.findElement(By.css(ex.listboxSelector));
+  await listbox.sendKeys(Key.ARROW_DOWN);
+
+  await assertAriaSelectedAndActivedescendant(t, ex.listboxSelector, ex.optionSelector, 2);
+});
+
+ariaTest('DOWN ARROW does not wrap to top of listbox', exampleFile, 'key-down-arrow', async(t) => {
+  const listbox = await t.context.session.findElement(By.css(ex.listboxSelector));
+  const options = await t.context.session.findElements(By.css(ex.optionSelector));
+
+  // click the last option
+  await options[options.length - 1].click();
+
+  // arrow down
+  await listbox.sendKeys(Key.ARROW_DOWN);
+
+  await assertAriaSelectedAndActivedescendant(t, ex.listboxSelector, ex.optionSelector, options.length - 1);
+});
+
+ariaTest('DOWN ARROW sends initial focus to the first option', exampleFile, 'key-down-arrow', async (t) => {
+  // Sending the key down arrow will put focus on the first option if no options are focused
+  const listbox = await t.context.session.findElement(By.css(ex.listboxSelector));
+  await listbox.sendKeys(Key.ARROW_DOWN);
+
+  await assertAriaSelectedAndActivedescendant(t, ex.listboxSelector, ex.optionSelector, 0);
+});
+
+ariaTest('DOWN ARROW moves through groups', exampleFile, 'key-down-arrow', async (t) => {
+  // Sending the key down arrow will put focus on the first option if no options are focused
+  const listbox = await t.context.session.findElement(By.css(ex.listboxSelector));
+  const group1 = await listbox.findElement(By.css('[role="group"]'));
+  const groupOptions = await group1.findElements(By.css('[role="option"]'));
+
+  // click last option in group
+  await groupOptions[groupOptions.length - 1].click();
+
+  await listbox.sendKeys(Key.ARROW_DOWN);
+
+  // focus should be on the first option in the second group; i.e. index === groupOptions.length
+  await assertAriaSelectedAndActivedescendant(t, ex.listboxSelector, ex.optionSelector, groupOptions.length);
+});
+
+ariaTest('UP ARROW sends initial focus to the first option', exampleFile, 'key-up-arrow', async (t) => {
+  // Sending the key up arrow will put focus on the first option, if no options are focused
+  const listbox = await t.context.session.findElement(By.css(ex.listboxSelector));
+  await listbox.sendKeys(Key.ARROW_UP);
+
+  await assertAriaSelectedAndActivedescendant(t, ex.listboxSelector, ex.optionSelector, 0);
+});
+
+ariaTest('END moves focus', exampleFile, 'key-end', async (t) => {
+  const listbox = await t.context.session.findElement(By.css(ex.listboxSelector));
+  const options = await t.context.session.findElements(By.css(ex.optionSelector));
+
+  // Sending key end should put focus on the last item
+  await listbox.sendKeys(Key.END);
+  await assertAriaSelectedAndActivedescendant(t, ex.listboxSelector, ex.optionSelector,
+    options.length - 1);
+
+  // Sending key end twice should put focus on the last item
+  await listbox.sendKeys(Key.END);
+  await assertAriaSelectedAndActivedescendant(t, ex.listboxSelector, ex.optionSelector,
+    options.length - 1);
+});
+
+ariaTest('UP ARROW moves focus', exampleFile, 'key-up-arrow', async (t) => {
+  const listbox = await t.context.session.findElement(By.css(ex.listboxSelector));
+
+  // Click the second option
+  await t.context.session.findElement(By.css(`${ex.optionIdBase}2`)).click();
+
+  // Sending the key up arrow will put focus on the first option
+  await listbox.sendKeys(Key.ARROW_UP);
+  await assertAriaSelectedAndActivedescendant(t, ex.listboxSelector, ex.optionSelector, 0);
+});
+
+ariaTest('UP ARROW does not wrap to bottom of listbox', exampleFile, 'key-up-arrow', async(t) => {
+  const listbox = await t.context.session.findElement(By.css(ex.listboxSelector));
+
+  // click the first option
+  await t.context.session.findElement(By.css(`${ex.optionIdBase}1`)).click();
+
+  // arrow up
+  await listbox.sendKeys(Key.ARROW_UP);
+
+  await assertAriaSelectedAndActivedescendant(t, ex.listboxSelector, ex.optionSelector, 0);
+});
+
+ariaTest('UP ARROW moves through groups', exampleFile, 'key-up-arrow', async (t) => {
+  // Sending the key down arrow will put focus on the first option if no options are focused
+  const listbox = await t.context.session.findElement(By.css(ex.listboxSelector));
+  const group1 = await listbox.findElement(By.css('[role="group"]'));
+  const groupOptions = await group1.findElements(By.css('[role="option"]'));
+
+  // click first option in second group
+  await t.context.session.findElement(By.css(`${ex.optionIdBase}${groupOptions.length + 1}`)).click();
+
+  await listbox.sendKeys(Key.ARROW_UP);
+
+  // focus should be on the last option in the first group
+  await assertAriaSelectedAndActivedescendant(t, ex.listboxSelector, ex.optionSelector, groupOptions.length - 1);
+});
+
+ariaTest('HOME moves focus', exampleFile, 'key-home', async (t) => {
+  const listbox = await t.context.session.findElement(By.css(ex.listboxSelector));
+  await listbox.sendKeys(Key.ARROW_DOWN, Key.ARROW_DOWN);
+
+  // Sending key home should always put focus on the first item
+  await listbox.sendKeys(Key.HOME);
+  await assertAriaSelectedAndActivedescendant(t, ex.listboxSelector, ex.optionSelector, 0);
+
+  // Sending key home twice should always put focus on the first item
+  await listbox.sendKeys(Key.HOME);
+  await assertAriaSelectedAndActivedescendant(t, ex.listboxSelector, ex.optionSelector, 0);
+});

--- a/test/tests/listbox_grouped.js
+++ b/test/tests/listbox_grouped.js
@@ -191,3 +191,35 @@ ariaTest('HOME moves focus', exampleFile, 'key-home', async (t) => {
   await listbox.sendKeys(Key.HOME);
   await assertAriaSelectedAndActivedescendant(t, ex.listboxSelector, ex.optionSelector, 0);
 });
+
+ariaTest('END scrolls listbox option into view', exampleFile, 'key-end', async (t) => {
+  const listbox = await t.context.session.findElement(By.css(ex.listboxSelector));
+  const options = await t.context.session.findElements(By.css(ex.optionSelector));
+
+  let listboxBounds = await listbox.getRect();
+  let optionBounds = await options[options.length - 1].getRect();
+
+  t.true(listboxBounds.y + listboxBounds.height - optionBounds.y < 0, 'last option is not initially displayed');
+
+  await listbox.sendKeys(Key.END);
+  listboxBounds = await listbox.getRect();
+  optionBounds = await options[options.length - 1].getRect();
+
+  t.true(listboxBounds.y + listboxBounds.height - optionBounds.y >= 0, 'last option is in view after end key');
+});
+
+ariaTest('Click scrolls listbox option into view', exampleFile, 'key-end', async (t) => {
+  const listbox = await t.context.session.findElement(By.css(ex.listboxSelector));
+  const options = await t.context.session.findElements(By.css(ex.optionSelector));
+
+  let listboxBounds = await listbox.getRect();
+  let optionBounds = await options[options.length - 1].getRect();
+
+  t.true(listboxBounds.y + listboxBounds.height - optionBounds.y < 0, 'last option is not initially displayed');
+
+  await options[options.length - 1].click();
+  listboxBounds = await listbox.getRect();
+  optionBounds = await options[options.length - 1].getRect();
+
+  t.true(listboxBounds.y + listboxBounds.height - optionBounds.y >= 0, 'last option is in view after click');
+});


### PR DESCRIPTION
Adds a listbox pattern with grouped options with tests.

Additionally, fixes these bugs with clicking listbox options:
- Clicking any option below the initially visible aria results in the first option being selected instead of the clicked option
- Clicking any option within the initially visible area briefly selects the first option before moving selection to the clicked option

By:
- not immediately selecting the first option when the listbox receives focus (bringing it more inline with native `<select multiple>`
- only initiating automatic listbox scroll when interacting with the keyboard

Resolves #913 

### Review checklist

* [x] [Editorial review](https://github.com/w3c/aria-practices/wiki/Pull-Request-Review-Process#editorial_review) by @mcking65
* [x] [Functional review](https://github.com/w3c/aria-practices/wiki/Pull-Request-Review-Process#functional_review) by @ZoeBijl @smhigley 
* [x] [Visual design review](https://github.com/w3c/aria-practices/wiki/Pull-Request-Review-Process#design_review) by @ZoeBijl 
* [x] [Accessibility review](https://github.com/w3c/aria-practices/wiki/Pull-Request-Review-Process#accessibility_review) @ZoeBijl @carmacleod 
* [x] [Code review](https://github.com/w3c/aria-practices/wiki/Pull-Request-Review-Process#code_review) by @ZoeBijl 
* [x] [Test review](https://github.com/w3c/aria-practices/wiki/Pull-Request-Review-Process#test_review) by @spectranaut 
### Preview link

[View this example in the compare branch for this PR](https://raw.githack.com/w3c/aria-practices/913-listbox-groups/examples/listbox/listbox-grouped.html)