### PR TITLE
Infrastructure: Skip regression testing against landmark example files when they are edited

### DIFF
--- a/aria-practices.html
+++ b/aria-practices.html
@@ -2344,7 +2344,10 @@
         A slider is an input where the user selects a value from within a given range.
         Sliders typically have a slider thumb that can be moved along a bar or track to change the value of the slider.
       </p>
-
+      <p class="warning">
+        Users of touch-based assistive technologies may not be able to fully operate widgets that implement this pattern because APIs for capturing the necessary gestures and commands from assistive technologies are not yet available.
+        Authors should fully test widgets using this pattern with assistive technologies before considering incorporation into production systems.
+      </p>
       <section class="notoc">
         <h4>Examples</h4>
         <ul>
@@ -2406,6 +2409,10 @@
         For example, in a price range selector, the maximum value of the thumb that sets the lower end of the range is limited by the current value of the thumb that sets the upper end of the range.
         Conversely, the minimum value of the upper end thumb is limited by the current value of the lower end thumb.
         However, in some multi-thumb sliders, each thumb sets a value that does not depend on the other thumb values.
+      </p>
+      <p class="warning">
+        Users of touch-based assistive technologies may not be able to fully operate widgets that implement this pattern because APIs for capturing the necessary gestures and commands from assistive technologies are not yet available.
+        Authors should fully test widgets using this pattern with assistive technologies before considering incorporation into production systems.
       </p>
 
       <section class="notoc">

--- a/aria-practices.html
+++ b/aria-practices.html
@@ -1024,7 +1024,7 @@
           <li>The element that serves as an input and displays the combobox value has role <a href="#combobox" class="role-reference">combobox</a>.</li>
           <li>
             The combobox element has <a href="#aria-controls" class="property-reference">aria-controls</a> set to a value that refers to the element that serves as the popup.
-            Note that <code>aria-controls</code> only needs to be set when the popup is visible. However, it is valid to reference an element that is not visible. 
+            Note that <code>aria-controls</code> only needs to be set when the popup is visible. However, it is valid to reference an element that is not visible.
           </li>
           <li>The popup is an element that has role <a href="#listbox" class="role-reference">listbox</a>, <a href="#tree" class="role-reference">tree</a>, <a href="#grid" class="role-reference">grid</a>, or <a href="#dialog" class="role-reference">dialog</a>.</li>
           <li>
@@ -2632,8 +2632,11 @@
         <p>For the tab list:</p>
         <ul>
           <li>
-            <kbd>Tab</kbd>: When focus moves into the tab list, places focus on the active <code>tab</code> element.
-            When the tab list contains the focus, moves focus to the next element in the page tab sequence outside the tablist, which is typically either the first focusable element inside the tab panel or the tab panel itself.
+            <kbd>Tab</kbd>:
+            <ul>
+              <li>When focus moves into the tab list, places focus on the active <code>tab</code> element.</li>
+              <li>When the tab list contains the focus, moves focus to the next element in the page tab sequence outside the tablist, which is the tabpanel unless the first element containing meaningful content inside the tabpanel is focusable.</li>
+            </ul>
           </li>
           <li>When focus is on a tab element in a horizontal tab list:
             <ul>

--- a/aria-practices.html
+++ b/aria-practices.html
@@ -3786,7 +3786,7 @@
         Authors supply a description when there is a need to associate additional information with an element, such as instructions or format requirements for an input field.
       </p>
       <p>
-        assistive technologies present names differently from descriptions.
+        Assistive technologies present names differently from descriptions.
         For instance, screen readers typically announce the name and role of an element first, e.g., a button named <q>Mute Conversation</q>could be spoken as <q>Mute Conversation button</q>.
         If an element has a state, it could be announced either before or after the name and role; after name and role is the typical default.
          For example, a switch button named <q>Mute Conversation</q> in the <q>off</q> state could be announced as <q>Mute Conversation switch button off</q>.

