### PR TITLE
Add type="button" to non-submit buttons in examples

### DIFF
--- a/examples/accordion/accordion.html
+++ b/examples/accordion/accordion.html
@@ -54,7 +54,7 @@
         -->
         <div id="accordionGroup" class="Accordion">
           <h3>
-            <button aria-expanded="true" class="Accordion-trigger"
+            <button type="button" aria-expanded="true" class="Accordion-trigger"
               aria-controls="sect1" id="accordion1id">
               <span class="Accordion-title">
                 Personal Information
@@ -98,7 +98,7 @@
             </div>
           </div>
           <h3>
-            <button aria-expanded="false" class="Accordion-trigger"
+            <button type="button" aria-expanded="false" class="Accordion-trigger"
               aria-controls="sect2" id="accordion2id">
               <span class="Accordion-title">
                 Billing Address
@@ -133,7 +133,7 @@
             </div>
           </div>
           <h3>
-            <button aria-expanded="false" class="Accordion-trigger"
+            <button type="button" aria-expanded="false" class="Accordion-trigger"
               aria-controls="sect3" id="accordion3id">
               <span class="Accordion-title">
                 Shipping Address

--- a/examples/alert/alert.html
+++ b/examples/alert/alert.html
@@ -42,7 +42,7 @@
       </p>
       <div role="separator" id="ex_start_sep" aria-labelledby="ex_start_sep ex_label" aria-label="Start of"></div>
       <div id="ex1">
-        <button id="alert-trigger">Trigger Alert</button>
+        <button type="button" id="alert-trigger">Trigger Alert</button>
 
         <div id="example" role="alert"></div>
 

--- a/examples/carousel/carousel-1.html
+++ b/examples/carousel/carousel-1.html
@@ -64,7 +64,7 @@
 
                 <div class="controls">
 
-                  <button class="rotation pause"
+                  <button type="button" class="rotation pause"
                           aria-label="Stop automatic slide show">
                     <svg width="42" height="34" version="1.1" xmlns="http://www.w3.org/2000/svg">
                       <rect class="background" x="2" y="2" rx="5" ry="5" width="38" height="24"/>
@@ -80,7 +80,7 @@
                   </button>
 
 
-                  <button class="previous"
+                  <button type="button" class="previous"
                      aria-controls="myCarousel-items"
                      aria-label="Previous Slide">
                     <svg width="42" height="34" version="1.1" xmlns="http://www.w3.org/2000/svg">
@@ -90,7 +90,7 @@
                     </svg>
                   </button>
 
-                  <button class="next"
+                  <button type="button" class="next"
                      aria-controls="myCarousel-items"
                      aria-label="Next Slide">
                     <svg width="42" height="34" version="1.1" xmlns="http://www.w3.org/2000/svg">

--- a/examples/combobox/aria1.0pattern/combobox-autocomplete-both.html
+++ b/examples/combobox/aria1.0pattern/combobox-autocomplete-both.html
@@ -62,7 +62,7 @@
             <input id="cb1-input" class="cb_edit" type="text" role="combobox" aria-autocomplete="both"
               aria-expanded="false" aria-haspopup="true" aria-owns="lb1"
             />
-            <button id="cb1-button" aria-label="Open" tabindex="-1">&#9661;</button>
+            <button type="button" id="cb1-button" aria-label="Open" tabindex="-1">&#9661;</button>
           </div>
           <ul id="lb1" role="listbox" aria-label="States">
             <li id="lb1-al" role="option">Alabama</li>

--- a/examples/combobox/aria1.0pattern/combobox-autocomplete-list.html
+++ b/examples/combobox/aria1.0pattern/combobox-autocomplete-list.html
@@ -61,7 +61,7 @@
             <input id="cb1-input" class="cb_edit" type="text" role="combobox" aria-autocomplete="list"
               aria-expanded="false" aria-haspopup="true" aria-owns="cb1-listbox"
             />
-            <button id="cb1-button" tabindex="-1" aria-label="Open">&#9661;</button>
+            <button type="button" id="cb1-button" tabindex="-1" aria-label="Open">&#9661;</button>
           </div>
           <ul id="cb1-listbox" role="listbox" aria-label="States">
             <li id="lb1-al" role="option">Alabama</li>

--- a/examples/combobox/aria1.0pattern/combobox-autocomplete-none.html
+++ b/examples/combobox/aria1.0pattern/combobox-autocomplete-none.html
@@ -62,7 +62,7 @@
                    aria-haspopup="true"
                    aria-owns="cb1-listbox"
             />
-            <button id="cb1-button" tabindex="-1" aria-label="Open">
+            <button type="button" id="cb1-button" tabindex="-1" aria-label="Open">
               &#9661;
             </button>
           </div>

--- a/examples/dialog-modal/datepicker-dialog.html
+++ b/examples/dialog-modal/datepicker-dialog.html
@@ -57,7 +57,7 @@
                 id="id-textbox-1"
                 aria-autocomplete="none">
 
-          <button class="icon"
+          <button type="button" class="icon"
             aria-label="Choose Date"
             >
             <span class="fa fa-calendar-alt fa-2x"></span>
@@ -73,12 +73,12 @@
 
           <div class="header">
 
-            <button class="prevYear"
+            <button type="button" class="prevYear"
               aria-label="previous year">
               <span class="fas fa-angle-double-left fa-lg"></span>
             </button>
 
-            <button class="prevMonth"
+            <button type="button" class="prevMonth"
               aria-label="previous month">
               <span class="fas fa-angle-left fa-lg"></span>
             </button>
@@ -89,12 +89,12 @@
               Month Year
             </h2>
 
-            <button class="nextMonth"
+            <button type="button" class="nextMonth"
               aria-label="next month">
               <span class="fas fa-angle-right fa-lg"></span>
             </button>
 
