### PR TITLE
Infrastructure: Don't run regression tests for landmark files

### DIFF
--- a/scripts/regression-tests.sh
+++ b/scripts/regression-tests.sh
@@ -9,8 +9,8 @@ fi
 TEST_DIRS=$(git diff --name-only $TRAVIS_COMMIT_RANGE | grep -oP 'test/tests/\K[\w-]+(?=_)' | uniq)
 EXAMPLE_DIRS=$(git diff --name-only $TRAVIS_COMMIT_RANGE | grep -oP 'examples/\K[\w-]+(?=/)' | uniq)
 
-# Only add match args if the example/js or example/css directories or test/index.hs
-# or the test/utils.js directories have not been edited
+# Only add match args if the example/js or example/css directories or test/index.hs or the
+# test/utils.js directories have not been edited. If they have been edited, run all tests.
 
 TEST_INFRA=$(git diff --name-only $TRAVIS_COMMIT_RANGE | grep -oP 'test/(util|index)')
 EXAMPLE_INFRA=$(echo "$EXAMPLE_DIRS" | grep -P '^(js|css)$')
@@ -21,7 +21,11 @@ if [ -z $TEST_INFRA ] && [ -z $EXAMPLE_INFRA ]
 then
   for D in $EXAMPLE_DIRS
   do
-    ARGS="${ARGS} --match ${D}/*"
+    # Remove this if statement if we add regression tests for landmark pages
+    if [ $D != 'landmarks' ]
+    then
+      ARGS="${ARGS} --match ${D}/*"
+    fi
   done
 
   for F in $TEST_DIRS


### PR DESCRIPTION
Contains changes from pull #1315, which couldn't be merged to master because it was behind and GitHub was not giving an update option.