--- a/package-lock.json
+++ b/package-lock.json
@@ -308,9 +308,9 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.7.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.7.tgz",
-      "integrity": "sha512-uCnC2JEVAu8AKB5do1WRIsvrdJ0flYx/A/9f/6chdacnEZ7LmavjdsDXr5ksYBegxtuTPR5Va9/+13QF/kFkCA==",
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.2.tgz",
+      "integrity": "sha512-JONRbXbTXc9WQE2mAZd1p0Z3DZ/6vaQIkgYMSTP3KjRCyd7rCZCcfhCyX+YjwcKxcZ82UrxbRD358bpExNgrjw==",
       "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.2"
@@ -496,13 +496,12 @@
       }
     },
     "@types/vfile-message": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@types/vfile-message/-/vfile-message-1.0.1.tgz",
-      "integrity": "sha512-mlGER3Aqmq7bqR1tTTIVHq8KSAFFRyGbrxuM8C/H82g6k7r2fS+IMEkIu3D7JHzG10NvPdR8DNx0jr0pwpp4dA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/vfile-message/-/vfile-message-2.0.0.tgz",
+      "integrity": "sha512-GpTIuDpb9u4zIO165fUy9+fXcULdD8HFRNli04GehoMVbeNq7D6OBnqSmg3lxZnC+UvgUhEWKxdKiwYUkGltIw==",
       "dev": true,
       "requires": {
-        "@types/node": "*",
-        "@types/unist": "*"
+        "vfile-message": "*"
       }
     },
     "acorn": {
@@ -715,26 +714,18 @@
       "dev": true
     },
     "autoprefixer": {
-      "version": "9.6.4",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.6.4.tgz",
-      "integrity": "sha512-Koz2cJU9dKOxG8P1f8uVaBntOv9lP4yz9ffWvWaicv9gHBPhpQB22nGijwd8gqW9CNT+UdkbQOQNLVI8jN1ZfQ==",
+      "version": "9.7.1",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.7.1.tgz",
+      "integrity": "sha512-w3b5y1PXWlhYulevrTJ0lizkQ5CyqfeU6BIRDbuhsMupstHQOeb1Ur80tcB1zxSu7AwyY/qCQ7Vvqklh31ZBFw==",
       "dev": true,
       "requires": {
-        "browserslist": "^4.7.0",
-        "caniuse-lite": "^1.0.30000998",
+        "browserslist": "^4.7.2",
+        "caniuse-lite": "^1.0.30001006",
         "chalk": "^2.4.2",
         "normalize-range": "^0.1.2",
         "num2fraction": "^1.2.2",
-        "postcss": "^7.0.18",
+        "postcss": "^7.0.21",
         "postcss-value-parser": "^4.0.2"
-      },
-      "dependencies": {
-        "postcss-value-parser": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.0.2.tgz",
-          "integrity": "sha512-LmeoohTpp/K4UiyQCwuGWlONxXamGzCMtFxLq4W1nZVGIQLYvMCJx3yAF9qyyuFpflABI9yVdtJAqbihOsCsJQ==",
-          "dev": true
-        }
       }
     },
     "ava": {
@@ -1017,14 +1008,14 @@
       }
     },
     "browserslist": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.7.0.tgz",
