### PR TITLE
Listbox Design Pattern: Add link to grouped listbox example

### DIFF
--- a/aria-practices.html
+++ b/aria-practices.html
@@ -1805,6 +1805,7 @@
           <li><a href="examples/listbox/listbox-scrollable.html">Scrollable Listbox Example</a>: Single-select listbox that scrolls to reveal more options, similar to HTML <code>select</code> with <code>size</code> attribute greater than one.</li>
           <li><a href="examples/listbox/listbox-collapsible.html">Collapsible Dropdown Listbox Example</a>: Single-select collapsible listbox that expands when activated, similar to HTML <code>select</code> with the attribute <code>size=&quot;1&quot;</code>.</li>
           <li><a href="examples/listbox/listbox-rearrangeable.html">Example Listboxes with Rearrangeable Options</a>: Examples of both single-select and multi-select listboxes with accompanying toolbars where options can be added, moved, and removed.</li>
+          <li><a href="examples/listbox/listbox-grouped.html">Listbox Example with Grouped Options</a>: Single-select listbox with grouped options, similar to an HTML <code>select</code> with <code>optgroup</code> children.</li>
         </ul>
       </section>
 


### PR DESCRIPTION
I noticed a link to the grouped listbox example was missing in `aria-practices.html`, so I added it in, with the same wording as on the other example pages.

Single-line PR :)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):
#Listbox
    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria-practices/pull/1341.html#Listbox" title="Last updated on Feb 28, 2020, 10:46 AM UTC (7c51184)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria-practices/1341/2fd5bf2...7c51184.html" title="Last updated on Feb 28, 2020, 10:46 AM UTC (7c51184)">Diff</a>