-            <button class="nextYear"
+            <button type="button" class="nextYear"
               aria-label="next year">
               <span class="fas fa-angle-double-right fa-lg"></span>
             </button>
@@ -119,65 +119,65 @@
 
             <tbody>
               <tr>
-                <td class="dateCell"><button class="dateButton disabled" tabindex="-1">25</button></td>
-                <td class="dateCell"><button class="dateButton disabled" tabindex="-1">26</button></td>
-                <td class="dateCell"><button class="dateButton disabled" tabindex="-1">27</button></td>
-                <td class="dateCell"><button class="dateButton disabled" tabindex="-1">28</button></td>
-                <td class="dateCell"><button class="dateButton disabled" tabindex="-1">29</button></td>
-                <td class="dateCell"><button class="dateButton disabled" tabindex="-1">30</button></td>
-                <td class="dateCell"><button class="dateButton" tabindex="-1">1</button></td>
+                <td class="dateCell"><button type="button" class="dateButton disabled" tabindex="-1">25</button></td>
+                <td class="dateCell"><button type="button" class="dateButton disabled" tabindex="-1">26</button></td>
+                <td class="dateCell"><button type="button" class="dateButton disabled" tabindex="-1">27</button></td>
+                <td class="dateCell"><button type="button" class="dateButton disabled" tabindex="-1">28</button></td>
+                <td class="dateCell"><button type="button" class="dateButton disabled" tabindex="-1">29</button></td>
+                <td class="dateCell"><button type="button" class="dateButton disabled" tabindex="-1">30</button></td>
+                <td class="dateCell"><button type="button" class="dateButton" tabindex="-1">1</button></td>
               </tr>
               <tr>
-                <td class="dateCell"><button class="dateButton" tabindex="-1">2</button></td>
-                <td class="dateCell"><button class="dateButton" tabindex="-1">3</button></td>
-                <td class="dateCell"><button class="dateButton" tabindex="-1">4</button></td>
-                <td class="dateCell"><button class="dateButton" tabindex="-1">5</button></td>
-                <td class="dateCell"><button class="dateButton" tabindex="-1">6</button></td>
-                <td class="dateCell"><button class="dateButton" tabindex="-1">7</button></td>
-                <td class="dateCell"><button class="dateButton" tabindex="-1">8</button></td>
+                <td class="dateCell"><button type="button" class="dateButton" tabindex="-1">2</button></td>
+                <td class="dateCell"><button type="button" class="dateButton" tabindex="-1">3</button></td>
+                <td class="dateCell"><button type="button" class="dateButton" tabindex="-1">4</button></td>
+                <td class="dateCell"><button type="button" class="dateButton" tabindex="-1">5</button></td>
+                <td class="dateCell"><button type="button" class="dateButton" tabindex="-1">6</button></td>
+                <td class="dateCell"><button type="button" class="dateButton" tabindex="-1">7</button></td>
+                <td class="dateCell"><button type="button" class="dateButton" tabindex="-1">8</button></td>
               </tr>
               <tr>
-                <td class="dateCell"><button class="dateButton" tabindex="-1">9</button></td>
-                <td class="dateCell"><button class="dateButton" tabindex="-1">10</button></td>
-                <td class="dateCell"><button class="dateButton" tabindex="-1">11</button></td>
-                <td class="dateCell"><button class="dateButton" tabindex="-1">12</button></td>
-                <td class="dateCell"><button class="dateButton" tabindex="-1">13</button></td>
-                <td class="dateCell"><button class="dateButton">14</button></td>
-                <td class="dateCell"><button class="dateButton" tabindex="-1">15</button></td>
+                <td class="dateCell"><button type="button" class="dateButton" tabindex="-1">9</button></td>
+                <td class="dateCell"><button type="button" class="dateButton" tabindex="-1">10</button></td>
+                <td class="dateCell"><button type="button" class="dateButton" tabindex="-1">11</button></td>
+                <td class="dateCell"><button type="button" class="dateButton" tabindex="-1">12</button></td>
+                <td class="dateCell"><button type="button" class="dateButton" tabindex="-1">13</button></td>
+                <td class="dateCell"><button type="button" class="dateButton">14</button></td>
+                <td class="dateCell"><button type="button" class="dateButton" tabindex="-1">15</button></td>
               </tr>
               <tr>
-                <td class="dateCell"><button class="dateButton" tabindex="-1">16</button></td>
-                <td class="dateCell"><button class="dateButton" tabindex="-1">17</button></td>
-                <td class="dateCell"><button class="dateButton" tabindex="-1">18</button></td>
-                <td class="dateCell"><button class="dateButton" tabindex="-1">19</button></td>
-                <td class="dateCell"><button class="dateButton" tabindex="-1">20</button></td>
-                <td class="dateCell"><button class="dateButton" tabindex="-1">21</button></td>
-                <td class="dateCell"><button class="dateButton" tabindex="-1">22</button></td>
+                <td class="dateCell"><button type="button" class="dateButton" tabindex="-1">16</button></td>
+                <td class="dateCell"><button type="button" class="dateButton" tabindex="-1">17</button></td>
+                <td class="dateCell"><button type="button" class="dateButton" tabindex="-1">18</button></td>
+                <td class="dateCell"><button type="button" class="dateButton" tabindex="-1">19</button></td>
+                <td class="dateCell"><button type="button" class="dateButton" tabindex="-1">20</button></td>
+                <td class="dateCell"><button type="button" class="dateButton" tabindex="-1">21</button></td>
+                <td class="dateCell"><button type="button" class="dateButton" tabindex="-1">22</button></td>
               </tr>
               <tr>