-      "integrity": "sha512-9rGNDtnj+HaahxiVV38Gn8n8Lr8REKsel68v1sPFfIGEK6uSXTY3h9acgiT1dZVtOOUtifo/Dn8daDQ5dUgVsA==",
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.7.2.tgz",
+      "integrity": "sha512-uZavT/gZXJd2UTi9Ov7/Z340WOSQ3+m1iBVRUknf+okKxonL9P83S3ctiBDtuRmRu8PiCHjqyueqQ9HYlJhxiw==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30000989",
-        "electron-to-chromium": "^1.3.247",
-        "node-releases": "^1.1.29"
+        "caniuse-lite": "^1.0.30001004",
+        "electron-to-chromium": "^1.3.295",
+        "node-releases": "^1.1.38"
       }
     },
     "buffer-from": {
@@ -1164,9 +1155,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30000999",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000999.tgz",
-      "integrity": "sha512-1CUyKyecPeksKwXZvYw0tEoaMCo/RwBlXmEtN5vVnabvO0KPd9RQLcaAuR9/1F+KDMv6esmOFWlsXuzDk+8rxg==",
+      "version": "1.0.30001010",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001010.tgz",
+      "integrity": "sha512-RA5GH9YjFNea4ZQszdWgh2SC+dpLiRAg4VDQS2b5JRI45OxmbGrYocYHTa9x0bKMQUE7uvHkNPNffUr+pCxSGw==",
       "dev": true
     },
     "capture-stack-trace": {
@@ -1992,9 +1983,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.280",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.280.tgz",
-      "integrity": "sha512-qYWNMjKLEfQAWZF2Sarvo+ahigu0EArnpCFSoUuZJS3W5wIeVfeEvsgmT2mgIrieQkeQ0+xFmykK3nx2ezekPQ==",
+      "version": "1.3.306",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.306.tgz",
+      "integrity": "sha512-frDqXvrIROoYvikSKTIKbHbzO6M3/qC6kCIt/1FOa9kALe++c4VAJnwjSFvf1tYLEUsP2n9XZ4XSCyqc3l7A/A==",
       "dev": true
     },
     "elegant-spinner": {
@@ -3768,9 +3759,9 @@
       "dev": true
     },
     "known-css-properties": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.14.0.tgz",
-      "integrity": "sha512-P+0a/gBzLgVlCnK8I7VcD0yuYJscmWn66wH9tlKsQnmVdg689tLEmziwB9PuazZYLkcm07fvWOKCJJqI55sD5Q==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.17.0.tgz",
+      "integrity": "sha512-Vi3nxDGMm/z+lAaCjvAR1u+7fiv+sG6gU/iYDj5QOF8h76ytK9EW/EKfF0NeTyiGBi8Jy6Hklty/vxISrLox3w==",
       "dev": true
     },
     "latest-version": {
@@ -4449,9 +4440,9 @@
       "dev": true
     },
     "mdast-util-compact": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/mdast-util-compact/-/mdast-util-compact-1.0.3.tgz",
