### PR TITLE
chore: Use LTS Node version instead of "latest"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 
 node_js:
-  - "lts"
+  - "lts/*"
 
 addons:
   firefox: "60.0.2"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 
 node_js:
-  - "node"
+  - "lts"
 
 addons:
   firefox: "60.0.2"


### PR DESCRIPTION
Since this cut over to 13 when it was released, and not all stuff (like node-sass) support latest on day 1