### PR TITLE
Editorial: Final prep of master for working draft publication

### DIFF
--- a/aria-practices.html
+++ b/aria-practices.html
@@ -6579,11 +6579,6 @@ So, As advised by <a href="#naming_rule_avoid_fallback">Rule 4: Avoid Browser Fa
   <section id="structural_roles">
     <h2>Structural Roles</h2>
     <p>
-      <strong>NOTE:</strong> This is a new section.
-      Please provide feedback in
-      <a href="https://github.com/w3c/aria-practices/issues/739">issue 739.</a>
-    </p>
-    <p>
       ARIA provides a set of roles that convey the accessibility semantics of structures on a page.
       These roles express the meaning that is conveyed by the layout and appearance of elements that organize and structure content, such as headings, lists, and tables.
     </p>
@@ -6615,9 +6610,6 @@ So, As advised by <a href="#naming_rule_avoid_fallback">Rule 4: Avoid Browser Fa
       <tbody>
         <tr><th>application</th><td>No equivalent element</td></tr>
         <tr><th>article</th><td>article</td></tr>
-        <tr><th>associationlist</th><td>dl</td></tr>
-        <tr><th>associationlistitemkey</th><td>dt</td></tr>
-        <tr><th>associationlistitemvalue</th><td>dd</td></tr>
         <tr><th>blockquote</th><td>blockquote</td></tr>
         <tr><th>caption</th><td>caption</td></tr>
         <tr><th>cell</th><td>td</td></tr>

--- a/examples/index.html
+++ b/examples/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
   <meta content="width=device-width, initial-scale=1.0" name="viewport">
-  <title>Index of ARIA Design Pattern Examples | WAI-ARIA Authoring Practices 1.1</title>
+  <title>Index of ARIA Design Pattern Examples | WAI-ARIA Authoring Practices 1.2</title>
   <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/base.css">
   <link rel="stylesheet" href="css/core.css">
   <script src="js/examples.js"></script>
@@ -12,14 +12,14 @@
 </head>
 <body>
   <nav aria-label="ARIA Practices">
-    <a href="../">WAI-ARIA Authoring Practices 1.1</a>
+    <a href="../">WAI-ARIA Authoring Practices 1.2</a>
   </nav>
   <main>
     <h1>Index of ARIA Design Pattern Examples</h1>
     <p>
       This page includes the following indexes of example implementations of
       <a href="../#aria_ex">ARIA design patterns</a> included in
-      <a href="../">WAI-ARIA Authoring Practices 1.1.</a>
+      <a href="../">WAI-ARIA Authoring Practices 1.2.</a>
     </p>
     <ul>
       <li><a href="#examples_by_role_label">Examples by Role</a></li>
@@ -53,7 +53,12 @@
           </tr>
           <tr>
             <td><code>button</code></td>
-            <td><a href="button/button.html">Button</a></td>
+            <td>
+              <ul>
+                <li><a href="button/button_idl.html">Button  (IDL Version)</a></li>
+                <li><a href="button/button.html">Button</a></li>
+              </ul>
+            </td>
           </tr>
           <tr>
             <td><code>checkbox</code></td>
@@ -146,6 +151,7 @@
                 <li><a href="combobox/aria1.0pattern/combobox-autocomplete-none.html">Legacy ARIA 1.0 Combobox without Autocomplete</a></li>
                 <li><a href="combobox/aria1.1pattern/listbox-combo.html">ARIA 1.1 Combobox with Listbox Popup</a></li>
                 <li><a href="listbox/listbox-collapsible.html">Collapsible Dropdown Listbox</a></li>
+                <li><a href="listbox/listbox-grouped.html">Listbox  with Grouped Options</a></li>
                 <li><a href="listbox/listbox-rearrangeable.html">Listboxes with Rearrangeable Options</a></li>
                 <li><a href="listbox/listbox-scrollable.html">Scrollable Listbox</a></li>
               </ul>
@@ -374,6 +380,7 @@
                 <li><a href="combobox/aria1.1pattern/grid-combo.html">ARIA 1.1 Combobox with Grid Popup</a></li>
                 <li><a href="combobox/aria1.1pattern/listbox-combo.html">ARIA 1.1 Combobox with Listbox Popup</a></li>
                 <li><a href="listbox/listbox-collapsible.html">Collapsible Dropdown Listbox</a></li>