-      "integrity": "sha512-nRiU5GpNy62rZppDKbLwhhtw5DXoFMqw9UNZFmlPsNaQCZ//WLjGKUwWMdJrUH+Se7UvtO2gXtAMe0g/N+eI5w==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mdast-util-compact/-/mdast-util-compact-1.0.4.tgz",
+      "integrity": "sha512-3YDMQHI5vRiS2uygEFYaqckibpJtKq5Sj2c8JioeOQBU6INpKbdWzfyLqFFnDwEcEnRFIdMsguzs5pC1Jp4Isg==",
       "dev": true,
       "requires": {
         "unist-util-visit": "^1.1.0"
@@ -4669,9 +4660,9 @@
       "dev": true
     },
     "node-releases": {
-      "version": "1.1.35",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.35.tgz",
-      "integrity": "sha512-JGcM/wndCN/2elJlU0IGdVEJQQnJwsLbgPCFd2pY7V0mxf17bZ0Gb/lgOtL29ZQhvEX5shnVhxQyZz3ex94N8w==",
+      "version": "1.1.40",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.40.tgz",
+      "integrity": "sha512-r4LPcC5b/bS8BdtWH1fbeK88ib/wg9aqmg6/s3ngNLn2Ewkn/8J6Iw3P9RTlfIAdSdvYvQl2thCY5Y+qTAQ2iQ==",
       "dev": true,
       "requires": {
         "semver": "^6.3.0"
@@ -5267,9 +5258,9 @@
       "dev": true
     },
     "postcss": {
-      "version": "7.0.18",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.18.tgz",
-      "integrity": "sha512-/7g1QXXgegpF+9GJj4iN7ChGF40sYuGYJ8WZu8DZWnmhQ/G36hfdk3q9LBJmoK+lZ+yzZ5KYpOoxq7LF1BxE8g==",
+      "version": "7.0.21",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.21.tgz",
+      "integrity": "sha512-uIFtJElxJo29QC753JzhidoAhvp/e/Exezkdhfmt8AymWT6/5B7W1WmponYWkHk2eg6sONyTch0A3nkMPun3SQ==",
       "dev": true,
       "requires": {
         "chalk": "^2.4.2",
@@ -5365,13 +5356,13 @@
       }
     },
     "postcss-sass": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/postcss-sass/-/postcss-sass-0.3.5.tgz",
-      "integrity": "sha512-B5z2Kob4xBxFjcufFnhQ2HqJQ2y/Zs/ic5EZbCywCkxKd756Q40cIQ/veRDwSrw1BF6+4wUgmpm0sBASqVi65A==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/postcss-sass/-/postcss-sass-0.4.2.tgz",
+      "integrity": "sha512-hcRgnd91OQ6Ot9R90PE/khUDCJHG8Uxxd3F7Y0+9VHjBiJgNv7sK5FxyHMCBtoLmmkzVbSj3M3OlqUfLJpq0CQ==",
       "dev": true,
       "requires": {
-        "gonzales-pe": "^4.2.3",
-        "postcss": "^7.0.1"
+        "gonzales-pe": "^4.2.4",
+        "postcss": "^7.0.21"
       }
     },
     "postcss-scss": {
@@ -5418,9 +5409,9 @@
       "dev": true
     },
     "postcss-value-parser": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
-      "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.0.2.tgz",
+      "integrity": "sha512-LmeoohTpp/K4UiyQCwuGWlONxXamGzCMtFxLq4W1nZVGIQLYvMCJx3yAF9qyyuFpflABI9yVdtJAqbihOsCsJQ==",
       "dev": true
     },
     "prelude-ls": {
@@ -6477,15 +6468,15 @@
       "dev": true
     },
     "stylelint": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-10.1.0.tgz",
-      "integrity": "sha512-OmlUXrgzEMLQYj1JPTpyZPR9G4bl0StidfHnGJEMpdiQ0JyTq0MPg1xkHk1/xVJ2rTPESyJCDWjG8Kbpoo7Kuw==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-12.0.0.tgz",
+      "integrity": "sha512-TwqtATrFOT07SPlUGyHN7tVhWqxwitn5BlAvyBQy/ekA+Nwu4mLU9L1dvGQPNxHUBLowjvkSW18QzHHR6/FVVQ==",
       "dev": true,
       "requires": {
-        "autoprefixer": "^9.5.1",
+        "autoprefixer": "^9.7.1",
         "balanced-match": "^1.0.0",
-        "chalk": "^2.4.2",
-        "cosmiconfig": "^5.2.0",
+        "chalk": "^3.0.0",
+        "cosmiconfig": "^6.0.0",
         "debug": "^4.1.1",
         "execall": "^2.0.0",
         "file-entry-cache": "^5.0.1",
@@ -6493,49 +6484,55 @@
         "global-modules": "^2.0.0",
         "globby": "^9.2.0",
         "globjoin": "^0.1.4",
-        "html-tags": "^3.0.0",
-        "ignore": "^5.0.6",
+        "html-tags": "^3.1.0",
+        "ignore": "^5.1.4",
         "import-lazy": "^4.0.0",
         "imurmurhash": "^0.1.4",
-        "known-css-properties": "^0.14.0",
+        "known-css-properties": "^0.17.0",
         "leven": "^3.1.0",
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.15",
         "log-symbols": "^3.0.0",
-        "mathml-tag-names": "^2.1.0",
+        "mathml-tag-names": "^2.1.1",
         "meow": "^5.0.0",
-        "micromatch": "^4.0.0",
+        "micromatch": "^4.0.2",
         "normalize-selector": "^0.2.0",
-        "pify": "^4.0.1",
-        "postcss": "^7.0.14",
+        "postcss": "^7.0.21",
         "postcss-html": "^0.36.0",
-        "postcss-jsx": "^0.36.1",
+        "postcss-jsx": "^0.36.3",
         "postcss-less": "^3.1.4",
         "postcss-markdown": "^0.36.0",
         "postcss-media-query-parser": "^0.2.3",
         "postcss-reporter": "^6.0.1",
         "postcss-resolve-nested-selector": "^0.1.1",
         "postcss-safe-parser": "^4.0.1",
-        "postcss-sass": "^0.3.5",
+        "postcss-sass": "^0.4.2",
         "postcss-scss": "^2.0.0",
         "postcss-selector-parser": "^3.1.0",
         "postcss-syntax": "^0.36.2",
-        "postcss-value-parser": "^3.3.1",
+        "postcss-value-parser": "^4.0.2",
         "resolve-from": "^5.0.0",
-        "signal-exit": "^3.0.2",
         "slash": "^3.0.0",
         "specificity": "^0.4.1",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^5.2.0",
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
         "style-search": "^0.1.0",
         "sugarss": "^2.0.0",
         "svg-tags": "^1.0.0",
-        "table": "^5.2.3"
+        "table": "^5.4.6",
+        "v8-compile-cache": "^2.1.0",
+        "write-file-atomic": "^3.0.1"
       },
       "dependencies": {
         "@nodelib/fs.stat": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
           "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==",
+          "dev": true
+        },
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
           "dev": true
         },
         "array-union": {
@@ -6582,6 +6579,29 @@
             }
           }
         },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "cosmiconfig": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
