### PR TITLE
Tabs Pattern: Revise tabpanel tabindex guidance for issue 1164

### DIFF
--- a/aria-practices.html
+++ b/aria-practices.html
@@ -1024,7 +1024,7 @@
           <li>The element that serves as an input and displays the combobox value has role <a href="#combobox" class="role-reference">combobox</a>.</li>
           <li>
             The combobox element has <a href="#aria-controls" class="property-reference">aria-controls</a> set to a value that refers to the element that serves as the popup.
-            Note that <code>aria-controls</code> only needs to be set when the popup is visible. However, it is valid to reference an element that is not visible. 
+            Note that <code>aria-controls</code> only needs to be set when the popup is visible. However, it is valid to reference an element that is not visible.
           </li>
           <li>The popup is an element that has role <a href="#listbox" class="role-reference">listbox</a>, <a href="#tree" class="role-reference">tree</a>, <a href="#grid" class="role-reference">grid</a>, or <a href="#dialog" class="role-reference">dialog</a>.</li>
           <li>
@@ -2632,8 +2632,12 @@
         <p>For the tab list:</p>
         <ul>
           <li>
-            <kbd>Tab</kbd>: When focus moves into the tab list, places focus on the active <code>tab</code> element.
-            When the tab list contains the focus, moves focus to the next element in the page tab sequence outside the tablist, which is typically either the first focusable element inside the tab panel or the tab panel itself.
+            <kbd>Tab</kbd>:
+            <ul>
+              <li>When focus moves into the tab list, places focus on the active <code>tab</code> element.</li>
+              <li>When the tab list contains the focus, moves focus to the next element in the page tab sequence outside the tablist, which is typically either the first focusable element inside the tab panel or the tab panel itself.</li>
+              <li>When the first element contained within a <code>tabpanel</code> element is not focusable, it should set <code>tabindex="0"</code> to make it part of the tab sequence.</li>
+            </ul>
           </li>
           <li>When focus is on a tab element in a horizontal tab list:
             <ul>

--- a/aria-practices.html
+++ b/aria-practices.html
@@ -2636,7 +2636,7 @@
             <ul>
               <li>When focus moves into the tab list, places focus on the active <code>tab</code> element.</li>
               <li>When the tab list contains the focus, moves focus to the next element in the page tab sequence outside the tablist, which is typically either the first focusable element inside the tab panel or the tab panel itself.</li>
-              <li>When the first element contained within a <code>tabpanel</code> element is not focusable, it should set <code>tabindex="0"</code> to make it part of the tab sequence.</li>
+              <li>When the first element contained within a <code>tabpanel</code> element is not focusable, the <code>tabpanel</code> element should have <code>tabindex="0"</code> to make it part of the tab sequence.</li>
             </ul>
           </li>
           <li>When focus is on a tab element in a horizontal tab list:

--- a/aria-practices.html
+++ b/aria-practices.html
@@ -2636,7 +2636,7 @@
             <ul>
               <li>When focus moves into the tab list, places focus on the active <code>tab</code> element.</li>
               <li>When the tab list contains the focus, moves focus to the next element in the page tab sequence outside the tablist, which is typically either the first focusable element inside the tab panel or the tab panel itself.</li>
-              <li>When the first element contained within a <code>tabpanel</code> element is not focusable, the <code>tabpanel</code> element should have <code>tabindex="0"</code> to make it part of the tab sequence.</li>
+              <li>When the first element contained within a tab panel element is not focusable, the <code>tabpanel</code> element should have <code>tabindex="0"</code> to make it part of the tab sequence.</li>
             </ul>
           </li>
           <li>When focus is on a tab element in a horizontal tab list:

--- a/aria-practices.html
+++ b/aria-practices.html
@@ -2636,7 +2636,7 @@
             <ul>
               <li>When focus moves into the tab list, places focus on the active <code>tab</code> element.</li>
               <li>When the tab list contains the focus, moves focus to the next element in the page tab sequence outside the tablist, which is typically either the first focusable element inside the tab panel or the tab panel itself.</li>
-              <li>When the first element contained within a tab panel element is not focusable, the <code>tabpanel</code> element should have <code>tabindex="0"</code> to make it part of the tab sequence.</li>
+              <li>When the first element within a tab panel is not focusable, the <code>tabpanel</code> element should have <code>tabindex="0"</code> to make it part of the tab sequence.</li>
             </ul>
           </li>
           <li>When focus is on a tab element in a horizontal tab list:

--- a/aria-practices.html
+++ b/aria-practices.html
@@ -2635,8 +2635,7 @@
             <kbd>Tab</kbd>:
             <ul>
               <li>When focus moves into the tab list, places focus on the active <code>tab</code> element.</li>
-              <li>When the tab list contains the focus, moves focus to the next element in the page tab sequence outside the tablist, which is typically either the first focusable element inside the tab panel or the tab panel itself.</li>
-              <li>When the first element within a tab panel is not focusable, the <code>tabpanel</code> element should have <code>tabindex="0"</code> to make it part of the tab sequence.</li>
+              <li>When the tab list contains the focus, moves focus to the next element in the page tab sequence outside the tablist, which is the tabpanel unless the first element containing meaningful content inside the tabpanel is focusable.</li>
             </ul>
           </li>
           <li>When focus is on a tab element in a horizontal tab list:


### PR DESCRIPTION
To resolve #1164, revises the Tab key guidance for tabbing out of the tablist and to the tabpanel.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria-practices/pull/1274.html" title="Last updated on Jan 23, 2020, 7:28 AM UTC (7d9c7c8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria-practices/1274/c59168a...7d9c7c8.html" title="Last updated on Jan 23, 2020, 7:28 AM UTC (7d9c7c8)">Diff</a>