### PR TITLE
Issue1332 listbox not updating

### DIFF
--- a/examples/combobox/js/combobox-autocomplete.js
+++ b/examples/combobox/js/combobox-autocomplete.js
@@ -391,6 +391,7 @@ ComboboxAutocomplete.prototype.handleComboboxKeyUp = function (event) {
   if (this.comboboxNode.value.length < this.filter.length) {
     this.filter = this.comboboxNode.value;
     this.option = null;
+    this.filterOptions()
   }
 
   if (event.key === "Escape" || event.key === "Esc") {

--- a/examples/combobox/js/combobox-autocomplete.js
+++ b/examples/combobox/js/combobox-autocomplete.js
@@ -403,7 +403,9 @@ ComboboxAutocomplete.prototype.handleComboboxKeyUp = function (event) {
     case "Backspace":
       this.setVisualFocusCombobox();
       this.setCurrentOptionStyle(false);
+      this.filter = this.comboboxNode.value;
       this.option = null;
+      this.filterOptions()
       flag = true;
       break;
 


### PR DESCRIPTION
@mcking65 

[Preview link for fix for listbox not properly updating using backspace (Issue 1332)](https://raw.githack.com/w3c/aria-practices/issue1332-listbox-not-updating/examples/combobox/combobox-autocomplete-both.html)

I added calls to the code that filters the options after the filter property is updated when backspace is pressed or if the length of the textbox value is less than the length of the filter property.