+          "integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
+          "dev": true,
+          "requires": {
+            "@types/parse-json": "^4.0.0",
+            "import-fresh": "^3.1.0",
+            "parse-json": "^5.0.0",
+            "path-type": "^4.0.0",
+            "yaml": "^1.7.2"
+          }
+        },
         "debug": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -6598,7 +6618,30 @@
           "dev": true,
           "requires": {
             "path-type": "^3.0.0"
+          },
+          "dependencies": {
+            "path-type": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+              "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+              "dev": true,
+              "requires": {
+                "pify": "^3.0.0"
+              }
+            },
+            "pify": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+              "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+              "dev": true
+            }
           }
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+          "dev": true
         },
         "fast-glob": {
           "version": "2.2.7",
@@ -6717,6 +6760,12 @@
           "integrity": "sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==",
           "dev": true
         },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        },
         "is-number": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
@@ -6750,23 +6799,69 @@
           "dev": true,
           "requires": {
             "chalk": "^2.4.2"
-          }
-        },
-        "path-type": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
-          "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
-          "dev": true,
-          "requires": {
-            "pify": "^3.0.0"
           },
           "dependencies": {
-            "pify": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-              "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-              "dev": true
+            "ansi-styles": {
+              "version": "3.2.1",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+              "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+              "dev": true,
+              "requires": {
+                "color-convert": "^1.9.0"
+              }
+            },
+            "chalk": {
+              "version": "2.4.2",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+              "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+              "dev": true,
+              "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+              }
+            },
+            "supports-color": {
+              "version": "5.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+              "dev": true,
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
             }
+          }
+        },
+        "parse-json": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
+          "integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1",
+            "lines-and-columns": "^1.1.6"
+          }
+        },
+        "string-width": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
           }
         },
         "to-regex-range": {
@@ -6777,6 +6872,18 @@
           "requires": {
             "is-number": "^3.0.0",
             "repeat-string": "^1.6.1"
+          }
+        },
+        "write-file-atomic": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.1.tgz",
+          "integrity": "sha512-JPStrIyyVJ6oCSz/691fAjFtefZ6q+fP6tm+OS4Qw6o+TGQxNp1ziY2PgS+X/m0V8OWhZiO/m4xSj+Pr4RrZvw==",
+          "dev": true,
+          "requires": {
+            "imurmurhash": "^0.1.4",
+            "is-typedarray": "^1.0.0",
+            "signal-exit": "^3.0.2",
+            "typedarray-to-buffer": "^3.1.5"
           }
         }
       }
