### PR TITLE
Up arrow scrolls to top in grouped listbox

### DIFF
--- a/examples/listbox/js/listbox.js
+++ b/examples/listbox/js/listbox.js
@@ -110,7 +110,6 @@ aria.Listbox.prototype.checkKeyPress = function (evt) {
       break;
     case aria.KeyCode.UP:
     case aria.KeyCode.DOWN:
-      evt.preventDefault();
 
       if (!this.activeDescendant) {
         // focus first option if no option was previously focused, and perform no other actions
@@ -119,6 +118,7 @@ aria.Listbox.prototype.checkKeyPress = function (evt) {
       }
 
       if (this.moveUpDownEnabled && evt.altKey) {
+        evt.preventDefault();
         if (key === aria.KeyCode.UP) {
           this.moveUpItems();
         }
@@ -137,6 +137,7 @@ aria.Listbox.prototype.checkKeyPress = function (evt) {
 
       if (nextItem) {
         this.focusItem(nextItem);
+        evt.preventDefault();
       }
 
       break;


### PR DESCRIPTION
Updates up/down arrow key handling in listbox to only prevent default scroll behavior if focus is actually moved. This allows the up/down arrow keys to scroll the listbox to its upper and lower bounds.

Resolves #1249 

### Preview link

[View listbox example in compare branch for this PR](https://raw.githack.com/w3c/aria-practices/1249-listbox-scroll/examples/listbox/listbox-grouped.html)

### Reviewers

* [x] [Functional review](https://github.com/w3c/aria-practices/wiki/Pull-Request-Review-Process#functional_review) by Carolyn (@carmacleod)
* [x] [Code review](https://github.com/w3c/aria-practices/wiki/Pull-Request-Review-Process#code_review) by Valerie (@spectranaut)
* [x] [Test review](https://github.com/w3c/aria-practices/wiki/Pull-Request-Review-Process#test_review) by Valerie (@spectranaut)