### PR TITLE
Add sentence to Menu/Menubar pattern stating that the behavior is lik…

### DIFF
--- a/aria-practices.html
+++ b/aria-practices.html
@@ -1909,6 +1909,7 @@
       <h3>Menu or Menu bar</h3>
       <p>
         A <a href="#menu" class="role-reference">menu</a> is a widget that offers a list of choices to the user, such as a set of actions or functions.
+        Menu widgets behave like native operating system menus, such as the menus that pull down from the menubars commonly found at the top of many desktop application windows.
         A menu is usually opened, or made visible, by activating a <a href="#menubutton">menu button</a>, choosing an item in a menu that opens a sub menu, or by invoking a command, such as <kbd>Shift + F10</kbd> in Windows, that opens a context specific menu.
         When a user activates a choice in a menu, the menu usually closes unless the choice opened a submenu.
       </p>


### PR DESCRIPTION
…e native OS menu behavior.

Adds the following sentence to the first paragraph of the Menu/Menubar pattern, as agreed upon by @mcking65 in https://github.com/w3c/aria-practices/issues/353#issuecomment-368091861 and @aardrian in https://github.com/w3c/aria-practices/issues/353#issuecomment-378703816:

> Menu widgets behave like native operating system menus, such as the menus that pull down from the menubars commonly found at the top of many desktop application windows.

Note that this addresses one aspect of https://github.com/w3c/aria-practices/issues/353 but does not close it.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria-practices/pull/1232.html" title="Last updated on Nov 11, 2019, 8:09 AM UTC (8944892)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria-practices/1232/9a2bbb7...8944892.html" title="Last updated on Nov 11, 2019, 8:09 AM UTC (8944892)">Diff</a>