+                <li><a href="listbox/listbox-grouped.html">Listbox  with Grouped Options</a></li>
                 <li><a href="listbox/listbox-rearrangeable.html">Listboxes with Rearrangeable Options</a></li>
                 <li><a href="listbox/listbox-scrollable.html">Scrollable Listbox</a></li>
                 <li><a href="menu-button/menu-button-actions-active-descendant.html">Actions Menu Button  Using aria-activedescendant</a></li>
@@ -534,6 +541,7 @@
                 <li><a href="grid/dataGrids.html">Data Grid</a></li>
                 <li><a href="grid/LayoutGrids.html">Layout Grid</a></li>
                 <li><a href="listbox/listbox-collapsible.html">Collapsible Dropdown Listbox</a></li>
+                <li><a href="listbox/listbox-grouped.html">Listbox  with Grouped Options</a></li>
                 <li><a href="listbox/listbox-rearrangeable.html">Listboxes with Rearrangeable Options</a></li>
                 <li><a href="listbox/listbox-scrollable.html">Scrollable Listbox</a></li>
                 <li><a href="menu-button/menu-button-actions-active-descendant.html">Actions Menu Button  Using aria-activedescendant</a></li>
@@ -570,6 +578,7 @@
                 <li><a href="grid/dataGrids.html">Data Grid</a></li>
                 <li><a href="grid/LayoutGrids.html">Layout Grid</a></li>
                 <li><a href="listbox/listbox-collapsible.html">Collapsible Dropdown Listbox</a></li>
+                <li><a href="listbox/listbox-grouped.html">Listbox  with Grouped Options</a></li>
                 <li><a href="listbox/listbox-rearrangeable.html">Listboxes with Rearrangeable Options</a></li>
                 <li><a href="listbox/listbox-scrollable.html">Scrollable Listbox</a></li>
                 <li><a href="menu-button/menu-button-actions-active-descendant.html">Actions Menu Button  Using aria-activedescendant</a></li>
@@ -659,6 +668,7 @@
             <td><code>aria-pressed</code></td>
             <td>
               <ul>
+                <li><a href="button/button_idl.html">Button  (IDL Version)</a></li>
                 <li><a href="button/button.html">Button</a></li>
                 <li><a href="toolbar/toolbar.html">Toolbar</a></li>
               </ul>
@@ -716,6 +726,7 @@
             <td><code>aria-valuemax</code></td>
             <td>
               <ul>
+                <li><a href="meter/meter.html">Meter</a></li>
                 <li><a href="slider/multithumb-slider.html">Horizontal Multi-Thumb Slider</a></li>
                 <li><a href="slider/slider-1.html">Horizontal Slider</a></li>
                 <li><a href="slider/slider-2.html">Slider  with aria-orientation and aria-valuetext</a></li>
@@ -727,6 +738,7 @@
             <td><code>aria-valuemin</code></td>
             <td>
               <ul>
+                <li><a href="meter/meter.html">Meter</a></li>
                 <li><a href="slider/multithumb-slider.html">Horizontal Multi-Thumb Slider</a></li>
                 <li><a href="slider/slider-1.html">Horizontal Slider</a></li>
                 <li><a href="slider/slider-2.html">Slider  with aria-orientation and aria-valuetext</a></li>
@@ -739,6 +751,7 @@
             <td><code>aria-valuenow</code></td>
             <td>
               <ul>
+                <li><a href="meter/meter.html">Meter</a></li>
                 <li><a href="slider/multithumb-slider.html">Horizontal Multi-Thumb Slider</a></li>
                 <li><a href="slider/slider-1.html">Horizontal Slider</a></li>
                 <li><a href="slider/slider-2.html">Slider  with aria-orientation and aria-valuetext</a></li>
@@ -762,7 +775,7 @@
     </section>
   </main>
   <nav aria-label="ARIA Practices">
-    <a href="../">WAI-ARIA Authoring Practices 1.1</a>
+    <a href="../">WAI-ARIA Authoring Practices 1.2</a>
   </nav>
 
 

--- a/examples/index.html
+++ b/examples/index.html
@@ -77,11 +77,10 @@
             <td><code>combobox</code></td>
             <td>
               <ul>
