### PR TITLE
Navigation menubar: Fix scroll-to-top problem reported in issue #1307

### DIFF
--- a/examples/menubar/menubar-1/js/MenubarItemLinks.js
+++ b/examples/menubar/menubar-1/js/MenubarItemLinks.js
@@ -33,6 +33,7 @@ MenubarItem.prototype.init = function () {
   this.domNode.tabIndex = -1;
 
   this.domNode.addEventListener('keydown', this.handleKeydown.bind(this));
+  this.domNode.addEventListener('click', this.handleClick.bind(this));
   this.domNode.addEventListener('focus', this.handleFocus.bind(this));
   this.domNode.addEventListener('blur', this.handleBlur.bind(this));
   this.domNode.addEventListener('mouseover', this.handleMouseover.bind(this));
@@ -118,6 +119,13 @@ MenubarItem.prototype.handleKeydown = function (event) {
 
   if (flag) {
     event.stopPropagation();
+    event.preventDefault();
+  }
+};
+
+MenubarItem.prototype.handleClick = function (event) {
+  if (this.popupMenu) {
+    // prevent scroll to top of page when anchor element is clicked
     event.preventDefault();
   }
 };

--- a/examples/menubar/menubar-1/js/MenubarItemLinks.js
+++ b/examples/menubar/menubar-1/js/MenubarItemLinks.js
@@ -125,7 +125,8 @@ MenubarItem.prototype.handleKeydown = function (event) {
 
 MenubarItem.prototype.handleClick = function (event) {
   if (this.popupMenu) {
-    // prevent scroll to top of page when anchor element is clicked
+    // for menuitem with menu, prevent default anchor behavior on click
+    // (which jumps to top of page for href="#" in some browsers)
     event.preventDefault();
   }
 };

--- a/examples/menubar/menubar-1/js/PopupMenuItemLinks.js
+++ b/examples/menubar/menubar-1/js/PopupMenuItemLinks.js
@@ -174,7 +174,8 @@ MenuItem.prototype.handleClick = function (event) {
   this.menu.setFocusToController();
   this.menu.close(true);
   if (this.popupMenu) {
-    // prevent scroll to top of page when anchor element is clicked
+    // for menuitem with menu, prevent default anchor behavior on click
+    // (which jumps to top of page for href="#" in some browsers)
     event.preventDefault();
   }
 };

--- a/examples/menubar/menubar-1/js/PopupMenuItemLinks.js
+++ b/examples/menubar/menubar-1/js/PopupMenuItemLinks.js
@@ -173,6 +173,10 @@ MenuItem.prototype.setExpanded = function (value) {
 MenuItem.prototype.handleClick = function (event) {
   this.menu.setFocusToController();
   this.menu.close(true);
+  if (this.popupMenu) {
+    // prevent scroll to top of page when anchor element is clicked
+    event.preventDefault();
+  }
 };
 
 MenuItem.prototype.handleFocus = function (event) {


### PR DESCRIPTION
Issue #1307 reports 2 issues with the navigation menubar example. This PR resolves the scroll to top issue by preventing `menuitem` anchor elements from jumping to `href="#"` (i.e. top of page in Chrome) if they have a menu/submenu.

Here's a [preview link](https://raw.githack.com/w3c/aria-practices/issue1307-scroll-to-top/examples/menubar/menubar-1/menubar-1.html).

### Review checklist

* [x] [Functional review](https://github.com/w3c/aria-practices/wiki/Pull-Request-Review-Process#functional_review) Sarah (@@smhigley)
* [x] [Code review](https://github.com/w3c/aria-practices/wiki/Pull-Request-Review-Process#code_review) by Valerie (@spectranaut)
* [x] [Test review](https://github.com/w3c/aria-practices/wiki/Pull-Request-Review-Process#test_review) Valerie (@spectranaut)
