### PR TITLE
Update title and footers in example pages to 1.2 (issue #1225)

### DIFF
--- a/examples/accordion/accordion.html
+++ b/examples/accordion/accordion.html
@@ -3,7 +3,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 <meta content="width=device-width, initial-scale=1.0" name="viewport" />
-<title>Accordion Example | WAI-ARIA Authoring Practices 1.1</title>
+<title>Accordion Example | WAI-ARIA Authoring Practices 1.2</title>
 <!--  Core js and css shared by all examples; do not modify when using this template. -->
 <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/base.css">
 <link rel="stylesheet" href="../css/core.css">
@@ -344,7 +344,7 @@
 
   </main>
   <nav>
-    <a href="../../#accordion">Accordion Design Pattern in WAI-ARIA Authoring Practices 1.1</a>
+    <a href="../../#accordion">Accordion Design Pattern in WAI-ARIA Authoring Practices 1.2</a>
   </nav>
   <script src="js/accordion.js"></script>
 </body>

--- a/examples/alert/alert.html
+++ b/examples/alert/alert.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <title>Alert Example | WAI-ARIA Authoring Practices 1.1</title>
+    <title>Alert Example | WAI-ARIA Authoring Practices 1.2</title>
 
     <!--  Core js and css shared by all examples; do not modify when using this template. -->
     <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/base.css">
@@ -137,7 +137,7 @@
     </section>
     </main>
     <nav>
-      <a href="../../#alert">Alert Design Pattern in WAI-ARIA Authoring Practices 1.1</a>
+      <a href="../../#alert">Alert Design Pattern in WAI-ARIA Authoring Practices 1.2</a>
     </nav>
   </body>
 </html>

--- a/examples/breadcrumb/index.html
+++ b/examples/breadcrumb/index.html
@@ -32,7 +32,7 @@
         <nav aria-label="Breadcrumb" class="breadcrumb">
           <ol>
             <li>
-              <a href="../../">WAI-ARIA Authoring Practices 1.1</a>
+              <a href="../../">WAI-ARIA Authoring Practices</a>
             </li>
             <li>
               <a href="../../#aria_ex">Design Patterns</a>

--- a/examples/breadcrumb/index.html
+++ b/examples/breadcrumb/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <title>Breadcrumb Example | WAI-ARIA Authoring Practices 1.1</title>
+    <title>Breadcrumb Example | WAI-ARIA Authoring Practices 1.2</title>
 
     <!--  Core js and css shared by all examples; do not modify when using this template. -->
     <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/base.css">
@@ -134,7 +134,7 @@
     </main>
 
     <nav>
-      <a href="../../#breadcrumb">Breadcrumb Design Pattern in WAI-ARIA Authoring Practices 1.1</a>
+      <a href="../../#breadcrumb">Breadcrumb Design Pattern in WAI-ARIA Authoring Practices 1.2</a>
     </nav>
   </body>
 </html>

--- a/examples/button/button.html
+++ b/examples/button/button.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Button Examples | WAI-ARIA Authoring Practices 1.1</title>
+  <title>Button Examples | WAI-ARIA Authoring Practices 1.2</title>
 
   <!-- Core JS and CSS shared by all examples. Do not modify when using this template. -->
   <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/base.css">
@@ -183,7 +183,7 @@
   </main>
 
   <nav>
-    <a href="../../#button">Button Design Pattern in WAI-ARIA Authoring Practices 1.1</a>
+    <a href="../../#button">Button Design Pattern in WAI-ARIA Authoring Practices 1.2</a>
   </nav>
 </body>
 </html>

--- a/examples/carousel/carousel-1.html
+++ b/examples/carousel/carousel-1.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <title>Auto-Rotating Image Carousel Example | WAI-ARIA Authoring Practices 1.1</title>
+    <title>Auto-Rotating Image Carousel Example | WAI-ARIA Authoring Practices 1.2</title>
 
     <!--  Core js and css shared by all examples; do not modify when using this template. -->
     <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/base.css">
@@ -533,7 +533,7 @@
     </main>
 
     <nav>
-      <a href="../../#carousel">Carousel Pattern in WAI-ARIA Authoring Practices 1.1</a>
+      <a href="../../#carousel">Carousel Pattern in WAI-ARIA Authoring Practices 1.2</a>
     </nav>
 
   </body>

--- a/examples/checkbox/checkbox-1/checkbox-1.html
+++ b/examples/checkbox/checkbox-1/checkbox-1.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8" />
-  <title>Checkbox Example (Two State) | WAI-ARIA Authoring Practices 1.1</title>
+  <title>Checkbox Example (Two State) | WAI-ARIA Authoring Practices 1.2</title>
 
   <!--  Core js and css shared by all examples; do not modify when using this template. -->
   <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/base.css">
@@ -201,7 +201,7 @@
   </section>
   </main>
   <nav>
-    <a href="../../../#checkbox">Checkbox Design Pattern in WAI-ARIA Authoring Practices 1.1</a>
+    <a href="../../../#checkbox">Checkbox Design Pattern in WAI-ARIA Authoring Practices 1.2</a>
   </nav>
 </body>
 </html>

--- a/examples/checkbox/checkbox-2/checkbox-2.html
+++ b/examples/checkbox/checkbox-2/checkbox-2.html
@@ -2,7 +2,7 @@
   <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <title>Checkbox Example (Mixed-State) | WAI-ARIA Authoring Practices 1.1</title>
+    <title>Checkbox Example (Mixed-State) | WAI-ARIA Authoring Practices 1.2</title>
 
     <!--  Core js and css shared by all examples; do not modify when using this template. -->
     <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/base.css">
@@ -216,7 +216,7 @@
       </section>
   </main>
   <nav>
-    <a href="../../../#checkbox">Checkbox Design Pattern in WAI-ARIA Authoring Practices 1.1</a>
+    <a href="../../../#checkbox">Checkbox Design Pattern in WAI-ARIA Authoring Practices 1.2</a>
   </nav>
 </body>
 </html>

--- a/examples/coding-template/Depricated-MultipleImplementationExample-Template.html
+++ b/examples/coding-template/Depricated-MultipleImplementationExample-Template.html
@@ -20,7 +20,7 @@
   The name should be unique if the pattern will have multiple implementations,
   e.g., "Simple Two-State Checkbox" or "Three-State Checkbox".
   -->
-<title>EXAMPLE_NAME | WAI-ARIA Authoring Practices 1.1</title>
+<title>EXAMPLE_NAME | WAI-ARIA Authoring Practices 1.2</title>
 
 <!--  Core js and css shared by all examples; do not modify when using this template. -->
 <link href="../css/core.css" rel="stylesheet">
@@ -297,7 +297,7 @@
   </main>
   <nav>
     <!--  Update the pattern_ID parameter of this link to refer to the APG design pattern section related to this example.  -->
-    <a href="../../#pattern_ID">EXAMPLE_NAME Design Pattern in WAI-ARIA Authoring Practices 1.1</a>
+    <a href="../../#pattern_ID">EXAMPLE_NAME Design Pattern in WAI-ARIA Authoring Practices 1.2</a>
   </nav>
 </body>
 </html>

--- a/examples/coding-template/Example-Template.html
+++ b/examples/coding-template/Example-Template.html
@@ -15,7 +15,7 @@
   The name should be unique if the pattern will have multiple implementations,
   e.g., "Simple Two-State Checkbox" or "Three-State Checkbox".
 -->
-<title>EXAMPLE_NAME Example | WAI-ARIA Authoring Practices 1.1</title>
+<title>EXAMPLE_NAME Example | WAI-ARIA Authoring Practices 1.2</title>
 
 <!--  Core js and css shared by all examples; do not modify when using this template. -->
 <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/base.css">
@@ -219,7 +219,7 @@
   </main>
   <nav>
     <!--  Update the pattern_ID parameter of this link to refer to the APG design pattern section related to this example.  -->
-    <a href="../../#pattern_ID">EXAMPLE_NAME Design Pattern in WAI-ARIA Authoring Practices 1.1</a>
+    <a href="../../#pattern_ID">EXAMPLE_NAME Design Pattern in WAI-ARIA Authoring Practices 1.2</a>
   </nav>
 </body>
 </html>

--- a/examples/combobox/aria1.0pattern/combobox-autocomplete-both.html
+++ b/examples/combobox/aria1.0pattern/combobox-autocomplete-both.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8" />
-<title>Legacy ARIA 1.0 Combobox With Both List and Inline Autocomplete Example | WAI-ARIA Authoring Practices 1.1</title>
+<title>Legacy ARIA 1.0 Combobox With Both List and Inline Autocomplete Example | WAI-ARIA Authoring Practices 1.2</title>
 
 <!--  Core js and css shared by all examples; do not modify when using this template. -->
 <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/base.css">
@@ -476,7 +476,7 @@
     </section>
   </main>
   <nav>
-    <a href="../../../#combobox">Combobox Design Pattern in WAI-ARIA Authoring Practices 1.1</a>
+    <a href="../../../#combobox">Combobox Design Pattern in WAI-ARIA Authoring Practices 1.2</a>
   </nav>
 </body>
 </html>

--- a/examples/combobox/aria1.0pattern/combobox-autocomplete-both.html
+++ b/examples/combobox/aria1.0pattern/combobox-autocomplete-both.html
@@ -2,8 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8" />
-<title>Legacy ARIA 1.0 Combobox With Both List and Inline Autocomplete Example | WAI-ARIA Authoring Practices
-  1.1</title>
+<title>Legacy ARIA 1.0 Combobox With Both List and Inline Autocomplete Example | WAI-ARIA Authoring Practices 1.1</title>
 
 <!--  Core js and css shared by all examples; do not modify when using this template. -->
 <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/base.css">

--- a/examples/combobox/aria1.0pattern/combobox-autocomplete-list.html
+++ b/examples/combobox/aria1.0pattern/combobox-autocomplete-list.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8" />
-<title>Legacy ARIA 1.0 Combobox With List Autocomplete Example | WAI-ARIA Authoring Practices 1.1</title>
+<title>Legacy ARIA 1.0 Combobox With List Autocomplete Example | WAI-ARIA Authoring Practices 1.2</title>
 
 <!--  Core js and css shared by all examples; do not modify when using this template. -->
 <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/base.css">
@@ -465,7 +465,7 @@
     </section>
   </main>
   <nav>
-    <a href="../../../#combobox">Combobox Design Pattern in WAI-ARIA Authoring Practices 1.1</a>
+    <a href="../../../#combobox">Combobox Design Pattern in WAI-ARIA Authoring Practices 1.2</a>
   </nav>
 </body>
 </html>

--- a/examples/combobox/aria1.0pattern/combobox-autocomplete-none.html
+++ b/examples/combobox/aria1.0pattern/combobox-autocomplete-none.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8" />
-<title>Legacy ARIA 1.0 Combobox without Autocomplete Example | WAI-ARIA Authoring Practices 1.1</title>
+<title>Legacy ARIA 1.0 Combobox without Autocomplete Example | WAI-ARIA Authoring Practices 1.2</title>
 
 <!--  Core js and css shared by all examples; do not modify when using this template. -->
 <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/base.css">
@@ -415,7 +415,7 @@
     </section>
   </main>
   <nav>
-    <a href="../../../#combobox">Combobox Design Pattern in WAI-ARIA Authoring Practices 1.1</a>
+    <a href="../../../#combobox">Combobox Design Pattern in WAI-ARIA Authoring Practices 1.2</a>
   </nav>
 </body>
 </html>

--- a/examples/combobox/aria1.0pattern/combobox-autocomplete-none.html
+++ b/examples/combobox/aria1.0pattern/combobox-autocomplete-none.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8" />
-<title>Legacy ARIA 1.0 Combobox without Autocomplete Example | WAI-ARIA Authoring Practices 1.0</title>
+<title>Legacy ARIA 1.0 Combobox without Autocomplete Example | WAI-ARIA Authoring Practices 1.1</title>
 
 <!--  Core js and css shared by all examples; do not modify when using this template. -->
 <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/base.css">

--- a/examples/combobox/aria1.1pattern/grid-combo.html
+++ b/examples/combobox/aria1.1pattern/grid-combo.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8" />
-<title>ARIA 1.1 Combobox with Grid Popup Example | WAI-ARIA Authoring Practices 1.1</title>
+<title>ARIA 1.1 Combobox with Grid Popup Example | WAI-ARIA Authoring Practices 1.2</title>
 
 <!--  Core js and css shared by all examples; do not modify when using this template. -->
 <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/base.css">
@@ -449,7 +449,7 @@
     </section>
   </main>
   <nav>
-    <a href="../../../#combobox">Combobox Design Pattern in WAI-ARIA Authoring Practices 1.1</a>
+    <a href="../../../#combobox">Combobox Design Pattern in WAI-ARIA Authoring Practices 1.2</a>
   </nav>
 </body>
 </html>

--- a/examples/combobox/aria1.1pattern/listbox-combo.html
+++ b/examples/combobox/aria1.1pattern/listbox-combo.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8" />
-<title>ARIA 1.1 Combobox with Listbox Popup Examples | WAI-ARIA Authoring Practices 1.1</title>
+<title>ARIA 1.1 Combobox with Listbox Popup Examples | WAI-ARIA Authoring Practices 1.2</title>
 
 <!--  Core js and css shared by all examples; do not modify when using this template. -->
 <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/base.css">
@@ -573,7 +573,7 @@
     </section>
   </main>
   <nav>
-    <a href="../../../#combobox">combobox design pattern in WAI-ARIA Authoring Practices 1.1</a>
+    <a href="../../../#combobox">combobox design pattern in WAI-ARIA Authoring Practices 1.2</a>
   </nav>
 </body>
 </html>

--- a/examples/dialog-modal/alertdialog.html
+++ b/examples/dialog-modal/alertdialog.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <title>Alert Dialog Example | WAI-ARIA Authoring Practices 1.1</title>
+    <title>Alert Dialog Example | WAI-ARIA Authoring Practices 1.2</title>
     <!--  Core js and css shared by all examples; do not modify when using this template. -->
     <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/base.css">
     <link rel="stylesheet" href="../css/core.css">
@@ -230,7 +230,7 @@
       </section>
     </main>
     <nav>
-      <a href="../../#alertdialog">Alert and Message Dialogs Design Pattern in WAI-ARIA Authoring Practices 1.1</a>
+      <a href="../../#alertdialog">Alert and Message Dialogs Design Pattern in WAI-ARIA Authoring Practices 1.2</a>
     </nav>
   </body>
 </html>

--- a/examples/dialog-modal/datepicker-dialog.html
+++ b/examples/dialog-modal/datepicker-dialog.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8" />
-<title>Date Picker Dialog Example | WAI-ARIA Authoring Practices 1.1</title>
+<title>Date Picker Dialog Example | WAI-ARIA Authoring Practices 1.2</title>
 
 <!--  Core js and css shared by all examples; do not modify when using this template. -->
 <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/base.css">
@@ -633,7 +633,7 @@
   </section>
   </main>
   <nav>
-    <a href="../../#dialog-modal">Dialog Design Pattern in WAI-ARIA Authoring Practices 1.1</a>
+    <a href="../../#dialog-modal">Dialog Design Pattern in WAI-ARIA Authoring Practices 1.2</a>
   </nav>
 </body>
 </html>

--- a/examples/dialog-modal/dialog.html
+++ b/examples/dialog-modal/dialog.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8" />
-<title>Modal Dialog Example | WAI-ARIA Authoring Practices 1.1</title>
+<title>Modal Dialog Example | WAI-ARIA Authoring Practices 1.2</title>
 
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
@@ -233,7 +233,7 @@
     </section>
   </main>
   <nav>
-    <a href="../../#dialog_modal">Modal Dialog Design Pattern in WAI-ARIA Authoring Practices 1.1</a>
+    <a href="../../#dialog_modal">Modal Dialog Design Pattern in WAI-ARIA Authoring Practices 1.2</a>
   </nav>
   <div id="dialog_layer" class="dialogs">
     <div role="dialog" id="dialog1" aria-labelledby="dialog1_label" aria-modal="true" class="hidden">

--- a/examples/disclosure/disclosure-faq.html
+++ b/examples/disclosure/disclosure-faq.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8" />
-<title>Example Disclosure (Show/Hide) for Answers to Frequently Asked Questions | WAI-ARIA Authoring Practices 1.1</title>
+<title>Example Disclosure (Show/Hide) for Answers to Frequently Asked Questions | WAI-ARIA Authoring Practices 1.2</title>
 
   <!--  Core js and css shared by all examples; do not modify when using this template. -->
   <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/base.css">
@@ -246,7 +246,7 @@
   </section>
   </main>
   <nav>
-    <a href="../../#disclosure">Disclosure (Show/Hide) Design Pattern in WAI-ARIA Authoring Practices 1.1</a>
+    <a href="../../#disclosure">Disclosure (Show/Hide) Design Pattern in WAI-ARIA Authoring Practices 1.2</a>
   </nav>
 </body>
 </html>

--- a/examples/disclosure/disclosure-faq.html
+++ b/examples/disclosure/disclosure-faq.html
@@ -2,8 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8" />
-<title>Example Disclosure (Show/Hide) for Answers to Frequently Asked Questions | WAI-ARIA Authoring
-  Practices 1.1</title>
+<title>Example Disclosure (Show/Hide) for Answers to Frequently Asked Questions | WAI-ARIA Authoring Practices 1.1</title>
 
   <!--  Core js and css shared by all examples; do not modify when using this template. -->
   <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/base.css">
@@ -247,8 +246,7 @@
   </section>
   </main>
   <nav>
-    <a href="../../#disclosure">Disclosure (Show/Hide) Design Pattern in WAI-ARIA Authoring
-      Practices 1.1</a>
+    <a href="../../#disclosure">Disclosure (Show/Hide) Design Pattern in WAI-ARIA Authoring Practices 1.1</a>
   </nav>
 </body>
 </html>

--- a/examples/disclosure/disclosure-img-long-description.html
+++ b/examples/disclosure/disclosure-img-long-description.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8" />
-<title>Example Disclosure (Show/Hide) for Image Description | WAI-ARIA Authoring Practices 1.1</title>
+<title>Example Disclosure (Show/Hide) for Image Description | WAI-ARIA Authoring Practices 1.2</title>
 
 <!--  Core js and css shared by all examples; do not modify when using this template. -->
 <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/base.css">
@@ -397,7 +397,7 @@
   </section>
   </main>
   <nav>
-  <a href="../../#disclosure">Disclosure (Show/Hide) Design Pattern in WAI-ARIA Authoring Practices 1.1</a>
+  <a href="../../#disclosure">Disclosure (Show/Hide) Design Pattern in WAI-ARIA Authoring Practices 1.2</a>
   </nav>
 </body>
 </html>

--- a/examples/disclosure/disclosure-navigation.html
+++ b/examples/disclosure/disclosure-navigation.html
@@ -2,8 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8" />
-<title>Example Disclosure for Navigation Menus | WAI-ARIA Authoring
-  Practices 1.1</title>
+<title>Example Disclosure for Navigation Menus | WAI-ARIA Authoring Practices 1.1</title>
 
   <!--  Core js and css shared by all examples; do not modify when using this template. -->
   <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/base.css">

--- a/examples/disclosure/disclosure-navigation.html
+++ b/examples/disclosure/disclosure-navigation.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8" />
-<title>Example Disclosure for Navigation Menus | WAI-ARIA Authoring Practices 1.1</title>
+<title>Example Disclosure for Navigation Menus | WAI-ARIA Authoring Practices 1.2</title>
 
   <!--  Core js and css shared by all examples; do not modify when using this template. -->
   <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/base.css">
@@ -367,7 +367,7 @@
   </section>
   </main>
   <nav>
-    <a href="../../#disclosure">Disclosure (Show/Hide) Design Pattern in WAI-ARIA Authoring Practices 1.1</a>
+    <a href="../../#disclosure">Disclosure (Show/Hide) Design Pattern in WAI-ARIA Authoring Practices 1.2</a>
   </nav>
 </body>
 </html>

--- a/examples/feed/feed.html
+++ b/examples/feed/feed.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8" />
-<title>Feed Example | WAI-ARIA Authoring Practices 1.1</title>
+<title>Feed Example | WAI-ARIA Authoring Practices 1.2</title>
 
 <!--  Core js and css shared by all examples; do not modify when using this template. -->
 <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/base.css">
@@ -208,7 +208,7 @@
   </section>
   </main>
   <nav>
-    <a href="../../#feed">Feed Design Pattern in WAI-ARIA Authoring Practices 1.1</a>
+    <a href="../../#feed">Feed Design Pattern in WAI-ARIA Authoring Practices 1.2</a>
   </nav>
 </body>
 </html>

--- a/examples/feed/feedDisplay.html
+++ b/examples/feed/feedDisplay.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8" />
-<title>Feed Display | WAI-ARIA Authoring Practices 1.1</title>
+<title>Feed Display | WAI-ARIA Authoring Practices 1.2</title>
 
 <!--  Core js and css shared by all examples; do not modify when using this template. -->
 <link href="../css/core.css" rel="stylesheet">

--- a/examples/grid/LayoutGrids.html
+++ b/examples/grid/LayoutGrids.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8" />
-<title>Layout Grid Examples | WAI-ARIA Authoring Practices 1.1</title>
+<title>Layout Grid Examples | WAI-ARIA Authoring Practices 1.2</title>
 
 <!--  Core js and css shared by all examples; do not modify when using this template. -->
 <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/base.css">
@@ -731,7 +731,7 @@
   </main>
   <nav>
     <!--  Update the pattern_ID parameter of this link to refer to the APG design pattern section related to this example.  -->
-    <a href="../../#grid">Grid Design Pattern in WAI-ARIA Authoring Practices 1.1</a>
+    <a href="../../#grid">Grid Design Pattern in WAI-ARIA Authoring Practices 1.2</a>
   </nav>
 </body>
 </html>

--- a/examples/grid/advancedDataGrid.html
+++ b/examples/grid/advancedDataGrid.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8" />
-<title>Advanced Data Grid Example | WAI-ARIA Authoring Practices 1.1</title>
+<title>Advanced Data Grid Example | WAI-ARIA Authoring Practices 1.2</title>
 
 <!--  Core js and css shared by all examples; do not modify when using this template. -->
 <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/base.css">
@@ -168,7 +168,7 @@
   </main>
   <nav>
     <!--  Update the pattern_ID parameter of this link to refer to the APG design pattern section related to this example.  -->
-    <a href="../../#grid">Grid Design Pattern in WAI-ARIA Authoring Practices 1.1</a>
+    <a href="../../#grid">Grid Design Pattern in WAI-ARIA Authoring Practices 1.2</a>
   </nav>
 </body>
 </html>

--- a/examples/grid/dataGrids.html
+++ b/examples/grid/dataGrids.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8" />
-<title>Data Grid Examples | WAI-ARIA Authoring Practices 1.1</title>
+<title>Data Grid Examples | WAI-ARIA Authoring Practices 1.2</title>
 
 <!--  Core js and css shared by all examples; do not modify when using this template. -->
 <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/base.css">
@@ -831,7 +831,7 @@
   </main>
   <nav>
     <!--  Update the pattern_ID parameter of this link to refer to the APG design pattern section related to this example.  -->
-    <a href="../../#grid">Grid Design Pattern in WAI-ARIA Authoring Practices 1.1</a>
+    <a href="../../#grid">Grid Design Pattern in WAI-ARIA Authoring Practices 1.2</a>
   </nav>
 </body>
 </html>

--- a/examples/link/link.html
+++ b/examples/link/link.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8" />
 
-<title>Link Examples | WAI-ARIA Authoring Practices 1.1</title>
+<title>Link Examples | WAI-ARIA Authoring Practices 1.2</title>
 
 <!--  Core js and css shared by all examples; do not modify when using this template. -->
 <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/base.css">
@@ -209,7 +209,7 @@
   </section>
   </main>
   <nav>
-    <a href="../../#link">Link Design Pattern in WAI-ARIA Authoring Practices 1.1</a>
+    <a href="../../#link">Link Design Pattern in WAI-ARIA Authoring Practices 1.2</a>
   </nav>
 </body>
 </html>

--- a/examples/listbox/listbox-collapsible.html
+++ b/examples/listbox/listbox-collapsible.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8" />
-<title>Collapsible Dropdown Listbox Example | WAI-ARIA Authoring Practices 1.1</title>
+<title>Collapsible Dropdown Listbox Example | WAI-ARIA Authoring Practices 1.2</title>
 
 <!--  Core js and css shared by all examples; do not modify when using this template. -->
 <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/base.css">
@@ -306,7 +306,7 @@
   </section>
   </main>
   <nav>
-    <a href="../../#Listbox">Listbox Design Pattern in WAI-ARIA Authoring Practices 1.1</a>
+    <a href="../../#Listbox">Listbox Design Pattern in WAI-ARIA Authoring Practices 1.2</a>
   </nav>
 </body>
 </html>

--- a/examples/listbox/listbox-rearrangeable.html
+++ b/examples/listbox/listbox-rearrangeable.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8" />
-<title>Example Listboxes with Rearrangeable Options | WAI-ARIA Authoring Practices 1.1</title>
+<title>Example Listboxes with Rearrangeable Options | WAI-ARIA Authoring Practices 1.2</title>
 
 <!--  Core js and css shared by all examples; do not modify when using this template. -->
 <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/base.css">
@@ -430,7 +430,7 @@ while in the second example, they may select multiple options before activating 
   </section>
   </main>
   <nav>
-    <a href="../../#Listbox">Listbox Design Pattern in WAI-ARIA Authoring Practices 1.1</a>
+    <a href="../../#Listbox">Listbox Design Pattern in WAI-ARIA Authoring Practices 1.2</a>
   </nav>
 </body>
 </html>

--- a/examples/listbox/listbox-scrollable.html
+++ b/examples/listbox/listbox-scrollable.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8" />
-<title>Scrollable Listbox Example | WAI-ARIA Authoring Practices 1.1</title>
+<title>Scrollable Listbox Example | WAI-ARIA Authoring Practices 1.2</title>
 
 <!--  Core js and css shared by all examples; do not modify when using this template. -->
 <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/base.css">
@@ -231,7 +231,7 @@
   </section>
   </main>
   <nav>
-    <a href="../../#Listbox">Listbox Design Pattern in WAI-ARIA Authoring Practices 1.1</a>
+    <a href="../../#Listbox">Listbox Design Pattern in WAI-ARIA Authoring Practices 1.2</a>
   </nav>
 </body>
 </html>

--- a/examples/menu-button/menu-button-actions-active-descendant.html
+++ b/examples/menu-button/menu-button-actions-active-descendant.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en"><head>
     <meta http-equiv="content-type" content="text/html; charset=UTF-8">
-    <title>Actions Menu Button Example Using aria-activedescendant | WAI-ARIA Authoring Practices 1.1</title>
+    <title>Actions Menu Button Example Using aria-activedescendant | WAI-ARIA Authoring Practices 1.2</title>
 
     <!--  Core js and css shared by all examples; do not modify when using this template. -->
     <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/base.css">
@@ -345,7 +345,7 @@
       </section>
     </main>
     <nav>
-      <a href="../../#menubutton">Menu Button Design Pattern in WAI-ARIA Authoring Practices 1.1</a>
+      <a href="../../#menubutton">Menu Button Design Pattern in WAI-ARIA Authoring Practices 1.2</a>
     </nav>
   </body>
   </html>

--- a/examples/menu-button/menu-button-actions.html
+++ b/examples/menu-button/menu-button-actions.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en"><head>
     <meta http-equiv="content-type" content="text/html; charset=UTF-8">
-    <title>Actions Menu Button Example Using element.focus() | WAI-ARIA Authoring Practices 1.1</title>
+    <title>Actions Menu Button Example Using element.focus() | WAI-ARIA Authoring Practices 1.2</title>
 
     <!--  Core js and css shared by all examples; do not modify when using this template. -->
     <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/base.css">
@@ -327,7 +327,7 @@
 
     </main>
     <nav>
-      <a href="../../#menubutton">Menu Button Design Pattern in WAI-ARIA Authoring Practices 1.1</a>
+      <a href="../../#menubutton">Menu Button Design Pattern in WAI-ARIA Authoring Practices 1.2</a>
     </nav>
   </body>
   </html>

--- a/examples/menu-button/menu-button-links.html
+++ b/examples/menu-button/menu-button-links.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta http-equiv="content-type" content="text/html; charset=UTF-8">
-    <title>Navigation Menu Button Example | WAI-ARIA Authoring Practices 1.1</title>
+    <title>Navigation Menu Button Example | WAI-ARIA Authoring Practices 1.2</title>
 
     <!--  Core js and css shared by all examples; do not modify when using this template. -->
     <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/base.css">
@@ -359,7 +359,7 @@
       </section>
     </main>
     <nav>
-      <a href="../../#menubutton">Menu Button Design Pattern in WAI-ARIA Authoring Practices 1.1</a>
+      <a href="../../#menubutton">Menu Button Design Pattern in WAI-ARIA Authoring Practices 1.2</a>
     </nav>
   </body>
 </html>

--- a/examples/menubar/menubar-1/menubar-1.html
+++ b/examples/menubar/menubar-1/menubar-1.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta http-equiv="content-type" content="text/html; charset=UTF-8">
-<title>Navigation Menubar Example | WAI-ARIA Authoring Practices 1.1</title>
+<title>Navigation Menubar Example | WAI-ARIA Authoring Practices 1.2</title>
 
 <!--  Core js and css shared by all examples; do not modify when using this template. -->
 <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/base.css">
@@ -652,7 +652,7 @@
   </section>
   </main>
   <nav>
-    <a href="../../../#menu">Menu or Menubar Design Pattern in WAI-ARIA Authoring Practices 1.1</a>
+    <a href="../../../#menu">Menu or Menubar Design Pattern in WAI-ARIA Authoring Practices 1.2</a>
   </nav>
 </body>
 </html>

--- a/examples/menubar/menubar-2/menubar-2.html
+++ b/examples/menubar/menubar-2/menubar-2.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta http-equiv="content-type" content="text/html; charset=UTF-8">
-  <title>Editor Menubar Example | WAI-ARIA Authoring Practices 1.1</title>
+  <title>Editor Menubar Example | WAI-ARIA Authoring Practices 1.2</title>
 
   <!--  Core js and css shared by all examples; do not modify when using this template. -->
   <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/base.css">
@@ -791,7 +791,7 @@ sourceCode.make();
   </section>
   </main>
   <nav>
-    <a href="../../../#menu">Menu or Menubar Design Pattern in WAI-ARIA Authoring Practices 1.1</a>
+    <a href="../../../#menu">Menu or Menubar Design Pattern in WAI-ARIA Authoring Practices 1.2</a>
   </nav>
 
 </body>

--- a/examples/meter/meter.html
+++ b/examples/meter/meter.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<title>Meter Example | WAI-ARIA Authoring Practices 1.1</title>
+<title>Meter Example | WAI-ARIA Authoring Practices 1.2</title>
 <!--  Core js and css shared by all examples; do not modify when using this template. -->
 <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/base.css">
 <link rel="stylesheet" href="../css/core.css">
@@ -136,7 +136,7 @@
 </main>
 
   <nav>
-      <a href="../../#meter">Meter Design Pattern in WAI-ARIA Authoring Practices 1.1</a>
+      <a href="../../#meter">Meter Design Pattern in WAI-ARIA Authoring Practices 1.2</a>
   </nav>
 </body>
 </html>

--- a/examples/radio/radio-1/radio-1.html
+++ b/examples/radio/radio-1/radio-1.html
@@ -2,7 +2,7 @@
   <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <title>Radio Group Example Using Roving tabindex | WAI-ARIA Authoring Practices 1.1</title>
+    <title>Radio Group Example Using Roving tabindex | WAI-ARIA Authoring Practices 1.2</title>
 
     <!--  Core js and css shared by all examples; do not modify when using this template. -->
     <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/base.css">
@@ -281,7 +281,7 @@
       </section>
     </main>
     <nav>
-      <a href="../../../#radiobutton">Radio Group Design Pattern in WAI-ARIA Authoring Practices 1.1</a>
+      <a href="../../../#radiobutton">Radio Group Design Pattern in WAI-ARIA Authoring Practices 1.2</a>
     </nav>
   </body>
 </html>

--- a/examples/radio/radio-2/radio-2.html
+++ b/examples/radio/radio-2/radio-2.html
@@ -2,7 +2,7 @@
   <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <title>Radio Group Example Using aria-activedescendant | WAI-ARIA Authoring Practices 1.1</title>
+    <title>Radio Group Example Using aria-activedescendant | WAI-ARIA Authoring Practices 1.2</title>
 
     <!--  Core js and css shared by all examples; do not modify when using this template. -->
     <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/base.css">
@@ -310,7 +310,7 @@
       </section>
     </main>
     <nav>
-      <a href="../../../#radiobutton"> Radio Button Design Pattern in WAI-ARIA Authoring Practices 1.1</a>
+      <a href="../../../#radiobutton"> Radio Button Design Pattern in WAI-ARIA Authoring Practices 1.2</a>
     </nav>
   </body>
   </html>

--- a/examples/slider/multithumb-slider.html
+++ b/examples/slider/multithumb-slider.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8" />
-  <title>Horizontal Multi-Thumb Slider Example | WAI-ARIA Authoring Practices 1.1</title>
+  <title>Horizontal Multi-Thumb Slider Example | WAI-ARIA Authoring Practices 1.2</title>
 
   <!--  Core js and css shared by all examples; do not modify when using this template. -->
   <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/base.css">
@@ -269,7 +269,7 @@
 
   </main>
   <nav>
-    <a href="../../#slidertwothumb">Slider (Multi-Thumb) design pattern in WAI-ARIA Authoring Practices 1.1</a>
+    <a href="../../#slidertwothumb">Slider (Multi-Thumb) design pattern in WAI-ARIA Authoring Practices 1.2</a>
   </nav>
 </body>
 </html>

--- a/examples/slider/slider-1.html
+++ b/examples/slider/slider-1.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8" />
-  <title>Horizontal Slider Example | WAI-ARIA Authoring Practices 1.1</title>
+  <title>Horizontal Slider Example | WAI-ARIA Authoring Practices 1.2</title>
 
   <!--  Core js and css shared by all examples; do not modify when using this template. -->
   <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/base.css">
@@ -248,7 +248,7 @@
 
   </main>
   <nav>
-    <a href="../../#slider">Slider Design Pattern in WAI-ARIA Authoring Practices 1.1</a>
+    <a href="../../#slider">Slider Design Pattern in WAI-ARIA Authoring Practices 1.2</a>
   </nav>
 </body>
 </html>

--- a/examples/slider/slider-2.html
+++ b/examples/slider/slider-2.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8" />
-  <title>Slider Examples with aria-orientation and aria-valuetext | WAI-ARIA Authoring Practices 1.1</title>
+  <title>Slider Examples with aria-orientation and aria-valuetext | WAI-ARIA Authoring Practices 1.2</title>
 
   <!--  Core js and css shared by all examples; do not modify when using this template. -->
   <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/base.css">
@@ -278,7 +278,7 @@
     </section>
   </main>
   <nav>
-    <a href="../../#slider">Slider Design Pattern in WAI-ARIA Authoring Practices 1.1</a>
+    <a href="../../#slider">Slider Design Pattern in WAI-ARIA Authoring Practices 1.2</a>
   </nav>
 </body>
 </html>

--- a/examples/spinbutton/datepicker-spinbuttons.html
+++ b/examples/spinbutton/datepicker-spinbuttons.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8" />
-<title>Date Picker Spin Button Example | WAI-ARIA Authoring Practices 1.1</title>
+<title>Date Picker Spin Button Example | WAI-ARIA Authoring Practices 1.2</title>
 
 <!--  Core js and css shared by all examples; do not modify when using this template. -->
 <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/base.css">
@@ -346,7 +346,7 @@
     </section>
   </main>
   <nav>
-    <a href="../../#spinbutton">Spin Button Design Pattern in WAI-ARIA Authoring Practices 1.1</a>
+    <a href="../../#spinbutton">Spin Button Design Pattern in WAI-ARIA Authoring Practices 1.2</a>
   </nav>
 </body>
 </html>

--- a/examples/table/table.html
+++ b/examples/table/table.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8" />
-<title>Table Example | WAI-ARIA Authoring Practices 1.1</title>
+<title>Table Example | WAI-ARIA Authoring Practices 1.2</title>
 
 <!--  Core js and css shared by all examples; do not modify when using this template. -->
 <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/base.css">
@@ -180,7 +180,7 @@
   </section>
   </main>
   <nav>
-    <a href="../../#table">Table Design Pattern in WAI-ARIA Authoring Practices 1.1</a>
+    <a href="../../#table">Table Design Pattern in WAI-ARIA Authoring Practices 1.2</a>
   </nav>
 </body>
 </html>

--- a/examples/tabs/tabs-1/tabs.html
+++ b/examples/tabs/tabs-1/tabs.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <title>Example of Tabs with Automatic Activation | WAI-ARIA Authoring Practices 1.1</title>
+    <title>Example of Tabs with Automatic Activation | WAI-ARIA Authoring Practices 1.2</title>
 
     <!--  Core js and css shared by all examples; do not modify when using this template. -->
     <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/base.css">
@@ -319,7 +319,7 @@
 
     <nav>
       <!--  Update the pattern_ID parameter of this link to refer to the APG design pattern section related to this example.  -->
-      <a href="../../../#tabpanel">Tabs Design Pattern in WAI-ARIA Authoring Practices 1.1</a>
+      <a href="../../../#tabpanel">Tabs Design Pattern in WAI-ARIA Authoring Practices 1.2</a>
     </nav>
 
     <script src="js/tabs.js"></script>

--- a/examples/tabs/tabs-2/tabs.html
+++ b/examples/tabs/tabs-2/tabs.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <title>Example of Tabs with Manual Activation | WAI-ARIA Authoring Practices 1.1</title>
+    <title>Example of Tabs with Manual Activation | WAI-ARIA Authoring Practices 1.2</title>
 
     <!--  Core js and css shared by all examples; do not modify when using this template. -->
     <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/base.css">
@@ -321,7 +321,7 @@
     </main>
 
     <nav>
-      <a href="../../../#tabpanel">Tabs Design Pattern in WAI-ARIA Authoring Practices 1.1</a>
+      <a href="../../../#tabpanel">Tabs Design Pattern in WAI-ARIA Authoring Practices 1.2</a>
     </nav>
 
     <script src="js/tabs.js" type="text/javascript"></script>

--- a/examples/toolbar/help.html
+++ b/examples/toolbar/help.html
@@ -19,7 +19,7 @@
 
 <h1>Toolbar Help</h1>
 
-<p>Learn more about toolbar behaviors by reading the <a href="https://www.w3.org/TR/wai-aria-practices-1.1/#toolbar">ARIA Authoring Practices Guide</a>.</p>
+<p>Learn more about toolbar behaviors by reading the <a href="https://w3c.github.io/aria-practices/#toolbar">ARIA Authoring Practices Guide</a>.</p>
 
 </body>
 </html>

--- a/examples/toolbar/help.html
+++ b/examples/toolbar/help.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8" />
-<title>Toolbar Example | WAI-ARIA Authoring Practices 1.1</title>
+<title>Toolbar Example | WAI-ARIA Authoring Practices 1.2</title>
 
 <!--  Core js and css shared by all examples; do not modify when using this template. -->
 <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/base.css">

--- a/examples/toolbar/help.html
+++ b/examples/toolbar/help.html
@@ -19,7 +19,7 @@
 
 <h1>Toolbar Help</h1>
 
-<p>Learn more about toolbar behaviors by reading the <a href="https://w3c.github.io/aria-practices/#toolbar">ARIA Authoring Practices Guide</a>.</p>
+<p>Learn more about toolbar behaviors by reading the <a href="../../#toolbar">ARIA Authoring Practices Guide</a>.</p>
 
 </body>
 </html>

--- a/examples/toolbar/toolbar.html
+++ b/examples/toolbar/toolbar.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8" />
-<title>Toolbar Example | WAI-ARIA Authoring Practices 1.1</title>
+<title>Toolbar Example | WAI-ARIA Authoring Practices 1.2</title>
 
 <!--  Core js and css shared by all examples; do not modify when using this template. -->
 <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/base.css">
@@ -983,7 +983,7 @@ But, in a larger sense, we can not dedicate, we can not consecrate, we can not h
   </section>
   </main>
   <nav>
-    <a href="../../#toolbar">Toolbar Design Pattern in WAI-ARIA Authoring Practices 1.1</a>
+    <a href="../../#toolbar">Toolbar Design Pattern in WAI-ARIA Authoring Practices 1.2</a>
   </nav>
 </body>
 </html>

--- a/examples/treegrid/treegrid-1.html
+++ b/examples/treegrid/treegrid-1.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8" />
 
-<title>Treegrid Email Inbox Example | WAI-ARIA Authoring Practices 1.1</title>
+<title>Treegrid Email Inbox Example | WAI-ARIA Authoring Practices 1.2</title>
 
 <!--  Core js and css shared by all examples; do not modify when using this template. -->
 <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/base.css">
@@ -520,7 +520,7 @@ document.addEventListener('DOMContentLoaded', function () {
   </main>
   <nav>
     <!--  Update the pattern_ID parameter of this link to refer to the APG design pattern section related to this example.  -->
-    <a href="../../#treegrid">Treegrid Design Pattern in WAI-ARIA Authoring Practices 1.1</a>
+    <a href="../../#treegrid">Treegrid Design Pattern in WAI-ARIA Authoring Practices 1.2</a>
   </nav>
 </body>
 </html>

--- a/examples/treeview/treeview-1/treeview-1a.html
+++ b/examples/treeview/treeview-1/treeview-1a.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta http-equiv="content-type" content="text/html; charset=UTF-8">
-    <title>File Directory Treeview Example Using Computed Properties | WAI-ARIA Authoring Practices 1.1</title>
+    <title>File Directory Treeview Example Using Computed Properties | WAI-ARIA Authoring Practices 1.2</title>
 
     <!--  Core js and css shared by all examples; do not modify when using this template. -->
     <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/base.css">
@@ -504,7 +504,7 @@
       </section>
     </main>
     <nav>
-      <a href="../../../#TreeView">Tree View Design Pattern in WAI-ARIA Authoring Practices 1.1</a>
+      <a href="../../../#TreeView">Tree View Design Pattern in WAI-ARIA Authoring Practices 1.2</a>
     </nav>
   </body>
 </html>

--- a/examples/treeview/treeview-1/treeview-1b.html
+++ b/examples/treeview/treeview-1/treeview-1b.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta http-equiv="content-type" content="text/html; charset=UTF-8">
-    <title>File Directory Treeview Example Using Declared Properties | WAI-ARIA Authoring Practices 1.1</title>
+    <title>File Directory Treeview Example Using Declared Properties | WAI-ARIA Authoring Practices 1.2</title>
 
     <!--  Core js and css shared by all examples; do not modify when using this template. -->
     <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/base.css">
@@ -693,7 +693,7 @@
       </section>
     </main>
     <nav>
-      <a href="../../../#TreeView">Tree View Design Pattern in WAI-ARIA Authoring Practices 1.1</a>
+      <a href="../../../#TreeView">Tree View Design Pattern in WAI-ARIA Authoring Practices 1.2</a>
     </nav>
   </body>
 </html>

--- a/examples/treeview/treeview-2/treeview-2a.html
+++ b/examples/treeview/treeview-2/treeview-2a.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta http-equiv="content-type" content="text/html; charset=UTF-8">
-    <title>Navigation Treeview Example Using Computed Properties | WAI-ARIA Authoring Practices 1.1</title>
+    <title>Navigation Treeview Example Using Computed Properties | WAI-ARIA Authoring Practices 1.2</title>
 
     <!--  Core js and css shared by all examples; do not modify when using this template. -->
     <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/base.css">
@@ -603,7 +603,7 @@
       </section>
   </main>
   <nav>
-    <a href="../../../#TreeView">Tree View Design Pattern in WAI-ARIA Authoring Practices 1.1</a>
+    <a href="../../../#TreeView">Tree View Design Pattern in WAI-ARIA Authoring Practices 1.2</a>
   </nav>
   </body>
 </html>

--- a/examples/treeview/treeview-2/treeview-2b.html
+++ b/examples/treeview/treeview-2/treeview-2b.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta http-equiv="content-type" content="text/html; charset=UTF-8">
-    <title>Navigation Treeview Example Using Declared Properties | WAI-ARIA Authoring Practices 1.1</title>
+    <title>Navigation Treeview Example Using Declared Properties | WAI-ARIA Authoring Practices 1.2</title>
 
     <!--  Core js and css shared by all examples; do not modify when using this template. -->
     <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/base.css">
@@ -764,7 +764,7 @@
       </section>
   </main>
   <nav>
-    <a href="../../../#TreeView">Tree View Design Pattern in WAI-ARIA Authoring Practices 1.1</a>
+    <a href="../../../#TreeView">Tree View Design Pattern in WAI-ARIA Authoring Practices 1.2</a>
   </nav>
   </body>
 </html>

--- a/scripts/reference-tables.template
+++ b/scripts/reference-tables.template
@@ -3,7 +3,7 @@
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
   <meta content="width=device-width, initial-scale=1.0" name="viewport" />
-  <title>Index of ARIA Design Pattern Examples | WAI-ARIA Authoring Practices 1.1</title>
+  <title>Index of ARIA Design Pattern Examples | WAI-ARIA Authoring Practices 1.2</title>
   <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/base.css">
   <link rel="stylesheet" href="css/core.css">
   <script src="js/examples.js"></script>
@@ -12,14 +12,14 @@
 </head>
 <body>
   <nav aria-label="ARIA Practices">
-    <a href="../">WAI-ARIA Authoring Practices 1.1</a>
+    <a href="../">WAI-ARIA Authoring Practices 1.2</a>
   </nav>
   <main>
     <h1>Index of ARIA Design Pattern Examples</h1>
     <p>
       This page includes the following indexes of example implementations of
       <a href="../#aria_ex">ARIA design patterns</a> included in
-      <a href="../">WAI-ARIA Authoring Practices 1.1.</a>
+      <a href="../">WAI-ARIA Authoring Practices 1.2.</a>
     </p>
     <ul>
       <li><a href="#examples_by_role_label">Examples by Role</a></li>
@@ -54,7 +54,7 @@
     </section>
   </main>
   <nav aria-label="ARIA Practices">
-    <a href="../">WAI-ARIA Authoring Practices 1.1</a>
+    <a href="../">WAI-ARIA Authoring Practices 1.2</a>
   </nav>
 </body>
 </html>


### PR DESCRIPTION
To explain the several commits:

1. In order to be able to change all of the references in one `sed`, I fixed some example file's formatting for the title and footers in separate commits for disclosure example pages and combobox example pages.

2. There were a few relative links with link text that said "WAI-ARIA Authoring Practices 1.1", so I removed the "1.1" in order for the links to not be wrong when looking at the editors draft. This is in the "toolbar" and "breadcrumbs" commits.

3. I also updated the reference table template, but examples/index.html is still out of date.
