### PR TITLE
Allow for tests that do not refer to example tables rows

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -81,11 +81,13 @@ const _ariaTest = (desc, page, testId, body, failing) => {
     t.context.url = url;
     await t.context.session.get(url);
 
-    const assert = require('assert');
-    assert(
-      (await t.context.session.findElements(By.css(selector))).length,
-      'Cannot find behavior description for this test in example page:' + testId
-    );
+    if (testId !== 'test-additional-behavior') {
+      const assert = require('assert');
+      assert(
+        (await t.context.session.findElements(By.css(selector))).length,
+        'Cannot find behavior description for this test in example page:' + testId
+      );
+    }
 
     return body.apply(this, arguments);
   });


### PR DESCRIPTION
@smhigley request something like this in https://github.com/w3c/aria-practices/issues/1205.

If you want to write regression tests for an APG example that cover behavior not specifically discussed in the attributes and keyboard interaction tables, you can use the data-test-id `test-additional-behavior`. 

If everyone is ok with it, we can merge this and I'll add it to the documentation!