-                <td class="dateCell"><button class="dateButton" tabindex="-1">23</button></td>
-                <td class="dateCell"><button class="dateButton" tabindex="-1">24</button></td>
-                <td class="dateCell"><button class="dateButton" tabindex="-1">25</button></td>
-                <td class="dateCell"><button class="dateButton" tabindex="-1">26</button></td>
-                <td class="dateCell"><button class="dateButton" tabindex="-1">27</button></td>
-                <td class="dateCell"><button class="dateButton" tabindex="-1">28</button></td>
-                <td class="dateCell"><button class="dateButton" tabindex="-1">29</button></td>
+                <td class="dateCell"><button type="button" class="dateButton" tabindex="-1">23</button></td>
+                <td class="dateCell"><button type="button" class="dateButton" tabindex="-1">24</button></td>
+                <td class="dateCell"><button type="button" class="dateButton" tabindex="-1">25</button></td>
+                <td class="dateCell"><button type="button" class="dateButton" tabindex="-1">26</button></td>
+                <td class="dateCell"><button type="button" class="dateButton" tabindex="-1">27</button></td>
+                <td class="dateCell"><button type="button" class="dateButton" tabindex="-1">28</button></td>
+                <td class="dateCell"><button type="button" class="dateButton" tabindex="-1">29</button></td>
               </tr>
               <tr>
-                <td class="dateCell"><button class="dateButton" tabindex="-1">30</button></td>
-                <td class="dateCell"><button class="dateButton" tabindex="-1">31</button></td>
-                <td class="dateCell"><button class="dateButton disabled" tabindex="-1">1</button></td>
-                <td class="dateCell"><button class="dateButton disabled" tabindex="-1">2</button></td>
-                <td class="dateCell"><button class="dateButton disabled" tabindex="-1">3</button></td>
-                <td class="dateCell"><button class="dateButton disabled" tabindex="-1">4</button></td>
-                <td class="dateCell"><button class="dateButton disabled" tabindex="-1">5</button></td>
+                <td class="dateCell"><button type="button" class="dateButton" tabindex="-1">30</button></td>
+                <td class="dateCell"><button type="button" class="dateButton" tabindex="-1">31</button></td>
+                <td class="dateCell"><button type="button" class="dateButton disabled" tabindex="-1">1</button></td>
+                <td class="dateCell"><button type="button" class="dateButton disabled" tabindex="-1">2</button></td>
+                <td class="dateCell"><button type="button" class="dateButton disabled" tabindex="-1">3</button></td>
+                <td class="dateCell"><button type="button" class="dateButton disabled" tabindex="-1">4</button></td>
+                <td class="dateCell"><button type="button" class="dateButton disabled" tabindex="-1">5</button></td>
               </tr>
             </tbody>
           </table>
 
           <div class="dialogButtonGroup">
-            <button class="dialogButton" value="cancel">Cancel</button>
-            <button class="dialogButton" value="ok">OK</button>
+            <button type="button" class="dialogButton" value="cancel">Cancel</button>
+            <button type="button" class="dialogButton" value="ok">OK</button>
           </div>
 
           <div class="message" aria-live="polite">

--- a/examples/dialog-modal/dialog.html
+++ b/examples/dialog-modal/dialog.html
@@ -45,7 +45,7 @@
       <h2 id="ex_label">Example</h2>
       <div role="separator" id="ex_start_sep" aria-labelledby="ex_start_sep ex_label" aria-label="Start of"></div>
       <div id="ex1">
-        <button onclick="openDialog('dialog1', this)">Add Delivery Address</button>
+        <button type="button" onclick="openDialog('dialog1', this)">Add Delivery Address</button>
       </div>
       <div role="separator" id="ex_end_sep" aria-labelledby="ex_end_sep ex_label" aria-label="End of"></div>
     </section>
@@ -275,9 +275,9 @@
         </div>
       </div>
       <div class="dialog_form_actions">
-        <button onclick="openDialog('dialog2', this, 'dialog2_para1')">Verify Address</button>
-        <button onclick="replaceDialog('dialog3', undefined, 'dialog3_close_btn')">Add</button>
-        <button onclick="closeDialog(this)">Cancel</button>
+        <button type="button" onclick="openDialog('dialog2', this, 'dialog2_para1')">Verify Address</button>
+        <button type="button" onclick="replaceDialog('dialog3', undefined, 'dialog3_close_btn')">Add</button>
+        <button type="button" onclick="closeDialog(this)">Cancel</button>
       </div>
     </div>
 
@@ -336,8 +336,8 @@
       </div>
       <div class="dialog_form_actions">
         <a href="#" onclick="openDialog('dialog4', this)">link to help</a>
-        <button onclick="openDialog('dialog4', this)">accepting an alternative form</button>
-        <button onclick="closeDialog(this)">Close</button>
+        <button type="button" onclick="openDialog('dialog4', this)">accepting an alternative form</button>
+        <button type="button" onclick="closeDialog(this)">Close</button>
       </div>
     </div>
 
@@ -351,7 +351,7 @@
         <a href="#" onclick="openDialog('dialog4', this)">your profile.</a>
       </p>
       <div class="dialog_form_actions">
-        <button id="dialog3_close_btn" onclick="closeDialog(this)">OK</button>
+        <button type="button" id="dialog3_close_btn" onclick="closeDialog(this)">OK</button>
       </div>
     </div>
 
@@ -364,7 +364,7 @@
         The link or button is present for demonstration purposes only.
       </p>
       <div class="dialog_form_actions">
-        <button id="dialog4_close_btn" onclick="closeDialog(this)">Close</button>
+        <button type="button" id="dialog4_close_btn" onclick="closeDialog(this)">Close</button>
       </div>
     </div>
   </div>