-                <li><a href="combobox/aria1.0pattern/combobox-autocomplete-both.html">Legacy ARIA 1.0 Combobox With Both List and Inline Autocomplete</a></li>
-                <li><a href="combobox/aria1.0pattern/combobox-autocomplete-list.html">Legacy ARIA 1.0 Combobox With List Autocomplete</a></li>
-                <li><a href="combobox/aria1.0pattern/combobox-autocomplete-none.html">Legacy ARIA 1.0 Combobox without Autocomplete</a></li>
-                <li><a href="combobox/aria1.1pattern/grid-combo.html">ARIA 1.1 Combobox with Grid Popup</a></li>
-                <li><a href="combobox/aria1.1pattern/listbox-combo.html">ARIA 1.1 Combobox with Listbox Popup</a></li>
+                <li><a href="combobox/combobox-autocomplete-both.html">Editable Combobox With Both List and Inline Autocomplete</a></li>
+                <li><a href="combobox/combobox-autocomplete-list.html">Editable Combobox With List Autocomplete</a></li>
+                <li><a href="combobox/combobox-autocomplete-none.html">Editable Combobox without Autocomplete</a></li>
+                <li><a href="combobox/grid-combo.html">Editable Combobox with Grid Popup</a></li>
               </ul>
             </td>
           </tr>
@@ -114,7 +113,7 @@
             <td><code>grid</code></td>
             <td>
               <ul>
-                <li><a href="combobox/aria1.1pattern/grid-combo.html">ARIA 1.1 Combobox with Grid Popup</a></li>
+                <li><a href="combobox/grid-combo.html">Editable Combobox with Grid Popup</a></li>
                 <li><a href="dialog-modal/datepicker-dialog.html">Date Picker Dialog</a></li>
                 <li><a href="grid/dataGrids.html">Data Grid</a></li>
                 <li><a href="grid/LayoutGrids.html">Layout Grid</a></li>
@@ -146,10 +145,9 @@
             <td><code>listbox</code></td>
             <td>
               <ul>
-                <li><a href="combobox/aria1.0pattern/combobox-autocomplete-both.html">Legacy ARIA 1.0 Combobox With Both List and Inline Autocomplete</a></li>
-                <li><a href="combobox/aria1.0pattern/combobox-autocomplete-list.html">Legacy ARIA 1.0 Combobox With List Autocomplete</a></li>
-                <li><a href="combobox/aria1.0pattern/combobox-autocomplete-none.html">Legacy ARIA 1.0 Combobox without Autocomplete</a></li>
-                <li><a href="combobox/aria1.1pattern/listbox-combo.html">ARIA 1.1 Combobox with Listbox Popup</a></li>
+                <li><a href="combobox/combobox-autocomplete-both.html">Editable Combobox With Both List and Inline Autocomplete</a></li>
+                <li><a href="combobox/combobox-autocomplete-list.html">Editable Combobox With List Autocomplete</a></li>
+                <li><a href="combobox/combobox-autocomplete-none.html">Editable Combobox without Autocomplete</a></li>
                 <li><a href="listbox/listbox-collapsible.html">Collapsible Dropdown Listbox</a></li>
                 <li><a href="listbox/listbox-grouped.html">Listbox  with Grouped Options</a></li>
                 <li><a href="listbox/listbox-rearrangeable.html">Listboxes with Rearrangeable Options</a></li>
@@ -224,10 +222,9 @@
             <td><code>option</code></td>
             <td>
               <ul>
-                <li><a href="combobox/aria1.0pattern/combobox-autocomplete-both.html">Legacy ARIA 1.0 Combobox With Both List and Inline Autocomplete</a></li>
-                <li><a href="combobox/aria1.0pattern/combobox-autocomplete-list.html">Legacy ARIA 1.0 Combobox With List Autocomplete</a></li>
-                <li><a href="combobox/aria1.0pattern/combobox-autocomplete-none.html">Legacy ARIA 1.0 Combobox without Autocomplete</a></li>
-                <li><a href="combobox/aria1.1pattern/listbox-combo.html">ARIA 1.1 Combobox with Listbox Popup</a></li>
+                <li><a href="combobox/combobox-autocomplete-both.html">Editable Combobox With Both List and Inline Autocomplete</a></li>
+                <li><a href="combobox/combobox-autocomplete-list.html">Editable Combobox With List Autocomplete</a></li>
+                <li><a href="combobox/combobox-autocomplete-none.html">Editable Combobox without Autocomplete</a></li>
               </ul>
             </td>
           </tr>
@@ -259,7 +256,7 @@
             <td><code>row</code></td>
             <td>
               <ul>