@@ -7190,9 +7297,9 @@
       }
     },
     "unist-util-find-all-after": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/unist-util-find-all-after/-/unist-util-find-all-after-1.0.4.tgz",
-      "integrity": "sha512-CaxvMjTd+yF93BKLJvZnEfqdM7fgEACsIpQqz8vIj9CJnUb9VpyymFS3tg6TCtgrF7vfCJBF5jbT2Ox9CBRYRQ==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/unist-util-find-all-after/-/unist-util-find-all-after-1.0.5.tgz",
+      "integrity": "sha512-lWgIc3rrTMTlK1Y0hEuL+k+ApzFk78h+lsaa2gHf63Gp5Ww+mt11huDniuaoq1H+XMK2lIIjjPkncxXcDp3QDw==",
       "dev": true,
       "requires": {
         "unist-util-is": "^3.0.0"
@@ -7205,19 +7312,22 @@
       "dev": true
     },
     "unist-util-remove-position": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-1.1.3.tgz",
-      "integrity": "sha512-CtszTlOjP2sBGYc2zcKA/CvNdTdEs3ozbiJ63IPBxh8iZg42SCCb8m04f8z2+V1aSk5a7BxbZKEdoDjadmBkWA==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-1.1.4.tgz",
+      "integrity": "sha512-tLqd653ArxJIPnKII6LMZwH+mb5q+n/GtXQZo6S6csPRs5zB0u79Yw8ouR3wTw8wxvdJFhpP6Y7jorWdCgLO0A==",
       "dev": true,
       "requires": {
         "unist-util-visit": "^1.1.0"
       }
     },
     "unist-util-stringify-position": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-1.1.2.tgz",
-      "integrity": "sha512-pNCVrk64LZv1kElr0N1wPiHEUoXNVFERp+mlTg/s9R5Lwg87f9bM/3sQB99w+N9D/qnM9ar3+AKDBwo/gm/iQQ==",
-      "dev": true
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-2.0.2.tgz",
+      "integrity": "sha512-nK5n8OGhZ7ZgUwoUbL8uiVRwAbZyzBsB/Ddrlbu6jwwubFza4oe15KlyEaLNMXQW1svOQq4xesUeqA85YrIUQA==",
+      "dev": true,
+      "requires": {
+        "@types/unist": "^2.0.2"
+      }
     },
     "unist-util-visit": {
       "version": "1.4.1",
@@ -7378,22 +7488,38 @@
           "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
           "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
           "dev": true
+        },
+        "unist-util-stringify-position": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-1.1.2.tgz",
+          "integrity": "sha512-pNCVrk64LZv1kElr0N1wPiHEUoXNVFERp+mlTg/s9R5Lwg87f9bM/3sQB99w+N9D/qnM9ar3+AKDBwo/gm/iQQ==",
+          "dev": true
+        },
+        "vfile-message": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-1.1.1.tgz",
+          "integrity": "sha512-1WmsopSGhWt5laNir+633LszXvZ+Z/lxveBf6yhGsqnQIhlhzooZae7zV6YVM1Sdkw68dtAW3ow0pOdPANugvA==",
+          "dev": true,
+          "requires": {
+            "unist-util-stringify-position": "^1.1.1"
+          }
         }
       }
     },
     "vfile-location": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-2.0.5.tgz",
