### PR TITLE
Tree Examples: Correct result of selecting parent node

### DIFF
--- a/examples/treeview/treeview-1/js/treeitemClick.js
+++ b/examples/treeview/treeview-1/js/treeitemClick.js
@@ -23,7 +23,8 @@ window.addEventListener('load', function () {
       var treeitem = event.currentTarget;
       var label = treeitem.getAttribute('aria-label');
       if (!label) {
-        label = treeitem.innerHTML;
+        var child = treeitem.firstElementChild;
+        label = child ? child.innerText : treeitem.innerText;
       }
 
       document.getElementById('last_action').value = label.trim();


### PR DESCRIPTION
Fixes TreeView problem pointed out in PR https://github.com/w3c/aria-practices/pull/1186#issuecomment-577840796 :

> I have tested https://www.w3.org/TR/wai-aria-practices-1.1/examples/treeview/treeview-1/treeview-1a.html with Talkback (Chrome) and VoiceOver (Safari) and the tree works well with both screenreaders on the smartphone without keyboard. The only problem: The hierarchy of the treeitems is not output.
>
> Note: The following small problem occurs in every browser: in the input field "File or Folder Selected" after selecting a folder not the name of the folder is displayed, but the entire HTML code including all child elements (`<span class="focus">Reports</span><ul role="group">`...)