--- a/examples/dialog-modal/js/datepicker.js
+++ b/examples/dialog-modal/js/datepicker.js
@@ -97,6 +97,7 @@ DatePicker.prototype.init = function () {
       cell.classList.add('dateCell');
       var cellButton = document.createElement('button');
       cellButton.classList.add('dateButton');
+      cellButton.setAttribute('type', 'button');
       cell.appendChild(cellButton);
       row.appendChild(cell);
       var dpDay = new DatePickerDay(cellButton, this, index, i, j);

--- a/examples/disclosure/disclosure-faq.html
+++ b/examples/disclosure/disclosure-faq.html
@@ -48,7 +48,7 @@
     <div id="ex1">
       <dl class="faq">
         <dt>
-          <button aria-expanded="false" aria-controls="faq1_desc">What do I do if I have a permit for an assigned lot, but can't find a space there?</button>
+          <button type="button" aria-expanded="false" aria-controls="faq1_desc">What do I do if I have a permit for an assigned lot, but can't find a space there?</button>
         </dt>
         <dd>
           <p id="faq1_desc" class="desc">
@@ -58,7 +58,7 @@
           </p>
         </dd>
         <dt>
-          <button aria-expanded="false" aria-controls="faq2_desc">What do I do if I lose my permit or if my permit is stolen?</button>
+          <button type="button" aria-expanded="false" aria-controls="faq2_desc">What do I do if I lose my permit or if my permit is stolen?</button>
         </dt>
         <dd>
           <p id="faq2_desc" class="desc">You should come to the Parking office and report the
@@ -68,7 +68,7 @@
           </p>
         </dd>
         <dt>
-          <button aria-expanded="false" aria-controls="faq3_desc">Is there free parking on holidays?</button>
+          <button type="button" aria-expanded="false" aria-controls="faq3_desc">Is there free parking on holidays?</button>
         </dt>
         <dd>
           <p id="faq3_desc" class="desc">
@@ -79,7 +79,7 @@
           </p>
         </dd>
         <dt>
-          <button aria-expanded="false" aria-controls="faq4_desc">Do all parking facilities have the same enforcement rules?</button>
+          <button type="button" aria-expanded="false" aria-controls="faq4_desc">Do all parking facilities have the same enforcement rules?</button>
         </dt>
         <dd>
           <p id="faq4_desc" class="desc">

--- a/examples/disclosure/disclosure-img-long-description.html
+++ b/examples/disclosure/disclosure-img-long-description.html
@@ -65,7 +65,7 @@
             In order to facilitate the judgement of the eye regarding the diminution of the army, I supposed that the troops under Prince Jèrôme and under Marshal Davoust, who were sent to Minsk and Mobilow and who rejoined near Orscha and Witebsk, had always marched with the army.
           </p>
   <p><strong>Note: A French translation from Wikipedia.</strong></p>
-        <button aria-expanded="true" aria-controls="id_long_desc">Data Table for Minard's Chart</button>
+        <button type="button" aria-expanded="true" aria-controls="id_long_desc">Data Table for Minard's Chart</button>
         <div id="id_long_desc">
           <h3 id="id_data_label">Data for Charles Minard's Chart of Napoleon's Invasion of Russia</h3>
           <table aria-labelledby="id_data_label" class="data">

--- a/examples/disclosure/disclosure-navigation.html
+++ b/examples/disclosure/disclosure-navigation.html
@@ -58,7 +58,7 @@
       <nav aria-label="Mythical University">
         <ul id="exTest" class="disclosure-nav">
           <li>
-            <button aria-expanded="true" aria-controls="id_about_menu">About</button>
+            <button type="button" aria-expanded="true" aria-controls="id_about_menu">About</button>
             <ul id="id_about_menu">
               <li>
                 <a href="#mythical-page-content">Overview</a>
@@ -75,7 +75,7 @@
             </ul>
           </li>
           <li>
-            <button aria-expanded="true" aria-controls="id_admissions_menu">Admissions</button>
+            <button type="button" aria-expanded="true" aria-controls="id_admissions_menu">Admissions</button>
             <ul id="id_admissions_menu">
               <li>
                 <a href="#mythical-page-content">Apply</a>
@@ -98,7 +98,7 @@
             </ul>
           </li>
           <li>
-            <button aria-expanded="true" aria-controls="id_academics_menu">Academics</button>
+            <button type="button" aria-expanded="true" aria-controls="id_academics_menu">Academics</button>
             <ul id="id_academics_menu">
               <li>
                 <a href="#mythical-page-content">Colleges &amp; Schools</a>

--- a/examples/feed/js/feedDisplay.js
+++ b/examples/feed/js/feedDisplay.js
@@ -249,7 +249,7 @@ aria.FeedDisplay.prototype.renderItemData = function (itemData) {
 
   var actions = document.createElement('div');
   actions.className = 'restaurant-actions';
-  actions.innerHTML = '<button class="bookmark-button">Bookmark</button>';
+  actions.innerHTML = '<button type="button" class="bookmark-button">Bookmark</button>';
   feedItem.appendChild(actions);
 
   return feedItem;

--- a/examples/grid/LayoutGrids.html
+++ b/examples/grid/LayoutGrids.html
@@ -157,7 +157,7 @@
 
           <div id="recipient-form">
             <input id="add-recipient-input" type="text" aria-label="Add Recipient" placeholder="New Recipient Name">
-            <button id="add-recipient-button">Add</button>
+            <button type="button" id="add-recipient-button">Add</button>
             <div class="accessible_elem">
               Last change to recipient list:
               <span aria-live="polite" aria-relevant="text" id="form-action-text"></span>
@@ -372,8 +372,8 @@
         </div>
 
         <div class="ex3_pagination">
-          <button disabled id="ex3_pageup_button">Previous</button>
-          <button id="ex3_pagedown_button">Next</button>
+          <button type="button" disabled id="ex3_pageup_button">Previous</button>
+          <button type="button" id="ex3_pagedown_button">Next</button>
         </div>
       </div>
       <div role="separator" id="ex3_end_sep" aria-labelledby="ex3_end_sep ex3_label" aria-label="End of"></div>

--- a/examples/grid/dataGrids.html
+++ b/examples/grid/dataGrids.html
@@ -162,7 +162,7 @@
               </div>
             </td>
             <td class="menu-wrapper">
-              <button tabindex="-1" aria-haspopup="true" aria-controls="menu1">Income</button>
+              <button type="button" tabindex="-1" aria-haspopup="true" aria-controls="menu1">Income</button>
               <ul role="menu" id="menu1">
                 <li role="menuitem">Income</li>
                 <li role="menuitem">Groceries</li>
@@ -186,7 +186,7 @@
               </div>
             </td>
             <td class="menu-wrapper">
-              <button tabindex="-1" aria-haspopup="true" aria-controls="menu2">Groceries
+              <button type="button" tabindex="-1" aria-haspopup="true" aria-controls="menu2">Groceries
               </button>
               <ul role="menu" id="menu2">
                 <li role="menuitem">Income</li>
@@ -210,7 +210,7 @@
               </div>
             </td>
             <td class="menu-wrapper">
-              <button tabindex="-1" aria-haspopup="true" aria-controls="menu3">Dining Out
+              <button type="button" tabindex="-1" aria-haspopup="true" aria-controls="menu3">Dining Out
               </button>
               <ul role="menu" id="menu3">
                 <li role="menuitem">Income</li>
@@ -235,7 +235,7 @@
               </div>
             </td>
             <td class="menu-wrapper">
-              <button tabindex="-1" aria-haspopup="true" aria-controls="menu4">Auto</button>
+              <button type="button" tabindex="-1" aria-haspopup="true" aria-controls="menu4">Auto</button>
               <ul role="menu" id="menu4">
                 <li role="menuitem">Income</li>
                 <li role="menuitem">Groceries</li>
@@ -259,7 +259,7 @@
               </div>
             </td>
             <td class="menu-wrapper">
-              <button tabindex="-1" aria-haspopup="true" aria-controls="menu5">Household
+              <button type="button" tabindex="-1" aria-haspopup="true" aria-controls="menu5">Household
               </button>
               <ul role="menu" id="menu5">
                 <li role="menuitem">Income</li>
@@ -283,7 +283,7 @@
               </div>
             </td>
             <td class="menu-wrapper">
-              <button tabindex="-1" aria-haspopup="true" aria-controls="menu6">Beauty</button>
+              <button type="button" tabindex="-1" aria-haspopup="true" aria-controls="menu6">Beauty</button>
               <ul role="menu" id="menu6">
                 <li role="menuitem">Income</li>
                 <li role="menuitem">Groceries</li>
@@ -307,7 +307,7 @@
               </div>
             </td>
             <td class="menu-wrapper">
-              <button tabindex="-1" aria-haspopup="true" aria-controls="menu7">Dining Out
+              <button type="button" tabindex="-1" aria-haspopup="true" aria-controls="menu7">Dining Out
               </button>
               <ul role="menu" id="menu7">
                 <li role="menuitem">Income</li>
@@ -337,7 +337,7 @@
       <div role="separator" id="ex3_start_sep" aria-labelledby="ex3_start_sep ex3_label" aria-label="Start of"></div>
       <div id="ex3">
         <h4 id="grid3Label">Transactions for January 1 through January 15</h4>
-        <button id="toggle_column_btn" type="button" name="toggle_columns">Hide Type and
+        <button type="button" id="toggle_column_btn" name="toggle_columns">Hide Type and
           Category</button>
         <table role="grid" aria-labelledby="grid3Label" aria-rowcount="16" aria-colcount="6"
           data-per-page="5" class="data">

--- a/examples/landmarks/HTML5.html
+++ b/examples/landmarks/HTML5.html
@@ -18,8 +18,8 @@
         <div class="col-xs-12 col-sm-9 col-md-9 col-lg-10">
           <h1>ARIA Landmarks Example</h1>
           <p id="inst" class="inst">Visually outline the landmarks and/or headings on the page using the following buttons.</p>
-          <button onclick="showLandmarks(event)" aria-describedby="inst">Show Landmarks</button>
-          <button onclick="showHeadings(event)"  aria-describedby="inst">Show Headings</button>
+          <button type="button" onclick="showLandmarks(event)" aria-describedby="inst">Show Landmarks</button>
+          <button type="button" onclick="showHeadings(event)"  aria-describedby="inst">Show Headings</button>
         </div>
       </header>
       <div class="row">

--- a/examples/landmarks/at.html
+++ b/examples/landmarks/at.html
@@ -18,8 +18,8 @@
         <div class="col-xs-12 col-sm-9 col-md-9 col-lg-10">
           <h1>ARIA Landmarks Example</h1>
           <p id="inst" class="inst">Visually outline the landmarks and/or headings on the page using the following buttons.</p>
-          <button onclick="showLandmarks(event)" aria-describedby="inst">Show Landmarks</button>
-          <button onclick="showHeadings(event)"  aria-describedby="inst">Show Headings</button>
+          <button type="button" onclick="showLandmarks(event)" aria-describedby="inst">Show Landmarks</button>
+          <button type="button" onclick="showHeadings(event)"  aria-describedby="inst">Show Headings</button>
         </div>
       </header>
       <div class="row">

--- a/examples/landmarks/banner.html
+++ b/examples/landmarks/banner.html
@@ -18,8 +18,8 @@
         <div class="col-xs-12 col-sm-9 col-md-9 col-lg-10">
           <h1>ARIA Landmarks Example</h1>
           <p id="inst" class="inst">Visually outline the landmarks and/or headings on the page using the following buttons.</p>
-          <button onclick="showLandmarks(event)" aria-describedby="inst">Show Landmarks</button>
-          <button onclick="showHeadings(event)"  aria-describedby="inst">Show Headings</button>
+          <button type="button" onclick="showLandmarks(event)" aria-describedby="inst">Show Landmarks</button>
+          <button type="button" onclick="showHeadings(event)"  aria-describedby="inst">Show Headings</button>
         </div>
       </header>
       <div class="row">

--- a/examples/landmarks/complementary.html
+++ b/examples/landmarks/complementary.html
@@ -18,8 +18,8 @@
         <div class="col-xs-12 col-sm-9 col-md-9 col-lg-10">
           <h1>ARIA Landmarks Example</h1>
           <p id="inst" class="inst">Visually outline the landmarks and/or headings on the page using the following buttons.</p>
-          <button onclick="showLandmarks(event)" aria-describedby="inst">Show Landmarks</button>
-          <button onclick="showHeadings(event)"  aria-describedby="inst">Show Headings</button>
+          <button type="button" onclick="showLandmarks(event)" aria-describedby="inst">Show Landmarks</button>
+          <button type="button" onclick="showHeadings(event)"  aria-describedby="inst">Show Headings</button>
         </div>
       </header>
       <div class="row">

--- a/examples/landmarks/contentinfo.html
+++ b/examples/landmarks/contentinfo.html
@@ -18,8 +18,8 @@
         <div class="col-xs-12 col-sm-9 col-md-9 col-lg-10">
           <h1>ARIA Landmarks Example</h1>
           <p id="inst" class="inst">Visually outline the landmarks and/or headings on the page using the following buttons.</p>
-          <button onclick="showLandmarks(event)" aria-describedby="inst">Show Landmarks</button>
-          <button onclick="showHeadings(event)"  aria-describedby="inst">Show Headings</button>
+          <button type="button" onclick="showLandmarks(event)" aria-describedby="inst">Show Landmarks</button>
+          <button type="button" onclick="showHeadings(event)"  aria-describedby="inst">Show Headings</button>
         </div>
       </header>
       <div class="row">

--- a/examples/landmarks/form.html
+++ b/examples/landmarks/form.html
@@ -50,8 +50,8 @@
         <div class="col-xs-12 col-sm-9 col-md-9 col-lg-10">
           <h1>ARIA Landmarks Example</h1>
           <p id="inst" class="inst">Visually outline the landmarks and/or headings on the page using the following buttons.</p>
-          <button onclick="showLandmarks(event)" aria-describedby="inst">Show Landmarks</button>
-          <button onclick="showHeadings(event)"  aria-describedby="inst">Show Headings</button>
+          <button type="button" onclick="showLandmarks(event)" aria-describedby="inst">Show Landmarks</button>
+          <button type="button" onclick="showHeadings(event)"  aria-describedby="inst">Show Headings</button>
         </div>
       </header>
       <div class="row">

--- a/examples/landmarks/index.html
+++ b/examples/landmarks/index.html
@@ -18,8 +18,8 @@
         <div class="col-xs-12 col-sm-9 col-md-9 col-lg-10">
           <h1>ARIA Landmarks Example</h1>
           <p id="inst" class="inst">Visually outline the landmarks and/or headings on the page using the following buttons.</p>
-          <button onclick="showLandmarks(event)" aria-describedby="inst">Show Landmarks</button>
-          <button onclick="showHeadings(event)"  aria-describedby="inst">Show Headings</button>
+          <button type="button" onclick="showLandmarks(event)" aria-describedby="inst">Show Landmarks</button>
+          <button type="button" onclick="showHeadings(event)"  aria-describedby="inst">Show Headings</button>
         </div>
       </header>
       <div class="row">

--- a/examples/landmarks/main.html
+++ b/examples/landmarks/main.html
@@ -19,8 +19,8 @@
         <div class="col-xs-12 col-sm-9 col-md-9 col-lg-10">
           <h1>ARIA Landmarks Example</h1>
           <p id="inst" class="inst">Visually outline the landmarks and/or headings on the page using the following buttons.</p>
-          <button onclick="showLandmarks(event)" aria-describedby="inst">Show Landmarks</button>
-          <button onclick="showHeadings(event)"  aria-describedby="inst">Show Headings</button>
+          <button type="button" onclick="showLandmarks(event)" aria-describedby="inst">Show Landmarks</button>
+          <button type="button" onclick="showHeadings(event)"  aria-describedby="inst">Show Headings</button>
         </div>
       </header>
       <div class="row">

--- a/examples/landmarks/navigation.html
+++ b/examples/landmarks/navigation.html
@@ -18,8 +18,8 @@
         <div class="col-xs-12 col-sm-9 col-md-9 col-lg-10">
           <h1>ARIA Landmark Example</h1>
           <p id="inst" class="inst">Visually outline the landmarks and/or headings on the page using the following buttons.</p>
-          <button onclick="showLandmarks(event)" aria-describedby="inst">Show Landmarks</button>
-          <button onclick="showHeadings(event)"  aria-describedby="inst">Show Headings</button>
+          <button type="button" onclick="showLandmarks(event)" aria-describedby="inst">Show Landmarks</button>
+          <button type="button" onclick="showHeadings(event)"  aria-describedby="inst">Show Headings</button>
         </div>
       </header>
       <div class="row">

--- a/examples/landmarks/region.html
+++ b/examples/landmarks/region.html
@@ -18,8 +18,8 @@
         <div class="col-xs-12 col-sm-9 col-md-9 col-lg-10">
           <h1>ARIA Landmarks Example</h1>
           <p id="inst" class="inst">Visually outline the landmarks and/or headings on the page using the following buttons.</p>
-          <button onclick="showLandmarks(event)" aria-describedby="inst">Show Landmarks</button>
-          <button onclick="showHeadings(event)"  aria-describedby="inst">Show Headings</button>
+          <button type="button" onclick="showLandmarks(event)" aria-describedby="inst">Show Landmarks</button>
+          <button type="button" onclick="showHeadings(event)"  aria-describedby="inst">Show Headings</button>
         </div>
       </header>
       <div class="row">

--- a/examples/landmarks/resources.html
+++ b/examples/landmarks/resources.html
@@ -19,8 +19,8 @@
                 <div class="col-xs-12 col-sm-9 col-md-9 col-lg-10">
                   <h1>ARIA Landmarks Example</h1>
                   <p id="inst" class="inst">Visually outline the landmarks and/or headings on the page using the following buttons.</p>
-                  <button onclick="showLandmarks(event)" aria-describedby="inst">Show Landmarks</button>
-                  <button onclick="showHeadings(event)"  aria-describedby="inst">Show Headings</button>
+                  <button type="button" onclick="showLandmarks(event)" aria-describedby="inst">Show Landmarks</button>
+                  <button type="button" onclick="showHeadings(event)"  aria-describedby="inst">Show Headings</button>
                 </div>
             </header>
             <div class="row">

--- a/examples/landmarks/search.html
+++ b/examples/landmarks/search.html
@@ -18,8 +18,8 @@
         <div class="col-xs-12 col-sm-9 col-md-9 col-lg-10">
           <h1>ARIA Landmarks Example</h1>
           <p id="inst" class="inst">Visually outline the landmarks and/or headings on the page using the following buttons.</p>
-          <button onclick="showLandmarks(event)" aria-describedby="inst">Show Landmarks</button>
-          <button onclick="showHeadings(event)"  aria-describedby="inst">Show Headings</button>
+          <button type="button" onclick="showLandmarks(event)" aria-describedby="inst">Show Landmarks</button>
+          <button type="button" onclick="showHeadings(event)"  aria-describedby="inst">Show Headings</button>
         </div>
       </header>
       <div class="row">

--- a/examples/listbox/listbox-collapsible.html
+++ b/examples/listbox/listbox-collapsible.html
@@ -50,7 +50,7 @@
         <div class="left-area">
           <span id="exp_elem">Choose an element:</span>
           <div id="exp_wrapper">
-            <button aria-haspopup="listbox" aria-labelledby="exp_elem exp_button" id="exp_button">Neptunium</button>
+            <button type="button" aria-haspopup="listbox" aria-labelledby="exp_elem exp_button" id="exp_button">Neptunium</button>
             <ul id="exp_elem_list" tabindex="-1" role="listbox" aria-labelledby="exp_elem" class="hidden">
               <li id="exp_elem_Np" role="option">Neptunium</li>
               <li id="exp_elem_Pu" role="option">Plutonium</li>

--- a/examples/listbox/listbox-rearrangeable.html
+++ b/examples/listbox/listbox-rearrangeable.html
@@ -64,16 +64,16 @@ while in the second example, they may select multiple options before activating 
               <li id="ss_opt10" role="option">Access to major highways</li>
             </ul>
             <div role="toolbar" aria-label="Actions" class="toolbar">
-              <button id="ex1-up" class="toolbar-item selected" aria-keyshortcuts="Alt+ArrowUp" aria-disabled="true">Up</button>
-              <button id="ex1-down" class="toolbar-item" tabindex="-1" aria-keyshortcuts="Alt+ArrowDown" aria-disabled="true">Down</button>
-              <button id="ex1-delete" class="toolbar-item move-right-btn" tabindex="-1" aria-keyshortcuts="Alt+ArrowRight Delete" aria-disabled="true">Not Important</button>
+              <button type="button" id="ex1-up" class="toolbar-item selected" aria-keyshortcuts="Alt+ArrowUp" aria-disabled="true">Up</button>
+              <button type="button" id="ex1-down" class="toolbar-item" tabindex="-1" aria-keyshortcuts="Alt+ArrowDown" aria-disabled="true">Down</button>
+              <button type="button" id="ex1-delete" class="toolbar-item move-right-btn" tabindex="-1" aria-keyshortcuts="Alt+ArrowRight Delete" aria-disabled="true">Not Important</button>
             </div>
           </div>
           <div class="right-area">
             <span id="ss_unimp_l">Unimportant Features:</span>
             <ul id="ss_unimp_list" tabindex="0" role="listbox" aria-labelledby="ss_unimp_l" aria-activedescendant="">
             </ul>
-            <button id="ex1-add" class="move-left-btn" aria-keyshortcuts="Alt+ArrowLeft Enter" aria-disabled="true">Important</button>
+            <button type="button" id="ex1-add" class="move-left-btn" aria-keyshortcuts="Alt+ArrowLeft Enter" aria-disabled="true">Important</button>
           </div>
           <div class="offscreen">Last change: <span aria-live="polite" id="ss_live_region"></span></div>
         </div>
@@ -127,7 +127,7 @@ while in the second example, they may select multiple options before activating 
               <li id="ms_opt9" role="option" aria-selected="false">Advanced waste recycling system</li>
               <li id="ms_opt10" role="option" aria-selected="false">Turbo vertical take-off capability</li>
             </ul>
-            <button id="ex2-add" class="move-right-btn" aria-keyshortcuts="Alt+ArrowRight Enter" aria-disabled="true">Add</button>
+            <button type="button" id="ex2-add" class="move-right-btn" aria-keyshortcuts="Alt+ArrowRight Enter" aria-disabled="true">Add</button>
           </div>
           <div class="right-area">
             <span id="ms_ch_l">Upgrades you have chosen:</span>
@@ -139,7 +139,7 @@ while in the second example, they may select multiple options before activating 
               aria-activedescendant=""
               aria-multiselectable="true">
             </ul>
-            <button id="ex2-delete" class="move-left-btn" aria-keyshortcuts="Alt+ArrowLeft Delete" aria-disabled="true">Remove</button>
+            <button type="button" id="ex2-delete" class="move-left-btn" aria-keyshortcuts="Alt+ArrowLeft Delete" aria-disabled="true">Remove</button>
           </div>
           <div class="offscreen">Last change: <span aria-live="polite" id="ms_live_region"></span></div>
         </div>

--- a/examples/menu-button/menu-button-actions-active-descendant.html
+++ b/examples/menu-button/menu-button-actions-active-descendant.html
@@ -48,7 +48,7 @@
         <div role="separator" id="ex_start_sep" aria-labelledby="ex_start_sep ex_label" aria-label="Start of"></div>        
         <div id="ex1">
           <div class="menu_button">
-            <button
+            <button type="button"
                 id="menubutton1"
                 aria-haspopup="true"
                 aria-controls="menu1"

--- a/examples/menu-button/menu-button-actions.html
+++ b/examples/menu-button/menu-button-actions.html
@@ -48,7 +48,7 @@
         <div role="separator" id="ex_start_sep" aria-labelledby="ex_start_sep ex_label" aria-label="Start of"></div>
         <div id="ex1">
           <div class="menu_button">
-            <button
+            <button type="button"
                 id="menubutton1"
                 aria-haspopup="true"
                 aria-controls="menu1"

--- a/examples/menu-button/menu-button-links.html
+++ b/examples/menu-button/menu-button-links.html
@@ -53,7 +53,7 @@
         <div role="separator" id="ex_start_sep" aria-labelledby="ex_start_sep ex_label" aria-label="Start of"></div>
         <div id="ex1">
           <div class="menu_button">
-            <button
+            <button type="button"
               id="menubutton"
               aria-haspopup="true"
               aria-controls="menu2"

--- a/examples/spinbutton/datepicker-spinbuttons.html
+++ b/examples/spinbutton/datepicker-spinbuttons.html
@@ -51,7 +51,7 @@
              <div class="date" hidden id="myDatepickerDate">current value is Friday, June 30th, 2019</div>
   
           <div  class="day spinbutton"
-  >         <button class="decrease"
+  >         <button type="button" class="decrease"
                   tabindex="-1"
                   aria-label="previous day">
               <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20">
@@ -67,7 +67,7 @@
                   aria-valuemax="31"
                   aria-label="Day">1</div>
             <div class="next" aria-hidden="true">2</div>
-            <button class="increase"
+            <button type="button" class="increase"
                   tabindex="-1"
                   aria-label="next day">
               <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20">
@@ -77,7 +77,7 @@
           </div>
   
           <div  class="month spinbutton">
-            <button class="decrease"
+            <button type="button" class="decrease"
                   tabindex="-1"
                   aria-label="previous month">
               <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20">
@@ -93,7 +93,7 @@
                   aria-valuemax="11"
                   aria-label="Month">June</div>
             <div class="next" aria-hidden="true">July</div>
-            <button class="increase"
+            <button type="button" class="increase"
                   tabindex="-1"
                   aria-label="next month">
               <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20">
@@ -103,7 +103,7 @@
           </div>
   
           <div  class="year spinbutton">
-            <button class="decrease"
+            <button type="button" class="decrease"
                   tabindex="-1"
                   aria-label="previous year">
               <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20">
@@ -118,7 +118,7 @@
                     aria-valuemax="2040"
                     aria-label="Year">2019</div>
             <div class="next" aria-hidden="true">2020</div>
-            <button class="increase"
+            <button type="button" class="increase"
                   tabindex="-1"
                   aria-label="next year">
               <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20">

--- a/examples/toolbar/toolbar.html
+++ b/examples/toolbar/toolbar.html
@@ -52,7 +52,7 @@
     <div id="ex1">
       <div class="format" role="toolbar" aria-label="Text Formatting" aria-controls="textarea1">
           <div class="group characteristics">
-            <button
+            <button type="button"
                 class="item bold popup"
                 aria-pressed="false"
                 value="bold"
@@ -60,7 +60,7 @@
               <span class="fas fa-bold" aria-hidden="true"></span>
               <span class="popup-label">Bold</span>
             </button>
-            <button
+            <button type="button"
                 class="item italic popup"
                 aria-pressed="false"
                 value="italic"
@@ -68,7 +68,7 @@
               <span class="fas fa-italic" aria-hidden="true"></span>
               <span class="popup-label">Italic</span>
             </button>
-            <button
+            <button type="button"
                 class="item underline popup"
                 aria-pressed="false"
                 value="underline"
@@ -80,7 +80,7 @@
           <div class="group"
                role="radiogroup"
                aria-label="Text Alignment">
-            <button
+            <button type="button"
                 role="radio"
                 class="item align-left popup"
                 aria-checked="true"
@@ -88,7 +88,7 @@
               <span class="fas fa-align-left" aria-hidden="true"></span>
               <span class="popup-label">Text Align Left</span>
             </button>
-            <button
+            <button type="button"
                 role="radio"
                 class="item align-center popup"
                 aria-checked="false"
@@ -96,7 +96,7 @@
               <span class="fas fa-align-center" aria-hidden="true"></span>
               <span class="popup-label">Text Align Center</span>
             </button>
-            <button
+            <button type="button"
                 role="radio"
                 class="item align-right popup"
                 aria-checked="false"
@@ -106,19 +106,19 @@
             </button>
           </div>
           <div class="group">
-            <button
+            <button type="button"
                 class="item copy"
                 aria-disabled="true"
                 tabindex="-1">
               Copy
             </button>
-            <button
+            <button type="button"
                 class="item paste"
                 aria-disabled="true"
                 tabindex="-1">
                 Paste
             </button>
-            <button
+            <button type="button"
                 class="item cut"
                 aria-disabled="true"
                 tabindex="-1">
@@ -126,7 +126,7 @@
             </button>
           </div>
           <div class="menu-popup group" >
-            <button
+            <button type="button"
               aria-haspopup="true"
               aria-controls="menu1"
               class="item menu-button"


### PR DESCRIPTION
Resolves #1199, should add `type="button"` to all button elements in the examples folder apart from tabs, which is covered by PR #1185 