-      "integrity": "sha512-Pa1ey0OzYBkLPxPZI3d9E+S4BmvfVwNAAXrrqGbwTVXWaX2p9kM1zZ+n35UtVM06shmWKH4RPRN8KI80qE3wNQ==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-2.0.6.tgz",
+      "integrity": "sha512-sSFdyCP3G6Ka0CEmN83A2YCMKIieHx0EDaj5IDP4g1pa5ZJ4FJDvpO0WODLxo4LUX4oe52gmSCK7Jw4SBghqxA==",
       "dev": true
     },
     "vfile-message": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-1.1.1.tgz",
-      "integrity": "sha512-1WmsopSGhWt5laNir+633LszXvZ+Z/lxveBf6yhGsqnQIhlhzooZae7zV6YVM1Sdkw68dtAW3ow0pOdPANugvA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-2.0.2.tgz",
+      "integrity": "sha512-gNV2Y2fDvDOOqq8bEe7cF3DXU6QgV4uA9zMR2P8tix11l1r7zju3zry3wZ8sx+BEfuO6WQ7z2QzfWTvqHQiwsA==",
       "dev": true,
       "requires": {
-        "unist-util-stringify-position": "^1.1.1"
+        "@types/unist": "^2.0.0",
+        "unist-util-stringify-position": "^2.0.0"
       }
     },
     "vnu-jar": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "husky": "^4.0.2",
     "lint-staged": "^9.2.0",
     "selenium-webdriver": "^4.0.0-alpha.1",
-    "stylelint": "^10.1.0",
+    "stylelint": "^12.0.0",
     "stylelint-config-standard": "^18.2.0",
     "vnu-jar": "^20.1.2"
   },

--- a/scripts/reference-tables.js
+++ b/scripts/reference-tables.js
@@ -66,6 +66,7 @@ const ariaRoles = [
   'progressbar',
   'radio',
   'radiogroup',
+  // 'region', Region is generated differently from other roles
   'row',
   'rowgroup',
   'rowheader',

--- a/scripts/regression-tests.sh
+++ b/scripts/regression-tests.sh
@@ -9,8 +9,8 @@ fi
 TEST_DIRS=$(git diff --name-only $TRAVIS_COMMIT_RANGE | grep -oP 'test/tests/\K[\w-]+(?=_)' | uniq)
 EXAMPLE_DIRS=$(git diff --name-only $TRAVIS_COMMIT_RANGE | grep -oP 'examples/\K[\w-]+(?=/)' | uniq)
 
-# Only add match args if the example/js or example/css directories or test/index.hs
-# or the test/utils.js directories have not been edited
+# Only add match args if the example/js or example/css directories or test/index.hs or the
+# test/utils.js directories have not been edited. If they have been edited, run all tests.
 
 TEST_INFRA=$(git diff --name-only $TRAVIS_COMMIT_RANGE | grep -oP 'test/(util|index)')
 EXAMPLE_INFRA=$(echo "$EXAMPLE_DIRS" | grep -P '^(js|css)$')
@@ -21,7 +21,11 @@ if [ -z $TEST_INFRA ] && [ -z $EXAMPLE_INFRA ]
 then
   for D in $EXAMPLE_DIRS
   do
-    ARGS="${ARGS} --match ${D}/*"
+    # Remove this if statement if we add regression tests for landmark pages
+    if [ $D != 'landmarks' ]
+    then
+      ARGS="${ARGS} --match ${D}/*"
+    fi
   done
 
   for F in $TEST_DIRS


### PR DESCRIPTION
This fixes the CI error in: https://github.com/w3c/aria-practices/pull/1303

The problem was that AVA is looking for landmark tests because the landmark directory is in the examples directory, and [this script](https://github.com/w3c/aria-practices/blob/master/scripts/regression-tests.sh) tries to run only the tests for the examples that have been edited.

I tested these changes on top of #1303 in this PR, where you can see the CI now passing.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/bocoup/aria-practices/pull/1315.html" title="Last updated on Feb 3, 2020, 7:08 AM UTC (0486008)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria-practices/1315/d75c28b...bocoup:0486008.html" title="Last updated on Feb 3, 2020, 7:08 AM UTC (0486008)">Diff</a>