### PR TITLE
Windows Regression Test Fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lint:es": "eslint .",
     "lint:js": "npm run lint:es",
     "lint:html": "npm run vnu-jar",
-    "regression": "ava test/tests/*.js",
+    "regression": "ava",
     "regression-report": "node test/util/report",
     "test": "npm run lint && npm run regression",
     "vnu-jar": "java -jar node_modules/vnu-jar/build/dist/vnu.jar --errors-only --filterfile .vnurc --no-langdetect --skip-non-html *.html examples/"

--- a/package.json
+++ b/package.json
@@ -55,5 +55,10 @@
       "eslint --fix",
       "git add"
     ]
+  },
+  "ava": {
+    "files": [
+      "test/tests/*"
+    ]
   }
 }


### PR DESCRIPTION
This just moves the test globbing to [the Ava configuration](https://github.com/avajs/ava/blob/master/docs/06-configuration.md), which should solve issues where Windows wasn't able to find files.

Some background: npm `scripts` will run command line operations, leveraging whatever syntax features the operating system has in place, which results in ` test/tests/*.js does not exist.` on Windows. This change forces Ava to use [its own internal globbing algorithm](https://github.com/avajs/ava/blob/master/package.json#L91) ([globby](https://github.com/sindresorhus/globby)), which has cross-platform support.