-                <li><a href="combobox/aria1.1pattern/grid-combo.html">ARIA 1.1 Combobox with Grid Popup</a></li>
+                <li><a href="combobox/grid-combo.html">Editable Combobox with Grid Popup</a></li>
                 <li><a href="grid/LayoutGrids.html">Layout Grid</a></li>
                 <li><a href="table/table.html">Table</a></li>
                 <li><a href="treegrid/treegrid-1.html">Treegrid Email Inbox</a></li>
@@ -374,11 +371,10 @@
             <td><code>aria-activedescendant</code></td>
             <td>
               <ul>
-                <li><a href="combobox/aria1.0pattern/combobox-autocomplete-both.html">Legacy ARIA 1.0 Combobox With Both List and Inline Autocomplete</a></li>
-                <li><a href="combobox/aria1.0pattern/combobox-autocomplete-list.html">Legacy ARIA 1.0 Combobox With List Autocomplete</a></li>
-                <li><a href="combobox/aria1.0pattern/combobox-autocomplete-none.html">Legacy ARIA 1.0 Combobox without Autocomplete</a></li>
-                <li><a href="combobox/aria1.1pattern/grid-combo.html">ARIA 1.1 Combobox with Grid Popup</a></li>
-                <li><a href="combobox/aria1.1pattern/listbox-combo.html">ARIA 1.1 Combobox with Listbox Popup</a></li>
+                <li><a href="combobox/combobox-autocomplete-both.html">Editable Combobox With Both List and Inline Autocomplete</a></li>
+                <li><a href="combobox/combobox-autocomplete-list.html">Editable Combobox With List Autocomplete</a></li>
+                <li><a href="combobox/combobox-autocomplete-none.html">Editable Combobox without Autocomplete</a></li>
+                <li><a href="combobox/grid-combo.html">Editable Combobox with Grid Popup</a></li>
                 <li><a href="listbox/listbox-collapsible.html">Collapsible Dropdown Listbox</a></li>
                 <li><a href="listbox/listbox-grouped.html">Listbox  with Grouped Options</a></li>
                 <li><a href="listbox/listbox-rearrangeable.html">Listboxes with Rearrangeable Options</a></li>
@@ -392,11 +388,10 @@
             <td><code>aria-autocomplete</code></td>
             <td>
               <ul>
-                <li><a href="combobox/aria1.0pattern/combobox-autocomplete-both.html">Legacy ARIA 1.0 Combobox With Both List and Inline Autocomplete</a></li>
-                <li><a href="combobox/aria1.0pattern/combobox-autocomplete-list.html">Legacy ARIA 1.0 Combobox With List Autocomplete</a></li>
-                <li><a href="combobox/aria1.0pattern/combobox-autocomplete-none.html">Legacy ARIA 1.0 Combobox without Autocomplete</a></li>
-                <li><a href="combobox/aria1.1pattern/grid-combo.html">ARIA 1.1 Combobox with Grid Popup</a></li>
-                <li><a href="combobox/aria1.1pattern/listbox-combo.html">ARIA 1.1 Combobox with Listbox Popup</a></li>
+                <li><a href="combobox/combobox-autocomplete-both.html">Editable Combobox With Both List and Inline Autocomplete</a></li>
+                <li><a href="combobox/combobox-autocomplete-list.html">Editable Combobox With List Autocomplete</a></li>
+                <li><a href="combobox/combobox-autocomplete-none.html">Editable Combobox without Autocomplete</a></li>
+                <li><a href="combobox/grid-combo.html">Editable Combobox with Grid Popup</a></li>
               </ul>
             </td>
           </tr>
@@ -427,8 +422,10 @@
               <ul>
                 <li><a href="accordion/accordion.html">Accordion</a></li>
                 <li><a href="checkbox/checkbox-2/checkbox-2.html">Checkbox  (Mixed-State)</a></li>
-                <li><a href="combobox/aria1.1pattern/grid-combo.html">ARIA 1.1 Combobox with Grid Popup</a></li>
-                <li><a href="combobox/aria1.1pattern/listbox-combo.html">ARIA 1.1 Combobox with Listbox Popup</a></li>
+                <li><a href="combobox/combobox-autocomplete-both.html">Editable Combobox With Both List and Inline Autocomplete</a></li>
+                <li><a href="combobox/combobox-autocomplete-list.html">Editable Combobox With List Autocomplete</a></li>
+                <li><a href="combobox/combobox-autocomplete-none.html">Editable Combobox without Autocomplete</a></li>
+                <li><a href="combobox/grid-combo.html">Editable Combobox with Grid Popup</a></li>
                 <li><a href="disclosure/disclosure-faq.html">Disclosure (Show/Hide) for Answers to Frequently Asked Questions</a></li>
                 <li><a href="disclosure/disclosure-img-long-description.html">Disclosure (Show/Hide) for Image Description</a></li>
                 <li><a href="disclosure/disclosure-navigation.html">Disclosure for Navigation Menus</a></li>
@@ -471,11 +468,10 @@
             <td>
               <ul>
                 <li><a href="accordion/accordion.html">Accordion</a></li>
-                <li><a href="combobox/aria1.0pattern/combobox-autocomplete-both.html">Legacy ARIA 1.0 Combobox With Both List and Inline Autocomplete</a></li>
-                <li><a href="combobox/aria1.0pattern/combobox-autocomplete-list.html">Legacy ARIA 1.0 Combobox With List Autocomplete</a></li>
-                <li><a href="combobox/aria1.0pattern/combobox-autocomplete-none.html">Legacy ARIA 1.0 Combobox without Autocomplete</a></li>
-                <li><a href="combobox/aria1.1pattern/grid-combo.html">ARIA 1.1 Combobox with Grid Popup</a></li>
-                <li><a href="combobox/aria1.1pattern/listbox-combo.html">ARIA 1.1 Combobox with Listbox Popup</a></li>
+                <li><a href="combobox/combobox-autocomplete-both.html">Editable Combobox With Both List and Inline Autocomplete</a></li>
+                <li><a href="combobox/combobox-autocomplete-list.html">Editable Combobox With List Autocomplete</a></li>
+                <li><a href="combobox/combobox-autocomplete-none.html">Editable Combobox without Autocomplete</a></li>
+                <li><a href="combobox/grid-combo.html">Editable Combobox with Grid Popup</a></li>
                 <li><a href="disclosure/disclosure-faq.html">Disclosure (Show/Hide) for Answers to Frequently Asked Questions</a></li>
                 <li><a href="disclosure/disclosure-img-long-description.html">Disclosure (Show/Hide) for Image Description</a></li>
                 <li><a href="disclosure/disclosure-navigation.html">Disclosure for Navigation Menus</a></li>
@@ -498,11 +494,7 @@
             <td><code>aria-haspopup</code></td>
             <td>
               <ul>
-                <li><a href="combobox/aria1.0pattern/combobox-autocomplete-both.html">Legacy ARIA 1.0 Combobox With Both List and Inline Autocomplete</a></li>
-                <li><a href="combobox/aria1.0pattern/combobox-autocomplete-list.html">Legacy ARIA 1.0 Combobox With List Autocomplete</a></li>
-                <li><a href="combobox/aria1.0pattern/combobox-autocomplete-none.html">Legacy ARIA 1.0 Combobox without Autocomplete</a></li>
-                <li><a href="combobox/aria1.1pattern/grid-combo.html">ARIA 1.1 Combobox with Grid Popup</a></li>
-                <li><a href="combobox/aria1.1pattern/listbox-combo.html">ARIA 1.1 Combobox with Listbox Popup</a></li>
+                <li><a href="combobox/grid-combo.html">Editable Combobox with Grid Popup</a></li>
                 <li><a href="listbox/listbox-collapsible.html">Collapsible Dropdown Listbox</a></li>
                 <li><a href="menu-button/menu-button-actions-active-descendant.html">Actions Menu Button  Using aria-activedescendant</a></li>
                 <li><a href="menu-button/menu-button-actions.html">Actions Menu Button  Using element.focus()</a></li>
@@ -529,11 +521,10 @@
               <ul>
                 <li><a href="carousel/carousel-1.html">Auto-Rotating Image Carousel</a></li>
                 <li><a href="checkbox/checkbox-1/checkbox-1.html">Checkbox  (Two State)</a></li>
-                <li><a href="combobox/aria1.0pattern/combobox-autocomplete-both.html">Legacy ARIA 1.0 Combobox With Both List and Inline Autocomplete</a></li>
-                <li><a href="combobox/aria1.0pattern/combobox-autocomplete-list.html">Legacy ARIA 1.0 Combobox With List Autocomplete</a></li>
-                <li><a href="combobox/aria1.0pattern/combobox-autocomplete-none.html">Legacy ARIA 1.0 Combobox without Autocomplete</a></li>
-                <li><a href="combobox/aria1.1pattern/grid-combo.html">ARIA 1.1 Combobox with Grid Popup</a></li>
-                <li><a href="combobox/aria1.1pattern/listbox-combo.html">ARIA 1.1 Combobox with Listbox Popup</a></li>
+                <li><a href="combobox/combobox-autocomplete-both.html">Editable Combobox With Both List and Inline Autocomplete</a></li>
+                <li><a href="combobox/combobox-autocomplete-list.html">Editable Combobox With List Autocomplete</a></li>
+                <li><a href="combobox/combobox-autocomplete-none.html">Editable Combobox without Autocomplete</a></li>
+                <li><a href="combobox/grid-combo.html">Editable Combobox with Grid Popup</a></li>
                 <li><a href="dialog-modal/alertdialog.html">Alert Dialog</a></li>
                 <li><a href="dialog-modal/datepicker-dialog.html">Date Picker Dialog</a></li>
                 <li><a href="dialog-modal/dialog.html">Modal Dialog</a></li>
@@ -569,8 +560,7 @@
             <td>
               <ul>
                 <li><a href="checkbox/checkbox-1/checkbox-1.html">Checkbox  (Two State)</a></li>
-                <li><a href="combobox/aria1.1pattern/grid-combo.html">ARIA 1.1 Combobox with Grid Popup</a></li>
-                <li><a href="combobox/aria1.1pattern/listbox-combo.html">ARIA 1.1 Combobox with Listbox Popup</a></li>
+                <li><a href="combobox/grid-combo.html">Editable Combobox with Grid Popup</a></li>
                 <li><a href="dialog-modal/alertdialog.html">Alert Dialog</a></li>
                 <li><a href="dialog-modal/datepicker-dialog.html">Date Picker Dialog</a></li>
                 <li><a href="dialog-modal/dialog.html">Modal Dialog</a></li>
@@ -641,18 +631,6 @@
             <td><a href="slider/slider-2.html">Slider  with aria-orientation and aria-valuetext</a></td>
           </tr>
           <tr>
-            <td><code>aria-owns</code></td>
-            <td>
-              <ul>
-                <li><a href="combobox/aria1.0pattern/combobox-autocomplete-both.html">Legacy ARIA 1.0 Combobox With Both List and Inline Autocomplete</a></li>
-                <li><a href="combobox/aria1.0pattern/combobox-autocomplete-list.html">Legacy ARIA 1.0 Combobox With List Autocomplete</a></li>
-                <li><a href="combobox/aria1.0pattern/combobox-autocomplete-none.html">Legacy ARIA 1.0 Combobox without Autocomplete</a></li>
-                <li><a href="combobox/aria1.1pattern/grid-combo.html">ARIA 1.1 Combobox with Grid Popup</a></li>
-                <li><a href="combobox/aria1.1pattern/listbox-combo.html">ARIA 1.1 Combobox with Listbox Popup</a></li>
-              </ul>
-            </td>
-          </tr>
-          <tr>
             <td><code>aria-posinset</code></td>
             <td>
               <ul>
@@ -700,7 +678,7 @@
             <td><code>aria-selected</code></td>
             <td>
               <ul>
-                <li><a href="combobox/aria1.1pattern/grid-combo.html">ARIA 1.1 Combobox with Grid Popup</a></li>
+                <li><a href="combobox/grid-combo.html">Editable Combobox with Grid Popup</a></li>
                 <li><a href="listbox/listbox-rearrangeable.html">Listboxes with Rearrangeable Options</a></li>
                 <li><a href="tabs/tabs-1/tabs.html">Tabs with Automatic Activation</a></li>
                 <li><a href="tabs/tabs-2/tabs.html">Tabs with Manual Activation</a></li>


### PR DESCRIPTION
Updates:
1. Structural roles section to remove the 3 rows related to associationlist, which is now slated for ARIA 1.3.
2. Structural roles section to remove link outdated link to feedback issue 739.
3. Update indexes of examples.

After merging combobox changes from PR 1255, I will re-reun the reference-tables script, push the updated index, and merge this.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria-practices/pull/1269.html" title="Last updated on Nov 15, 2019, 4:08 AM UTC (b7acf4b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria-practices/1269/632bc8a...b7acf4b.html" title="Last updated on Nov 15, 2019, 4:08 AM UTC (b7acf4b)">Diff</a>