### PR TITLE
Add queryElements test helper, remove t.plan

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,6 +5,10 @@
   },
   "rules": {
     "no-unused-vars": 0,
-    "no-undef": 0
+    "no-undef": 0,
+    "no-restricted-properties": [2, {
+      "property": "findElements",
+      "message": "Please use t.context.queryElements()."
+    }]
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -88,7 +88,7 @@ const _ariaTest = (desc, page, testId, body, failing) => {
     if (testId !== 'test-additional-behavior') {
       const assert = require('assert');
       assert(
-        (await t.context.session.findElements(By.css(selector))).length,
+        (await t.context.queryElements(t, selector)).length,
         'Cannot find behavior description for this test in example page:' + testId
       );
     }

--- a/test/index.js
+++ b/test/index.js
@@ -6,6 +6,7 @@ const webdriver = require('selenium-webdriver');
 const { By } = require('selenium-webdriver');
 
 const startGeckodriver = require('./util/start-geckodriver');
+const queryElements = require('./util/queryElements');
 
 let session, geckodriver;
 const firefoxArgs = process.env.CI ? [ '-headless' ] : [];
@@ -30,6 +31,7 @@ if (!coverageReportRun) {
   test.beforeEach((t) => {
     t.context.session = session;
     t.context.waitTime = testWaitTime;
+    t.context.queryElements = queryElements;
   });
 
   test.after.always(() => {

--- a/test/index.js
+++ b/test/index.js
@@ -1,3 +1,5 @@
+/* eslint no-restricted-properties: 0 */
+
 'use strict';
 
 const path = require('path');

--- a/test/index.js
+++ b/test/index.js
@@ -1,5 +1,3 @@
-/* eslint no-restricted-properties: 0 */
-
 'use strict';
 
 const path = require('path');

--- a/test/tests/accordion_accordion.js
+++ b/test/tests/accordion_accordion.js
@@ -2,7 +2,6 @@
 
 const { ariaTest } = require('..');
 const { By, Key } = require('selenium-webdriver');
-const assertAttributeValues = require('../util/assertAttributeValues');
 const assertAriaControls = require('../util/assertAriaControls');
 const assertAriaLabelledby = require('../util/assertAriaLabelledby');
 
@@ -45,9 +44,8 @@ const focusMatchesElement = async function (t, selector) {
 // Attributes
 
 ariaTest('h3 element should wrap accordion button', exampleFile, 'h3-element', async (t) => {
-  t.plan(3);
-
-  const buttons = await t.context.session.findElements(By.css(ex.buttonSelector));
+  
+  const buttons = await t.context.queryElements(t, ex.buttonSelector);
 
   for (let button of buttons) {
     t.is(
@@ -59,9 +57,8 @@ ariaTest('h3 element should wrap accordion button', exampleFile, 'h3-element', a
 });
 
 ariaTest('aria-expanded on button element', exampleFile, 'button-aria-expanded', async (t) => {
-  t.plan(9);
-
-  const buttons = await t.context.session.findElements(By.css(ex.buttonSelector));
+  
+  const buttons = await t.context.queryElements(t, ex.buttonSelector);
 
   for (let expandIndex = 0; expandIndex < buttons.length; expandIndex++) {
 
@@ -81,15 +78,13 @@ ariaTest('aria-expanded on button element', exampleFile, 'button-aria-expanded',
 });
 
 ariaTest('aria-controls on button element', exampleFile, 'button-aria-controls', async (t) => {
-  t.plan(1);
-
+  
   await assertAriaControls(t, ex.buttonSelector);
 });
 
 ariaTest('"aria-disabled" set on expanded sections', exampleFile, 'button-aria-disabled', async (t) => {
-  t.plan(9);
-
-  const buttons = await t.context.session.findElements(By.css(ex.buttonSelector));
+  
+  const buttons = await t.context.queryElements(t, ex.buttonSelector);
 
   for (let expandIndex = 0; expandIndex < buttons.length; expandIndex++) {
 
@@ -109,9 +104,8 @@ ariaTest('"aria-disabled" set on expanded sections', exampleFile, 'button-aria-d
 });
 
 ariaTest('role "region" exists on accordion panels', exampleFile, 'region-role', async (t) => {
-  t.plan(3);
-
-  const buttons = await t.context.session.findElements(By.css(ex.buttonSelector));
+  
+  const buttons = await t.context.queryElements(t, ex.buttonSelector);
   const panelIds = [];
   for (let button of buttons) {
     panelIds.push(await button.getAttribute('aria-controls'));
@@ -127,18 +121,16 @@ ariaTest('role "region" exists on accordion panels', exampleFile, 'region-role',
 });
 
 ariaTest('"aria-labelledby" on region', exampleFile, 'region-aria-labelledby', async (t) => {
-  t.plan(1);
-  await assertAriaLabelledby(t, ex.panelSelector);
+    await assertAriaLabelledby(t, ex.panelSelector);
 });
 
 
 // Keys
 
 ariaTest('ENTER key expands section', exampleFile, 'key-enter-or-space', async (t) => {
-  t.plan(12);
-
-  const buttons = await t.context.session.findElements(By.css(ex.buttonSelector));
-  const panels = await t.context.session.findElements(By.css(ex.panelSelector));
+  
+  const buttons = await t.context.queryElements(t, ex.buttonSelector);
+  const panels = await t.context.queryElements(t, ex.panelSelector);
 
   for (let expandIndex of [1, 2, 0]) {
     await buttons[expandIndex].sendKeys(Key.ENTER);
@@ -170,10 +162,9 @@ ariaTest('ENTER key expands section', exampleFile, 'key-enter-or-space', async (
 });
 
 ariaTest('SPACE key expands section', exampleFile, 'key-enter-or-space', async (t) => {
-  t.plan(12);
-
-  const buttons = await t.context.session.findElements(By.css(ex.buttonSelector));
-  const panels = await t.context.session.findElements(By.css(ex.panelSelector));
+  
+  const buttons = await t.context.queryElements(t, ex.buttonSelector);
+  const panels = await t.context.queryElements(t, ex.panelSelector);
 
   for (let expandIndex of [1, 2, 0]) {
     await buttons[expandIndex].sendKeys(Key.SPACE);
@@ -205,9 +196,8 @@ ariaTest('SPACE key expands section', exampleFile, 'key-enter-or-space', async (
 });
 
 ariaTest('TAB moves focus between headers and displayed inputs', exampleFile, 'key-tab', async (t) => {
-  t.plan(22);
-
-  const buttons = await t.context.session.findElements(By.css(ex.buttonSelector));
+  
+  const buttons = await t.context.queryElements(t, ex.buttonSelector);
 
   // Open a panel
   await buttons[0].click();
@@ -280,9 +270,8 @@ ariaTest('TAB moves focus between headers and displayed inputs', exampleFile, 'k
 });
 
 ariaTest('SHIFT+TAB moves focus between headers and displayed inputs', exampleFile, 'key-shift-tab', async (t) => {
-  t.plan(22);
-
-  const buttons = await t.context.session.findElements(By.css(ex.buttonSelector));
+  
+  const buttons = await t.context.queryElements(t, ex.buttonSelector);
 
   // Open a panel
   await buttons[0].click();
@@ -358,9 +347,8 @@ ariaTest('SHIFT+TAB moves focus between headers and displayed inputs', exampleFi
 });
 
 ariaTest('DOWN ARROW moves focus between headers', exampleFile, 'key-down-arrow', async (t) => {
-  t.plan(3);
-
-  const buttons = await t.context.session.findElements(By.css(ex.buttonSelector));
+  
+  const buttons = await t.context.queryElements(t, ex.buttonSelector);
 
   // Confirm focus moves through remaining items
   for (let index = 0; index < ex.buttonsInOrder.length - 1; index++) {
@@ -387,7 +375,7 @@ ariaTest('DOWN ARROW moves focus between headers', exampleFile, 'key-down-arrow'
 
 ariaTest('UP ARROW moves focus between headers', exampleFile, 'key-up-arrow', async (t) => {
 
-  const buttons = await t.context.session.findElements(By.css(ex.buttonSelector));
+  const buttons = await t.context.queryElements(t, ex.buttonSelector);
 
   // Confirm focus moves through remaining items
   for (let index = ex.buttonsInOrder.length - 1; index > 0; index--) {
@@ -413,9 +401,8 @@ ariaTest('UP ARROW moves focus between headers', exampleFile, 'key-up-arrow', as
 });
 
 ariaTest('HOME key will always move focus to first button', exampleFile, 'key-home', async (t) => {
-  t.plan(3);
-
-  const buttons = await t.context.session.findElements(By.css(ex.buttonSelector));
+  
+  const buttons = await t.context.queryElements(t, ex.buttonSelector);
   const lastIndex = ex.buttonsInOrder.length - 1;
 
   // Confirm focus moves through remaining items
@@ -433,9 +420,8 @@ ariaTest('HOME key will always move focus to first button', exampleFile, 'key-ho
 });
 
 ariaTest('END key will always move focus to last button', exampleFile, 'key-end', async (t) => {
-  t.plan(3);
-
-  const buttons = await t.context.session.findElements(By.css(ex.buttonSelector));
+  
+  const buttons = await t.context.queryElements(t, ex.buttonSelector);
   const lastIndex = ex.buttonsInOrder.length - 1;
 
   // Confirm focus moves through remaining items

--- a/test/tests/alert_alert.js
+++ b/test/tests/alert_alert.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { ariaTest } = require('..');
-const { By, Key } = require('selenium-webdriver');
+const { By } = require('selenium-webdriver');
 
 const exampleFile = 'alert/alert.html';
 
@@ -13,8 +13,7 @@ const ex = {
 // Attributes
 
 ariaTest('role="alert" on alert element', exampleFile, 'alert-role', async (t) => {
-  t.plan(2);
-
+  
   t.false(
     await t.context.session.findElement(By.css(ex.alertSelector)).isDisplayed(),
     '[role="alert"] element found and should not be displayed on pageload'

--- a/test/tests/breadcrumb_index.js
+++ b/test/tests/breadcrumb_index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { ariaTest } = require('..');
-const { By, Key } = require('selenium-webdriver');
+const { By } = require('selenium-webdriver');
 const assertAriaLabelExists = require('../util/assertAriaLabelExists');
 
 const exampleFile = 'breadcrumb/index.html';
@@ -13,15 +13,13 @@ const ex = {
 // Attributes
 
 ariaTest('aria-label attribute on nav element', exampleFile, 'aria-label', async (t) => {
-  t.plan(1);
-  await assertAriaLabelExists(t, ex.breadcrumbSelector);
+    await assertAriaLabelExists(t, ex.breadcrumbSelector);
 });
 
 ariaTest('aria-current element should exist on relevent link', exampleFile, 'aria-current', async (t) => {
-  t.plan(2);
-
+  
   let navElement = await t.context.session.findElement(By.css(ex.breadcrumbSelector));
-  let currentElement = await navElement.findElements(By.css('[aria-current]'));
+  let currentElement = await t.context.queryElements(t, '[aria-current]', navElement);
 
   t.is(
     currentElement.length,

--- a/test/tests/button_button.js
+++ b/test/tests/button_button.js
@@ -22,8 +22,7 @@ const ex = {
 // Attributes
 
 ariaTest('Example elements should have role="button" set', exampleFile, 'button-role', async (t) => {
-  t.plan(4);
-
+  
   for (let button of ex.buttons) {
     let buttonEl = await t.context.session.findElement(By.id(button.id));
 
@@ -42,8 +41,7 @@ ariaTest('Example elements should have role="button" set', exampleFile, 'button-
 });
 
 ariaTest('Button examples should have tabindex="0"', exampleFile, 'button-tabindex', async (t) => {
-  t.plan(2);
-
+  
   for (let button of ex.buttons) {
     let buttonEl = await t.context.session.findElement(By.id(button.id));
 
@@ -56,8 +54,7 @@ ariaTest('Button examples should have tabindex="0"', exampleFile, 'button-tabind
 });
 
 ariaTest('"aria-pressed" reflects button state', exampleFile, 'button-aria-pressed', async (t) => {
-  t.plan(3);
-
+  
   let toggleButtonSelector = '#' + ex.buttons[1].id;
 
   let ariaPressedExists = await t.context.session.executeScript(async function () {
@@ -93,8 +90,7 @@ ariaTest('"aria-pressed" reflects button state', exampleFile, 'button-aria-press
 });
 
 ariaTest('key ENTER activates button', exampleFile, 'key-enter', async (t) => {
-  t.plan(3);
-
+  
   let toggleButtonSelector = '#' + ex.buttons[1].id;
   let toggleButtonEl = await t.context.session.findElement(By.css(toggleButtonSelector));
 
@@ -149,8 +145,7 @@ ariaTest('key ENTER activates button', exampleFile, 'key-enter', async (t) => {
 });
 
 ariaTest('key SPACE activates button', exampleFile, 'key-space', async (t) => {
-  t.plan(3);
-
+  
   let toggleButtonSelector = '#' + ex.buttons[1].id;
   let toggleButtonEl = await t.context.session.findElement(By.css(toggleButtonSelector));
 

--- a/test/tests/carousel_carousel-1.js
+++ b/test/tests/carousel_carousel-1.js
@@ -2,7 +2,6 @@
 
 const { ariaTest } = require('..');
 const { By, Key } = require('selenium-webdriver');
-const assertAttributeDNE = require('../util/assertAttributeDNE');
 const assertAttributeValues = require('../util/assertAttributeValues');
 const assertAriaControls = require('../util/assertAriaControls');
 const assertAriaLabelExists = require('../util/assertAriaLabelExists');
@@ -33,8 +32,7 @@ const ex = {
 // Attributes
 
 ariaTest('section element used to contain slider', exampleFile, 'carousel-region-role', async (t) => {
-  t.plan(1);
-
+  
   // This test primarially tests that the ex.landmarkSelector points to a `section` element
   const landmarkEl = await t.context.session.findElement(By.css(ex.landmarkSelector));
   t.is(
@@ -45,21 +43,18 @@ ariaTest('section element used to contain slider', exampleFile, 'carousel-region
 });
 
 ariaTest('section has aria-roledescription set to carousel', exampleFile, 'carousel-region-aria-roledescription', async (t) => {
-  t.plan(1);
-
+  
   // check the aria-roledescrption set to carousel
   await assertAttributeValues(t, ex.landmarkSelector, 'aria-roledescription', 'carousel');
 });
 
 ariaTest('section has aria-label', exampleFile, 'carousel-region-aria-label', async (t) => {
-  t.plan(1);
-
+  
   await assertAriaLabelExists(t, ex.landmarkSelector);
 });
 
 ariaTest('slide container have aria-live initially set to off', exampleFile, 'carousel-aria-live', async (t) => {
-  t.plan(4);
-
+  
   // On page load, `aria-level` is `off`
   await assertAttributeValues(t, ex.slideContainerSelector, 'aria-live', 'off');
 
@@ -79,29 +74,24 @@ ariaTest('slide container have aria-live initially set to off', exampleFile, 'ca
 });
 
 ariaTest('pause, previous and next buttons have aria-label', exampleFile, 'carousel-button-aria-label', async (t) => {
-  t.plan(1);
-  await assertAriaLabelExists(t, ex.buttonSelector);
+    await assertAriaLabelExists(t, ex.buttonSelector);
 });
 
 ariaTest('previous and next buttons have aria-controls', exampleFile, 'carousel-button-aria-controls', async (t) => {
-  t.plan(2);
-  await assertAriaControls(t, ex.previousButtonSelector);
+    await assertAriaControls(t, ex.previousButtonSelector);
   await assertAriaControls(t, ex.nextButtonSelector);
 });
 
 ariaTest('slides have role group', exampleFile, 'carousel-group-role', async (t) => {
-  t.plan(1);
-  await assertAriaRoles(t, 'myCarousel', 'group', 6, 'div');
+    await assertAriaRoles(t, 'myCarousel', 'group', 6, 'div');
 });
 
 ariaTest('slides have aria-label', exampleFile, 'carousel-group-aria-label', async (t) => {
-  t.plan(1);
-  await assertAriaLabelExists(t, ex.slideSelector);
+    await assertAriaLabelExists(t, ex.slideSelector);
 });
 
 ariaTest('slides have aria-roledescription set to slide', exampleFile, 'carousel-group-aria-roledescription', async (t) => {
-  t.plan(1);
-
+  
   // check the aria-roledescrption set to carousel
   await assertAttributeValues(t, ex.slideSelector, 'aria-roledescription', 'slide');
 });
@@ -109,14 +99,12 @@ ariaTest('slides have aria-roledescription set to slide', exampleFile, 'carousel
 // Keyboard interaction
 
 ariaTest('TAB moves key through buttons', exampleFile, 'carousel-key-tab', async (t) => {
-  t.plan(1);
-
+  
   await assertTabOrder(t, ex.allFocusableItems);
 });
 
 ariaTest('ENTER pause and start carousel motion', exampleFile, 'carousel-enter-or-space-toggle', async (t) => {
-  t.plan(2);
-
+  
   let activeElement = await t.context.session.findElement(By.css(ex.activeCarouselItem)).getAttribute('aria-label');
 
   await t.context.session.findElement(By.css(ex.pausePlayButtonSelector)).sendKeys(Key.ENTER);
@@ -151,8 +139,7 @@ ariaTest('ENTER pause and start carousel motion', exampleFile, 'carousel-enter-o
 
 
 ariaTest('SPACE pause and start carousel motion', exampleFile, 'carousel-enter-or-space-toggle', async (t) => {
-  t.plan(2);
-
+  
   let activeElement = await t.context.session.findElement(By.css(ex.activeCarouselItem)).getAttribute('aria-label');
 
   await t.context.session.findElement(By.css(ex.pausePlayButtonSelector)).sendKeys(Key.SPACE);
@@ -186,8 +173,7 @@ ariaTest('SPACE pause and start carousel motion', exampleFile, 'carousel-enter-o
 
 
 ariaTest('SPACE on previous and next', exampleFile, 'carousel-key-enter-or-space-move', async (t) => {
-  t.plan(2);
-
+  
   let activeElement = await t.context.session.findElement(By.css(ex.activeCarouselItem))
     .getAttribute('aria-label');
 
@@ -219,8 +205,7 @@ ariaTest('SPACE on previous and next', exampleFile, 'carousel-key-enter-or-space
 });
 
 ariaTest('ENTER on previous and next', exampleFile, 'carousel-key-enter-or-space-move', async (t) => {
-  t.plan(2);
-
+  
   let activeElement = await t.context.session.findElement(By.css(ex.activeCarouselItem))
     .getAttribute('aria-label');
 

--- a/test/tests/carousel_carousel-2-tablist.js
+++ b/test/tests/carousel_carousel-2-tablist.js
@@ -41,7 +41,7 @@ const ex = {
 };
 
 const openTabAtIndex = async function (t, index) {
-  const tabs = await t.context.session.findElements(By.css(ex.tabSelector));
+  const tabs = await t.context.queryElements(t, ex.tabSelector);
   await tabs[index].click();
 };
 
@@ -57,7 +57,7 @@ const waitAndCheckFocus = async function (t, selector, index) {
 
 const waitAndCheckAriaSelected = async function (t, index) {
   return t.context.session.wait(async function () {
-    const tabs = await t.context.session.findElements(By.css(ex.tabSelector));
+    const tabs = await t.context.queryElements(t, ex.tabSelector);
     return (await tabs[index].getAttribute('aria-selected')) === 'true';
   }, t.context.waitTime, 'Timeout waiting for aria-selected to be set to true.');
 };
@@ -113,8 +113,8 @@ ariaTest('"aria-label" attribute on role="tab"', exampleFile, 'tab-aria-label', 
 ariaTest('"aria-selected" set on role="tab"', exampleFile, 'tab-aria-selected', async (t) => {
   t.plan(2 * ex.tabCount * ex.tabCount);
 
-  let tabs = await t.context.session.findElements(By.css(ex.tabSelector));
-  let tabpanels = await t.context.session.findElements(By.css(ex.tabpanelSelector));
+  let tabs = await t.context.queryElements(t, ex.tabSelector);
+  let tabpanels = await t.context.queryElements(t, ex.tabpanelSelector);
 
   for (let selectedEl = 0; selectedEl < tabs.length; selectedEl++) {
 
@@ -148,7 +148,7 @@ ariaTest('"aria-selected" set on role="tab"', exampleFile, 'tab-aria-selected', 
 ariaTest('"tabindex" on role="tab"', exampleFile, 'tab-tabindex', async (t) => {
   t.plan(ex.tabCount * ex.tabCount);
 
-  let tabs = await t.context.session.findElements(By.css(ex.tabSelector));
+  let tabs = await t.context.queryElements(t, ex.tabSelector);
   for (let selectedEl = 0; selectedEl < tabs.length; selectedEl++) {
 
     // Open the tab
@@ -256,8 +256,8 @@ ariaTest('ARROW_RIGHT key moves focus and activates tab', exampleFile, 'key-righ
   // Put focus on first tab
   await openTabAtIndex(t, 0);
 
-  const tabs = await t.context.session.findElements(By.css(ex.tabSelector));
-  const tabpanels = await t.context.session.findElements(By.css(ex.tabpanelSelector));
+  const tabs = await t.context.queryElements(t, ex.tabSelector);
+  const tabpanels = await t.context.queryElements(t, ex.tabpanelSelector);
   for (let index = 0; index < tabs.length - 1; index++) {
 
     // Send the arrow right key to move focus
@@ -302,8 +302,8 @@ ariaTest('ARROW_RIGHT key moves focus and activates tab', exampleFile, 'key-righ
 ariaTest('ARROW_LEFT key moves focus and activates tab', exampleFile, 'key-left-arrow', async (t) => {
   t.plan(3 * ex.tabCount);
 
-  const tabs = await t.context.session.findElements(By.css(ex.tabSelector));
-  const tabpanels = await t.context.session.findElements(By.css(ex.tabpanelSelector));
+  const tabs = await t.context.queryElements(t, ex.tabSelector);
+  const tabpanels = await t.context.queryElements(t, ex.tabpanelSelector);
 
   // Put focus on first tab
   await openTabAtIndex(t, 0);
@@ -350,8 +350,8 @@ ariaTest('ARROW_LEFT key moves focus and activates tab', exampleFile, 'key-left-
 ariaTest('HOME key moves focus and selects tab', exampleFile, 'key-home', async (t) => {
   t.plan(3 * ex.tabCount);
 
-  const tabs = await t.context.session.findElements(By.css(ex.tabSelector));
-  const tabpanels = await t.context.session.findElements(By.css(ex.tabpanelSelector));
+  const tabs = await t.context.queryElements(t, ex.tabSelector);
+  const tabpanels = await t.context.queryElements(t, ex.tabpanelSelector);
   for (let index = 0; index < tabs.length; index++) {
 
     // Put focus on the tab
@@ -379,8 +379,8 @@ ariaTest('HOME key moves focus and selects tab', exampleFile, 'key-home', async 
 ariaTest('END key moves focus and selects tab', exampleFile, 'key-end', async (t) => {
   t.plan(3 * ex.tabCount);
 
-  const tabs = await t.context.session.findElements(By.css(ex.tabSelector));
-  const tabpanels = await t.context.session.findElements(By.css(ex.tabpanelSelector));
+  const tabs = await t.context.queryElements(t, ex.tabSelector);
+  const tabpanels = await t.context.queryElements(t, ex.tabpanelSelector);
   for (let index = 0; index < tabs.length; index++) {
 
     // Put focus on the tab

--- a/test/tests/checkbox_checkbox-1.js
+++ b/test/tests/checkbox_checkbox-1.js
@@ -56,9 +56,8 @@ const uncheckAllSelectedByDefault = async function (t) {
 // Attributes
 
 ariaTest('element h3 exists', exampleFile, 'h3', async (t) => {
-  t.plan(2);
-
-  let header = await t.context.session.findElements(By.css('#ex1 h3'));
+  
+  let header = await t.context.queryElements(t, '#ex1 h3');
 
   t.is(
     header.length,
@@ -74,22 +73,19 @@ ariaTest('element h3 exists', exampleFile, 'h3', async (t) => {
 });
 
 ariaTest('role="group" element exists', exampleFile, 'group-role', async (t) => {
-  t.plan(1);
-  await assertAriaRoles(t, 'ex1', 'group', '1', 'div');
+    await assertAriaRoles(t, 'ex1', 'group', '1', 'div');
 });
 
 ariaTest('"aria-labelledby" on group element', exampleFile, 'group-aria-labelledby', async (t) => {
-  t.plan(1);
-  await assertAriaLabelledby(t, ex.groupSelector);
+    await assertAriaLabelledby(t, ex.groupSelector);
 });
 
 ariaTest('role="checkbox" elements exist', exampleFile, 'checkbox-role', async (t) => {
-  t.plan(5);
-  await assertAriaRoles(t, 'ex1', 'checkbox', '4', 'div');
+    await assertAriaRoles(t, 'ex1', 'checkbox', '4', 'div');
 
   // Test that each checkbox has an accessible name
   // In this case, the accessible name is the text within the div
-  let checkboxes = await t.context.session.findElements(By.css(ex.checkboxSelector));
+  let checkboxes = await t.context.queryElements(t, ex.checkboxSelector);
 
   for (let index = 0; index < checkboxes.length; index++) {
     let text = await checkboxes[index].getText();
@@ -101,13 +97,11 @@ ariaTest('role="checkbox" elements exist', exampleFile, 'checkbox-role', async (
 });
 
 ariaTest('tabindex="0" for checkbox elements', exampleFile, 'checkbox-tabindex', async (t) => {
-  t.plan(1);
-  await assertAttributeValues(t, ex.checkboxSelector, 'tabindex', '0');
+    await assertAttributeValues(t, ex.checkboxSelector, 'tabindex', '0');
 });
 
 ariaTest('"aria-checked" on checkbox element', exampleFile, 'checkbox-aria-checked', async (t) => {
-  t.plan(10);
-
+  
   await uncheckAllSelectedByDefault(t);
 
   // check the aria-checked attribute is false to begin
@@ -122,7 +116,7 @@ ariaTest('"aria-checked" on checkbox element', exampleFile, 'checkbox-aria-check
   }
 
   // Click all checkboxes to select them
-  let checkboxes = await t.context.session.findElements(By.css(ex.checkboxSelector));
+  let checkboxes = await t.context.queryElements(t, ex.checkboxSelector);
   for (let checkbox of checkboxes) {
     await checkbox.click();
   }
@@ -140,14 +134,12 @@ ariaTest('"aria-checked" on checkbox element', exampleFile, 'checkbox-aria-check
 });
 
 ariaTest('key TAB moves focus between checkboxes', exampleFile, 'key-tab', async (t) => {
-  t.plan(1);
-
+  
   await assertTabOrder(t, ex.checkboxes);
 });
 
 ariaTest('key SPACE selects or unselects checkbox', exampleFile, 'key-space', async (t) => {
-  t.plan(16);
-
+  
   await uncheckAllSelectedByDefault(t);
 
   for (let checkboxSelector of ex.checkboxes) {

--- a/test/tests/checkbox_checkbox-1.js
+++ b/test/tests/checkbox_checkbox-1.js
@@ -56,7 +56,7 @@ const uncheckAllSelectedByDefault = async function (t) {
 // Attributes
 
 ariaTest('element h3 exists', exampleFile, 'h3', async (t) => {
-  
+
   let header = await t.context.queryElements(t, '#ex1 h3');
 
   t.is(
@@ -101,7 +101,7 @@ ariaTest('tabindex="0" for checkbox elements', exampleFile, 'checkbox-tabindex',
 });
 
 ariaTest('"aria-checked" on checkbox element', exampleFile, 'checkbox-aria-checked', async (t) => {
-  
+
   await uncheckAllSelectedByDefault(t);
 
   // check the aria-checked attribute is false to begin
@@ -134,12 +134,12 @@ ariaTest('"aria-checked" on checkbox element', exampleFile, 'checkbox-aria-check
 });
 
 ariaTest('key TAB moves focus between checkboxes', exampleFile, 'key-tab', async (t) => {
-  
+
   await assertTabOrder(t, ex.checkboxes);
 });
 
 ariaTest('key SPACE selects or unselects checkbox', exampleFile, 'key-space', async (t) => {
-  
+
   await uncheckAllSelectedByDefault(t);
 
   for (let checkboxSelector of ex.checkboxes) {

--- a/test/tests/checkbox_checkbox-2.js
+++ b/test/tests/checkbox_checkbox-2.js
@@ -1,3 +1,5 @@
+/* eslint no-restricted-properties: 0 */
+
 'use strict';
 
 const { ariaTest } = require('..');
@@ -40,7 +42,7 @@ ariaTest('"tabindex" on checkbox element', exampleFile, 'checkbox-tabindex', asy
 });
 
 ariaTest('"aria-controls" ', exampleFile, 'checkbox-aria-controls', async (t) => {
-  
+
   const checkbox = await t.context.session.findElement(By.css(ex.checkboxSelector));
   const controls = (await checkbox.getAttribute('aria-controls')).split(' ');
 
@@ -60,7 +62,7 @@ ariaTest('"aria-controls" ', exampleFile, 'checkbox-aria-controls', async (t) =>
 });
 
 ariaTest('"aria-checked" on checkbox element', exampleFile, 'checkbox-aria-checked-false', async (t) => {
-  
+
   await uncheckAllConds(t);
   let checkbox = t.context.session.findElement(By.css(ex.checkboxSelector));
 
@@ -90,7 +92,7 @@ ariaTest('"aria-checked" on checkbox element', exampleFile, 'checkbox-aria-check
 });
 
 ariaTest('"aria-checked" on checkbox element', exampleFile, 'checkbox-aria-checked-mixed', async (t) => {
-  
+
   await uncheckAllConds(t);
   let checkbox = t.context.session.findElement(By.css(ex.checkboxSelector));
 
@@ -124,7 +126,7 @@ ariaTest('"aria-checked" on checkbox element', exampleFile, 'checkbox-aria-check
 });
 
 ariaTest('"aria-checked" on checkbox element', exampleFile, 'checkbox-aria-checked-true', async (t) => {
-  
+
   await uncheckAllConds(t);
   let checkbox = t.context.session.findElement(By.css(ex.checkboxSelector));
 
@@ -159,12 +161,12 @@ ariaTest('"aria-checked" on checkbox element', exampleFile, 'checkbox-aria-check
 });
 
 ariaTest('key TAB moves focus between checkboxes', exampleFile, 'key-tab', async (t) => {
-  
+
   await assertTabOrder(t, ex.allCheckboxes);
 });
 
 ariaTest('key SPACE selects or unselects checkbox', exampleFile, 'key-space', async (t) => {
-  
+
   // Check one box
   await uncheckAllConds(t);
   const condiments = await t.context.queryElements(t, ex.condimentsSelector);

--- a/test/tests/checkbox_checkbox-2.js
+++ b/test/tests/checkbox_checkbox-2.js
@@ -23,7 +23,7 @@ const ex = {
 };
 
 const uncheckAllConds = async function (t) {
-  const checkboxes = await t.context.session.findElements(By.css(ex.checkedCondsSelector));
+  const checkboxes = await t.context.queryElements(t, ex.checkedCondsSelector);
   for (let checkbox of checkboxes) {
     await checkbox.click();
   }
@@ -32,18 +32,15 @@ const uncheckAllConds = async function (t) {
 // Attributes
 
 ariaTest('role="checkbox" element exists', exampleFile, 'checkbox-role', async (t) => {
-  t.plan(1);
-  await assertAriaRoles(t, 'ex1', 'checkbox', '1', 'div');
+    await assertAriaRoles(t, 'ex1', 'checkbox', '1', 'div');
 });
 
 ariaTest('"tabindex" on checkbox element', exampleFile, 'checkbox-tabindex', async (t) => {
-  t.plan(1);
-  await assertAttributeValues(t, ex.checkboxSelector, 'tabindex', '0');
+    await assertAttributeValues(t, ex.checkboxSelector, 'tabindex', '0');
 });
 
 ariaTest('"aria-controls" ', exampleFile, 'checkbox-aria-controls', async (t) => {
-  t.plan(5);
-
+  
   const checkbox = await t.context.session.findElement(By.css(ex.checkboxSelector));
   const controls = (await checkbox.getAttribute('aria-controls')).split(' ');
 
@@ -63,8 +60,7 @@ ariaTest('"aria-controls" ', exampleFile, 'checkbox-aria-controls', async (t) =>
 });
 
 ariaTest('"aria-checked" on checkbox element', exampleFile, 'checkbox-aria-checked-false', async (t) => {
-  t.plan(3);
-
+  
   await uncheckAllConds(t);
   let checkbox = t.context.session.findElement(By.css(ex.checkboxSelector));
 
@@ -94,13 +90,12 @@ ariaTest('"aria-checked" on checkbox element', exampleFile, 'checkbox-aria-check
 });
 
 ariaTest('"aria-checked" on checkbox element', exampleFile, 'checkbox-aria-checked-mixed', async (t) => {
-  t.plan(3);
-
+  
   await uncheckAllConds(t);
   let checkbox = t.context.session.findElement(By.css(ex.checkboxSelector));
 
   // Check one box
-  const condiments = await t.context.session.findElements(By.css(ex.condimentsSelector));
+  const condiments = await t.context.queryElements(t, ex.condimentsSelector);
   await condiments[0].click();
 
   t.is(
@@ -122,20 +117,19 @@ ariaTest('"aria-checked" on checkbox element', exampleFile, 'checkbox-aria-check
   );
 
   t.is(
-    (await t.context.session.findElements(By.css(ex.checkedCondsSelector))).length,
+    (await t.context.queryElements(t, ex.checkedCondsSelector)).length,
     1,
     '1 condiments should be selected via: ' + ex.checkedCondsSelector
   );
 });
 
 ariaTest('"aria-checked" on checkbox element', exampleFile, 'checkbox-aria-checked-true', async (t) => {
-  t.plan(3);
-
+  
   await uncheckAllConds(t);
   let checkbox = t.context.session.findElement(By.css(ex.checkboxSelector));
 
   // Check the all boxes
-  const condiments = await t.context.session.findElements(By.css(ex.condimentsSelector));
+  const condiments = await t.context.queryElements(t, ex.condimentsSelector);
   for (let cond of condiments) {
     await cond.click();
   }
@@ -158,24 +152,22 @@ ariaTest('"aria-checked" on checkbox element', exampleFile, 'checkbox-aria-check
   );
 
   t.is(
-    (await t.context.session.findElements(By.css(ex.checkedCondsSelector))).length,
+    (await t.context.queryElements(t, ex.checkedCondsSelector)).length,
     ex.numCondiments,
     ex.numCondiments + ' condiments should be selected via: ' + ex.checkedCondsSelector
   );
 });
 
 ariaTest('key TAB moves focus between checkboxes', exampleFile, 'key-tab', async (t) => {
-  t.plan(1);
-
+  
   await assertTabOrder(t, ex.allCheckboxes);
 });
 
 ariaTest('key SPACE selects or unselects checkbox', exampleFile, 'key-space', async (t) => {
-  t.plan(6);
-
+  
   // Check one box
   await uncheckAllConds(t);
-  const condiments = await t.context.session.findElements(By.css(ex.condimentsSelector));
+  const condiments = await t.context.queryElements(t, ex.condimentsSelector);
   await condiments[0].click();
 
   // Send SPACE key to checkbox to change state
@@ -190,7 +182,7 @@ ariaTest('key SPACE selects or unselects checkbox', exampleFile, 'key-space', as
   );
 
   t.is(
-    (await t.context.session.findElements(By.css(ex.checkedCondsSelector))).length,
+    (await t.context.queryElements(t, ex.checkedCondsSelector)).length,
     ex.numCondiments,
     'After sending SPACE to the checkbox in a mixed state, ' + ex.numCondiments + ' condiments should be selected via: ' + ex.checkedCondsSelector
   );
@@ -222,7 +214,7 @@ ariaTest('key SPACE selects or unselects checkbox', exampleFile, 'key-space', as
   );
 
   t.is(
-    (await t.context.session.findElements(By.css(ex.checkedCondsSelector))).length,
+    (await t.context.queryElements(t, ex.checkedCondsSelector)).length,
     1,
     'After sending SPACE to the checkbox in a uncheck state, 1 condiments should be selected via: ' + ex.checkedCondsSelector
   );

--- a/test/tests/checkbox_checkbox-2.js
+++ b/test/tests/checkbox_checkbox-2.js
@@ -1,5 +1,3 @@
-/* eslint no-restricted-properties: 0 */
-
 'use strict';
 
 const { ariaTest } = require('..');

--- a/test/tests/checkbox_checkbox-2.js
+++ b/test/tests/checkbox_checkbox-2.js
@@ -7,6 +7,7 @@ const { By, Key } = require('selenium-webdriver');
 const assertAttributeValues = require('../util/assertAttributeValues');
 const assertAriaRoles = require('../util/assertAriaRoles');
 const assertTabOrder = require('../util/assertTabOrder');
+const assertNoElements = require('../util/assertNoElements');
 
 const exampleFile = 'checkbox/checkbox-2/checkbox-2.html';
 
@@ -54,7 +55,7 @@ ariaTest('"aria-controls" ', exampleFile, 'checkbox-aria-controls', async (t) =>
 
   for (let id of controls) {
     t.is(
-      (await t.context.session.findElements(By.id(id))).length,
+      (await t.context.queryElements(t, `#${id}`)).length,
       1,
       'An element with id ' + id + ' should exist'
     );
@@ -83,12 +84,7 @@ ariaTest('"aria-checked" on checkbox element', exampleFile, 'checkbox-aria-check
     'The control checkbox should have attribute aria-checked = "false" after clicking checkbox twice (with no parially checked state)'
   );
 
-  t.is(
-    (await t.context.session.findElements(By.css(ex.checkedCondsSelector))).length,
-    0,
-    'No condiments should be selected via: ' + ex.checkedCondsSelector
-  );
-
+  assertNoElements(t, ex.checkedCondsSelector, 'No condiments should be selected via: ' + ex.checkedCondsSelector);
 });
 
 ariaTest('"aria-checked" on checkbox element', exampleFile, 'checkbox-aria-checked-mixed', async (t) => {
@@ -199,11 +195,7 @@ ariaTest('key SPACE selects or unselects checkbox', exampleFile, 'key-space', as
     'After sending SPACE to the checkbox in a all-checked state, aria-checked should equal "false"'
   );
 
-  t.is(
-    (await t.context.session.findElements(By.css(ex.checkedCondsSelector))).length,
-    0,
-    'After sending SPACE to the checkbox in a check state, 0 condiments should be selected via: ' + ex.checkedCondsSelector
-  );
+  assertNoElements(t, ex.checkedCondsSelector, 'After sending SPACE to the checkbox in a check state, 0 condiments should be selected via: ' + ex.checkedCondsSelector);
 
   // Send SPACE key to checkbox to change state
   await checkbox.sendKeys(Key.SPACE);

--- a/test/tests/combobox_autocomplete-both.js
+++ b/test/tests/combobox_autocomplete-both.js
@@ -1,5 +1,3 @@
-/* eslint no-restricted-properties: 0 */
-
 'use strict';
 
 const { ariaTest } = require('..');

--- a/test/tests/combobox_autocomplete-both.js
+++ b/test/tests/combobox_autocomplete-both.js
@@ -40,18 +40,15 @@ const confirmCursorIndex = async (t, selector, cursorIndex) => {
 // Attributes
 
 ariaTest('Test for role="combobox"', exampleFile, 'combobox-role', async (t) => {
-  t.plan(1);
-  await assertAriaRoles(t, 'ex1', 'combobox', '1', 'input');
+    await assertAriaRoles(t, 'ex1', 'combobox', '1', 'input');
 });
 
 ariaTest('"aria-autocomplete" on comboxbox element', exampleFile, 'combobox-aria-autocomplete', async (t) => {
-  t.plan(1);
-  await assertAttributeValues(t, ex.textboxSelector, 'aria-autocomplete', 'both');
+    await assertAttributeValues(t, ex.textboxSelector, 'aria-autocomplete', 'both');
 });
 
 ariaTest('"aria-controls" attribute on combobox element', exampleFile, 'combobox-aria-controls', async (t) => {
-  t.plan(2);
-
+  
   const popupId = await t.context.session
     .findElement(By.css(ex.textboxSelector))
     .getAttribute('aria-controls');
@@ -61,9 +58,7 @@ ariaTest('"aria-controls" attribute on combobox element', exampleFile, 'combobox
     '"aria-controls" attribute should exist on: ' + ex.textboxSelector
   );
 
-  const popupElements = await t.context.session
-    .findElement(By.id('ex1'))
-    .findElements(By.id(popupId));
+  const popupElements = await t.context.queryElements(t, `#ex1 #${popupId}`);
 
   t.is(
     popupElements.length,
@@ -73,8 +68,7 @@ ariaTest('"aria-controls" attribute on combobox element', exampleFile, 'combobox
 });
 
 ariaTest('"aria-expanded" on combobox element', exampleFile, 'combobox-aria-expanded', async (t) => {
-  t.plan(4);
-
+  
   const combobox = await t.context.session.findElement(By.css(ex.textboxSelector));
 
   // Check that aria-expanded is false and the listbox is not visible before interacting
@@ -120,39 +114,32 @@ ariaTest('"aria-expanded" on combobox element', exampleFile, 'combobox-aria-expa
 });
 
 ariaTest('"aria-activedescendant" on combobox element', exampleFile, 'combobox-aria-activedescendant', async (t) => {
-  t.plan(1);
-  await assertAttributeValues(t, ex.textboxSelector, 'aria-activedescendant', null);
+    await assertAttributeValues(t, ex.textboxSelector, 'aria-activedescendant', null);
 });
 
 ariaTest('role "listbox" on ul element', exampleFile, 'listbox-role', async (t) => {
-  t.plan(1);
-  await assertAriaRoles(t, 'ex1', 'listbox', '1', 'ul');
+    await assertAriaRoles(t, 'ex1', 'listbox', '1', 'ul');
 });
 
 ariaTest('"aria-label" attribute on listbox element', exampleFile, 'listbox-aria-label', async (t) => {
-  t.plan(1);
-  await assertAriaLabelExists(t, ex.listboxSelector);
+    await assertAriaLabelExists(t, ex.listboxSelector);
 });
 
 ariaTest('role "option" on lu elements', exampleFile, 'option-role', async (t) => {
-  t.plan(1);
-
+  
   // Send arrow down to reveal all options
   await t.context.session.findElement(By.css(ex.textboxSelector)).sendKeys(Key.ARROW_DOWN);
   await assertAriaRoles(t, 'ex1', 'option', '56', 'li');
 });
 
 ariaTest('"aria-selected" attribute on options element', exampleFile, 'option-aria-selected', async (t) => {
-  t.plan(1);
-
+  
   // Send key "a"
   await t.context.session.findElement(By.css(ex.textboxSelector)).sendKeys('a');
   await assertAttributeValues(t, ex.optionsSelector + ':nth-of-type(1)', 'aria-selected', 'true');
 });
 
 ariaTest('Button should have tabindex="-1"', exampleFile, 'button-tabindex', async (t) => {
-  t.plan(1);
-
   const button = await t.context.session.findElement(By.css(ex.buttonSelector))
 
   t.is(
@@ -163,14 +150,11 @@ ariaTest('Button should have tabindex="-1"', exampleFile, 'button-tabindex', asy
 });
 
 ariaTest('"aria-label" attribute on button element', exampleFile, 'button-aria-label', async (t) => {
-  t.plan(1);
   await assertAriaLabelExists(t, ex.buttonSelector);
 });
 
 
 ariaTest('"aria-controls" attribute on button element', exampleFile, 'button-aria-controls', async (t) => {
-  t.plan(2);
-
   const popupId = await t.context.session
     .findElement(By.css(ex.buttonSelector))
     .getAttribute('aria-controls');
@@ -180,9 +164,7 @@ ariaTest('"aria-controls" attribute on button element', exampleFile, 'button-ari
     '"aria-controls" attribute should exist on: ' + ex.buttonSelector
   );
 
-  const popupElements = await t.context.session
-    .findElement(By.id('ex1'))
-    .findElements(By.id(popupId));
+  const popupElements = await t.context.queryElements(t, `#ex1 #${popupId}`);
 
   t.is(
     popupElements.length,
@@ -192,8 +174,6 @@ ariaTest('"aria-controls" attribute on button element', exampleFile, 'button-ari
 });
 
 ariaTest('"aria-expanded" on button element', exampleFile, 'button-aria-expanded', async (t) => {
-  t.plan(4);
-
   const button = await t.context.session.findElement(By.css(ex.buttonSelector));
 
   // Check that aria-expanded is false and the listbox is not visible before interacting
@@ -243,8 +223,7 @@ ariaTest('"aria-expanded" on button element', exampleFile, 'button-aria-expanded
 ariaTest('Test alt + down key press with focus on textbox',
   exampleFile, 'textbox-key-alt-down-arrow', async (t) => {
 
-    t.plan(2);
-
+    
     // Send ARROW_DOWN to the textbox
     await t.context.session
       .findElement(By.css(ex.textboxSelector))
@@ -264,8 +243,7 @@ ariaTest('Test alt + down key press with focus on textbox',
 ariaTest('Test down key press with focus on textbox',
   exampleFile, 'textbox-key-down-arrow', async (t) => {
 
-    t.plan(2);
-
+    
     // Send ARROW_DOWN to the textbox
     await t.context.session
       .findElement(By.css(ex.textboxSelector))
@@ -289,8 +267,7 @@ ariaTest('Test down key press with focus on textbox',
 ariaTest('Test down key press with focus on list',
   exampleFile, 'listbox-key-down-arrow', async (t) => {
 
-    t.plan(4);
-
+    
     // Send 'a' to text box, then send ARROW_DOWN to textbox to set focus on listbox
     await t.context.session
       .findElement(By.css(ex.textboxSelector))
@@ -318,8 +295,7 @@ ariaTest('Test down key press with focus on list',
 ariaTest('Test up key press with focus on textbox',
   exampleFile, 'textbox-key-up-arrow', async (t) => {
 
-    t.plan(2);
-
+    
     // Send ARROW_UP to the textbox
     await t.context.session
       .findElement(By.css(ex.textboxSelector))
@@ -335,7 +311,7 @@ ariaTest('Test up key press with focus on textbox',
     await waitForFocusChange(t, ex.textboxSelector, null);
 
     // Check that the active descendent focus is correct
-    let numOptions = (await t.context.session.findElements(By.css(ex.optionsSelector))).length;
+    let numOptions = (await t.context.queryElements(t, ex.optionsSelector)).length;
     await assertAriaSelectedAndActivedescendant(t, ex.textboxSelector, ex.optionsSelector, numOptions - 1);
   });
 
@@ -343,8 +319,7 @@ ariaTest('Test up key press with focus on textbox',
 ariaTest('Test up key press with focus on listbox',
   exampleFile, 'listbox-key-up-arrow', async (t) => {
 
-    t.plan(4);
-
+    
     // Send 'a' to text box, then send ARROW_UP to textbox to textbox to put focus in textbox
     // Up arrow should move selection to the last item in the list
     await t.context.session
@@ -377,8 +352,7 @@ ariaTest('Test up key press with focus on listbox',
 ariaTest('Test enter key press with focus on textbox',
   exampleFile, 'textbox-key-enter', async (t) => {
 
-    t.plan(2);
-
+    
     // Send key "a" to the textbox
 
     await t.context.session
@@ -413,8 +387,7 @@ ariaTest('Test enter key press with focus on textbox',
 ariaTest('Test enter key press with focus on listbox',
   exampleFile, 'listbox-key-enter', async (t) => {
 
-    t.plan(2);
-
+    
     // Send key "a" to the textbox, then two ARROW_DOWNS
 
     await t.context.session
@@ -423,7 +396,7 @@ ariaTest('Test enter key press with focus on listbox',
 
     // Get the value of the first option in the listbox
 
-    const secondOption = await(await t.context.session.findElements(By.css(ex.optionsSelector)))[1]
+    const secondOption = await(await t.context.queryElements(t, ex.optionsSelector))[1]
       .getText();
 
     // Send key ENTER
@@ -451,8 +424,7 @@ ariaTest('Test enter key press with focus on listbox',
 
 ariaTest('Test single escape key press with focus on textbox',
   exampleFile, 'textbox-key-escape', async (t) => {
-    t.plan(2);
-
+    
     // Send key "a", then key ESCAPE once to the textbox
 
     await t.context.session
@@ -474,8 +446,7 @@ ariaTest('Test single escape key press with focus on textbox',
 
 ariaTest('Test double escape key press with focus on textbox',
   exampleFile, 'textbox-key-escape', async (t) => {
-    t.plan(2);
-
+    
     // Send key "a", then key ESCAPE twice to the textbox
 
     await t.context.session
@@ -497,8 +468,7 @@ ariaTest('Test double escape key press with focus on textbox',
 
 ariaTest('Test escape key press with focus on textbox',
   exampleFile, 'listbox-key-escape', async (t) => {
-    t.plan(2);
-
+    
     // Send key "a" then key "ARROW_DOWN to put the focus on the listbox,
     // then key ESCAPE to the textbox
 
@@ -521,8 +491,7 @@ ariaTest('Test escape key press with focus on textbox',
 
 ariaTest('left arrow from focus on list puts focus on listbox and moves cursor right',
   exampleFile, 'listbox-key-left-arrow', async (t) => {
-    t.plan(2);
-
+    
     // Send key "a" then key "ARROW_DOWN" to put the focus on the listbox
     const textbox = await t.context.session.findElement(By.css(ex.textboxSelector));
     await textbox.sendKeys('a', Key.ARROW_DOWN);
@@ -545,8 +514,7 @@ ariaTest('left arrow from focus on list puts focus on listbox and moves cursor r
 
 ariaTest('Right arrow from focus on list puts focus on listbox',
   exampleFile, 'listbox-key-right-arrow', async (t) => {
-    t.plan(2);
-
+    
     // Send key "a" then key "ARROW_DOWN" to put the focus on the listbox
     const textbox = await t.context.session.findElement(By.css(ex.textboxSelector));
     await textbox.sendKeys('a', Key.ARROW_DOWN);
@@ -568,8 +536,7 @@ ariaTest('Right arrow from focus on list puts focus on listbox',
 
 ariaTest('Home from focus on list puts focus on listbox and moves cursor',
   exampleFile, 'listbox-key-home', async (t) => {
-    t.plan(2);
-
+    
     // Send key "a" then key "ARROW_DOWN" to put the focus on the listbox
     const textbox = await t.context.session.findElement(By.css(ex.textboxSelector));
     await textbox.sendKeys('a', Key.ARROW_DOWN);
@@ -591,8 +558,7 @@ ariaTest('Home from focus on list puts focus on listbox and moves cursor',
 
 ariaTest('End from focus on list puts focus on listbox',
   exampleFile, 'listbox-key-end', async (t) => {
-    t.plan(2);
-
+    
     // Send key "a" then key "ARROW_DOWN" to put the focus on the listbox
     const textbox = await t.context.session.findElement(By.css(ex.textboxSelector));
     await textbox.sendKeys('a', Key.ARROW_DOWN);
@@ -614,8 +580,7 @@ ariaTest('End from focus on list puts focus on listbox',
 
 ariaTest('Sending character keys while focus is on listbox moves focus',
   exampleFile, 'listbox-characters', async (t) => {
-    t.plan(2);
-
+    
     // Send key "ARROW_DOWN" to put the focus on the listbox
     const textbox = await t.context.session.findElement(By.css(ex.textboxSelector));
     await textbox.sendKeys(Key.ARROW_DOWN);
@@ -643,14 +608,13 @@ ariaTest('Sending character keys while focus is on listbox moves focus',
 
 ariaTest('Expected behavior for all other standard single line editing keys',
   exampleFile, 'standard-single-line-editing-keys', async (t) => {
-    t.plan(1);
-
+    
     // Send key "a"
     const textbox = await t.context.session.findElement(By.css(ex.textboxSelector));
     await textbox.sendKeys('a');
 
     t.is(
-      (await t.context.session.findElements(By.css(ex.optionsSelector))).length,
+      (await t.context.queryElements(t, ex.optionsSelector)).length,
       ex.numAOptions,
       'Sending standard editing keys should filter results'
     );

--- a/test/tests/combobox_autocomplete-both.js
+++ b/test/tests/combobox_autocomplete-both.js
@@ -1,3 +1,5 @@
+/* eslint no-restricted-properties: 0 */
+
 'use strict';
 
 const { ariaTest } = require('..');
@@ -48,7 +50,7 @@ ariaTest('"aria-autocomplete" on comboxbox element', exampleFile, 'combobox-aria
 });
 
 ariaTest('"aria-controls" attribute on combobox element', exampleFile, 'combobox-aria-controls', async (t) => {
-  
+
   const popupId = await t.context.session
     .findElement(By.css(ex.textboxSelector))
     .getAttribute('aria-controls');
@@ -68,7 +70,7 @@ ariaTest('"aria-controls" attribute on combobox element', exampleFile, 'combobox
 });
 
 ariaTest('"aria-expanded" on combobox element', exampleFile, 'combobox-aria-expanded', async (t) => {
-  
+
   const combobox = await t.context.session.findElement(By.css(ex.textboxSelector));
 
   // Check that aria-expanded is false and the listbox is not visible before interacting
@@ -126,14 +128,14 @@ ariaTest('"aria-label" attribute on listbox element', exampleFile, 'listbox-aria
 });
 
 ariaTest('role "option" on lu elements', exampleFile, 'option-role', async (t) => {
-  
+
   // Send arrow down to reveal all options
   await t.context.session.findElement(By.css(ex.textboxSelector)).sendKeys(Key.ARROW_DOWN);
   await assertAriaRoles(t, 'ex1', 'option', '56', 'li');
 });
 
 ariaTest('"aria-selected" attribute on options element', exampleFile, 'option-aria-selected', async (t) => {
-  
+
   // Send key "a"
   await t.context.session.findElement(By.css(ex.textboxSelector)).sendKeys('a');
   await assertAttributeValues(t, ex.optionsSelector + ':nth-of-type(1)', 'aria-selected', 'true');
@@ -223,7 +225,7 @@ ariaTest('"aria-expanded" on button element', exampleFile, 'button-aria-expanded
 ariaTest('Test alt + down key press with focus on textbox',
   exampleFile, 'textbox-key-alt-down-arrow', async (t) => {
 
-    
+
     // Send ARROW_DOWN to the textbox
     await t.context.session
       .findElement(By.css(ex.textboxSelector))
@@ -243,7 +245,7 @@ ariaTest('Test alt + down key press with focus on textbox',
 ariaTest('Test down key press with focus on textbox',
   exampleFile, 'textbox-key-down-arrow', async (t) => {
 
-    
+
     // Send ARROW_DOWN to the textbox
     await t.context.session
       .findElement(By.css(ex.textboxSelector))
@@ -267,7 +269,7 @@ ariaTest('Test down key press with focus on textbox',
 ariaTest('Test down key press with focus on list',
   exampleFile, 'listbox-key-down-arrow', async (t) => {
 
-    
+
     // Send 'a' to text box, then send ARROW_DOWN to textbox to set focus on listbox
     await t.context.session
       .findElement(By.css(ex.textboxSelector))
@@ -295,7 +297,7 @@ ariaTest('Test down key press with focus on list',
 ariaTest('Test up key press with focus on textbox',
   exampleFile, 'textbox-key-up-arrow', async (t) => {
 
-    
+
     // Send ARROW_UP to the textbox
     await t.context.session
       .findElement(By.css(ex.textboxSelector))
@@ -319,7 +321,7 @@ ariaTest('Test up key press with focus on textbox',
 ariaTest('Test up key press with focus on listbox',
   exampleFile, 'listbox-key-up-arrow', async (t) => {
 
-    
+
     // Send 'a' to text box, then send ARROW_UP to textbox to textbox to put focus in textbox
     // Up arrow should move selection to the last item in the list
     await t.context.session
@@ -352,7 +354,7 @@ ariaTest('Test up key press with focus on listbox',
 ariaTest('Test enter key press with focus on textbox',
   exampleFile, 'textbox-key-enter', async (t) => {
 
-    
+
     // Send key "a" to the textbox
 
     await t.context.session
@@ -387,7 +389,7 @@ ariaTest('Test enter key press with focus on textbox',
 ariaTest('Test enter key press with focus on listbox',
   exampleFile, 'listbox-key-enter', async (t) => {
 
-    
+
     // Send key "a" to the textbox, then two ARROW_DOWNS
 
     await t.context.session
@@ -424,7 +426,7 @@ ariaTest('Test enter key press with focus on listbox',
 
 ariaTest('Test single escape key press with focus on textbox',
   exampleFile, 'textbox-key-escape', async (t) => {
-    
+
     // Send key "a", then key ESCAPE once to the textbox
 
     await t.context.session
@@ -446,7 +448,7 @@ ariaTest('Test single escape key press with focus on textbox',
 
 ariaTest('Test double escape key press with focus on textbox',
   exampleFile, 'textbox-key-escape', async (t) => {
-    
+
     // Send key "a", then key ESCAPE twice to the textbox
 
     await t.context.session
@@ -468,7 +470,7 @@ ariaTest('Test double escape key press with focus on textbox',
 
 ariaTest('Test escape key press with focus on textbox',
   exampleFile, 'listbox-key-escape', async (t) => {
-    
+
     // Send key "a" then key "ARROW_DOWN to put the focus on the listbox,
     // then key ESCAPE to the textbox
 
@@ -491,7 +493,7 @@ ariaTest('Test escape key press with focus on textbox',
 
 ariaTest('left arrow from focus on list puts focus on listbox and moves cursor right',
   exampleFile, 'listbox-key-left-arrow', async (t) => {
-    
+
     // Send key "a" then key "ARROW_DOWN" to put the focus on the listbox
     const textbox = await t.context.session.findElement(By.css(ex.textboxSelector));
     await textbox.sendKeys('a', Key.ARROW_DOWN);
@@ -514,7 +516,7 @@ ariaTest('left arrow from focus on list puts focus on listbox and moves cursor r
 
 ariaTest('Right arrow from focus on list puts focus on listbox',
   exampleFile, 'listbox-key-right-arrow', async (t) => {
-    
+
     // Send key "a" then key "ARROW_DOWN" to put the focus on the listbox
     const textbox = await t.context.session.findElement(By.css(ex.textboxSelector));
     await textbox.sendKeys('a', Key.ARROW_DOWN);
@@ -536,7 +538,7 @@ ariaTest('Right arrow from focus on list puts focus on listbox',
 
 ariaTest('Home from focus on list puts focus on listbox and moves cursor',
   exampleFile, 'listbox-key-home', async (t) => {
-    
+
     // Send key "a" then key "ARROW_DOWN" to put the focus on the listbox
     const textbox = await t.context.session.findElement(By.css(ex.textboxSelector));
     await textbox.sendKeys('a', Key.ARROW_DOWN);
@@ -558,7 +560,7 @@ ariaTest('Home from focus on list puts focus on listbox and moves cursor',
 
 ariaTest('End from focus on list puts focus on listbox',
   exampleFile, 'listbox-key-end', async (t) => {
-    
+
     // Send key "a" then key "ARROW_DOWN" to put the focus on the listbox
     const textbox = await t.context.session.findElement(By.css(ex.textboxSelector));
     await textbox.sendKeys('a', Key.ARROW_DOWN);
@@ -580,7 +582,7 @@ ariaTest('End from focus on list puts focus on listbox',
 
 ariaTest('Sending character keys while focus is on listbox moves focus',
   exampleFile, 'listbox-characters', async (t) => {
-    
+
     // Send key "ARROW_DOWN" to put the focus on the listbox
     const textbox = await t.context.session.findElement(By.css(ex.textboxSelector));
     await textbox.sendKeys(Key.ARROW_DOWN);
@@ -608,7 +610,7 @@ ariaTest('Sending character keys while focus is on listbox moves focus',
 
 ariaTest('Expected behavior for all other standard single line editing keys',
   exampleFile, 'standard-single-line-editing-keys', async (t) => {
-    
+
     // Send key "a"
     const textbox = await t.context.session.findElement(By.css(ex.textboxSelector));
     await textbox.sendKeys('a');

--- a/test/tests/combobox_autocomplete-list.js
+++ b/test/tests/combobox_autocomplete-list.js
@@ -41,18 +41,15 @@ const confirmCursorIndex = async (t, selector, cursorIndex) => {
 
 // Attributes
 ariaTest('Test for role="combobox"', exampleFile, 'combobox-role', async (t) => {
-  t.plan(1);
-  await assertAriaRoles(t, 'ex1', 'combobox', '1', 'input');
+    await assertAriaRoles(t, 'ex1', 'combobox', '1', 'input');
 });
 
 ariaTest('"aria-autocomplete" on comboxbox element', exampleFile, 'combobox-aria-autocomplete', async (t) => {
-  t.plan(1);
-  await assertAttributeValues(t, ex.textboxSelector, 'aria-autocomplete', 'list');
+    await assertAttributeValues(t, ex.textboxSelector, 'aria-autocomplete', 'list');
 });
 
 ariaTest('"aria-controls" attribute on combobox element', exampleFile, 'combobox-aria-controls', async (t) => {
-  t.plan(2);
-
+  
   const popupId = await t.context.session
     .findElement(By.css(ex.textboxSelector))
     .getAttribute('aria-controls');
@@ -62,9 +59,7 @@ ariaTest('"aria-controls" attribute on combobox element', exampleFile, 'combobox
     '"aria-controls" attribute should exist on: ' + ex.textboxSelector
   );
 
-  const popupElements = await t.context.session
-    .findElement(By.id('ex1'))
-    .findElements(By.id(popupId));
+  const popupElements = await t.context.queryElements(t, `#ex1 #${popupId}`);
 
   t.is(
     popupElements.length,
@@ -74,8 +69,7 @@ ariaTest('"aria-controls" attribute on combobox element', exampleFile, 'combobox
 });
 
 ariaTest('"aria-expanded" on combobox element', exampleFile, 'combobox-aria-expanded', async (t) => {
-  t.plan(4);
-
+  
   const combobox = await t.context.session.findElement(By.css(ex.textboxSelector));
 
   // Check that aria-expanded is false and the listbox is not visible before interacting
@@ -121,31 +115,26 @@ ariaTest('"aria-expanded" on combobox element', exampleFile, 'combobox-aria-expa
 });
 
 ariaTest('"aria-activedescendant" on combobox element', exampleFile, 'combobox-aria-activedescendant', async (t) => {
-  t.plan(1);
-  await assertAttributeValues(t, ex.textboxSelector, 'aria-activedescendant', null);
+    await assertAttributeValues(t, ex.textboxSelector, 'aria-activedescendant', null);
 });
 
 ariaTest('role "listbox" on ul element', exampleFile, 'listbox-role', async (t) => {
-  t.plan(1);
-  await assertAriaRoles(t, 'ex1', 'listbox', '1', 'ul');
+    await assertAriaRoles(t, 'ex1', 'listbox', '1', 'ul');
 });
 
 ariaTest('"aria-label" attribute on listbox element', exampleFile, 'listbox-aria-label', async (t) => {
-  t.plan(1);
-  await assertAriaLabelExists(t, ex.listboxSelector);
+    await assertAriaLabelExists(t, ex.listboxSelector);
 });
 
 ariaTest('role "option" on lu elements', exampleFile, 'option-role', async (t) => {
-  t.plan(1);
-
+  
   // Send arrow down to reveal all options
   await t.context.session.findElement(By.css(ex.textboxSelector)).sendKeys(Key.ARROW_DOWN);
   await assertAriaRoles(t, 'ex1', 'option', '56', 'li');
 });
 
 ariaTest('"aria-selected" attribute on options element', exampleFile, 'option-aria-selected', async (t) => {
-  t.plan(2);
-
+  
   // Send key "a"
   await t.context.session.findElement(By.css(ex.textboxSelector)).sendKeys('a');
   await assertAttributeDNE(t, ex.optionsSelector + ':nth-of-type(1)', 'aria-selected');
@@ -156,8 +145,6 @@ ariaTest('"aria-selected" attribute on options element', exampleFile, 'option-ar
 });
 
 ariaTest('Button should have tabindex="-1"', exampleFile, 'button-tabindex', async (t) => {
-  t.plan(1);
-
   const button = await t.context.session.findElement(By.css(ex.buttonSelector))
 
   t.is(
@@ -168,13 +155,10 @@ ariaTest('Button should have tabindex="-1"', exampleFile, 'button-tabindex', asy
 });
 
 ariaTest('"aria-label" attribute on button element', exampleFile, 'button-aria-label', async (t) => {
-  t.plan(1);
   await assertAriaLabelExists(t, ex.buttonSelector);
 });
 
 ariaTest('"aria-controls" attribute on button element', exampleFile, 'button-aria-controls', async (t) => {
-  t.plan(2);
-
   const popupId = await t.context.session
     .findElement(By.css(ex.buttonSelector))
     .getAttribute('aria-controls');
@@ -184,9 +168,7 @@ ariaTest('"aria-controls" attribute on button element', exampleFile, 'button-ari
     '"aria-controls" attribute should exist on: ' + ex.buttonSelector
   );
 
-  const popupElements = await t.context.session
-    .findElement(By.id('ex1'))
-    .findElements(By.id(popupId));
+  const popupElements = await t.context.queryElements(t, `#ex1 #${popupId}`);
 
   t.is(
     popupElements.length,
@@ -197,8 +179,6 @@ ariaTest('"aria-controls" attribute on button element', exampleFile, 'button-ari
 
 
 ariaTest('"aria-expanded" on button element', exampleFile, 'button-aria-expanded', async (t) => {
-  t.plan(4);
-
   const button = await t.context.session.findElement(By.css(ex.buttonSelector));
 
   // Check that aria-expanded is false and the listbox is not visible before interacting
@@ -249,8 +229,7 @@ ariaTest('"aria-expanded" on button element', exampleFile, 'button-aria-expanded
 ariaTest('Test alt + down key press with focus on textbox',
   exampleFile, 'textbox-key-alt-down-arrow', async (t) => {
 
-    t.plan(2);
-
+    
     // Send ARROW_DOWN to the textbox
     await t.context.session
       .findElement(By.css(ex.textboxSelector))
@@ -270,8 +249,7 @@ ariaTest('Test alt + down key press with focus on textbox',
 ariaTest('Test down key press with focus on textbox',
   exampleFile, 'textbox-key-down-arrow', async (t) => {
 
-    t.plan(2);
-
+    
     // Send ARROW_DOWN to the textbox
     await t.context.session
       .findElement(By.css(ex.textboxSelector))
@@ -293,8 +271,7 @@ ariaTest('Test down key press with focus on textbox',
 ariaTest('Test down key press with focus on list',
   exampleFile, 'listbox-key-down-arrow', async (t) => {
 
-    t.plan(5);
-
+    
     // Send 'a' to text box, then send ARROW_DOWN to textbox to set focus on listbox
     await t.context.session
       .findElement(By.css(ex.textboxSelector))
@@ -336,8 +313,7 @@ ariaTest('Test down key press with focus on list',
 ariaTest('Test up key press with focus on textbox',
   exampleFile, 'textbox-key-up-arrow', async (t) => {
 
-    t.plan(2);
-
+    
     // Send ARROW_UP to the textbox
     await t.context.session
       .findElement(By.css(ex.textboxSelector))
@@ -352,15 +328,14 @@ ariaTest('Test up key press with focus on textbox',
     await waitForFocusChange(t, ex.textboxSelector, null);
 
     // Check that the active descendent focus is correct
-    let numOptions = (await t.context.session.findElements(By.css(ex.optionsSelector))).length;
+    let numOptions = (await t.context.queryElements(t, ex.optionsSelector)).length;
     await assertAriaSelectedAndActivedescendant(t, ex.textboxSelector, ex.optionsSelector, numOptions - 1);
   });
 
 ariaTest('Test up key press with focus on listbox',
   exampleFile, 'listbox-key-up-arrow', async (t) => {
 
-    t.plan(3);
-
+    
     // Send 'a' to text box, then send ARROW_UP to textbox to textbox to put focus in textbox
     // Up arrow should move selection to the last item in the list
     await t.context.session
@@ -387,8 +362,7 @@ ariaTest('Test up key press with focus on listbox',
 ariaTest('Test enter key press with focus on textbox',
   exampleFile, 'textbox-key-enter', async (t) => {
 
-    t.plan(2);
-
+    
     // Send key "a" to the textbox, then key ARROW_DOWN to select the first item
 
     await t.context.session
@@ -420,8 +394,7 @@ ariaTest('Test enter key press with focus on textbox',
 ariaTest('Test enter key press with focus on listbox',
   exampleFile, 'listbox-key-enter', async (t) => {
 
-    t.plan(2);
-
+    
     // Send key "a" to the textbox, then key ARROW_DOWN to select the first item
 
     await t.context.session
@@ -456,8 +429,7 @@ ariaTest('Test enter key press with focus on listbox',
 
 ariaTest('Test single escape key press with focus on textbox',
   exampleFile, 'textbox-key-escape', async (t) => {
-    t.plan(2);
-
+    
     // Send key "a", then key ESCAPE once to the textbox
 
     await t.context.session
@@ -479,8 +451,7 @@ ariaTest('Test single escape key press with focus on textbox',
 
 ariaTest('Test double escape key press with focus on textbox',
   exampleFile, 'textbox-key-escape', async (t) => {
-    t.plan(2);
-
+    
     // Send key "a", then key ESCAPE twice to the textbox
 
     await t.context.session
@@ -502,8 +473,7 @@ ariaTest('Test double escape key press with focus on textbox',
 
 ariaTest('Test escape key press with focus on textbox',
   exampleFile, 'listbox-key-escape', async (t) => {
-    t.plan(2);
-
+    
     // Send key "a" then key "ARROW_DOWN to put the focus on the listbox,
     // then key ESCAPE to the textbox
 
@@ -526,8 +496,7 @@ ariaTest('Test escape key press with focus on textbox',
 
 ariaTest('left arrow from focus on list puts focus on listbox and moves cursor right',
   exampleFile, 'listbox-key-left-arrow', async (t) => {
-    t.plan(2);
-
+    
     // Send key "a" then key "ARROW_DOWN" to put the focus on the listbox
     const textbox = await t.context.session.findElement(By.css(ex.textboxSelector));
     await textbox.sendKeys('a', Key.ARROW_DOWN);
@@ -550,8 +519,7 @@ ariaTest('left arrow from focus on list puts focus on listbox and moves cursor r
 
 ariaTest('Right arrow from focus on list puts focus on listbox',
   exampleFile, 'listbox-key-right-arrow', async (t) => {
-    t.plan(2);
-
+    
     // Send key "a" then key "ARROW_DOWN" to put the focus on the listbox
     const textbox = await t.context.session.findElement(By.css(ex.textboxSelector));
     await textbox.sendKeys('a', Key.ARROW_DOWN);
@@ -573,8 +541,7 @@ ariaTest('Right arrow from focus on list puts focus on listbox',
 
 ariaTest('Home from focus on list puts focus on listbox and moves cursor',
   exampleFile, 'listbox-key-home', async (t) => {
-    t.plan(2);
-
+    
     // Send key "a" then key "ARROW_DOWN" to put the focus on the listbox
     const textbox = await t.context.session.findElement(By.css(ex.textboxSelector));
     await textbox.sendKeys('a', Key.ARROW_DOWN);
@@ -596,8 +563,7 @@ ariaTest('Home from focus on list puts focus on listbox and moves cursor',
 
 ariaTest('End from focus on list puts focus on listbox',
   exampleFile, 'listbox-key-end', async (t) => {
-    t.plan(2);
-
+    
     // Send key "a" then key "ARROW_DOWN" to put the focus on the listbox
     const textbox = await t.context.session.findElement(By.css(ex.textboxSelector));
     await textbox.sendKeys('a', Key.ARROW_DOWN);
@@ -619,8 +585,7 @@ ariaTest('End from focus on list puts focus on listbox',
 
 ariaTest('Sending character keys while focus is on listbox moves focus',
   exampleFile, 'listbox-key-char', async (t) => {
-    t.plan(2);
-
+    
     // Send key "ARROW_DOWN" to put the focus on the listbox
     const textbox = await t.context.session.findElement(By.css(ex.textboxSelector));
     await textbox.sendKeys(Key.ARROW_DOWN);
@@ -645,14 +610,13 @@ ariaTest('Sending character keys while focus is on listbox moves focus',
 
 ariaTest('Expected behavior for all other standard single line editing keys',
   exampleFile, 'standard-single-line-editing-keys', async (t) => {
-    t.plan(1);
-
+    
     // Send key "a"
     const textbox = await t.context.session.findElement(By.css(ex.textboxSelector));
     await textbox.sendKeys('a');
 
     t.is(
-      (await t.context.session.findElements(By.css(ex.optionsSelector))).length,
+      (await t.context.queryElements(t, ex.optionsSelector)).length,
       ex.numAOptions,
       'Sending standard editing keys should filter results'
     );

--- a/test/tests/combobox_autocomplete-list.js
+++ b/test/tests/combobox_autocomplete-list.js
@@ -1,5 +1,3 @@
-/* eslint no-restricted-properties: 0 */
-
 'use strict';
 
 const { ariaTest } = require('..');

--- a/test/tests/combobox_autocomplete-list.js
+++ b/test/tests/combobox_autocomplete-list.js
@@ -1,3 +1,5 @@
+/* eslint no-restricted-properties: 0 */
+
 'use strict';
 
 const { ariaTest } = require('..');
@@ -49,7 +51,7 @@ ariaTest('"aria-autocomplete" on comboxbox element', exampleFile, 'combobox-aria
 });
 
 ariaTest('"aria-controls" attribute on combobox element', exampleFile, 'combobox-aria-controls', async (t) => {
-  
+
   const popupId = await t.context.session
     .findElement(By.css(ex.textboxSelector))
     .getAttribute('aria-controls');
@@ -69,7 +71,7 @@ ariaTest('"aria-controls" attribute on combobox element', exampleFile, 'combobox
 });
 
 ariaTest('"aria-expanded" on combobox element', exampleFile, 'combobox-aria-expanded', async (t) => {
-  
+
   const combobox = await t.context.session.findElement(By.css(ex.textboxSelector));
 
   // Check that aria-expanded is false and the listbox is not visible before interacting
@@ -127,14 +129,14 @@ ariaTest('"aria-label" attribute on listbox element', exampleFile, 'listbox-aria
 });
 
 ariaTest('role "option" on lu elements', exampleFile, 'option-role', async (t) => {
-  
+
   // Send arrow down to reveal all options
   await t.context.session.findElement(By.css(ex.textboxSelector)).sendKeys(Key.ARROW_DOWN);
   await assertAriaRoles(t, 'ex1', 'option', '56', 'li');
 });
 
 ariaTest('"aria-selected" attribute on options element', exampleFile, 'option-aria-selected', async (t) => {
-  
+
   // Send key "a"
   await t.context.session.findElement(By.css(ex.textboxSelector)).sendKeys('a');
   await assertAttributeDNE(t, ex.optionsSelector + ':nth-of-type(1)', 'aria-selected');
@@ -229,7 +231,7 @@ ariaTest('"aria-expanded" on button element', exampleFile, 'button-aria-expanded
 ariaTest('Test alt + down key press with focus on textbox',
   exampleFile, 'textbox-key-alt-down-arrow', async (t) => {
 
-    
+
     // Send ARROW_DOWN to the textbox
     await t.context.session
       .findElement(By.css(ex.textboxSelector))
@@ -249,7 +251,7 @@ ariaTest('Test alt + down key press with focus on textbox',
 ariaTest('Test down key press with focus on textbox',
   exampleFile, 'textbox-key-down-arrow', async (t) => {
 
-    
+
     // Send ARROW_DOWN to the textbox
     await t.context.session
       .findElement(By.css(ex.textboxSelector))
@@ -271,7 +273,7 @@ ariaTest('Test down key press with focus on textbox',
 ariaTest('Test down key press with focus on list',
   exampleFile, 'listbox-key-down-arrow', async (t) => {
 
-    
+
     // Send 'a' to text box, then send ARROW_DOWN to textbox to set focus on listbox
     await t.context.session
       .findElement(By.css(ex.textboxSelector))
@@ -313,7 +315,7 @@ ariaTest('Test down key press with focus on list',
 ariaTest('Test up key press with focus on textbox',
   exampleFile, 'textbox-key-up-arrow', async (t) => {
 
-    
+
     // Send ARROW_UP to the textbox
     await t.context.session
       .findElement(By.css(ex.textboxSelector))
@@ -335,7 +337,7 @@ ariaTest('Test up key press with focus on textbox',
 ariaTest('Test up key press with focus on listbox',
   exampleFile, 'listbox-key-up-arrow', async (t) => {
 
-    
+
     // Send 'a' to text box, then send ARROW_UP to textbox to textbox to put focus in textbox
     // Up arrow should move selection to the last item in the list
     await t.context.session
@@ -362,7 +364,7 @@ ariaTest('Test up key press with focus on listbox',
 ariaTest('Test enter key press with focus on textbox',
   exampleFile, 'textbox-key-enter', async (t) => {
 
-    
+
     // Send key "a" to the textbox, then key ARROW_DOWN to select the first item
 
     await t.context.session
@@ -394,7 +396,7 @@ ariaTest('Test enter key press with focus on textbox',
 ariaTest('Test enter key press with focus on listbox',
   exampleFile, 'listbox-key-enter', async (t) => {
 
-    
+
     // Send key "a" to the textbox, then key ARROW_DOWN to select the first item
 
     await t.context.session
@@ -429,7 +431,7 @@ ariaTest('Test enter key press with focus on listbox',
 
 ariaTest('Test single escape key press with focus on textbox',
   exampleFile, 'textbox-key-escape', async (t) => {
-    
+
     // Send key "a", then key ESCAPE once to the textbox
 
     await t.context.session
@@ -451,7 +453,7 @@ ariaTest('Test single escape key press with focus on textbox',
 
 ariaTest('Test double escape key press with focus on textbox',
   exampleFile, 'textbox-key-escape', async (t) => {
-    
+
     // Send key "a", then key ESCAPE twice to the textbox
 
     await t.context.session
@@ -473,7 +475,7 @@ ariaTest('Test double escape key press with focus on textbox',
 
 ariaTest('Test escape key press with focus on textbox',
   exampleFile, 'listbox-key-escape', async (t) => {
-    
+
     // Send key "a" then key "ARROW_DOWN to put the focus on the listbox,
     // then key ESCAPE to the textbox
 
@@ -496,7 +498,7 @@ ariaTest('Test escape key press with focus on textbox',
 
 ariaTest('left arrow from focus on list puts focus on listbox and moves cursor right',
   exampleFile, 'listbox-key-left-arrow', async (t) => {
-    
+
     // Send key "a" then key "ARROW_DOWN" to put the focus on the listbox
     const textbox = await t.context.session.findElement(By.css(ex.textboxSelector));
     await textbox.sendKeys('a', Key.ARROW_DOWN);
@@ -519,7 +521,7 @@ ariaTest('left arrow from focus on list puts focus on listbox and moves cursor r
 
 ariaTest('Right arrow from focus on list puts focus on listbox',
   exampleFile, 'listbox-key-right-arrow', async (t) => {
-    
+
     // Send key "a" then key "ARROW_DOWN" to put the focus on the listbox
     const textbox = await t.context.session.findElement(By.css(ex.textboxSelector));
     await textbox.sendKeys('a', Key.ARROW_DOWN);
@@ -541,7 +543,7 @@ ariaTest('Right arrow from focus on list puts focus on listbox',
 
 ariaTest('Home from focus on list puts focus on listbox and moves cursor',
   exampleFile, 'listbox-key-home', async (t) => {
-    
+
     // Send key "a" then key "ARROW_DOWN" to put the focus on the listbox
     const textbox = await t.context.session.findElement(By.css(ex.textboxSelector));
     await textbox.sendKeys('a', Key.ARROW_DOWN);
@@ -563,7 +565,7 @@ ariaTest('Home from focus on list puts focus on listbox and moves cursor',
 
 ariaTest('End from focus on list puts focus on listbox',
   exampleFile, 'listbox-key-end', async (t) => {
-    
+
     // Send key "a" then key "ARROW_DOWN" to put the focus on the listbox
     const textbox = await t.context.session.findElement(By.css(ex.textboxSelector));
     await textbox.sendKeys('a', Key.ARROW_DOWN);
@@ -585,7 +587,7 @@ ariaTest('End from focus on list puts focus on listbox',
 
 ariaTest('Sending character keys while focus is on listbox moves focus',
   exampleFile, 'listbox-key-char', async (t) => {
-    
+
     // Send key "ARROW_DOWN" to put the focus on the listbox
     const textbox = await t.context.session.findElement(By.css(ex.textboxSelector));
     await textbox.sendKeys(Key.ARROW_DOWN);
@@ -610,7 +612,7 @@ ariaTest('Sending character keys while focus is on listbox moves focus',
 
 ariaTest('Expected behavior for all other standard single line editing keys',
   exampleFile, 'standard-single-line-editing-keys', async (t) => {
-    
+
     // Send key "a"
     const textbox = await t.context.session.findElement(By.css(ex.textboxSelector));
     await textbox.sendKeys('a');

--- a/test/tests/combobox_autocomplete-none.js
+++ b/test/tests/combobox_autocomplete-none.js
@@ -1,3 +1,5 @@
+/* eslint no-restricted-properties: 0 */
+
 'use strict';
 
 const { ariaTest } = require('..');
@@ -49,7 +51,7 @@ ariaTest('"aria-autocomplete" on comboxbox element', exampleFile, 'combobox-aria
 });
 
 ariaTest('"aria-controls" attribute on combobox element', exampleFile, 'combobox-aria-controls', async (t) => {
-  
+
   const popupId = await t.context.session
     .findElement(By.css(ex.textboxSelector))
     .getAttribute('aria-controls');
@@ -69,7 +71,7 @@ ariaTest('"aria-controls" attribute on combobox element', exampleFile, 'combobox
 });
 
 ariaTest('"aria-expanded" on combobox element', exampleFile, 'combobox-aria-expanded', async (t) => {
-  
+
   const combobox = await t.context.session.findElement(By.css(ex.textboxSelector));
 
   // Check that aria-expanded is false and the listbox is not visible before interacting
@@ -127,14 +129,14 @@ ariaTest('"aria-label" attribute on listbox element', exampleFile, 'listbox-aria
 });
 
 ariaTest('role "option" on lu elements', exampleFile, 'option-role', async (t) => {
-  
+
   // Send arrow down to reveal all options
   await t.context.session.findElement(By.css(ex.textboxSelector)).sendKeys(Key.ARROW_DOWN);
   await assertAriaRoles(t, 'ex1', 'option', ex.numOptions, 'li');
 });
 
 ariaTest('"aria-selected" attribute on options element', exampleFile, 'option-aria-selected', async (t) => {
-  
+
   // Send key "a"
   await t.context.session.findElement(By.css(ex.textboxSelector)).sendKeys('a');
   await assertAttributeDNE(t, ex.optionsSelector + ':nth-of-type(1)', 'aria-selected');
@@ -227,7 +229,7 @@ ariaTest('"aria-expanded" on button element', exampleFile, 'button-aria-expanded
 ariaTest('Test alt + down key press with focus on textbox',
   exampleFile, 'textbox-key-alt-down-arrow', async (t) => {
 
-    
+
     // Send ARROW_DOWN to the textbox
     await t.context.session
       .findElement(By.css(ex.textboxSelector))
@@ -248,7 +250,7 @@ ariaTest('Test alt + down key press with focus on textbox',
 ariaTest('Test down key press with focus on textbox',
   exampleFile, 'textbox-key-down-arrow', async (t) => {
 
-    
+
     // Send ARROW_DOWN to the textbox
     await t.context.session
       .findElement(By.css(ex.textboxSelector))
@@ -270,7 +272,7 @@ ariaTest('Test down key press with focus on textbox',
 ariaTest('Test down key press with focus on list',
   exampleFile, 'listbox-key-down-arrow', async (t) => {
 
-    
+
     // Send 'a' to text box, then send ARROW_DOWN to textbox to set focus on listbox
     await t.context.session
       .findElement(By.css(ex.textboxSelector))
@@ -312,7 +314,7 @@ ariaTest('Test down key press with focus on list',
 ariaTest('Test up key press with focus on textbox',
   exampleFile, 'textbox-key-up-arrow', async (t) => {
 
-    
+
     // Send ARROW_UP to the textbox
     await t.context.session
       .findElement(By.css(ex.textboxSelector))
@@ -334,7 +336,7 @@ ariaTest('Test up key press with focus on textbox',
 ariaTest('Test up key press with focus on listbox',
   exampleFile, 'listbox-key-up-arrow', async (t) => {
 
-    
+
     // Send 'a' to text box, then send ARROW_UP to textbox to textbox to put focus in textbox
     // Up arrow should move selection to the last item in the list
     await t.context.session
@@ -361,7 +363,7 @@ ariaTest('Test up key press with focus on listbox',
 ariaTest('Test enter key press with focus on textbox',
   exampleFile, 'textbox-key-enter', async (t) => {
 
-    
+
     // Send key "a" to the textbox, then key ARROW_DOWN to select the first item
 
     await t.context.session
@@ -392,7 +394,7 @@ ariaTest('Test enter key press with focus on textbox',
 ariaTest('Test enter key press with focus on listbox',
   exampleFile, 'listbox-key-enter', async (t) => {
 
-    
+
     // Send key "a" to the textbox, then key ARROW_DOWN to select the first item
 
     await t.context.session
@@ -427,7 +429,7 @@ ariaTest('Test enter key press with focus on listbox',
 
 ariaTest('Test escape key press with focus on textbox',
   exampleFile, 'listbox-key-escape', async (t) => {
-    
+
     // Send key "a" then key "ARROW_DOWN to put the focus on the listbox,
     // then key ESCAPE once to the textbox
 
@@ -450,7 +452,7 @@ ariaTest('Test escape key press with focus on textbox',
 
 ariaTest('Test double escape key press with focus on textbox',
   exampleFile, 'listbox-key-escape', async (t) => {
-    
+
     // Send key "a" then key "ARROW_DOWN to put the focus on the listbox,
     // then key ESCAPE twice to the textbox
 
@@ -473,7 +475,7 @@ ariaTest('Test double escape key press with focus on textbox',
 
 ariaTest('left arrow from focus on list puts focus on listbox and moves cursor right',
   exampleFile, 'listbox-key-left-arrow', async (t) => {
-    
+
     // Send key "a" then key "ARROW_DOWN" to put the focus on the listbox
     const textbox = await t.context.session.findElement(By.css(ex.textboxSelector));
     await textbox.sendKeys('a', Key.ARROW_DOWN);
@@ -496,7 +498,7 @@ ariaTest('left arrow from focus on list puts focus on listbox and moves cursor r
 
 ariaTest('Right arrow from focus on list puts focus on listbox',
   exampleFile, 'listbox-key-right-arrow', async (t) => {
-    
+
     // Send key "a" then key "ARROW_DOWN" to put the focus on the listbox
     const textbox = await t.context.session.findElement(By.css(ex.textboxSelector));
     await textbox.sendKeys('a', Key.ARROW_DOWN);
@@ -518,7 +520,7 @@ ariaTest('Right arrow from focus on list puts focus on listbox',
 
 ariaTest('Home from focus on list puts focus on listbox and moves cursor',
   exampleFile, 'listbox-key-home', async (t) => {
-    
+
     // Send key "a" then key "ARROW_DOWN" to put the focus on the listbox
     const textbox = await t.context.session.findElement(By.css(ex.textboxSelector));
     await textbox.sendKeys('a', Key.ARROW_DOWN);
@@ -540,7 +542,7 @@ ariaTest('Home from focus on list puts focus on listbox and moves cursor',
 
 ariaTest('End from focus on list puts focus on listbox',
   exampleFile, 'listbox-key-end', async (t) => {
-    
+
     // Send key "a" then key "ARROW_DOWN" to put the focus on the listbox
     const textbox = await t.context.session.findElement(By.css(ex.textboxSelector));
     await textbox.sendKeys('a', Key.ARROW_DOWN);
@@ -563,7 +565,7 @@ ariaTest('End from focus on list puts focus on listbox',
 
 ariaTest('Sending character keys while focus is on listbox moves focus',
   exampleFile, 'listbox-key-char', async (t) => {
-    
+
     // Send key "ARROW_DOWN" to put the focus on the listbox
     const textbox = await t.context.session.findElement(By.css(ex.textboxSelector));
     await textbox.sendKeys(Key.ARROW_DOWN);
@@ -588,7 +590,7 @@ ariaTest('Sending character keys while focus is on listbox moves focus',
 
 ariaTest('Expected behavior for all other standard single line editing keys',
   exampleFile, 'standard-single-line-editing-keys', async (t) => {
-    
+
     let numOptions = (await t.context.queryElements(t, ex.optionsSelector)).length;
 
     // Send key "w"

--- a/test/tests/combobox_autocomplete-none.js
+++ b/test/tests/combobox_autocomplete-none.js
@@ -1,5 +1,3 @@
-/* eslint no-restricted-properties: 0 */
-
 'use strict';
 
 const { ariaTest } = require('..');

--- a/test/tests/combobox_autocomplete-none.js
+++ b/test/tests/combobox_autocomplete-none.js
@@ -41,18 +41,15 @@ const confirmCursorIndex = async (t, selector, cursorIndex) => {
 
 // Attributes
 ariaTest('Test for role="combobox"', exampleFile, 'combobox-role', async (t) => {
-  t.plan(1);
-  await assertAriaRoles(t, 'ex1', 'combobox', '1', 'input');
+    await assertAriaRoles(t, 'ex1', 'combobox', '1', 'input');
 });
 
 ariaTest('"aria-autocomplete" on comboxbox element', exampleFile, 'combobox-aria-autocomplete', async (t) => {
-  t.plan(1);
-  await assertAttributeValues(t, ex.textboxSelector, 'aria-autocomplete', 'none');
+    await assertAttributeValues(t, ex.textboxSelector, 'aria-autocomplete', 'none');
 });
 
 ariaTest('"aria-controls" attribute on combobox element', exampleFile, 'combobox-aria-controls', async (t) => {
-  t.plan(2);
-
+  
   const popupId = await t.context.session
     .findElement(By.css(ex.textboxSelector))
     .getAttribute('aria-controls');
@@ -62,9 +59,7 @@ ariaTest('"aria-controls" attribute on combobox element', exampleFile, 'combobox
     '"aria-controls" attribute should exist on: ' + ex.textboxSelector
   );
 
-  const popupElements = await t.context.session
-    .findElement(By.id('ex1'))
-    .findElements(By.id(popupId));
+  const popupElements = await t.context.queryElements(t, `#ex1 #${popupId}`);
 
   t.is(
     popupElements.length,
@@ -74,8 +69,7 @@ ariaTest('"aria-controls" attribute on combobox element', exampleFile, 'combobox
 });
 
 ariaTest('"aria-expanded" on combobox element', exampleFile, 'combobox-aria-expanded', async (t) => {
-  t.plan(4);
-
+  
   const combobox = await t.context.session.findElement(By.css(ex.textboxSelector));
 
   // Check that aria-expanded is false and the listbox is not visible before interacting
@@ -121,31 +115,26 @@ ariaTest('"aria-expanded" on combobox element', exampleFile, 'combobox-aria-expa
 });
 
 ariaTest('"aria-activedescendant" on combobox element', exampleFile, 'combobox-aria-activedescendant', async (t) => {
-  t.plan(1);
-  await assertAttributeValues(t, ex.textboxSelector, 'aria-activedescendant', null);
+    await assertAttributeValues(t, ex.textboxSelector, 'aria-activedescendant', null);
 });
 
 ariaTest('role "listbox" on ul element', exampleFile, 'listbox-role', async (t) => {
-  t.plan(1);
-  await assertAriaRoles(t, 'ex1', 'listbox', '1', 'ul');
+    await assertAriaRoles(t, 'ex1', 'listbox', '1', 'ul');
 });
 
 ariaTest('"aria-label" attribute on listbox element', exampleFile, 'listbox-aria-label', async (t) => {
-  t.plan(1);
-  await assertAriaLabelExists(t, ex.listboxSelector);
+    await assertAriaLabelExists(t, ex.listboxSelector);
 });
 
 ariaTest('role "option" on lu elements', exampleFile, 'option-role', async (t) => {
-  t.plan(1);
-
+  
   // Send arrow down to reveal all options
   await t.context.session.findElement(By.css(ex.textboxSelector)).sendKeys(Key.ARROW_DOWN);
   await assertAriaRoles(t, 'ex1', 'option', ex.numOptions, 'li');
 });
 
 ariaTest('"aria-selected" attribute on options element', exampleFile, 'option-aria-selected', async (t) => {
-  t.plan(2);
-
+  
   // Send key "a"
   await t.context.session.findElement(By.css(ex.textboxSelector)).sendKeys('a');
   await assertAttributeDNE(t, ex.optionsSelector + ':nth-of-type(1)', 'aria-selected');
@@ -156,8 +145,6 @@ ariaTest('"aria-selected" attribute on options element', exampleFile, 'option-ar
 });
 
 ariaTest('Button should have tabindex="-1"', exampleFile, 'button-tabindex', async (t) => {
-  t.plan(1);
-
   const button = await t.context.session.findElement(By.css(ex.buttonSelector))
 
   t.is(
@@ -168,13 +155,10 @@ ariaTest('Button should have tabindex="-1"', exampleFile, 'button-tabindex', asy
 });
 
 ariaTest('"aria-label" attribute on button element', exampleFile, 'button-aria-label', async (t) => {
-  t.plan(1);
   await assertAriaLabelExists(t, ex.buttonSelector);
 });
 
 ariaTest('"aria-controls" attribute on button element', exampleFile, 'button-aria-controls', async (t) => {
-  t.plan(2);
-
   const popupId = await t.context.session
     .findElement(By.css(ex.buttonSelector))
     .getAttribute('aria-controls');
@@ -184,9 +168,7 @@ ariaTest('"aria-controls" attribute on button element', exampleFile, 'button-ari
     '"aria-controls" attribute should exist on: ' + ex.buttonSelector
   );
 
-  const popupElements = await t.context.session
-    .findElement(By.id('ex1'))
-    .findElements(By.id(popupId));
+  const popupElements = await t.context.queryElements(t, `#ex1 #${popupId}`);
 
   t.is(
     popupElements.length,
@@ -196,8 +178,6 @@ ariaTest('"aria-controls" attribute on button element', exampleFile, 'button-ari
 });
 
 ariaTest('"aria-expanded" on button element', exampleFile, 'button-aria-expanded', async (t) => {
-  t.plan(4);
-
   const button = await t.context.session.findElement(By.css(ex.buttonSelector));
 
   // Check that aria-expanded is false and the listbox is not visible before interacting
@@ -247,8 +227,7 @@ ariaTest('"aria-expanded" on button element', exampleFile, 'button-aria-expanded
 ariaTest('Test alt + down key press with focus on textbox',
   exampleFile, 'textbox-key-alt-down-arrow', async (t) => {
 
-    t.plan(2);
-
+    
     // Send ARROW_DOWN to the textbox
     await t.context.session
       .findElement(By.css(ex.textboxSelector))
@@ -269,8 +248,7 @@ ariaTest('Test alt + down key press with focus on textbox',
 ariaTest('Test down key press with focus on textbox',
   exampleFile, 'textbox-key-down-arrow', async (t) => {
 
-    t.plan(2);
-
+    
     // Send ARROW_DOWN to the textbox
     await t.context.session
       .findElement(By.css(ex.textboxSelector))
@@ -292,8 +270,7 @@ ariaTest('Test down key press with focus on textbox',
 ariaTest('Test down key press with focus on list',
   exampleFile, 'listbox-key-down-arrow', async (t) => {
 
-    t.plan(11);
-
+    
     // Send 'a' to text box, then send ARROW_DOWN to textbox to set focus on listbox
     await t.context.session
       .findElement(By.css(ex.textboxSelector))
@@ -335,8 +312,7 @@ ariaTest('Test down key press with focus on list',
 ariaTest('Test up key press with focus on textbox',
   exampleFile, 'textbox-key-up-arrow', async (t) => {
 
-    t.plan(2);
-
+    
     // Send ARROW_UP to the textbox
     await t.context.session
       .findElement(By.css(ex.textboxSelector))
@@ -351,15 +327,14 @@ ariaTest('Test up key press with focus on textbox',
     await waitForFocusChange(t, ex.textboxSelector, null);
 
     // Check that the active descendent focus is correct
-    let numOptions = (await t.context.session.findElements(By.css(ex.optionsSelector))).length;
+    let numOptions = (await t.context.queryElements(t, ex.optionsSelector)).length;
     await assertAriaSelectedAndActivedescendant(t, ex.textboxSelector, ex.optionsSelector, numOptions - 1);
   });
 
 ariaTest('Test up key press with focus on listbox',
   exampleFile, 'listbox-key-up-arrow', async (t) => {
 
-    t.plan(9);
-
+    
     // Send 'a' to text box, then send ARROW_UP to textbox to textbox to put focus in textbox
     // Up arrow should move selection to the last item in the list
     await t.context.session
@@ -386,8 +361,7 @@ ariaTest('Test up key press with focus on listbox',
 ariaTest('Test enter key press with focus on textbox',
   exampleFile, 'textbox-key-enter', async (t) => {
 
-    t.plan(2);
-
+    
     // Send key "a" to the textbox, then key ARROW_DOWN to select the first item
 
     await t.context.session
@@ -418,8 +392,7 @@ ariaTest('Test enter key press with focus on textbox',
 ariaTest('Test enter key press with focus on listbox',
   exampleFile, 'listbox-key-enter', async (t) => {
 
-    t.plan(2);
-
+    
     // Send key "a" to the textbox, then key ARROW_DOWN to select the first item
 
     await t.context.session
@@ -454,8 +427,7 @@ ariaTest('Test enter key press with focus on listbox',
 
 ariaTest('Test escape key press with focus on textbox',
   exampleFile, 'listbox-key-escape', async (t) => {
-    t.plan(2);
-
+    
     // Send key "a" then key "ARROW_DOWN to put the focus on the listbox,
     // then key ESCAPE once to the textbox
 
@@ -478,8 +450,7 @@ ariaTest('Test escape key press with focus on textbox',
 
 ariaTest('Test double escape key press with focus on textbox',
   exampleFile, 'listbox-key-escape', async (t) => {
-    t.plan(2);
-
+    
     // Send key "a" then key "ARROW_DOWN to put the focus on the listbox,
     // then key ESCAPE twice to the textbox
 
@@ -502,8 +473,7 @@ ariaTest('Test double escape key press with focus on textbox',
 
 ariaTest('left arrow from focus on list puts focus on listbox and moves cursor right',
   exampleFile, 'listbox-key-left-arrow', async (t) => {
-    t.plan(2);
-
+    
     // Send key "a" then key "ARROW_DOWN" to put the focus on the listbox
     const textbox = await t.context.session.findElement(By.css(ex.textboxSelector));
     await textbox.sendKeys('a', Key.ARROW_DOWN);
@@ -526,8 +496,7 @@ ariaTest('left arrow from focus on list puts focus on listbox and moves cursor r
 
 ariaTest('Right arrow from focus on list puts focus on listbox',
   exampleFile, 'listbox-key-right-arrow', async (t) => {
-    t.plan(2);
-
+    
     // Send key "a" then key "ARROW_DOWN" to put the focus on the listbox
     const textbox = await t.context.session.findElement(By.css(ex.textboxSelector));
     await textbox.sendKeys('a', Key.ARROW_DOWN);
@@ -549,8 +518,7 @@ ariaTest('Right arrow from focus on list puts focus on listbox',
 
 ariaTest('Home from focus on list puts focus on listbox and moves cursor',
   exampleFile, 'listbox-key-home', async (t) => {
-    t.plan(2);
-
+    
     // Send key "a" then key "ARROW_DOWN" to put the focus on the listbox
     const textbox = await t.context.session.findElement(By.css(ex.textboxSelector));
     await textbox.sendKeys('a', Key.ARROW_DOWN);
@@ -572,8 +540,7 @@ ariaTest('Home from focus on list puts focus on listbox and moves cursor',
 
 ariaTest('End from focus on list puts focus on listbox',
   exampleFile, 'listbox-key-end', async (t) => {
-    t.plan(2);
-
+    
     // Send key "a" then key "ARROW_DOWN" to put the focus on the listbox
     const textbox = await t.context.session.findElement(By.css(ex.textboxSelector));
     await textbox.sendKeys('a', Key.ARROW_DOWN);
@@ -596,8 +563,7 @@ ariaTest('End from focus on list puts focus on listbox',
 
 ariaTest('Sending character keys while focus is on listbox moves focus',
   exampleFile, 'listbox-key-char', async (t) => {
-    t.plan(2);
-
+    
     // Send key "ARROW_DOWN" to put the focus on the listbox
     const textbox = await t.context.session.findElement(By.css(ex.textboxSelector));
     await textbox.sendKeys(Key.ARROW_DOWN);
@@ -622,16 +588,15 @@ ariaTest('Sending character keys while focus is on listbox moves focus',
 
 ariaTest('Expected behavior for all other standard single line editing keys',
   exampleFile, 'standard-single-line-editing-keys', async (t) => {
-    t.plan(1);
-
-    let numOptions = (await t.context.session.findElements(By.css(ex.optionsSelector))).length;
+    
+    let numOptions = (await t.context.queryElements(t, ex.optionsSelector)).length;
 
     // Send key "w"
     const textbox = await t.context.session.findElement(By.css(ex.textboxSelector));
     await textbox.sendKeys('w');
 
     t.is(
-      (await t.context.session.findElements(By.css(ex.optionsSelector))).length,
+      (await t.context.queryElements(t, ex.optionsSelector)).length,
       numOptions,
       'Sending standard editing keys should NOT filter results'
     );

--- a/test/tests/combobox_grid-combo.js
+++ b/test/tests/combobox_grid-combo.js
@@ -1,5 +1,3 @@
-/* eslint no-restricted-properties: 0 */
-
 'use strict';
 
 const { ariaTest } = require('..');

--- a/test/tests/combobox_grid-combo.js
+++ b/test/tests/combobox_grid-combo.js
@@ -46,18 +46,15 @@ const gridcellId = (row, column) => {
 
 // Attributes
 ariaTest('Test for role="combobox"', exampleFile, 'combobox-role', async (t) => {
-  t.plan(1);
-  await assertAriaRoles(t, 'ex1', 'combobox', '1', 'input');
+    await assertAriaRoles(t, 'ex1', 'combobox', '1', 'input');
 });
 
 ariaTest('"aria-haspopup"=grid on combobox element', exampleFile, 'combobox-aria-haspopup', async (t) => {
-  t.plan(1);
-  await assertAttributeValues(t, ex.comboboxSelector, 'aria-haspopup', 'grid');
+    await assertAttributeValues(t, ex.comboboxSelector, 'aria-haspopup', 'grid');
 });
 
 ariaTest('"aria-expanded" on combobox element', exampleFile, 'combobox-aria-expanded', async (t) => {
-  t.plan(4);
-
+  
   const combobox = await t.context.session.findElement(By.css(ex.comboboxSelector));
 
   // Check that aria-expanded is false and the grid is not visible before interacting
@@ -102,8 +99,7 @@ ariaTest('"aria-expanded" on combobox element', exampleFile, 'combobox-aria-expa
 });
 
 ariaTest('"id" attribute on texbox used to discover accessible name', exampleFile, 'combobox-id', async (t) => {
-  t.plan(2);
-
+  
   const labelForTextboxId = await t.context.session
     .findElement(By.css(ex.labelSelector))
     .getAttribute('for');
@@ -124,13 +120,11 @@ ariaTest('"id" attribute on texbox used to discover accessible name', exampleFil
 });
 
 ariaTest('"aria-autocomplete" on grid element', exampleFile, 'combobox-aria-autocomplete', async (t) => {
-  t.plan(1);
-  await assertAttributeValues(t, ex.comboboxSelector, 'aria-autocomplete', 'list');
+    await assertAttributeValues(t, ex.comboboxSelector, 'aria-autocomplete', 'list');
 });
 
 ariaTest('"aria-controls" attribute on grid element', exampleFile, 'combobox-aria-controls', async (t) => {
-  t.plan(2);
-
+  
   const popupId = await t.context.session
     .findElement(By.css(ex.comboboxSelector))
     .getAttribute('aria-controls');
@@ -140,9 +134,7 @@ ariaTest('"aria-controls" attribute on grid element', exampleFile, 'combobox-ari
     '"aria-controls" attribute should exist on: ' + ex.comboboxSelector
   );
 
-  const popupElements = await t.context.session
-    .findElement(By.id('ex1'))
-    .findElements(By.id(popupId));
+  const popupElements = await t.context.queryElements(t, `#ex1 #${popupId}`);
 
   t.is(
     popupElements.length,
@@ -152,28 +144,24 @@ ariaTest('"aria-controls" attribute on grid element', exampleFile, 'combobox-ari
 });
 
 ariaTest('"aria-activedescendant" on combobox element', exampleFile, 'combobox-aria-activedescendant', async (t) => {
-  t.plan(1);
-  await assertAttributeValues(t, ex.comboboxSelector, 'aria-activedescendant', null);
+    await assertAttributeValues(t, ex.comboboxSelector, 'aria-activedescendant', null);
 });
 
 ariaTest('role "grid" on div element', exampleFile, 'grid-role', async (t) => {
-  t.plan(1);
-  await assertAriaRoles(t, 'ex1', 'grid', '1', 'div');
+    await assertAriaRoles(t, 'ex1', 'grid', '1', 'div');
 });
 
 ariaTest('"aria-labelledby" attribute on grid element', exampleFile, 'grid-aria-labelledby', async (t) => {
-  t.plan(1);
-  await assertAriaLabelledby(t, ex.gridSelector);
+    await assertAriaLabelledby(t, ex.gridSelector);
 });
 
 ariaTest('role "row" exists within grid element', exampleFile, 'row-role', async (t) => {
-  t.plan(1);
-
+  
   // Send key "a" then arrow down to reveal all options
   await t.context.session.findElement(By.css(ex.comboboxSelector)).sendKeys('a', Key.ARROW_DOWN);
 
-  let rowElements = await t.context.session.findElement(By.css(ex.gridSelector))
-    .findElements(By.css('[role="row"]'));
+  let gridEl = await t.context.session.findElement(By.css(ex.gridSelector));
+  let rowElements = t.context.queryElements(t, '[role="row"]', gridEl);
 
   t.truthy(
     await rowElements.length,
@@ -183,8 +171,7 @@ ariaTest('role "row" exists within grid element', exampleFile, 'row-role', async
 
 // This test fails due to bug: https://github.com/w3c/aria-practices/issues/859
 ariaTest.failing('"aria-selected" attribute on row element', exampleFile, 'row-aria-selected', async (t) => {
-  t.plan(2);
-
+  
   // Send key "a"
   await t.context.session.findElement(By.css(ex.comboboxSelector)).sendKeys('a');
   await assertAttributeDNE(t, ex.rowSelector + ':nth-of-type(1)', 'aria-selected');
@@ -195,16 +182,15 @@ ariaTest.failing('"aria-selected" attribute on row element', exampleFile, 'row-a
 });
 
 ariaTest('role "gridcell" exists within row element', exampleFile, 'gridcell-role', async (t) => {
-  t.plan(1);
-
+  
   // Send key "a" then arrow down to reveal all options
   await t.context.session.findElement(By.css(ex.comboboxSelector)).sendKeys('a', Key.ARROW_DOWN);
 
-  let rowElements = await t.context.session.findElement(By.css(ex.rowSelector))
-    .findElements(By.css('[role="gridcell"]'));
+  let rowElement = await t.context.session.findElement(By.css(ex.rowSelector));
+  let cellElements = t.context.queryElements(t, '[role="gridcell"]', rowElement);
 
   t.truthy(
-    await rowElements.length,
+    await cellElements.length,
     'role="gridcell" elements should be found within a row element after opening popup'
   );
 });
@@ -215,8 +201,7 @@ ariaTest('role "gridcell" exists within row element', exampleFile, 'gridcell-rol
 ariaTest('Test down key press with focus on combobox',
   exampleFile, 'popup-key-down-arrow', async (t) => {
 
-    t.plan(4);
-
+    
     // Send ARROW_DOWN to the combobox
     await t.context.session
       .findElement(By.css(ex.comboboxSelector))
@@ -265,8 +250,7 @@ ariaTest('Test down key press with focus on combobox',
 ariaTest('Test down key press with focus on list',
   exampleFile, 'popup-key-down-arrow', async (t) => {
 
-    t.plan(6);
-
+    
     // Send 'a' to text box, then send ARROW_DOWN to combobox to set focus on grid
     await t.context.session
       .findElement(By.css(ex.comboboxSelector))
@@ -337,8 +321,7 @@ ariaTest('Test down key press with focus on list',
 ariaTest('Test up key press with focus on combobox',
   exampleFile, 'popup-key-up-arrow', async (t) => {
 
-    t.plan(4);
-
+    
     // Send ARROW_UP to the combobox
     await t.context.session
       .findElement(By.css(ex.comboboxSelector))
@@ -387,8 +370,7 @@ ariaTest('Test up key press with focus on combobox',
 ariaTest('Test up key press with focus on grid',
   exampleFile, 'popup-key-up-arrow', async (t) => {
 
-    t.plan(6);
-
+    
     // Send 'a' to text box, then send ARROW_UP to combobox to put focus in combobox
     // Up arrow should move selection to the last item in the list
     await t.context.session
@@ -460,8 +442,7 @@ ariaTest('Test up key press with focus on grid',
 ariaTest('Test enter key press with focus on grid',
   exampleFile, 'popup-key-enter', async (t) => {
 
-    t.plan(2);
-
+    
     // Send key "a" to the combobox, then key ARROW_DOWN to select the first item
 
     await t.context.session
@@ -496,8 +477,6 @@ ariaTest('Test enter key press with focus on grid',
 
 ariaTest('Test escape key press with focus on combobox',
   exampleFile, 'textbox-key-escape', async (t) => {
-    t.plan(2);
-
     // Send key "a" then key "ARROW_DOWN to put the focus on the listbox,
     // then key ESCAPE to the textbox
 
@@ -521,8 +500,6 @@ ariaTest('Test escape key press with focus on combobox',
 
 ariaTest('Test double escape key press with focus on combobox',
   exampleFile, 'textbox-key-escape', async (t) => {
-    t.plan(2);
-
     // Send key "a", then key ESCAPE twice to the textbox
 
     await t.context.session
@@ -545,8 +522,7 @@ ariaTest('Test double escape key press with focus on combobox',
 
 ariaTest('Test escape key press with focus on popup',
   exampleFile, 'popup-key-escape', async (t) => {
-    t.plan(2);
-
+    
     // Send key "a" then key "ARROW_DOWN to put the focus on the grid,
     // then key ESCAPE to the combobox
 
@@ -584,8 +560,7 @@ ariaTest('Test escape key press with focus on popup',
 
 ariaTest('left arrow from focus on list puts focus on grid and moves cursor right',
   exampleFile, 'popup-key-left-arrow', async (t) => {
-    t.plan(4);
-
+    
     // Send key "a" then key "ARROW_DOWN" to put the focus on the grid
     const combobox = t.context.session.findElement(By.css(ex.comboboxSelector));
     await combobox.sendKeys('a', Key.ARROW_DOWN);
@@ -635,8 +610,7 @@ ariaTest('left arrow from focus on list puts focus on grid and moves cursor righ
 
 ariaTest('Right arrow from focus on list puts focus on grid',
   exampleFile, 'popup-key-right-arrow', async (t) => {
-    t.plan(6);
-
+    
     // Send key "a" then key "ARROW_DOWN" to put the focus on the grid
     const combobox = t.context.session.findElement(By.css(ex.comboboxSelector));
     await combobox.sendKeys('a', Key.ARROW_DOWN);
@@ -702,8 +676,7 @@ ariaTest('Right arrow from focus on list puts focus on grid',
 
 ariaTest('Home from focus on list puts focus on grid and moves cursor',
   exampleFile, 'popup-key-home', async (t) => {
-    t.plan(2);
-
+    
     // Send key "a" then key "ARROW_DOWN" to put the focus on the grid
     const combobox = t.context.session.findElement(By.css(ex.comboboxSelector));
     await combobox.sendKeys('a', Key.ARROW_DOWN);
@@ -725,8 +698,7 @@ ariaTest('Home from focus on list puts focus on grid and moves cursor',
 
 ariaTest('End from focus on list puts focus on grid',
   exampleFile, 'popup-key-end', async (t) => {
-    t.plan(2);
-
+    
     // Send key "a" then key "ARROW_DOWN" to put the focus on the grid
     const combobox = t.context.session.findElement(By.css(ex.comboboxSelector));
     await combobox.sendKeys('a', Key.ARROW_DOWN);
@@ -748,8 +720,7 @@ ariaTest('End from focus on list puts focus on grid',
 
 ariaTest('Sending character keys while focus is on grid moves focus',
   exampleFile, 'popup-key-char', async (t) => {
-    t.plan(2);
-
+    
     // Send key "ARROW_DOWN" to put the focus on the grid
     const combobox = t.context.session.findElement(By.css(ex.comboboxSelector));
     await combobox.sendKeys(Key.ARROW_DOWN);
@@ -774,7 +745,6 @@ ariaTest('Sending character keys while focus is on grid moves focus',
 
 ariaTest.failing('Expected behavior for all other standard single line editing keys',
   exampleFile, 'standard-single-line-editing-keys', async (t) => {
-    t.plan(1);
-    t.fail();
+        t.fail();
   });
 

--- a/test/tests/combobox_grid-combo.js
+++ b/test/tests/combobox_grid-combo.js
@@ -161,7 +161,7 @@ ariaTest('role "row" exists within grid element', exampleFile, 'row-role', async
   await t.context.session.findElement(By.css(ex.comboboxSelector)).sendKeys('a', Key.ARROW_DOWN);
 
   let gridEl = await t.context.session.findElement(By.css(ex.gridSelector));
-  let rowElements = t.context.queryElements(t, '[role="row"]', gridEl);
+  let rowElements = await t.context.queryElements(t, '[role="row"]', gridEl);
 
   t.truthy(
     await rowElements.length,
@@ -187,7 +187,7 @@ ariaTest('role "gridcell" exists within row element', exampleFile, 'gridcell-rol
   await t.context.session.findElement(By.css(ex.comboboxSelector)).sendKeys('a', Key.ARROW_DOWN);
 
   let rowElement = await t.context.session.findElement(By.css(ex.rowSelector));
-  let cellElements = t.context.queryElements(t, '[role="gridcell"]', rowElement);
+  let cellElements = await t.context.queryElements(t, '[role="gridcell"]', rowElement);
 
   t.truthy(
     await cellElements.length,

--- a/test/tests/combobox_grid-combo.js
+++ b/test/tests/combobox_grid-combo.js
@@ -1,3 +1,5 @@
+/* eslint no-restricted-properties: 0 */
+
 'use strict';
 
 const { ariaTest } = require('..');
@@ -54,7 +56,7 @@ ariaTest('"aria-haspopup"=grid on combobox element', exampleFile, 'combobox-aria
 });
 
 ariaTest('"aria-expanded" on combobox element', exampleFile, 'combobox-aria-expanded', async (t) => {
-  
+
   const combobox = await t.context.session.findElement(By.css(ex.comboboxSelector));
 
   // Check that aria-expanded is false and the grid is not visible before interacting
@@ -99,7 +101,7 @@ ariaTest('"aria-expanded" on combobox element', exampleFile, 'combobox-aria-expa
 });
 
 ariaTest('"id" attribute on texbox used to discover accessible name', exampleFile, 'combobox-id', async (t) => {
-  
+
   const labelForTextboxId = await t.context.session
     .findElement(By.css(ex.labelSelector))
     .getAttribute('for');
@@ -124,7 +126,7 @@ ariaTest('"aria-autocomplete" on grid element', exampleFile, 'combobox-aria-auto
 });
 
 ariaTest('"aria-controls" attribute on grid element', exampleFile, 'combobox-aria-controls', async (t) => {
-  
+
   const popupId = await t.context.session
     .findElement(By.css(ex.comboboxSelector))
     .getAttribute('aria-controls');
@@ -156,7 +158,7 @@ ariaTest('"aria-labelledby" attribute on grid element', exampleFile, 'grid-aria-
 });
 
 ariaTest('role "row" exists within grid element', exampleFile, 'row-role', async (t) => {
-  
+
   // Send key "a" then arrow down to reveal all options
   await t.context.session.findElement(By.css(ex.comboboxSelector)).sendKeys('a', Key.ARROW_DOWN);
 
@@ -171,7 +173,7 @@ ariaTest('role "row" exists within grid element', exampleFile, 'row-role', async
 
 // This test fails due to bug: https://github.com/w3c/aria-practices/issues/859
 ariaTest.failing('"aria-selected" attribute on row element', exampleFile, 'row-aria-selected', async (t) => {
-  
+
   // Send key "a"
   await t.context.session.findElement(By.css(ex.comboboxSelector)).sendKeys('a');
   await assertAttributeDNE(t, ex.rowSelector + ':nth-of-type(1)', 'aria-selected');
@@ -182,7 +184,7 @@ ariaTest.failing('"aria-selected" attribute on row element', exampleFile, 'row-a
 });
 
 ariaTest('role "gridcell" exists within row element', exampleFile, 'gridcell-role', async (t) => {
-  
+
   // Send key "a" then arrow down to reveal all options
   await t.context.session.findElement(By.css(ex.comboboxSelector)).sendKeys('a', Key.ARROW_DOWN);
 
@@ -201,7 +203,7 @@ ariaTest('role "gridcell" exists within row element', exampleFile, 'gridcell-rol
 ariaTest('Test down key press with focus on combobox',
   exampleFile, 'popup-key-down-arrow', async (t) => {
 
-    
+
     // Send ARROW_DOWN to the combobox
     await t.context.session
       .findElement(By.css(ex.comboboxSelector))
@@ -250,7 +252,7 @@ ariaTest('Test down key press with focus on combobox',
 ariaTest('Test down key press with focus on list',
   exampleFile, 'popup-key-down-arrow', async (t) => {
 
-    
+
     // Send 'a' to text box, then send ARROW_DOWN to combobox to set focus on grid
     await t.context.session
       .findElement(By.css(ex.comboboxSelector))
@@ -321,7 +323,7 @@ ariaTest('Test down key press with focus on list',
 ariaTest('Test up key press with focus on combobox',
   exampleFile, 'popup-key-up-arrow', async (t) => {
 
-    
+
     // Send ARROW_UP to the combobox
     await t.context.session
       .findElement(By.css(ex.comboboxSelector))
@@ -370,7 +372,7 @@ ariaTest('Test up key press with focus on combobox',
 ariaTest('Test up key press with focus on grid',
   exampleFile, 'popup-key-up-arrow', async (t) => {
 
-    
+
     // Send 'a' to text box, then send ARROW_UP to combobox to put focus in combobox
     // Up arrow should move selection to the last item in the list
     await t.context.session
@@ -442,7 +444,7 @@ ariaTest('Test up key press with focus on grid',
 ariaTest('Test enter key press with focus on grid',
   exampleFile, 'popup-key-enter', async (t) => {
 
-    
+
     // Send key "a" to the combobox, then key ARROW_DOWN to select the first item
 
     await t.context.session
@@ -522,7 +524,7 @@ ariaTest('Test double escape key press with focus on combobox',
 
 ariaTest('Test escape key press with focus on popup',
   exampleFile, 'popup-key-escape', async (t) => {
-    
+
     // Send key "a" then key "ARROW_DOWN to put the focus on the grid,
     // then key ESCAPE to the combobox
 
@@ -560,7 +562,7 @@ ariaTest('Test escape key press with focus on popup',
 
 ariaTest('left arrow from focus on list puts focus on grid and moves cursor right',
   exampleFile, 'popup-key-left-arrow', async (t) => {
-    
+
     // Send key "a" then key "ARROW_DOWN" to put the focus on the grid
     const combobox = t.context.session.findElement(By.css(ex.comboboxSelector));
     await combobox.sendKeys('a', Key.ARROW_DOWN);
@@ -610,7 +612,7 @@ ariaTest('left arrow from focus on list puts focus on grid and moves cursor righ
 
 ariaTest('Right arrow from focus on list puts focus on grid',
   exampleFile, 'popup-key-right-arrow', async (t) => {
-    
+
     // Send key "a" then key "ARROW_DOWN" to put the focus on the grid
     const combobox = t.context.session.findElement(By.css(ex.comboboxSelector));
     await combobox.sendKeys('a', Key.ARROW_DOWN);
@@ -676,7 +678,7 @@ ariaTest('Right arrow from focus on list puts focus on grid',
 
 ariaTest('Home from focus on list puts focus on grid and moves cursor',
   exampleFile, 'popup-key-home', async (t) => {
-    
+
     // Send key "a" then key "ARROW_DOWN" to put the focus on the grid
     const combobox = t.context.session.findElement(By.css(ex.comboboxSelector));
     await combobox.sendKeys('a', Key.ARROW_DOWN);
@@ -698,7 +700,7 @@ ariaTest('Home from focus on list puts focus on grid and moves cursor',
 
 ariaTest('End from focus on list puts focus on grid',
   exampleFile, 'popup-key-end', async (t) => {
-    
+
     // Send key "a" then key "ARROW_DOWN" to put the focus on the grid
     const combobox = t.context.session.findElement(By.css(ex.comboboxSelector));
     await combobox.sendKeys('a', Key.ARROW_DOWN);
@@ -720,7 +722,7 @@ ariaTest('End from focus on list puts focus on grid',
 
 ariaTest('Sending character keys while focus is on grid moves focus',
   exampleFile, 'popup-key-char', async (t) => {
-    
+
     // Send key "ARROW_DOWN" to put the focus on the grid
     const combobox = t.context.session.findElement(By.css(ex.comboboxSelector));
     await combobox.sendKeys(Key.ARROW_DOWN);

--- a/test/tests/dialog-modal_datepicker.js
+++ b/test/tests/dialog-modal_datepicker.js
@@ -7,8 +7,6 @@ const assertAttributeDNE = require('../util/assertAttributeDNE');
 const assertAriaLabelledby = require('../util/assertAriaLabelledby');
 const assertAriaLabelExists = require('../util/assertAriaLabelExists');
 const assertAriaRoles = require('../util/assertAriaRoles');
-const assertRovingTabindex = require('../util/assertRovingTabindex');
-const assertTabOrder = require('../util/assertTabOrder');
 
 const exampleFile = 'dialog-modal/datepicker-dialog.html';
 
@@ -86,58 +84,49 @@ const focusMatchesElement = async function (t, selector) {
 // Button Tests
 
 ariaTest('"aria-label" attribute on button', exampleFile, 'calendar-button-aria-label', async (t) => {
-  t.plan(1);
-  await assertAriaLabelExists(t,  ex.buttonSelector);
+    await assertAriaLabelExists(t,  ex.buttonSelector);
 });
 
 // Dialog Tests
 
 ariaTest('role="dialog" attribute on div', exampleFile, 'dialog-role', async (t) => {
-  t.plan(1);
-  await assertAriaRoles(t, 'example', 'dialog', 1, 'div');
+    await assertAriaRoles(t, 'example', 'dialog', 1, 'div');
 });
 
 ariaTest('aria-modal="true" on modal', exampleFile, 'dialog-aria-modal', async (t) => {
-  t.plan(1);
-  await assertAttributeValues(t, ex.dialogSelector, 'aria-modal', 'true');
+    await assertAttributeValues(t, ex.dialogSelector, 'aria-modal', 'true');
 });
 
 ariaTest('aria-labelledby exist on dialog', exampleFile, 'dialog-aria-labelledby', async (t) => {
-  t.plan(1);
-  await assertAriaLabelledby(t, ex.dialogSelector);
+    await assertAriaLabelledby(t, ex.dialogSelector);
 });
 
 ariaTest('aria-live="polite" on keyboard support message', exampleFile, 'dialog-aria-live', async (t) => {
-  t.plan(1);
-  await assertAttributeValues(t, ex.messageSelector, 'aria-live', 'polite');
+    await assertAttributeValues(t, ex.messageSelector, 'aria-live', 'polite');
 });
 
 ariaTest('"aria-label" exists on control buttons', exampleFile, 'change-date-button-aria-label', async (t) => {
-  t.plan(1);
-  await assertAriaLabelExists(t, ex.controlButtons);
+    await assertAriaLabelExists(t, ex.controlButtons);
 });
 
 ariaTest('aria-live="polite" on dialog header', exampleFile, 'change-date-aria-live', async (t) => {
-  t.plan(1);
-  await assertAttributeValues(t, `${ex.dialogSelector} h2`, 'aria-live', 'polite');
+    await assertAttributeValues(t, `${ex.dialogSelector} h2`, 'aria-live', 'polite');
 });
 
 ariaTest('grid role on table element', exampleFile, 'grid-role', async (t) => {
-  t.plan(1);
-  await assertAriaRoles(t, 'example', 'grid', 1, 'table');
+    await assertAriaRoles(t, 'example', 'grid', 1, 'table');
 });
 
 ariaTest('aria-labelledby on grid element', exampleFile, 'grid-aria-labelledby', async (t) => {
-  t.plan(1);
-  await assertAriaLabelledby(t, ex.gridSelector);
+    await assertAriaLabelledby(t, ex.gridSelector);
 });
 
 ariaTest('Roving tab index on dates in gridcell', exampleFile, 'gridcell-button-tabindex', async (t) => {
   await setDateToJanFirst2019(t);
   await t.context.session.findElement(By.css(ex.buttonSelector)).click();
 
-  let focusableButtons = await t.context.session.findElements(By.css(ex.currentMonthDateButtons));
-  let allButtons = await t.context.session.findElements(By.css(ex.allDateButtons));
+  let focusableButtons = await t.context.queryElements(t, ex.currentMonthDateButtons);
+  let allButtons = await t.context.queryElements(t, ex.allDateButtons);
 
   // test only one element has tabindex="0"
   for (let tabableEl = 0; tabableEl < 30; tabableEl++) {
@@ -162,8 +151,7 @@ ariaTest('Roving tab index on dates in gridcell', exampleFile, 'gridcell-button-
 });
 
 ariaTest('aria-selected on selected date', exampleFile, 'gridcell-button-aria-selected', async (t) => {
-  t.plan(5);
-
+  
   await t.context.session.findElement(By.css(ex.buttonSelector)).click();
   await assertAttributeDNE(t, ex.allDateButtons, 'aria-selected');
 
@@ -171,9 +159,7 @@ ariaTest('aria-selected on selected date', exampleFile, 'gridcell-button-aria-se
   await t.context.session.findElement(By.css(ex.buttonSelector)).click();
   await assertAttributeValues(t, ex.jan12019Button, 'aria-selected', 'true');
 
-  let selectedButtons = await t.context.session.findElements(
-    By.css(`${ex.allDateButtons}[aria-selected="true"]`)
-  );
+  let selectedButtons = await t.context.queryElements(t, `${ex.allDateButtons}[aria-selected="true"]`);
 
   t.is(
     selectedButtons.length,
@@ -185,9 +171,7 @@ ariaTest('aria-selected on selected date', exampleFile, 'gridcell-button-aria-se
   await t.context.session.findElement(By.css(ex.buttonSelector)).click();
   await assertAttributeValues(t, ex.jan22019Button, 'aria-selected', 'true');
 
-  selectedButtons = await t.context.session.findElements(
-    By.css(`${ex.allDateButtons}[aria-selected="true"]`)
-  );
+  selectedButtons = await t.context.queryElements(t, `${ex.allDateButtons}[aria-selected="true"]`);
 
   t.is(
     selectedButtons.length,
@@ -223,8 +207,7 @@ ariaTest('SPACE to open datepicker', exampleFile, 'button-space-return-down-arro
 });
 
 ariaTest('Sending key ESC when focus is in dialog closes dialog', exampleFile, 'dialog-esc', async (t) => {
-  t.plan(14);
-
+  
   let chooseDateButton = await t.context.session.findElement(By.css(ex.buttonSelector));
 
   for (let i = 0; i < ex.allFocusableElementsInDialog.length; i++) {
@@ -248,8 +231,7 @@ ariaTest('Sending key ESC when focus is in dialog closes dialog', exampleFile, '
 });
 
 ariaTest('Tab should go through all tabbable items, then loop', exampleFile, 'dialog-tab', async (t) => {
-  t.plan(8);
-
+  
   await t.context.session.findElement(By.css(ex.buttonSelector)).click();
 
   for (let itemSelector of ex.allFocusableElementsInDialog) {
@@ -268,8 +250,7 @@ ariaTest('Tab should go through all tabbable items, then loop', exampleFile, 'di
 });
 
 ariaTest('Shift+tab should send focus backwards through diaglog, then loop', exampleFile, 'dialog-shift-tab', async (t) => {
-  t.plan(7);
-
+  
   await t.context.session.findElement(By.css(ex.buttonSelector)).click();
 
   await t.context.session.findElement(By.css(ex.allFocusableElementsInDialog[0]))
@@ -288,8 +269,7 @@ ariaTest('Shift+tab should send focus backwards through diaglog, then loop', exa
 });
 
 ariaTest('ENTER to buttons change calendar and date in focus', exampleFile, 'month-year-button-space-return', async (t) => {
-  t.plan(4);
-
+  
   await t.context.session.findElement(By.css(ex.buttonSelector)).click();
   // By default, focus will be on todays date.
   let day = new Date();
@@ -350,8 +330,7 @@ ariaTest('ENTER to buttons change calendar and date in focus', exampleFile, 'mon
 });
 
 ariaTest('SPACE to buttons change calendar and date in focus', exampleFile, 'month-year-button-space-return', async (t) => {
-  t.plan(4);
-
+  
   await t.context.session.findElement(By.css(ex.buttonSelector)).click();
   // By default, focus will be on todays date.
   let day = new Date();
@@ -412,8 +391,7 @@ ariaTest('SPACE to buttons change calendar and date in focus', exampleFile, 'mon
 });
 
 ariaTest('SPACE or RETURN selects date in focus', exampleFile, 'grid-space-return', async (t) => {
-  t.plan(2);
-
+  
   // By default, focus will be on todays date.
   let day = new Date();
 
@@ -438,8 +416,7 @@ ariaTest('SPACE or RETURN selects date in focus', exampleFile, 'grid-space-retur
 });
 
 ariaTest('UP ARROW moves date up by week', exampleFile, 'grid-up-arrow', async (t) => {
-  t.plan(5);
-
+  
   await t.context.session.findElement(By.css(ex.buttonSelector)).click();
   let day = new Date();
 
@@ -457,8 +434,7 @@ ariaTest('UP ARROW moves date up by week', exampleFile, 'grid-up-arrow', async (
 });
 
 ariaTest('DOWN ARROW moves date down by week', exampleFile, 'grid-down-arrow', async (t) => {
-  t.plan(5);
-
+  
   await t.context.session.findElement(By.css(ex.buttonSelector)).click();
   let day = new Date();
 
@@ -476,8 +452,7 @@ ariaTest('DOWN ARROW moves date down by week', exampleFile, 'grid-down-arrow', a
 });
 
 ariaTest('RIGHT ARROW moves date greater by one', exampleFile, 'grid-right-arrow', async (t) => {
-  t.plan(31);
-
+  
   await t.context.session.findElement(By.css(ex.buttonSelector)).click();
   let day = new Date();
 
@@ -495,8 +470,7 @@ ariaTest('RIGHT ARROW moves date greater by one', exampleFile, 'grid-right-arrow
 });
 
 ariaTest('LEFT ARROW moves date previous one', exampleFile, 'grid-left-arrow', async (t) => {
-  t.plan(31);
-
+  
   await t.context.session.findElement(By.css(ex.buttonSelector)).click();
   let day = new Date();
 
@@ -514,8 +488,7 @@ ariaTest('LEFT ARROW moves date previous one', exampleFile, 'grid-left-arrow', a
 });
 
 ariaTest('Key HOME sends focus to begining of row', exampleFile, 'grid-home', async (t) => {
-  t.plan(2);
-  await t.context.session.findElement(By.css(ex.buttonSelector)).click();
+    await t.context.session.findElement(By.css(ex.buttonSelector)).click();
   let day = new Date();
 
   await t.context.session.findElement(By.css(ex.currentlyFocusedButton)).sendKeys(Key.HOME);
@@ -535,8 +508,7 @@ ariaTest('Key HOME sends focus to begining of row', exampleFile, 'grid-home', as
 });
 
 ariaTest('Key END sends focus to end of row', exampleFile, 'grid-end', async (t) => {
-  t.plan(2);
-  await t.context.session.findElement(By.css(ex.buttonSelector)).click();
+    await t.context.session.findElement(By.css(ex.buttonSelector)).click();
   let day = new Date();
 
   await t.context.session.findElement(By.css(ex.currentlyFocusedButton)).sendKeys(Key.END);
@@ -557,8 +529,7 @@ ariaTest('Key END sends focus to end of row', exampleFile, 'grid-end', async (t)
 });
 
 ariaTest('Sending PAGE UP moves focus by back month', exampleFile, 'grid-pageup', async (t) => {
-  t.plan(2);
-  await t.context.session.findElement(By.css(ex.buttonSelector)).click();
+    await t.context.session.findElement(By.css(ex.buttonSelector)).click();
   let day = new Date();
 
   await t.context.session.findElement(By.css(ex.currentlyFocusedButton)).sendKeys(Key.PAGE_UP);
@@ -579,8 +550,7 @@ ariaTest('Sending PAGE UP moves focus by back month', exampleFile, 'grid-pageup'
 });
 
 ariaTest('Sending SHIFT+PAGE UP moves focus back by year', exampleFile, 'grid-shift-pageup', async (t) => {
-  t.plan(2);
-  await t.context.session.findElement(By.css(ex.buttonSelector)).click();
+    await t.context.session.findElement(By.css(ex.buttonSelector)).click();
   let day = new Date();
 
   await t.context.session.findElement(By.css(ex.currentlyFocusedButton)).sendKeys(Key.chord(Key.SHIFT, Key.PAGE_UP));
@@ -601,8 +571,7 @@ ariaTest('Sending SHIFT+PAGE UP moves focus back by year', exampleFile, 'grid-sh
 });
 
 ariaTest('Sending PAGE DOWN moves focus back by month', exampleFile, 'grid-pagedown', async (t) => {
-  t.plan(2);
-  await t.context.session.findElement(By.css(ex.buttonSelector)).click();
+    await t.context.session.findElement(By.css(ex.buttonSelector)).click();
   let day = new Date();
 
   await t.context.session.findElement(By.css(ex.currentlyFocusedButton)).sendKeys(Key.PAGE_DOWN);
@@ -623,8 +592,7 @@ ariaTest('Sending PAGE DOWN moves focus back by month', exampleFile, 'grid-paged
 });
 
 ariaTest('Sending SHIFT+PAGE DOWN moves focus back by year', exampleFile, 'grid-shift-pagedown', async (t) => {
-  t.plan(2);
-  await t.context.session.findElement(By.css(ex.buttonSelector)).click();
+    await t.context.session.findElement(By.css(ex.buttonSelector)).click();
   let day = new Date();
 
   await t.context.session.findElement(By.css(ex.currentlyFocusedButton)).sendKeys(Key.chord(Key.SHIFT, Key.PAGE_DOWN));
@@ -646,8 +614,7 @@ ariaTest('Sending SHIFT+PAGE DOWN moves focus back by year', exampleFile, 'grid-
 
 ariaTest('ENTER on cancel button does not select date', exampleFile, 'okay-cancel-button-space-return', async (t) => {
 
-  t.plan(4);
-
+  
   await t.context.session.findElement(By.css(ex.buttonSelector)).click();
   await t.context.session.findElement(By.css(ex.cancelButton)).sendKeys(Key.ENTER);
   t.is(
@@ -679,8 +646,7 @@ ariaTest('ENTER on cancel button does not select date', exampleFile, 'okay-cance
 
 ariaTest('SPACE on cancel button does not select date', exampleFile, 'okay-cancel-button-space-return', async (t) => {
 
-  t.plan(4);
-
+  
   await t.context.session.findElement(By.css(ex.buttonSelector)).click();
   await t.context.session.findElement(By.css(ex.cancelButton)).sendKeys(Key.SPACE);
   t.is(
@@ -712,8 +678,7 @@ ariaTest('SPACE on cancel button does not select date', exampleFile, 'okay-cance
 
 ariaTest('ENTER on ok button does selects date', exampleFile, 'okay-cancel-button-space-return', async (t) => {
 
-  t.plan(4);
-
+  
   let day = new Date();
 
   await t.context.session.findElement(By.css(ex.buttonSelector)).click();
@@ -747,8 +712,7 @@ ariaTest('ENTER on ok button does selects date', exampleFile, 'okay-cancel-butto
 
 ariaTest('SPACE on ok button does selects date', exampleFile, 'okay-cancel-button-space-return', async (t) => {
 
-  t.plan(4);
-
+  
   let day = new Date();
 
   await t.context.session.findElement(By.css(ex.buttonSelector)).click();

--- a/test/tests/dialog-modal_dialog.js
+++ b/test/tests/dialog-modal_dialog.js
@@ -173,9 +173,8 @@ const sendEscapeTo = async function (t, selector) {
 
 ariaTest('role="dialog" on div element', exampleFile, 'dialog-role', async (t) => {
 
-  t.plan(5);
-
-  const dialogs = await t.context.session.findElements(By.css(ex.dialogSelector));
+  
+  const dialogs = await t.context.queryElements(t, ex.dialogSelector);
 
   t.is(
     dialogs.length,
@@ -193,26 +192,22 @@ ariaTest('role="dialog" on div element', exampleFile, 'dialog-role', async (t) =
 });
 
 ariaTest('"aria-labelledby" attribute on role="dialog"', exampleFile, 'aria-labelledby', async (t) => {
-  t.plan(1);
-  await assertAriaLabelledby(t, ex.dialogSelector);
+    await assertAriaLabelledby(t, ex.dialogSelector);
 });
 
 ariaTest('', exampleFile, 'aria-describedby', async (t) => {
-  t.plan(1);
-  await assertAriaDescribedby(t, ex.dialogsWithDescribedbySelector);
+    await assertAriaDescribedby(t, ex.dialogsWithDescribedbySelector);
 });
 
 ariaTest('"aria-modal" attribute on role="dialog"', exampleFile, 'aria-modal', async (t) => {
-  t.plan(1);
-  await assertAttributeValues(t, ex.dialogSelector, 'aria-modal', 'true');
+    await assertAttributeValues(t, ex.dialogSelector, 'aria-modal', 'true');
 });
 
 
 // Keys
 
 ariaTest('tab changes focus within dialog', exampleFile, 'key-tab', async (t) => {
-  t.plan(18);
-
+  
   /* DIALOG 1 */
 
   await openDialog1(t);
@@ -309,8 +304,7 @@ ariaTest('tab changes focus within dialog', exampleFile, 'key-tab', async (t) =>
 });
 
 ariaTest('shift tab changes focus within dialog', exampleFile, 'key-shift-tab', async (t) => {
-  t.plan(18);
-
+  
   /* DIALOG 1 */
 
   await openDialog1(t);
@@ -423,8 +417,7 @@ ariaTest('shift tab changes focus within dialog', exampleFile, 'key-shift-tab', 
 });
 
 ariaTest('escape closes dialog', exampleFile, 'key-escape', async (t) => {
-  t.plan(14);
-
+  
   /* DIALOG 1 */
 
   for (let selector of ex.dialog1FocusableEls) {

--- a/test/tests/disclosure_faq.js
+++ b/test/tests/disclosure_faq.js
@@ -44,21 +44,19 @@ const waitAndCheckExpandedFalse = async function (t, selector) {
 // Attributes
 
 ariaTest('"aria-controls" attribute on button', exampleFile, 'button-aria-controls', async (t) => {
-  t.plan(1);
-  await assertAriaControls(t, ex.buttonSelector);
+    await assertAriaControls(t, ex.buttonSelector);
 });
 
 ariaTest('"aria-expanded" attribute on button', exampleFile, 'button-aria-expanded', async (t) => {
-  t.plan(6);
-
+  
   await assertAttributeValues(t, ex.buttonSelector, 'aria-expanded', 'false');
 
-  let buttons = await t.context.session.findElements(By.css(ex.buttonSelector));
+  let buttons = await t.context.queryElements(t, ex.buttonSelector);
   for (let button of buttons) {
     await button.click();
   }
 
-  let answers = await t.context.session.findElements(By.css(ex.buttonSelector));
+  let answers = await t.context.queryElements(t, ex.buttonSelector);
   for (let answer of answers) {
     t.true(
       await answer.isDisplayed(),
@@ -72,11 +70,10 @@ ariaTest('"aria-expanded" attribute on button', exampleFile, 'button-aria-expand
 // Keys
 
 ariaTest('TAB should move focus', exampleFile, 'key-tab', async (t) => {
-  t.plan(2);
-
+  
   await assertTabOrder(t, ex.buttonSelectors);
 
-  let buttons = await t.context.session.findElements(By.css(ex.buttonSelector));
+  let buttons = await t.context.queryElements(t, ex.buttonSelector);
   for (let button of buttons) {
     await button.click();
   }
@@ -85,8 +82,7 @@ ariaTest('TAB should move focus', exampleFile, 'key-tab', async (t) => {
 });
 
 ariaTest('key ENTER expands details', exampleFile, 'key-enter-or-space', async (t) => {
-  t.plan(16);
-
+  
   for (let index = 0; index < ex.buttonSelectors.length; index++) {
     let buttonSelector = ex.buttonSelectors[index];
     let answerSelector = ex.answerSelectors[index];
@@ -119,8 +115,7 @@ ariaTest('key ENTER expands details', exampleFile, 'key-enter-or-space', async (
 });
 
 ariaTest('key SPACE expands details', exampleFile, 'key-enter-or-space', async (t) => {
-  t.plan(16);
-
+  
   for (let index = 0; index < ex.buttonSelectors.length; index++) {
     let buttonSelector = ex.buttonSelectors[index];
     let answerSelector = ex.answerSelectors[index];

--- a/test/tests/disclosure_img-long-description.js
+++ b/test/tests/disclosure_img-long-description.js
@@ -15,13 +15,11 @@ const ex = {
 // Attributes
 
 ariaTest('"aria-controls" attribute on button', exampleFile, 'aria-controls', async (t) => {
-  t.plan(1);
-  await assertAriaControls(t, ex.buttonSelector);
+    await assertAriaControls(t, ex.buttonSelector);
 });
 
 ariaTest('"aria-expanded" attribute on button', exampleFile, 'aria-expanded', async (t) => {
-  t.plan(4);
-
+  
   await assertAttributeValues(t, ex.buttonSelector, 'aria-expanded', 'false');
 
   let description = await t.context.session.findElement(By.css(ex.buttonSelector));
@@ -44,8 +42,7 @@ ariaTest('"aria-expanded" attribute on button', exampleFile, 'aria-expanded', as
 // Keys
 
 ariaTest('TAB should move focus to button', exampleFile, 'key-tab', async (t) => {
-  t.plan(1);
-
+  
   // Send SHIFT+TAB to button
   await await t.context.session.findElement(By.css(ex.buttonSelector))
     .sendKeys(Key.chord(Key.SHIFT, Key.TAB));
@@ -72,8 +69,7 @@ ariaTest('TAB should move focus to button', exampleFile, 'key-tab', async (t) =>
 });
 
 ariaTest('key ENTER expands details', exampleFile, 'key-space-or-enter', async (t) => {
-  t.plan(4);
-
+  
   const button = await t.context.session.findElement(By.css(ex.buttonSelector));
   const description = await t.context.session.findElement(By.css(ex.descriptionSelector));
   await button.sendKeys(Key.ENTER);
@@ -104,8 +100,7 @@ ariaTest('key ENTER expands details', exampleFile, 'key-space-or-enter', async (
 });
 
 ariaTest('key SPACE expands details', exampleFile, 'key-space-or-enter', async (t) => {
-  t.plan(4);
-
+  
   let button = await t.context.session.findElement(By.css(ex.buttonSelector));
   let description = await t.context.session.findElement(By.css(ex.descriptionSelector));
   await button.sendKeys(Key.SPACE);

--- a/test/tests/disclosure_navigation.js
+++ b/test/tests/disclosure_navigation.js
@@ -28,17 +28,15 @@ const ex = {
 // Attributes
 
 ariaTest('"aria-controls" attribute on button', exampleFile, 'button-aria-controls', async (t) => {
-  t.plan(1);
-  await assertAriaControls(t, ex.buttonSelector);
+    await assertAriaControls(t, ex.buttonSelector);
 });
 
 ariaTest('"aria-expanded" attribute on button', exampleFile, 'button-aria-expanded', async (t) => {
-  t.plan(7);
-
+  
   await assertAttributeValues(t, ex.buttonSelector, 'aria-expanded', 'false');
 
-  let buttons = await t.context.session.findElements(By.css(ex.buttonSelector));
-  let menus = await t.context.session.findElements(By.css(ex.menuSelector));
+  let buttons = await t.context.queryElements(t, ex.buttonSelector);
+  let menus = await t.context.queryElements(t, ex.menuSelector);
   for (let i = buttons.length - 1; i >= 0; i--) {
     await buttons[i].click();
     t.true(
@@ -50,13 +48,12 @@ ariaTest('"aria-expanded" attribute on button', exampleFile, 'button-aria-expand
 });
 
 ariaTest('"aria-current" attribute on links', exampleFile, 'link-aria-current', async (t) => {
-  t.plan(36);
-
-  const buttons = await t.context.session.findElements(By.css(ex.buttonSelector));
-  const menus = await t.context.session.findElements(By.css(ex.menuSelector));
+  
+  const buttons = await t.context.queryElements(t, ex.buttonSelector);
+  const menus = await t.context.queryElements(t, ex.menuSelector);
 
   for (let b = 0; b < buttons.length; b++) {
-    const links = await menus[b].findElements(By.css('a'));
+    const links = await t.context.queryElements(t, 'a', menus[b]);
 
     for (let l = 0; l < links.length; l++) {
 
@@ -69,9 +66,7 @@ ariaTest('"aria-current" attribute on links', exampleFile, 'link-aria-current', 
         'after clicking link at index ' + l + ' on menu ' + b + 'aria-current should be set to page'
       );
 
-      let ariaCurrentLinks = await t.context.session.findElements(
-        By.css(`${ex.linkSelector}[aria-current="page"]`)
-      );
+      let ariaCurrentLinks = await t.context.queryElements(t, `${ex.linkSelector}[aria-current="page"]`);
 
       t.is(
         ariaCurrentLinks.length,
@@ -86,16 +81,14 @@ ariaTest('"aria-current" attribute on links', exampleFile, 'link-aria-current', 
 // Keys
 
 ariaTest('TAB should move focus between buttons', exampleFile, 'key-tab', async (t) => {
-  t.plan(1);
-
+  
   await assertTabOrder(t, ex.buttonSelectors);
 });
 
 ariaTest('key ENTER expands dropdown', exampleFile, 'key-enter-space', async (t) => {
-  t.plan(12);
-
-  const buttons = await t.context.session.findElements(By.css(ex.buttonSelector));
-  const menus = await t.context.session.findElements(By.css(ex.menuSelector));
+  
+  const buttons = await t.context.queryElements(t, ex.buttonSelector);
+  const menus = await t.context.queryElements(t, ex.menuSelector);
 
   for (let i = buttons.length - 1; i >= 0; i--) {
     await buttons[i].sendKeys(Key.ENTER);
@@ -115,10 +108,9 @@ ariaTest('key ENTER expands dropdown', exampleFile, 'key-enter-space', async (t)
 });
 
 ariaTest('key SPACE expands dropdown', exampleFile, 'key-enter-space', async (t) => {
-  t.plan(12);
-
-  const buttons = await t.context.session.findElements(By.css(ex.buttonSelector));
-  const menus = await t.context.session.findElements(By.css(ex.menuSelector));
+  
+  const buttons = await t.context.queryElements(t, ex.buttonSelector);
+  const menus = await t.context.queryElements(t, ex.menuSelector);
 
   for (let i = buttons.length - 1; i >= 0; i--) {
     await buttons[i].sendKeys(Key.SPACE);
@@ -138,8 +130,7 @@ ariaTest('key SPACE expands dropdown', exampleFile, 'key-enter-space', async (t)
 });
 
 ariaTest('key ESCAPE closes dropdown', exampleFile, 'key-escape', async (t) => {
-  t.plan(3);
-
+  
   const button = await t.context.session.findElement(By.css(ex.buttonSelectors[0]));
   const menu = await t.context.session.findElement(By.css(ex.menuSelectors[0]));
   const firstLink = await t.context.session.findElement(By.css(`${ex.menuSelectors[0]} a`));
@@ -159,9 +150,8 @@ ariaTest('key ESCAPE closes dropdown', exampleFile, 'key-escape', async (t) => {
 });
 
 ariaTest('arrow keys move focus between disclosure buttons', exampleFile, 'key-arrows', async (t) => {
-  t.plan(8);
-
-  const buttons = await t.context.session.findElements(By.css(ex.buttonSelector));
+  
+  const buttons = await t.context.queryElements(t, ex.buttonSelector);
 
   await buttons[0].sendKeys(Key.ARROW_RIGHT);
   await assertHasFocus(t, ex.buttonSelectors[1], 'right arrow moves focus from first to second button');
@@ -189,9 +179,8 @@ ariaTest('arrow keys move focus between disclosure buttons', exampleFile, 'key-a
 });
 
 ariaTest('down arrow moves focus from button to open menu', exampleFile, 'key-arrows', async (t) => {
-  t.plan(2);
-
-  const buttons = await t.context.session.findElements(By.css(ex.buttonSelector));
+  
+  const buttons = await t.context.queryElements(t, ex.buttonSelector);
   const menu = await t.context.session.findElement(By.css(ex.menuSelectors[0]));
 
   // open menu
@@ -206,9 +195,8 @@ ariaTest('down arrow moves focus from button to open menu', exampleFile, 'key-ar
 });
 
 ariaTest('home and end move focus to first and last buttons', exampleFile, 'key-home-end', async (t) => {
-  t.plan(2);
-
-  const buttons = await t.context.session.findElements(By.css(ex.buttonSelector));
+  
+  const buttons = await t.context.queryElements(t, ex.buttonSelector);
 
   await buttons[1].sendKeys(Key.HOME);
   await assertHasFocus(t, ex.buttonSelectors[0], 'home key moves focus to first button');
@@ -218,11 +206,10 @@ ariaTest('home and end move focus to first and last buttons', exampleFile, 'key-
 });
 
 ariaTest('arrow keys move focus between open menu links', exampleFile, 'key-arrows', async (t) => {
-  t.plan(6);
-
+  
   const button = await t.context.session.findElement(By.css(ex.buttonSelectors[0]));
   const menu = await t.context.session.findElement(By.css(ex.menuSelectors[0]));
-  const menuLinks = await t.context.session.findElements(By.css(`${ex.menuSelectors[0]} a`));
+  const menuLinks = await t.context.queryElements(t, `${ex.menuSelectors[0]} a`);
 
   await button.click();
   await menu.isDisplayed();
@@ -247,11 +234,10 @@ ariaTest('arrow keys move focus between open menu links', exampleFile, 'key-arro
 });
 
 ariaTest('home and end move focus to first and last open menu link', exampleFile, 'key-home-end', async (t) => {
-  t.plan(2);
-
+  
   const button = await t.context.session.findElement(By.css(ex.buttonSelectors[0]));
   const menu = await t.context.session.findElement(By.css(ex.menuSelectors[0]));
-  const menuLinks = await t.context.session.findElements(By.css(`${ex.menuSelectors[0]} a`));
+  const menuLinks = await t.context.queryElements(t, `${ex.menuSelectors[0]} a`);
 
   await button.click();
   await menu.isDisplayed();

--- a/test/tests/feed_feed.js
+++ b/test/tests/feed_feed.js
@@ -69,60 +69,52 @@ const checkFocus = async function (t, selector, index) {
 // Attributes
 
 ariaTest('role="feed" exists', exampleFile, 'feed-role', async (t) => {
-  t.plan(1);
-  await navigateToFeed(t);
+    await navigateToFeed(t);
   await assertAriaRoles(t, 'main-content', 'feed', 1, 'div');
 });
 
 // This bug has been reported in issue: https://github.com/w3c/aria-practices/issues/911
 ariaTest.failing('aria-labelledby attribute on feed element', exampleFile, 'feed-aria-labelledby', async (t) => {
-  t.plan(1);
-  await navigateToFeed(t);
+    await navigateToFeed(t);
   await assertAriaLabelledby(t, ex.feedSelector);
 });
 
 ariaTest('aria-busy attribute on feed element', exampleFile, 'feed-aria-busy', async (t) => {
-  t.plan(2);
-  await navigateToFeed(t);
+    await navigateToFeed(t);
   await assertAttributeValues(t, ex.feedSelector, 'aria-busy', 'true');
   await waitForArticlesToLoad(t);
   await assertAttributeDNE(t, ex.feedSelector, 'aria-busy');
 });
 
 ariaTest('role="article" exists', exampleFile, 'article-role', async (t) => {
-  t.plan(1);
-  await navigateToFeed(t);
+    await navigateToFeed(t);
   await waitForArticlesToLoad(t);
   await assertAriaRoles(t, 'main-content', 'article', 10, 'div');
 });
 
 ariaTest('tabindex="-1" on article elements', exampleFile, 'article-tabindex', async (t) => {
-  t.plan(1);
-  await navigateToFeed(t);
+    await navigateToFeed(t);
   await waitForArticlesToLoad(t);
   await assertAttributeValues(t, ex.articleSelector, 'tabindex', '0');
 });
 
 ariaTest('aria-labelledby set on article elements', exampleFile, 'article-labelledby', async (t) => {
-  t.plan(1);
-  await navigateToFeed(t);
+    await navigateToFeed(t);
   await waitForArticlesToLoad(t);
   await assertAriaLabelledby(t, ex.articleSelector);
 });
 
 ariaTest('aria-describedby set on article elements', exampleFile, 'article-describedby', async (t) => {
-  t.plan(1);
-  await navigateToFeed(t);
+    await navigateToFeed(t);
   await waitForArticlesToLoad(t);
   await assertAriaDescribedby(t, ex.articleSelector);
 });
 
 ariaTest('aria-posinset on article element', exampleFile, 'article-aria-posinset', async (t) => {
-  t.plan(30);
-  await navigateToFeed(t);
+    await navigateToFeed(t);
   await waitForArticlesToLoad(t);
 
-  let articles = await t.context.session.findElements(By.css(ex.articleSelector));
+  let articles = await t.context.queryElements(t, ex.articleSelector);
   for (let index = 1; index <= articles.length; index++) {
     t.is(
       await articles[index - 1].getAttribute('aria-posinset'),
@@ -134,7 +126,7 @@ ariaTest('aria-posinset on article element', exampleFile, 'article-aria-posinset
   await loadMoreArticles(t);
   await waitForArticlesToLoad(t);
 
-  articles = await t.context.session.findElements(By.css(ex.articleSelector));
+  articles = await t.context.queryElements(t, ex.articleSelector);
   for (let index = 1; index <= articles.length; index++) {
     t.is(
       await articles[index - 1].getAttribute('aria-posinset'),
@@ -145,12 +137,11 @@ ariaTest('aria-posinset on article element', exampleFile, 'article-aria-posinset
 });
 
 ariaTest('aria-setsize on article element', exampleFile, 'article-aria-setsize', async (t) => {
-  t.plan(30);
-
+  
   await navigateToFeed(t);
   await waitForArticlesToLoad(t);
 
-  let articles = await t.context.session.findElements(By.css(ex.articleSelector));
+  let articles = await t.context.queryElements(t, ex.articleSelector);
   let numArticles = articles.length;
   for (let index = 1; index <= numArticles; index++) {
     t.is(
@@ -164,7 +155,7 @@ ariaTest('aria-setsize on article element', exampleFile, 'article-aria-setsize',
   await loadMoreArticles(t);
   await waitForArticlesToLoad(t);
 
-  articles = await t.context.session.findElements(By.css(ex.articleSelector));
+  articles = await t.context.queryElements(t, ex.articleSelector);
   numArticles = articles.length;
   for (let index = 1; index <= numArticles; index++) {
     t.is(
@@ -179,11 +170,10 @@ ariaTest('aria-setsize on article element', exampleFile, 'article-aria-setsize',
 // Keys
 
 ariaTest('PAGE DOWN moves focus between articles', exampleFile, 'key-page-down', async (t) => {
-  t.plan(1);
-  await navigateToFeed(t);
+    await navigateToFeed(t);
   await waitForArticlesToLoad(t);
 
-  let articles = await t.context.session.findElements(By.css(ex.articleSelector));
+  let articles = await t.context.queryElements(t, ex.articleSelector);
   articles[0].sendKeys(Key.PAGE_DOWN);
 
   t.true(
@@ -193,11 +183,10 @@ ariaTest('PAGE DOWN moves focus between articles', exampleFile, 'key-page-down',
 });
 
 ariaTest('PAGE UP moves focus between articles', exampleFile, 'key-page-up', async (t) => {
-  t.plan(1);
-  await navigateToFeed(t);
+    await navigateToFeed(t);
   await waitForArticlesToLoad(t);
 
-  let articles = await t.context.session.findElements(By.css(ex.articleSelector));
+  let articles = await t.context.queryElements(t, ex.articleSelector);
   articles[1].sendKeys(Key.PAGE_UP);
 
   t.true(
@@ -207,11 +196,10 @@ ariaTest('PAGE UP moves focus between articles', exampleFile, 'key-page-up', asy
 });
 
 ariaTest('CONTROL+END moves focus out of feed', exampleFile, 'key-control-end', async (t) => {
-  t.plan(1);
-  await navigateToFeed(t);
+    await navigateToFeed(t);
   await waitForArticlesToLoad(t);
 
-  let articles = await t.context.session.findElements(By.css(ex.articleSelector));
+  let articles = await t.context.queryElements(t, ex.articleSelector);
   articles[0].sendKeys(Key.chord(Key.CONTROL, Key.END));
 
   t.true(

--- a/test/tests/grid_LayoutGrids.js
+++ b/test/tests/grid_LayoutGrids.js
@@ -1,3 +1,5 @@
+/* eslint no-restricted-properties: 0 */
+
 'use strict';
 
 const { ariaTest } = require('..');
@@ -116,7 +118,7 @@ const exampleInitialized = async function (t, exId) {
 ariaTest('Test "role=grid" attribute exists',
   'grid/LayoutGrids.html', 'grid-role', async (t) => {
 
-    
+
     for (let exId in pageExamples) {
       const ex = pageExamples[exId];
       const gridLocator = By.css(ex.gridSelector);
@@ -132,7 +134,7 @@ ariaTest('Test "role=grid" attribute exists',
 ariaTest('Test "aria-labelledby" attribute exists',
   'grid/LayoutGrids.html', 'aria-labelledby', async (t) => {
 
-    
+
     for (let exId in pageExamples) {
       const ex = pageExamples[exId];
 
@@ -143,7 +145,7 @@ ariaTest('Test "aria-labelledby" attribute exists',
 ariaTest('Test "aria-rowcount" attribute exists',
   'grid/LayoutGrids.html', 'aria-rowcount', async (t) => {
 
-    
+
     // This test only applies to example 3
     const gridSelector = '#ex3 [role="grid"]';
     const gridLocator = By.css(gridSelector);
@@ -169,7 +171,7 @@ ariaTest('Test "aria-rowcount" attribute exists',
 ariaTest('Test "role=row" attribute exists',
   'grid/LayoutGrids.html', 'row-role', async (t) => {
 
-    
+
     for (let exId in pageExamples) {
       const ex = pageExamples[exId];
 
@@ -187,7 +189,7 @@ ariaTest('Test "role=row" attribute exists',
 ariaTest('test "aria-rowindex" attribute exists',
   'grid/LayoutGrids.html', 'aria-rowindex', async (t) => {
 
-    
+
     // This test only applies to example 3
     const gridSelector = '#ex3 [role="grid"]';
     const gridLocator = By.css(gridSelector);
@@ -209,7 +211,7 @@ ariaTest('test "aria-rowindex" attribute exists',
 ariaTest('Test "role=gridcell" attribute exists',
   'grid/LayoutGrids.html', 'gridcell-role', async (t) => {
 
-    
+
     for (let exId in pageExamples) {
       const ex = pageExamples[exId];
       const gridLocator = By.css(ex.gridSelector);
@@ -279,7 +281,7 @@ ariaTest('Test "tabindex" appropriately set',
 // Keys
 
 ariaTest('Right arrow key moves focus', 'grid/LayoutGrids.html', 'key-right-arrow', async (t) => {
-  
+
   for (let [exId, ex] of Object.entries(pageExamples)) {
     const gridcellElements = await t.context.queryElements(t, ex.gridcellSelector);
 
@@ -318,7 +320,7 @@ ariaTest('Right arrow key moves focus', 'grid/LayoutGrids.html', 'key-right-arro
 });
 
 ariaTest('Left arrow key moves focus', 'grid/LayoutGrids.html', 'key-left-arrow', async (t) => {
-  
+
   for (let [exId, ex] of Object.entries(pageExamples)) {
 
     if (exId == 'ex3') {
@@ -367,7 +369,7 @@ ariaTest('Left arrow key moves focus', 'grid/LayoutGrids.html', 'key-left-arrow'
 });
 
 ariaTest('Down arrow key moves focus', 'grid/LayoutGrids.html', 'key-down-arrow', async (t) => {
-  
+
   const cellSelectors = {
     ex1: '#ex1 [role="gridcell"]',
     ex2: '#ex2 [role="row"] [role="gridcell"]:first-of-type',
@@ -414,7 +416,7 @@ ariaTest('Down arrow key moves focus', 'grid/LayoutGrids.html', 'key-down-arrow'
 });
 
 ariaTest('Up arrow key moves focus', 'grid/LayoutGrids.html', 'key-up-arrow', async (t) => {
-  
+
   const cellSelectors = [
     ['ex1', '#ex1 [role="gridcell"]', 'a'],
     ['ex2', '#ex2 [role="row"] [role="gridcell"]:first-of-type', 'a'],
@@ -470,7 +472,7 @@ ariaTest('Up arrow key moves focus', 'grid/LayoutGrids.html', 'key-up-arrow', as
 });
 
 ariaTest('PageDown key moves focus', 'grid/LayoutGrids.html', 'key-page-down', async (t) => {
-  
+
   const ex = pageExamples.ex3;
   const cellSelectors = [
     ['first', '#ex3 [role="row"] [role="gridcell"]:nth-child(1)', 'a'],
@@ -525,7 +527,7 @@ ariaTest('PageDown key moves focus', 'grid/LayoutGrids.html', 'key-page-down', a
 });
 
 ariaTest('PageUp key moves focus', 'grid/LayoutGrids.html', 'key-page-up', async (t) => {
-  
+
   const ex = pageExamples.ex3;
   const cellSelectors = [
     ['first', '#ex3 [role="row"] [role="gridcell"]:nth-child(1)', 'a'],
@@ -589,7 +591,7 @@ ariaTest('PageUp key moves focus', 'grid/LayoutGrids.html', 'key-page-up', async
 });
 
 ariaTest('Home key moves focus', 'grid/LayoutGrids.html', 'key-home', async (t) => {
-  
+
   const firstElementInFirstRowText = {
     ex1: 'ARIA 1.1 Specification',
     ex2: 'Recipient Name 1',
@@ -628,7 +630,7 @@ ariaTest('Home key moves focus', 'grid/LayoutGrids.html', 'key-home', async (t) 
 });
 
 ariaTest('End key moves focus', 'grid/LayoutGrids.html', 'key-end', async (t) => {
-  
+
   const lastElementInFirstRowText = {
     ex1: 'SVG 2 Specification',
     ex2: 'X',
@@ -660,7 +662,7 @@ ariaTest('End key moves focus', 'grid/LayoutGrids.html', 'key-end', async (t) =>
 });
 
 ariaTest('control+home keys moves focus', 'grid/LayoutGrids.html', 'key-control-home', async (t) => {
-  
+
   const firstElementInFirstRowText = {
     ex1: 'ARIA 1.1 Specification',
     ex2: 'Recipient Name 1',
@@ -699,7 +701,7 @@ ariaTest('control+home keys moves focus', 'grid/LayoutGrids.html', 'key-control-
 
 
 ariaTest('Control+end keys moves focus', 'grid/LayoutGrids.html', 'key-control-end', async (t) => {
-  
+
   const lastElementInFirstRowText = {
     ex1: 'SVG 2 Specification',
     ex2: 'X',

--- a/test/tests/grid_LayoutGrids.js
+++ b/test/tests/grid_LayoutGrids.js
@@ -106,7 +106,7 @@ const exampleInitialized = async function (t, exId) {
   const initializedSelector = '#' + exId + ' [role="grid"] [tabindex="0"]';
 
   await t.context.session.wait(async function () {
-    const els = await t.context.session.findElements(By.css(initializedSelector));
+    const els = await t.context.queryElements(t, initializedSelector);
     return els.length === 1;
   }, t.context.waitTime, 'Timeout waiting for widget to initialize before running tests.');
 };
@@ -116,8 +116,7 @@ const exampleInitialized = async function (t, exId) {
 ariaTest('Test "role=grid" attribute exists',
   'grid/LayoutGrids.html', 'grid-role', async (t) => {
 
-    t.plan(3);
-
+    
     for (let exId in pageExamples) {
       const ex = pageExamples[exId];
       const gridLocator = By.css(ex.gridSelector);
@@ -133,8 +132,7 @@ ariaTest('Test "role=grid" attribute exists',
 ariaTest('Test "aria-labelledby" attribute exists',
   'grid/LayoutGrids.html', 'aria-labelledby', async (t) => {
 
-    t.plan(3);
-
+    
     for (let exId in pageExamples) {
       const ex = pageExamples[exId];
 
@@ -145,8 +143,7 @@ ariaTest('Test "aria-labelledby" attribute exists',
 ariaTest('Test "aria-rowcount" attribute exists',
   'grid/LayoutGrids.html', 'aria-rowcount', async (t) => {
 
-    t.plan(2);
-
+    
     // This test only applies to example 3
     const gridSelector = '#ex3 [role="grid"]';
     const gridLocator = By.css(gridSelector);
@@ -159,10 +156,8 @@ ariaTest('Test "aria-rowcount" attribute exists',
       '"aria-rowcount" attribute should exist on element selected by: ' + gridSelector
     );
 
-    const rowLocator = By.css('[role="row"]');
-    const rowElements = await t.context.session
-      .findElement(gridLocator)
-      .findElements(rowLocator);
+    const gridElement = await t.context.session.findElement(gridLocator);
+    const rowElements = await t.context.queryElements(t, '[role="row"]', gridElement);
 
     t.is(
       rowElements.length,
@@ -174,16 +169,13 @@ ariaTest('Test "aria-rowcount" attribute exists',
 ariaTest('Test "role=row" attribute exists',
   'grid/LayoutGrids.html', 'row-role', async (t) => {
 
-    t.plan(3);
-
+    
     for (let exId in pageExamples) {
       const ex = pageExamples[exId];
 
       const gridLocator = By.css(ex.gridSelector);
-      const rowLocator = By.css('div[role="row"]');
-      const rowElements = await t.context.session
-        .findElement(gridLocator)
-        .findElements(rowLocator);
+      const gridElement = await t.context.session.findElement(gridLocator);
+      const rowElements = await t.context.queryElements(t, 'div[role="row"]', gridElement);
 
       t.truthy(
         rowElements.length,
@@ -195,17 +187,13 @@ ariaTest('Test "role=row" attribute exists',
 ariaTest('test "aria-rowindex" attribute exists',
   'grid/LayoutGrids.html', 'aria-rowindex', async (t) => {
 
-    t.plan(19);
-
+    
     // This test only applies to example 3
-    const exId = 'ex3';
     const gridSelector = '#ex3 [role="grid"]';
     const gridLocator = By.css(gridSelector);
 
-    const rowLocator = By.css('[role="row"]');
-    const rowElements = await t.context.session
-      .findElement(gridLocator)
-      .findElements(rowLocator);
+    const gridElement = await t.context.session.findElement(gridLocator);
+    const rowElements = await t.context.queryElements(t, '[role="row"]', gridElement);
 
     for (let i = 0; i < rowElements.length; i++) {
       const value = (i + 1).toString();
@@ -221,16 +209,13 @@ ariaTest('test "aria-rowindex" attribute exists',
 ariaTest('Test "role=gridcell" attribute exists',
   'grid/LayoutGrids.html', 'gridcell-role', async (t) => {
 
-    t.plan(3);
-
+    
     for (let exId in pageExamples) {
       const ex = pageExamples[exId];
       const gridLocator = By.css(ex.gridSelector);
 
-      const gridcellLocator = By.css('[role="gridcell"]');
-      const gridcellElements = await t.context.session
-        .findElement(gridLocator)
-        .findElements(gridcellLocator);
+      const gridElement = await t.context.session.findElement(gridLocator);
+      const gridcellElements = await t.context.queryElements(t, '[role="gridcell"]', gridElement);
 
       t.truthy(
         gridcellElements.length,
@@ -249,7 +234,7 @@ ariaTest('Test "tabindex" appropriately set',
       // Wait for the javascript to run before testing example
       await exampleInitialized(t, exId);
 
-      const gridcellElements = await t.context.session.findElements(By.css(ex.gridcellSelector));
+      const gridcellElements = await t.context.queryElements(t, ex.gridcellSelector);
 
       for (let el = 0; el < gridcellElements.length; el++) {
 
@@ -294,12 +279,9 @@ ariaTest('Test "tabindex" appropriately set',
 // Keys
 
 ariaTest('Right arrow key moves focus', 'grid/LayoutGrids.html', 'key-right-arrow', async (t) => {
-  t.plan(67);
-
+  
   for (let [exId, ex] of Object.entries(pageExamples)) {
-    const gridcellElements = await t.context.session.findElements(
-      By.css(ex.gridcellSelector)
-    );
+    const gridcellElements = await t.context.queryElements(t, ex.gridcellSelector);
 
     // Find the first focusable element
     let activeElement = await focusOnOrInCell(t, gridcellElements[0], ex.focusableElements[0]);
@@ -336,8 +318,7 @@ ariaTest('Right arrow key moves focus', 'grid/LayoutGrids.html', 'key-right-arro
 });
 
 ariaTest('Left arrow key moves focus', 'grid/LayoutGrids.html', 'key-left-arrow', async (t) => {
-  t.plan(67);
-
+  
   for (let [exId, ex] of Object.entries(pageExamples)) {
 
     if (exId == 'ex3') {
@@ -347,7 +328,7 @@ ariaTest('Left arrow key moves focus', 'grid/LayoutGrids.html', 'key-left-arrow'
       await clickUntilDisabled(t.context.session, '#ex3_pagedown_button');
     }
 
-    const gridcellElements = await t.context.session.findElements(By.css(ex.gridcellSelector));
+    const gridcellElements = await t.context.queryElements(t, ex.gridcellSelector);
     const lastCellIndex = gridcellElements.length - 1;
 
     // Find the last focusable element
@@ -386,8 +367,7 @@ ariaTest('Left arrow key moves focus', 'grid/LayoutGrids.html', 'key-left-arrow'
 });
 
 ariaTest('Down arrow key moves focus', 'grid/LayoutGrids.html', 'key-down-arrow', async (t) => {
-  t.plan(27);
-
+  
   const cellSelectors = {
     ex1: '#ex1 [role="gridcell"]',
     ex2: '#ex2 [role="row"] [role="gridcell"]:first-of-type',
@@ -397,9 +377,7 @@ ariaTest('Down arrow key moves focus', 'grid/LayoutGrids.html', 'key-down-arrow'
   for (let [exId, selector] of Object.entries(cellSelectors)) {
     const ex = pageExamples[exId];
 
-    const gridcellElements = await t.context.session.findElements(
-      By.css(selector)
-    );
+    const gridcellElements = await t.context.queryElements(t, selector);
 
     // Find the first focusable element
     let activeElement = await focusOnOrInCell(t, gridcellElements[0], ex.focusableElements[0]);
@@ -436,8 +414,7 @@ ariaTest('Down arrow key moves focus', 'grid/LayoutGrids.html', 'key-down-arrow'
 });
 
 ariaTest('Up arrow key moves focus', 'grid/LayoutGrids.html', 'key-up-arrow', async (t) => {
-  t.plan(27);
-
+  
   const cellSelectors = [
     ['ex1', '#ex1 [role="gridcell"]', 'a'],
     ['ex2', '#ex2 [role="row"] [role="gridcell"]:first-of-type', 'a'],
@@ -454,7 +431,7 @@ ariaTest('Up arrow key moves focus', 'grid/LayoutGrids.html', 'key-up-arrow', as
       await clickUntilDisabled(t.context.session, '#ex3_pagedown_button');
     }
 
-    const gridcellElements = await t.context.session.findElements(By.css(selector));
+    const gridcellElements = await t.context.queryElements(t, selector);
     const lastCellIndex = gridcellElements.length - 1;
 
     // Find the last focusable element
@@ -493,8 +470,7 @@ ariaTest('Up arrow key moves focus', 'grid/LayoutGrids.html', 'key-up-arrow', as
 });
 
 ariaTest('PageDown key moves focus', 'grid/LayoutGrids.html', 'key-page-down', async (t) => {
-  t.plan(12);
-
+  
   const ex = pageExamples.ex3;
   const cellSelectors = [
     ['first', '#ex3 [role="row"] [role="gridcell"]:nth-child(1)', 'a'],
@@ -510,9 +486,7 @@ ariaTest('PageDown key moves focus', 'grid/LayoutGrids.html', 'key-page-down', a
     await reload(t);
 
     let finalIndex;
-    const gridcellElements = (await t.context.session.findElements(
-      By.css(selector)
-    ));
+    const gridcellElements = (await t.context.queryElements(t, selector));
 
     // Find the first focusable element
 
@@ -551,8 +525,7 @@ ariaTest('PageDown key moves focus', 'grid/LayoutGrids.html', 'key-page-down', a
 });
 
 ariaTest('PageUp key moves focus', 'grid/LayoutGrids.html', 'key-page-up', async (t) => {
-  t.plan(12);
-
+  
   const ex = pageExamples.ex3;
   const cellSelectors = [
     ['first', '#ex3 [role="row"] [role="gridcell"]:nth-child(1)', 'a'],
@@ -572,9 +545,7 @@ ariaTest('PageUp key moves focus', 'grid/LayoutGrids.html', 'key-page-up', async
     await clickUntilDisabled(t.context.session, '#ex3_pagedown_button');
 
     let finalIndex;
-    const gridcellElements = (await t.context.session.findElements(
-      By.css(selector)
-    ));
+    const gridcellElements = (await t.context.queryElements(t, selector));
 
     const lastCellIndex = gridcellElements.length - 1;
 
@@ -618,8 +589,7 @@ ariaTest('PageUp key moves focus', 'grid/LayoutGrids.html', 'key-page-up', async
 });
 
 ariaTest('Home key moves focus', 'grid/LayoutGrids.html', 'key-home', async (t) => {
-  t.plan(3);
-
+  
   const firstElementInFirstRowText = {
     ex1: 'ARIA 1.1 Specification',
     ex2: 'Recipient Name 1',
@@ -628,9 +598,7 @@ ariaTest('Home key moves focus', 'grid/LayoutGrids.html', 'key-home', async (t) 
 
   for (let [exId, ex] of Object.entries(pageExamples)) {
 
-    const gridcellElements = await t.context.session.findElements(
-      By.css(ex.gridcellSelector)
-    );
+    const gridcellElements = await t.context.queryElements(t, ex.gridcellSelector);
 
     // Find the first focusable element
     let activeElement = await focusOnOrInCell(t, gridcellElements[0], ex.focusableElements[0]);
@@ -660,8 +628,7 @@ ariaTest('Home key moves focus', 'grid/LayoutGrids.html', 'key-home', async (t) 
 });
 
 ariaTest('End key moves focus', 'grid/LayoutGrids.html', 'key-end', async (t) => {
-  t.plan(3);
-
+  
   const lastElementInFirstRowText = {
     ex1: 'SVG 2 Specification',
     ex2: 'X',
@@ -670,9 +637,7 @@ ariaTest('End key moves focus', 'grid/LayoutGrids.html', 'key-end', async (t) =>
 
   for (let [exId, ex] of Object.entries(pageExamples)) {
 
-    const gridcellElements = await t.context.session.findElements(
-      By.css(ex.gridcellSelector)
-    );
+    const gridcellElements = await t.context.queryElements(t, ex.gridcellSelector);
 
     // Find the first focusable element
     let activeElement = await focusOnOrInCell(t, gridcellElements[0], ex.focusableElements[0]);
@@ -695,8 +660,7 @@ ariaTest('End key moves focus', 'grid/LayoutGrids.html', 'key-end', async (t) =>
 });
 
 ariaTest('control+home keys moves focus', 'grid/LayoutGrids.html', 'key-control-home', async (t) => {
-  t.plan(3);
-
+  
   const firstElementInFirstRowText = {
     ex1: 'ARIA 1.1 Specification',
     ex2: 'Recipient Name 1',
@@ -705,9 +669,7 @@ ariaTest('control+home keys moves focus', 'grid/LayoutGrids.html', 'key-control-
 
   for (let [exId, ex] of Object.entries(pageExamples)) {
 
-    const gridcellElements = await t.context.session.findElements(
-      By.css(ex.gridcellSelector)
-    );
+    const gridcellElements = await t.context.queryElements(t, ex.gridcellSelector);
 
     // Find the first focusable element
     let activeElement = await focusOnOrInCell(t, gridcellElements[0], ex.focusableElements[0]);
@@ -737,8 +699,7 @@ ariaTest('control+home keys moves focus', 'grid/LayoutGrids.html', 'key-control-
 
 
 ariaTest('Control+end keys moves focus', 'grid/LayoutGrids.html', 'key-control-end', async (t) => {
-  t.plan(3);
-
+  
   const lastElementInFirstRowText = {
     ex1: 'SVG 2 Specification',
     ex2: 'X',
@@ -747,9 +708,7 @@ ariaTest('Control+end keys moves focus', 'grid/LayoutGrids.html', 'key-control-e
 
   for (let [exId, ex] of Object.entries(pageExamples)) {
 
-    const gridcellElements = await t.context.session.findElements(
-      By.css(ex.gridcellSelector)
-    );
+    const gridcellElements = await t.context.queryElements(t, ex.gridcellSelector);
 
     // Find the first focusable element
     let activeElement = await focusOnOrInCell(t, gridcellElements[0], ex.focusableElements[0]);

--- a/test/tests/grid_LayoutGrids.js
+++ b/test/tests/grid_LayoutGrids.js
@@ -121,10 +121,9 @@ ariaTest('Test "role=grid" attribute exists',
 
     for (let exId in pageExamples) {
       const ex = pageExamples[exId];
-      const gridLocator = By.css(ex.gridSelector);
 
       t.is(
-        (await t.context.session.findElements(gridLocator)).length,
+        (await t.context.queryElements(t, ex.gridSelector)).length,
         1,
         'One "role=grid" element should be found by selector: ' + ex.gridSelector
       );

--- a/test/tests/grid_LayoutGrids.js
+++ b/test/tests/grid_LayoutGrids.js
@@ -1,5 +1,3 @@
-/* eslint no-restricted-properties: 0 */
-
 'use strict';
 
 const { ariaTest } = require('..');

--- a/test/tests/grid_dataGrids.js
+++ b/test/tests/grid_dataGrids.js
@@ -86,33 +86,28 @@ const scrollToEndOfExample3 = async function (t) {
 // Attributes
 
 ariaTest('Test for role="grid"', exampleFile, 'grid-role', async (t) => {
-  t.plan(3);
-  await assertAriaRoles(t, 'ex1', 'grid', '1', 'table');
+    await assertAriaRoles(t, 'ex1', 'grid', '1', 'table');
   await assertAriaRoles(t, 'ex2', 'grid', '1', 'table');
   await assertAriaRoles(t, 'ex3', 'grid', '1', 'table');
 });
 
 ariaTest('aria-labelledby attribute on all examples', exampleFile, 'aria-labelledby', async (t) => {
-  t.plan(3);
-  await assertAriaLabelledby(t, ex[1].gridSelector);
+    await assertAriaLabelledby(t, ex[1].gridSelector);
   await assertAriaLabelledby(t, ex[2].gridSelector);
   await assertAriaLabelledby(t, ex[3].gridSelector);
 });
 
 ariaTest('aria-rowcount attribute in example 3', exampleFile, 'aria-rowcount', async (t) => {
-  t.plan(1);
-  await assertAttributeValues(t, ex[3].gridSelector, 'aria-rowcount', '16');
+    await assertAttributeValues(t, ex[3].gridSelector, 'aria-rowcount', '16');
 });
 
 ariaTest('aria-colcount attribute in example 3', exampleFile, 'aria-colcount', async (t) => {
-  t.plan(1);
-  await assertAttributeValues(t, ex[3].gridSelector, 'aria-colcount', '6');
+    await assertAttributeValues(t, ex[3].gridSelector, 'aria-colcount', '6');
 });
 
 ariaTest('aria-rowindex attribute in example 3', exampleFile, 'aria-rowindex', async (t) => {
-  t.plan(16);
-
-  let rows = await t.context.session.findElements(By.css(ex[3].rowSelector));
+  
+  let rows = await t.context.queryElements(t, ex[3].rowSelector);
 
   let index = 1;
   for (let row of rows) {
@@ -127,10 +122,10 @@ ariaTest('aria-rowindex attribute in example 3', exampleFile, 'aria-rowindex', a
 
 ariaTest('aria-colindex attribute in example 3', exampleFile, 'aria-colindex', async (t) => {
 
-  let rows = await t.context.session.findElements(By.css(ex[3].rowSelector));
+  let rows = await t.context.queryElements(t, ex[3].rowSelector);
 
   // Check all the headers
-  let items = await rows.shift().findElements(By.css('th'));
+  let items = await t.context.queryElements(t, 'th', rows.shift());
   let index = 1;
   for (let item of items) {
     t.is(
@@ -143,7 +138,7 @@ ariaTest('aria-colindex attribute in example 3', exampleFile, 'aria-colindex', a
 
   // Check all the grid items
   for (let row of rows) {
-    let items = await row.findElements(By.css('td'));
+    let items = await t.context.queryElements(t, 'td', row);
 
     let index = 1;
     for (let item of items) {
@@ -158,8 +153,7 @@ ariaTest('aria-colindex attribute in example 3', exampleFile, 'aria-colindex', a
 });
 
 ariaTest('aria-sort set appropriately in example 2', exampleFile, 'aria-sort', async (t) => {
-  t.plan(8);
-
+  
   let dateHeader = await t.context.session.findElement(By.css(ex[2].dateHeaderSelector));
   let dateButton = dateHeader.findElement(By.css('[role="button"]'));
 
@@ -222,8 +216,7 @@ ariaTest('aria-sort set appropriately in example 2', exampleFile, 'aria-sort', a
 // Keys
 
 ariaTest('Right arrow moves focus, example 1 and 2', exampleFile, 'key-right-arrow', async (t) => {
-  t.plan(39);
-
+  
   // Examples 1 and 2
   for (let example of [1,2]) {
     const gridSelector = ex[example].gridSelector;
@@ -257,8 +250,7 @@ ariaTest('Right arrow moves focus, example 1 and 2', exampleFile, 'key-right-arr
 });
 
 ariaTest('Right arrow moves focus, example 3', exampleFile, 'key-right-arrow', async (t) => {
-  t.plan(90);
-
+  
   let gridSelector = ex[3].gridSelector;
   let lastColumn = ex[3].lastColumn;
   let lastRow = ex[3].lastRow;
@@ -268,7 +260,7 @@ ariaTest('Right arrow moves focus, example 3', exampleFile, 'key-right-arrow', a
   for (let rowIndex = 2; rowIndex <= lastRow; rowIndex++) {
 
     // If the row is not displayed, send page down to the last rows first element
-    let rows = (await t.context.session.findElements(By.css(rowSelector)));
+    let rows = (await t.context.queryElements(t, rowSelector));
     if (!(await rows[rowIndex - 1].isDisplayed())) {
       let previousRowCell = rows[rowIndex - 2].findElement(By.css('td'));
       await previousRowCell.sendKeys(Key.PAGE_DOWN);
@@ -304,7 +296,7 @@ ariaTest('Right arrow moves focus, example 3', exampleFile, 'key-right-arrow', a
   for (let rowIndex = 2; rowIndex <= lastRow; rowIndex++) {
 
     // If the row is not displayed, send page down to the last rows first element
-    let rows = (await t.context.session.findElements(By.css(rowSelector)));
+    let rows = (await t.context.queryElements(t, rowSelector));
     if (!(await rows[rowIndex - 1].isDisplayed())) {
       let previousRowCell = rows[rowIndex - 2].findElement(By.css('td'));
       await previousRowCell.sendKeys(Key.PAGE_DOWN);
@@ -333,8 +325,7 @@ ariaTest('Right arrow moves focus, example 3', exampleFile, 'key-right-arrow', a
 });
 
 ariaTest('Left arrow moves focus, example 1 and 2', exampleFile, 'key-left-arrow', async (t) => {
-  t.plan(39);
-
+  
   // Examples 1 and 2
   for (let example of [1,2]) {
     const gridSelector = ex[example].gridSelector;
@@ -368,8 +359,7 @@ ariaTest('Left arrow moves focus, example 1 and 2', exampleFile, 'key-left-arrow
 });
 
 ariaTest('left arrow moves focus, example 3', exampleFile, 'key-left-arrow', async (t) => {
-  t.plan(90);
-
+  
   let gridSelector = ex[3].gridSelector;
   let lastColumn = ex[3].lastColumn;
   let lastRow = ex[3].lastRow;
@@ -379,7 +369,7 @@ ariaTest('left arrow moves focus, example 3', exampleFile, 'key-left-arrow', asy
   for (let rowIndex = 2; rowIndex <= lastRow; rowIndex++) {
 
     // If the row is not displayed, send page down to the last rows first element
-    let rows = (await t.context.session.findElements(By.css(rowSelector)));
+    let rows = (await t.context.queryElements(t, rowSelector));
     if (!(await rows[rowIndex - 1].isDisplayed())) {
       let previousRowCell = rows[rowIndex - 2].findElement(By.css('td'));
       await previousRowCell.sendKeys(Key.PAGE_DOWN);
@@ -415,7 +405,7 @@ ariaTest('left arrow moves focus, example 3', exampleFile, 'key-left-arrow', asy
   for (let rowIndex = 2; rowIndex <= lastRow; rowIndex++) {
 
     // If the row is not displayed, send page down to the last rows first element
-    let rows = (await t.context.session.findElements(By.css(rowSelector)));
+    let rows = (await t.context.queryElements(t, rowSelector));
     if (!(await rows[rowIndex - 1].isDisplayed())) {
       let previousRowCell = rows[rowIndex - 2].findElement(By.css('td'));
       await previousRowCell.sendKeys(Key.PAGE_DOWN);
@@ -444,8 +434,7 @@ ariaTest('left arrow moves focus, example 3', exampleFile, 'key-left-arrow', asy
 });
 
 ariaTest('Key down moves focus, examples 1,2,3', exampleFile, 'key-down-arrow', async (t) => {
-  t.plan(28);
-
+  
   // Examples 1 and 2 and 3
   for (let example of [1,2,3]) {
     const gridSelector = ex[example].gridSelector;
@@ -481,8 +470,7 @@ ariaTest('Key down moves focus, examples 1,2,3', exampleFile, 'key-down-arrow', 
 });
 
 ariaTest('Key up moves focus, examples 1,2,3', exampleFile, 'key-up-arrow', async (t) => {
-  t.plan(28);
-
+  
   // Examples 1 and 2 and 3
   for (let example of [1,2,3]) {
     const gridSelector = ex[example].gridSelector;
@@ -589,8 +577,7 @@ ariaTest('Page up moves focus in example 3', exampleFile, 'key-page-up', async (
 });
 
 ariaTest('Home key moves focus', exampleFile, 'key-home', async (t) => {
-  t.plan(28);
-
+  
   // Examples 1 and 2 and 3
   for (let example of [1,2,3]) {
     const gridSelector = ex[example].gridSelector;
@@ -605,7 +592,7 @@ ariaTest('Home key moves focus', exampleFile, 'key-home', async (t) => {
 
       // If the row is not displayed, send page down to the last rows first element
       if (example === 3) {
-        let rows = (await t.context.session.findElements(By.css(rowSelector)));
+        let rows = (await t.context.queryElements(t, rowSelector));
         if (!(await rows[rowIndex - 1].isDisplayed())) {
           let previousRowCell = rows[rowIndex - 2].findElement(By.css('td'));
           await previousRowCell.sendKeys(Key.PAGE_DOWN);
@@ -630,8 +617,7 @@ ariaTest('Home key moves focus', exampleFile, 'key-home', async (t) => {
 });
 
 ariaTest('End key moves focus', exampleFile, 'key-end', async (t) => {
-  t.plan(28);
-
+  
   // Examples 1 and 2 and 3
   for (let example of [1,2,3]) {
     const gridSelector = ex[example].gridSelector;
@@ -646,7 +632,7 @@ ariaTest('End key moves focus', exampleFile, 'key-end', async (t) => {
 
       // If the row is not displayed, send page down to the last rows first element
       if (example === 3) {
-        let rows = (await t.context.session.findElements(By.css(rowSelector)));
+        let rows = (await t.context.queryElements(t, rowSelector));
         if (!(await rows[rowIndex - 1].isDisplayed())) {
           let previousRowCell = rows[rowIndex - 2].findElement(By.css('td'));
           await previousRowCell.sendKeys(Key.PAGE_DOWN);
@@ -671,8 +657,7 @@ ariaTest('End key moves focus', exampleFile, 'key-end', async (t) => {
 });
 
 ariaTest('Control+home moves focus', exampleFile, 'key-control-home', async (t) => {
-  t.plan(28);
-
+  
   // Examples 1, 2, and 3
   for (let example of [1,2,3]) {
     const gridSelector = ex[example].gridSelector;
@@ -713,8 +698,7 @@ ariaTest('Control+home moves focus', exampleFile, 'key-control-home', async (t) 
 });
 
 ariaTest('Control+end moves focus', exampleFile, 'key-control-end', async (t) => {
-  t.plan(28);
-
+  
   // Examples 1, 2, and 3
   for (let example of [1,2,3]) {
     const gridSelector = ex[example].gridSelector;

--- a/test/tests/link_link.js
+++ b/test/tests/link_link.js
@@ -75,8 +75,7 @@ ariaTest('Test "alt" attribute exists',
 ariaTest('Test "aria-label" attribute exists',
   'link/link.html', 'aria-label', async (t) => {
 
-    t.plan(1);
-
+    
     for (let i = 0; i < pageExamples.length; i++) {
 
       let ex = pageExamples[i];

--- a/test/tests/listbox_collapsible.js
+++ b/test/tests/listbox_collapsible.js
@@ -28,19 +28,16 @@ const checkFocus = async function (t, selector) {
 };
 
 ariaTest('"aria-labelledby" on button element', exampleFile, 'button-aria-labelledby', async (t) => {
-  t.plan(1);
-  await assertAriaLabelledby(t, ex.buttonSelector);
+    await assertAriaLabelledby(t, ex.buttonSelector);
 });
 
 
 ariaTest('"aria-haspopup" on button element', exampleFile, 'button-aria-haspopup', async (t) => {
-  t.plan(1);
-  await assertAttributeValues(t, ex.buttonSelector, 'aria-haspopup', 'listbox');
+    await assertAttributeValues(t, ex.buttonSelector, 'aria-haspopup', 'listbox');
 });
 
 ariaTest('"aria-expanded" on button element', exampleFile, 'button-aria-expanded', async (t) => {
-  t.plan(4);
-
+  
   const button = await t.context.session.findElement(By.css(ex.buttonSelector));
 
   // Check that aria-expanded is not set and the listbox is not visible before interacting
@@ -70,18 +67,15 @@ ariaTest('"aria-expanded" on button element', exampleFile, 'button-aria-expanded
 });
 
 ariaTest('role="listbox" on ul element', exampleFile, 'listbox-role', async (t) => {
-  t.plan(1);
-  await assertAriaRoles(t, 'ex', 'listbox', 1, 'ul');
+    await assertAriaRoles(t, 'ex', 'listbox', 1, 'ul');
 });
 
 ariaTest('"aria-labelledby" on listbox element', exampleFile, 'listbox-aria-labelledby', async (t) => {
-  t.plan(1);
-  await assertAriaLabelledby(t, ex.listboxSelector);
+    await assertAriaLabelledby(t, ex.listboxSelector);
 });
 
 ariaTest('tabindex="0" on listbox element', exampleFile, 'listbox-tabindex', async (t) => {
-  t.plan(1);
-  await assertAttributeValues(t, ex.listboxSelector, 'tabindex', '-1');
+    await assertAttributeValues(t, ex.listboxSelector, 'tabindex', '-1');
 });
 
 ariaTest('aria-activedescendant on listbox element', exampleFile, 'listbox-aria-activedescendant', async (t) => {
@@ -89,7 +83,7 @@ ariaTest('aria-activedescendant on listbox element', exampleFile, 'listbox-aria-
   await t.context.session.findElement(By.css(ex.buttonSelector)).click();
 
   const listbox = await t.context.session.findElement(By.css(ex.listboxSelector));
-  const options = await t.context.session.findElements(By.css(ex.optionSelector));
+  const options = await t.context.queryElements(t, ex.optionSelector);
   const optionId = await options[0].getAttribute('id');
 
   // no active descendant is expected until arrow keys are used
@@ -106,13 +100,11 @@ ariaTest('aria-activedescendant on listbox element', exampleFile, 'listbox-aria-
 });
 
 ariaTest('role="option" on li elements', exampleFile, 'option-role', async (t) => {
-  t.plan(1);
-  await assertAriaRoles(t, 'ex', 'option', 26, 'li');
+    await assertAriaRoles(t, 'ex', 'option', 26, 'li');
 });
 
 ariaTest('"aria-selected" on option elements', exampleFile, 'option-aria-selected', async (t) => {
-  t.plan(2);
-
+  
   await assertAttributeDNE(t, ex.optionSelector, 'aria-selected');
 
   // Put the focus on the listbox with arrow down
@@ -128,7 +120,6 @@ ariaTest('"aria-selected" on option elements', exampleFile, 'option-aria-selecte
 ariaTest('ENTER opens and closes listbox', exampleFile, 'key-enter', async (t) => {
   let button = await t.context.session.findElement(By.css(ex.buttonSelector));
   let listbox = await t.context.session.findElement(By.css(ex.listboxSelector));
-  let buttonSelectedElement = await button.getText();
 
   await button.sendKeys(Key.ENTER);
 
@@ -162,8 +153,7 @@ ariaTest('ENTER opens and closes listbox', exampleFile, 'key-enter', async (t) =
 });
 
 ariaTest('ESCAPE closes listbox', exampleFile, 'key-escape', async (t) => {
-  t.plan(3);
-
+  
   let button = await t.context.session.findElement(By.css(ex.buttonSelector));
   let listbox = await t.context.session.findElement(By.css(ex.listboxSelector));
 
@@ -204,8 +194,7 @@ ariaTest('ESCAPE closes listbox', exampleFile, 'key-escape', async (t) => {
 });
 
 ariaTest('DOWN ARROW opens listbox and moves focus', exampleFile, 'key-down-arrow', async (t) => {
-  t.plan(5);
-
+  
   // Send DOWN ARROW to button should open listbo
   await t.context.session.findElement(By.css(ex.buttonSelector)).sendKeys(Key.ARROW_DOWN);
 
@@ -257,8 +246,7 @@ ariaTest('END moves focus', exampleFile, 'key-end', async (t) => {
 });
 
 ariaTest('UP ARROW moves focus', exampleFile, 'key-up-arrow', async (t) => {
-  t.plan(5);
-
+  
   // Send UP ARROW to button should open listboxx
   await t.context.session.findElement(By.css(ex.buttonSelector)).sendKeys(Key.ARROW_UP);
 
@@ -292,8 +280,7 @@ ariaTest('UP ARROW moves focus', exampleFile, 'key-up-arrow', async (t) => {
 });
 
 ariaTest('HOME moves focus', exampleFile, 'key-home', async (t) => {
-  t.plan(2);
-
+  
   // Put the focus on the listbox by clicking the button
   await t.context.session.findElement(By.css(ex.buttonSelector)).click();
 
@@ -311,8 +298,7 @@ ariaTest('HOME moves focus', exampleFile, 'key-home', async (t) => {
 
 
 ariaTest('Character keys moves focus', exampleFile, 'key-character', async (t) => {
-  t.plan(4);
-
+  
   // Put the focus on the listbox. In this example, focusing on the listbox
   // will automatically select the first option.
   await t.context.session.findElement(By.css(ex.buttonSelector)).click();

--- a/test/tests/listbox_grouped.js
+++ b/test/tests/listbox_grouped.js
@@ -35,7 +35,8 @@ ariaTest('aria-activedescendant on listbox element', exampleFile, 'listbox-aria-
   // will automatically select the first option.
   await t.context.session.findElement(By.css(`${ex.optionIdBase}1`)).click();
 
-  let options = await t.context.session.findElements(By.css(ex.optionSelector));
+  let options = await t.context.queryElements(t, ex.optionSelector);
+
   let optionId = await options[0].getAttribute('id');
 
   t.is(
@@ -84,7 +85,7 @@ ariaTest('DOWN ARROW moves focus', exampleFile, 'key-down-arrow', async (t) => {
 
 ariaTest('DOWN ARROW does not wrap to top of listbox', exampleFile, 'key-down-arrow', async (t) => {
   const listbox = await t.context.session.findElement(By.css(ex.listboxSelector));
-  const options = await t.context.session.findElements(By.css(ex.optionSelector));
+  const options = await t.context.queryElements(t, ex.optionSelector);
 
   // click the last option
   await options[options.length - 1].click();
@@ -107,7 +108,7 @@ ariaTest('DOWN ARROW moves through groups', exampleFile, 'key-down-arrow', async
   // Sending the key down arrow will put focus on the first option if no options are focused
   const listbox = await t.context.session.findElement(By.css(ex.listboxSelector));
   const group1 = await listbox.findElement(By.css('[role="group"]'));
-  const groupOptions = await group1.findElements(By.css('[role="option"]'));
+  const groupOptions = await t.context.queryElements(t, '[role="option"]', group1);
 
   // click last option in group
   await groupOptions[groupOptions.length - 1].click();
@@ -128,7 +129,7 @@ ariaTest('UP ARROW sends initial focus to the first option', exampleFile, 'key-u
 
 ariaTest('END moves focus', exampleFile, 'key-end', async (t) => {
   const listbox = await t.context.session.findElement(By.css(ex.listboxSelector));
-  const options = await t.context.session.findElements(By.css(ex.optionSelector));
+  const options = await t.context.queryElements(t, ex.optionSelector);
 
   // Sending key end should put focus on the last item
   await listbox.sendKeys(Key.END);
@@ -168,7 +169,7 @@ ariaTest('UP ARROW moves through groups', exampleFile, 'key-up-arrow', async (t)
   // Sending the key down arrow will put focus on the first option if no options are focused
   const listbox = await t.context.session.findElement(By.css(ex.listboxSelector));
   const group1 = await listbox.findElement(By.css('[role="group"]'));
-  const groupOptions = await group1.findElements(By.css('[role="option"]'));
+  const groupOptions = await t.context.queryElements(t, '[role="option"]', group1);
 
   // click first option in second group
   await t.context.session.findElement(By.css(`${ex.optionIdBase}${groupOptions.length + 1}`)).click();
@@ -194,7 +195,7 @@ ariaTest('HOME moves focus', exampleFile, 'key-home', async (t) => {
 
 ariaTest('END scrolls listbox option into view', exampleFile, 'key-end', async (t) => {
   const listbox = await t.context.session.findElement(By.css(ex.listboxSelector));
-  const options = await t.context.session.findElements(By.css(ex.optionSelector));
+  const options = await t.context.queryElements(t, ex.optionSelector);
 
   let listboxBounds = await listbox.getRect();
   let optionBounds = await options[options.length - 1].getRect();
@@ -210,7 +211,7 @@ ariaTest('END scrolls listbox option into view', exampleFile, 'key-end', async (
 
 ariaTest('Click scrolls listbox option into view', exampleFile, 'key-end', async (t) => {
   const listbox = await t.context.session.findElement(By.css(ex.listboxSelector));
-  const options = await t.context.session.findElements(By.css(ex.optionSelector));
+  const options = await t.context.queryElements(t, ex.optionSelector);
 
   let listboxBounds = await listbox.getRect();
   let optionBounds = await options[options.length - 1].getRect();

--- a/test/tests/listbox_rearrangeable.js
+++ b/test/tests/listbox_rearrangeable.js
@@ -33,37 +33,32 @@ const ex = {
 // Attributes
 
 ariaTest('role="listbox" on ul element', exampleFile, 'listbox-role', async (t) => {
-  t.plan(2);
-  await assertAriaRoles(t, 'ex1', 'listbox', 2, 'ul');
+    await assertAriaRoles(t, 'ex1', 'listbox', 2, 'ul');
   await assertAriaRoles(t, 'ex2', 'listbox', 2, 'ul');
 });
 
 ariaTest('"aria-labelledby" on listbox element', exampleFile, 'listbox-aria-labelledby', async (t) => {
-  t.plan(2);
-  await assertAriaLabelledby(t, ex[1].listboxSelector);
+    await assertAriaLabelledby(t, ex[1].listboxSelector);
   await assertAriaLabelledby(t, ex[2].listboxSelector);
 });
 
 ariaTest('tabindex="0" on listbox element', exampleFile, 'listbox-tabindex', async (t) => {
-  t.plan(2);
-  await assertAttributeValues(t, ex[1].listboxSelector, 'tabindex', '0');
+    await assertAttributeValues(t, ex[1].listboxSelector, 'tabindex', '0');
   await assertAttributeValues(t, ex[2].listboxSelector, 'tabindex', '0');
 });
 
 ariaTest('aria-multiselectable on listbox element', exampleFile, 'listbox-aria-multiselectable', async (t) => {
-  t.plan(1);
-  await assertAttributeValues(t, ex[2].listboxSelector, 'aria-multiselectable', 'true');
+    await assertAttributeValues(t, ex[2].listboxSelector, 'aria-multiselectable', 'true');
 });
 
 
 ariaTest('aria-activedescendant on listbox element', exampleFile, 'listbox-aria-activedescendant', async (t) => {
-  t.plan(2);
-
+  
   // Put the focus on the listbox. In this example, focusing on the listbox
   // will automatically select the first option.
   await t.context.session.findElement(By.css(ex[1].firstOptionSelector)).click();
 
-  let options = await t.context.session.findElements(By.css(ex[1].optionSelector));
+  let options = await t.context.queryElements(t, ex[1].optionSelector);
   let optionId = await options[0].getAttribute('id');
 
   t.is(
@@ -78,7 +73,7 @@ ariaTest('aria-activedescendant on listbox element', exampleFile, 'listbox-aria-
   // will automatically select the first option.
   await t.context.session.findElement(By.css(ex[2].firstOptionSelector)).click();
 
-  options = await t.context.session.findElements(By.css(ex[2].optionSelector));
+  options = await t.context.queryElements(t, ex[2].optionSelector);
   optionId = await options[0].getAttribute('id');
 
   t.is(
@@ -92,14 +87,12 @@ ariaTest('aria-activedescendant on listbox element', exampleFile, 'listbox-aria-
 });
 
 ariaTest('role="option" on li elements', exampleFile, 'option-role', async (t) => {
-  t.plan(2);
-  await assertAriaRoles(t, 'ex1', 'option', 10, 'li');
+    await assertAriaRoles(t, 'ex1', 'option', 10, 'li');
   await assertAriaRoles(t, 'ex2', 'option', 10, 'li');
 });
 
 ariaTest('"aria-selected" on option elements', exampleFile, 'option-aria-selected', async (t) => {
-  t.plan(4);
-
+  
   await assertAttributeDNE(t, ex[1].optionSelector, 'aria-selected');
   await t.context.session.findElement(By.css(ex[1].firstOptionSelector)).click();
   await assertAttributeValues(t, ex[1].optionSelector + ':nth-child(1)', 'aria-selected', 'true');
@@ -112,12 +105,11 @@ ariaTest('"aria-selected" on option elements', exampleFile, 'option-aria-selecte
 // Keys
 
 ariaTest('down arrow moves focus and selects', exampleFile, 'key-down-arrow', async (t) => {
-  t.plan(28);
-
+  
   // Example 1
 
-  let listbox = (await t.context.session.findElements(By.css(ex[1].listboxSelector)))[0];
-  let options = await t.context.session.findElements(By.css(ex[1].optionSelector));
+  let listbox = (await t.context.queryElements(t, ex[1].listboxSelector))[0];
+  let options = await t.context.queryElements(t, ex[1].optionSelector);
 
   // Put the focus on the first item
   await t.context.session.findElement(By.css(ex[1].firstOptionSelector)).click();
@@ -133,8 +125,8 @@ ariaTest('down arrow moves focus and selects', exampleFile, 'key-down-arrow', as
 
   // Example 2
 
-  listbox = (await t.context.session.findElements(By.css(ex[2].listboxSelector)))[0];
-  options = await t.context.session.findElements(By.css(ex[2].optionSelector));
+  listbox = (await t.context.queryElements(t, ex[2].listboxSelector))[0];
+  options = await t.context.queryElements(t, ex[2].optionSelector);
 
   // Put the focus on the first item, and selects item, so skip by sending down arrow once
   await t.context.session.findElement(By.css(ex[2].firstOptionSelector)).click();
@@ -143,7 +135,7 @@ ariaTest('down arrow moves focus and selects', exampleFile, 'key-down-arrow', as
   for (let index = 1; index < options.length - 1; index++) {
     await assertAriaActivedescendant(t, ex[2].availableSelector, ex[2].optionSelector, index);
     t.is(
-      await(await t.context.session.findElements(By.css(ex[2].optionSelector)))[index]
+      await(await t.context.queryElements(t, ex[2].optionSelector))[index]
         .getAttribute('aria-selected'),
       'false',
       'aria-selected is false when moving between options with down arrow in example 2'
@@ -156,7 +148,7 @@ ariaTest('down arrow moves focus and selects', exampleFile, 'key-down-arrow', as
   lastOption = options.length - 1;
   await assertAriaActivedescendant(t, ex[2].availableSelector, ex[2].optionSelector, lastOption);
   t.is(
-    await(await t.context.session.findElements(By.css(ex[2].optionSelector)))[lastOption]
+    await(await t.context.queryElements(t, ex[2].optionSelector))[lastOption]
       .getAttribute('aria-selected'),
     'false',
     'aria-selected is false when moving between options with down arrow in example 2'
@@ -164,12 +156,11 @@ ariaTest('down arrow moves focus and selects', exampleFile, 'key-down-arrow', as
 });
 
 ariaTest('up arrow moves focus and selects', exampleFile, 'key-up-arrow', async (t) => {
-  t.plan(28);
-
+  
   // Example 1
 
-  let listbox = (await t.context.session.findElements(By.css(ex[1].listboxSelector)))[0];
-  let options = await t.context.session.findElements(By.css(ex[1].optionSelector));
+  let listbox = (await t.context.queryElements(t, ex[1].listboxSelector))[0];
+  let options = await t.context.queryElements(t, ex[1].optionSelector);
 
   // Put the focus on the first item
   await t.context.session.findElement(By.css(ex[1].lastOptionSelector)).click();
@@ -184,8 +175,8 @@ ariaTest('up arrow moves focus and selects', exampleFile, 'key-up-arrow', async 
 
   // Example 2
 
-  listbox = (await t.context.session.findElements(By.css(ex[2].listboxSelector)))[0];
-  options = await t.context.session.findElements(By.css(ex[2].optionSelector));
+  listbox = (await t.context.queryElements(t, ex[2].listboxSelector))[0];
+  options = await t.context.queryElements(t, ex[2].optionSelector);
 
   // Put the focus on the last item, and selects item, so skip by sending down arrow once
   await t.context.session.findElement(By.css(ex[2].lastOptionSelector)).click();
@@ -194,7 +185,7 @@ ariaTest('up arrow moves focus and selects', exampleFile, 'key-up-arrow', async 
   for (let index = options.length - 2; index > 0; index--) {
     await assertAriaActivedescendant(t, ex[2].availableSelector, ex[2].optionSelector, index);
     t.is(
-      await(await t.context.session.findElements(By.css(ex[2].optionSelector)))[index]
+      await(await t.context.queryElements(t, ex[2].optionSelector))[index]
         .getAttribute('aria-selected'),
       'false',
       'aria-selected is false when moving between options with down arrow in example 2'
@@ -206,7 +197,7 @@ ariaTest('up arrow moves focus and selects', exampleFile, 'key-up-arrow', async 
   await listbox.sendKeys(Key.ARROW_UP);
   await assertAriaActivedescendant(t, ex[2].availableSelector, ex[2].optionSelector, 0);
   t.is(
-    await(await t.context.session.findElements(By.css(ex[2].optionSelector)))[0]
+    await(await t.context.queryElements(t, ex[2].optionSelector))[0]
       .getAttribute('aria-selected'),
     'false',
     'aria-selected is false when moving between options with down arrow in example 2'
@@ -214,12 +205,11 @@ ariaTest('up arrow moves focus and selects', exampleFile, 'key-up-arrow', async 
 });
 
 ariaTest('home moves focus and selects', exampleFile, 'key-home', async (t) => {
-  t.plan(6);
-
+  
   // Example 1
 
-  let listbox = (await t.context.session.findElements(By.css(ex[1].listboxSelector)))[0];
-  let options = await t.context.session.findElements(By.css(ex[1].optionSelector));
+  let listbox = (await t.context.queryElements(t, ex[1].listboxSelector))[0];
+  let options = await t.context.queryElements(t, ex[1].optionSelector);
 
   // Put the focus on the second item
   await options[1].click();
@@ -234,15 +224,15 @@ ariaTest('home moves focus and selects', exampleFile, 'key-home', async (t) => {
 
   // Example 2
 
-  listbox = (await t.context.session.findElements(By.css(ex[2].listboxSelector)))[0];
-  options = await t.context.session.findElements(By.css(ex[2].optionSelector));
+  listbox = (await t.context.queryElements(t, ex[2].listboxSelector))[0];
+  options = await t.context.queryElements(t, ex[2].optionSelector);
 
   // Put the focus on the second item
   await options[1].click();
   await listbox.sendKeys(Key.HOME);
   await assertAriaActivedescendant(t, ex[2].availableSelector, ex[2].optionSelector, 0);
   t.is(
-    await(await t.context.session.findElements(By.css(ex[2].optionSelector)))[0]
+    await(await t.context.queryElements(t, ex[2].optionSelector))[0]
       .getAttribute('aria-selected'),
     'false',
     'aria-selected is false when moving between options with HOME in example 2'
@@ -253,7 +243,7 @@ ariaTest('home moves focus and selects', exampleFile, 'key-home', async (t) => {
   await listbox.sendKeys(Key.HOME);
   await assertAriaActivedescendant(t, ex[2].availableSelector, ex[2].optionSelector, 0);
   t.is(
-    await(await t.context.session.findElements(By.css(ex[2].optionSelector)))[0]
+    await(await t.context.queryElements(t, ex[2].optionSelector))[0]
       .getAttribute('aria-selected'),
     'false',
     'aria-selected is false when moving between options with HOME in example 2'
@@ -261,12 +251,11 @@ ariaTest('home moves focus and selects', exampleFile, 'key-home', async (t) => {
 });
 
 ariaTest('end moves focus and selects', exampleFile, 'key-end', async (t) => {
-  t.plan(6);
-
+  
   // Example 1
 
-  let listbox = (await t.context.session.findElements(By.css(ex[1].listboxSelector)))[0];
-  let options = await t.context.session.findElements(By.css(ex[1].optionSelector));
+  let listbox = (await t.context.queryElements(t, ex[1].listboxSelector))[0];
+  let options = await t.context.queryElements(t, ex[1].optionSelector);
   let lastOption = options.length - 1;
 
   // Put the focus on the second item
@@ -282,15 +271,15 @@ ariaTest('end moves focus and selects', exampleFile, 'key-end', async (t) => {
 
   // Example 2
 
-  listbox = (await t.context.session.findElements(By.css(ex[2].listboxSelector)))[0];
-  options = await t.context.session.findElements(By.css(ex[2].optionSelector));
+  listbox = (await t.context.queryElements(t, ex[2].listboxSelector))[0];
+  options = await t.context.queryElements(t, ex[2].optionSelector);
 
   // Put the focus on the second item
   await options[1].click();
   await listbox.sendKeys(Key.END);
   await assertAriaActivedescendant(t, ex[2].availableSelector, ex[2].optionSelector, lastOption);
   t.is(
-    await(await t.context.session.findElements(By.css(ex[2].optionSelector)))[lastOption]
+    await(await t.context.queryElements(t, ex[2].optionSelector))[lastOption]
       .getAttribute('aria-selected'),
     'false',
     'aria-selected is false when moving between options with END in example 2'
@@ -301,7 +290,7 @@ ariaTest('end moves focus and selects', exampleFile, 'key-end', async (t) => {
   await listbox.sendKeys(Key.END);
   await assertAriaActivedescendant(t, ex[2].availableSelector, ex[2].optionSelector, lastOption);
   t.is(
-    await(await t.context.session.findElements(By.css(ex[2].optionSelector)))[lastOption]
+    await(await t.context.queryElements(t, ex[2].optionSelector))[lastOption]
       .getAttribute('aria-selected'),
     'false',
     'aria-selected is false when moving between options with END in example 2'
@@ -310,10 +299,9 @@ ariaTest('end moves focus and selects', exampleFile, 'key-end', async (t) => {
 });
 
 ariaTest('key space selects', exampleFile, 'key-space', async (t) => {
-  t.plan(19);
-
-  const listbox = (await t.context.session.findElements(By.css(ex[2].listboxSelector)))[0];
-  const options = await t.context.session.findElements(By.css(ex[2].optionSelector));
+  
+  const listbox = (await t.context.queryElements(t, ex[2].listboxSelector))[0];
+  const options = await t.context.queryElements(t, ex[2].optionSelector);
 
   // Put the focus on the first item, and selects item
   await t.context.session.findElement(By.css(ex[2].firstOptionSelector)).click();
@@ -321,7 +309,7 @@ ariaTest('key space selects', exampleFile, 'key-space', async (t) => {
   for (let index = 0; index < options.length - 1; index++) {
     await listbox.sendKeys(Key.ARROW_DOWN, Key.SPACE);
     t.is(
-      await(await t.context.session.findElements(By.css(ex[2].optionSelector)))[index + 1]
+      await(await t.context.queryElements(t, ex[2].optionSelector))[index + 1]
         .getAttribute('aria-selected'),
       'true',
       'aria-selected is true when sending space key to item at index: ' + (index + 1)
@@ -331,7 +319,7 @@ ariaTest('key space selects', exampleFile, 'key-space', async (t) => {
   for (let index = options.length - 1; index >= 0 ; index--) {
     await listbox.sendKeys(Key.SPACE);
     t.is(
-      await(await t.context.session.findElements(By.css(ex[2].optionSelector)))[index]
+      await(await t.context.queryElements(t, ex[2].optionSelector))[index]
         .getAttribute('aria-selected'),
       'false',
       'aria-selected is true when sending space key to item at index: ' + (index)
@@ -341,8 +329,7 @@ ariaTest('key space selects', exampleFile, 'key-space', async (t) => {
 });
 
 ariaTest('shift + click selects multiple options', exampleFile, 'key-shift-up-arrow', async (t) => {
-  const listbox = await t.context.session.findElement(By.css(ex[2].listboxSelector));
-  const options = await t.context.session.findElements(By.css(ex[2].optionSelector));
+  const options = await t.context.queryElements(t, ex[2].optionSelector);
 
   // Put the focus on the fourth item, and selects item
   await options[3].click();
@@ -369,7 +356,7 @@ ariaTest('shift + click selects multiple options', exampleFile, 'key-shift-up-ar
 
 ariaTest('key shift+down arrow moves focus and selects', exampleFile, 'key-shift-down-arrow', async (t) => {
   const listbox = await t.context.session.findElement(By.css(ex[2].listboxSelector));
-  const options = await t.context.session.findElements(By.css(ex[2].optionSelector));
+  const options = await t.context.queryElements(t, ex[2].optionSelector);
 
   // Put the focus on the first item, and selects item
   await t.context.session.findElement(By.css(ex[2].firstOptionSelector)).click();
@@ -389,7 +376,7 @@ ariaTest('key shift+down arrow moves focus and selects', exampleFile, 'key-shift
 
 ariaTest('key shift+down arrow overwrites previous selection', exampleFile, 'key-shift-down-arrow', async (t) => {
   const listbox = await t.context.session.findElement(By.css(ex[2].listboxSelector));
-  const options = await t.context.session.findElements(By.css(ex[2].optionSelector));
+  const options = await t.context.queryElements(t, ex[2].optionSelector);
 
   // Select first item
   await t.context.session.findElement(By.css(ex[2].firstOptionSelector)).click();
@@ -412,7 +399,7 @@ ariaTest('key shift+down arrow overwrites previous selection', exampleFile, 'key
 
 ariaTest('key shift+down arrow cannot move past last option', exampleFile, 'key-shift-down-arrow', async (t) => {
   const listbox = await t.context.session.findElement(By.css(ex[2].listboxSelector));
-  const options = await t.context.session.findElements(By.css(ex[2].optionSelector));
+  const options = await t.context.queryElements(t, ex[2].optionSelector);
 
   // Put the focus on the second to last item, and select item
   await t.context.session.findElement(By.css(`${ex[2].optionSelector}:nth-child(${options.length - 1})`)).click();
@@ -433,7 +420,7 @@ ariaTest('key shift+down arrow cannot move past last option', exampleFile, 'key-
 
 ariaTest('key shift+up arrow moves focus and selects', exampleFile, 'key-shift-up-arrow', async (t) => {
   const listbox = await t.context.session.findElement(By.css(ex[2].listboxSelector));
-  const options = await t.context.session.findElements(By.css(ex[2].optionSelector));
+  const options = await t.context.queryElements(t, ex[2].optionSelector);
 
   // Put the focus on the last item, and selects item
   await t.context.session.findElement(By.css(ex[2].lastOptionSelector)).click();
@@ -453,7 +440,7 @@ ariaTest('key shift+up arrow moves focus and selects', exampleFile, 'key-shift-u
 
 ariaTest('key shift+up arrow resets previous selection', exampleFile, 'key-shift-up-arrow', async (t) => {
   const listbox = await t.context.session.findElement(By.css(ex[2].listboxSelector));
-  const options = await t.context.session.findElements(By.css(ex[2].optionSelector));
+  const options = await t.context.queryElements(t, ex[2].optionSelector);
 
   // Select first item
   await t.context.session.findElement(By.css(ex[2].firstOptionSelector)).click();
@@ -476,7 +463,7 @@ ariaTest('key shift+up arrow resets previous selection', exampleFile, 'key-shift
 
 ariaTest('key shift+up arrow cannot move past first option', exampleFile, 'key-shift-up-arrow', async (t) => {
   const listbox = await t.context.session.findElement(By.css(ex[2].listboxSelector));
-  const options = await t.context.session.findElements(By.css(ex[2].optionSelector));
+  const options = await t.context.queryElements(t, ex[2].optionSelector);
 
   // Put the focus on the second item, and select item
   await t.context.session.findElement(By.css(`${ex[2].optionSelector}:nth-child(2)`)).click();
@@ -497,7 +484,7 @@ ariaTest('key shift+up arrow cannot move past first option', exampleFile, 'key-s
 
 ariaTest('key control+shift+home moves focus and selects all options', exampleFile, 'key-control-shift-home', async (t) => {
   const listbox = await t.context.session.findElement(By.css(ex[2].listboxSelector));
-  const options = await t.context.session.findElements(By.css(ex[2].optionSelector));
+  const options = await t.context.queryElements(t, ex[2].optionSelector);
 
   // Put the focus on the last item, and selects item
   await t.context.session.findElement(By.css(ex[2].lastOptionSelector)).click();
@@ -511,7 +498,7 @@ ariaTest('key control+shift+home moves focus and selects all options', exampleFi
 
 ariaTest('key control+shift+home moves focus and selects some options', exampleFile, 'key-control-shift-home', async (t) => {
   const listbox = await t.context.session.findElement(By.css(ex[2].listboxSelector));
-  const options = await t.context.session.findElements(By.css(ex[2].optionSelector));
+  const options = await t.context.queryElements(t, ex[2].optionSelector);
 
   // Put the focus on the 5th option, arrow up, then do home
   await t.context.session.findElement(By.css(`${ex[2].optionSelector}:nth-child(5)`)).click();
@@ -528,7 +515,7 @@ ariaTest('key control+shift+home moves focus and selects some options', exampleF
 
 ariaTest('key shift+home does not change selection', exampleFile, 'key-control-shift-home', async (t) => {
   const listbox = await t.context.session.findElement(By.css(ex[2].listboxSelector));
-  const options = await t.context.session.findElements(By.css(ex[2].optionSelector));
+  const options = await t.context.queryElements(t, ex[2].optionSelector);
 
   // Put the focus on the last option and select it
   await t.context.session.findElement(By.css(ex[2].lastOptionSelector)).click();
@@ -544,7 +531,7 @@ ariaTest('key shift+home does not change selection', exampleFile, 'key-control-s
 
 ariaTest('key control+shift+end moves focus and selects all options', exampleFile, 'key-control-shift-end', async (t) => {
   const listbox = await t.context.session.findElement(By.css(ex[2].listboxSelector));
-  const options = await t.context.session.findElements(By.css(ex[2].optionSelector));
+  const options = await t.context.queryElements(t, ex[2].optionSelector);
 
   // Put the focus on the first item, and selects item
   await t.context.session.findElement(By.css(ex[2].firstOptionSelector)).click();
@@ -558,7 +545,7 @@ ariaTest('key control+shift+end moves focus and selects all options', exampleFil
 
 ariaTest('key control+shift+end moves focus and selects some options', exampleFile, 'key-control-shift-end', async (t) => {
   const listbox = await t.context.session.findElement(By.css(ex[2].listboxSelector));
-  const options = await t.context.session.findElements(By.css(ex[2].optionSelector));
+  const options = await t.context.queryElements(t, ex[2].optionSelector);
 
   // Put the focus on the 3rd option, arrow down, then do end
   await t.context.session.findElement(By.css(`${ex[2].optionSelector}:nth-child(3)`)).click();
@@ -575,7 +562,7 @@ ariaTest('key control+shift+end moves focus and selects some options', exampleFi
 
 ariaTest('key shift+end does not change selection', exampleFile, 'key-control-shift-end', async (t) => {
   const listbox = await t.context.session.findElement(By.css(ex[2].listboxSelector));
-  const options = await t.context.session.findElements(By.css(ex[2].optionSelector));
+  const options = await t.context.queryElements(t, ex[2].optionSelector);
 
   // Put the focus on the first option and select it
   await t.context.session.findElement(By.css(ex[2].firstOptionSelector)).click();
@@ -591,7 +578,7 @@ ariaTest('key shift+end does not change selection', exampleFile, 'key-control-sh
 
 ariaTest('key control+A selects all options', exampleFile, 'key-control-a', async (t) => {
   const listbox = await t.context.session.findElement(By.css(ex[2].listboxSelector));
-  const options = await t.context.session.findElements(By.css(ex[2].optionSelector));
+  const options = await t.context.queryElements(t, ex[2].optionSelector);
 
   // click inside listbox
   await t.context.session.findElement(By.css(`${ex[2].optionSelector}:nth-child(2)`)).click();
@@ -606,7 +593,7 @@ ariaTest('key control+A selects all options', exampleFile, 'key-control-a', asyn
 
 ariaTest('A without control performs default focus move', exampleFile, 'key-control-a', async (t) => {
   const listbox = await t.context.session.findElement(By.css(ex[2].listboxSelector));
-  const options = await t.context.session.findElements(By.css(ex[2].optionSelector));
+  const options = await t.context.queryElements(t, ex[2].optionSelector);
   
   // get index of first option that begin with a
   const matchingOptions = [];
@@ -633,7 +620,7 @@ ariaTest('A without control performs default focus move', exampleFile, 'key-cont
 
 ariaTest('Control + A performs no action on single select listbox', exampleFile, 'key-control-a', async (t) => {
   const listbox = await t.context.session.findElement(By.css(ex[1].listboxSelector));
-  const options = await t.context.session.findElements(By.css(ex[1].optionSelector));
+  const options = await t.context.queryElements(t, ex[1].optionSelector);
 
   // click inside listbox
   await t.context.session.findElement(By.css(ex[1].firstOptionSelector)).click();

--- a/test/tests/listbox_scrollable.js
+++ b/test/tests/listbox_scrollable.js
@@ -20,28 +20,24 @@ const ex = {
 // Attributes
 
 ariaTest('role="listbox" on ul element', exampleFile, 'listbox-role', async (t) => {
-  t.plan(1);
-  await assertAriaRoles(t, 'ex', 'listbox', 1, 'ul');
+    await assertAriaRoles(t, 'ex', 'listbox', 1, 'ul');
 });
 
 ariaTest('"aria-labelledby" on listbox element', exampleFile, 'listbox-aria-labelledby', async (t) => {
-  t.plan(1);
-  await assertAriaLabelledby(t, ex.listboxSelector);
+    await assertAriaLabelledby(t, ex.listboxSelector);
 });
 
 ariaTest('tabindex="0" on listbox element', exampleFile, 'listbox-tabindex', async (t) => {
-  t.plan(1);
-  await assertAttributeValues(t, ex.listboxSelector, 'tabindex', '0');
+    await assertAttributeValues(t, ex.listboxSelector, 'tabindex', '0');
 });
 
 ariaTest('aria-activedescendant on listbox element', exampleFile, 'listbox-aria-activedescendant', async (t) => {
-  t.plan(1);
-
+  
   // Put the focus on the listbox. In this example, focusing on the listbox
   // will automatically select the first option.
   await t.context.session.findElement(By.css(ex.firstOptionSelector)).click();
 
-  let options = await t.context.session.findElements(By.css(ex.optionSelector));
+  let options = await t.context.queryElements(t, ex.optionSelector);
   let optionId = await options[0].getAttribute('id');
 
   t.is(
@@ -54,13 +50,11 @@ ariaTest('aria-activedescendant on listbox element', exampleFile, 'listbox-aria-
 });
 
 ariaTest('role="option" on li elements', exampleFile, 'option-role', async (t) => {
-  t.plan(1);
-  await assertAriaRoles(t, 'ex', 'option', 26, 'li');
+    await assertAriaRoles(t, 'ex', 'option', 26, 'li');
 });
 
 ariaTest('"aria-selected" on option elements', exampleFile, 'option-aria-selected', async (t) => {
-  t.plan(2);
-
+  
   await assertAttributeDNE(t, ex.optionSelector, 'aria-selected');
 
   // Put the focus on the listbox. In this example, focusing on the listbox
@@ -73,8 +67,7 @@ ariaTest('"aria-selected" on option elements', exampleFile, 'option-aria-selecte
 // Keys
 
 ariaTest('DOWN ARROW moves focus', exampleFile, 'key-down-arrow', async (t) => {
-  t.plan(2);
-
+  
   // Put the focus on the listbox. In this example, focusing on the listbox
   // will automatically select the first option.
   await t.context.session.findElement(By.css(ex.firstOptionSelector)).click();
@@ -115,8 +108,7 @@ ariaTest('END moves focus', exampleFile, 'key-end', async (t) => {
 });
 
 ariaTest('UP ARROW moves focus', exampleFile, 'key-up-arrow', async (t) => {
-  t.plan(2);
-
+  
   // Put the focus on the listbox. In this example, focusing on the listbox
   // will automatically select the first option.
   await t.context.session.findElement(By.css(ex.firstOptionSelector)).click();
@@ -140,8 +132,7 @@ ariaTest('UP ARROW moves focus', exampleFile, 'key-up-arrow', async (t) => {
 });
 
 ariaTest('HOME moves focus', exampleFile, 'key-home', async (t) => {
-  t.plan(2);
-
+  
   // Put the focus on the listbox. In this example, focusing on the listbox
   // will automatically select the first option.
   await t.context.session.findElement(By.css(ex.firstOptionSelector)).click();

--- a/test/tests/menu-button_actions-active-descendant.js
+++ b/test/tests/menu-button_actions-active-descendant.js
@@ -40,18 +40,15 @@ const openMenu = async function (t) {
 // Attributes
 
 ariaTest('"aria-haspopup" attribute on menu button', exampleFile, 'button-aria-haspopup', async (t) => {
-  t.plan(1);
-  await assertAttributeValues(t, ex.menubuttonSelector, 'aria-haspopup', 'true');
+    await assertAttributeValues(t, ex.menubuttonSelector, 'aria-haspopup', 'true');
 });
 
 ariaTest('"aria-controls" attribute on menu button', exampleFile, 'button-aria-controls', async (t) => {
-  t.plan(1);
-  await assertAriaControls(t, ex.menubuttonSelector);
+    await assertAriaControls(t, ex.menubuttonSelector);
 });
 
 ariaTest('"aria-expanded" attribute on menu button', exampleFile, 'button-aria-expanded', async (t) => {
-  t.plan(4);
-
+  
   const hasAttribute = await t.context.session.executeScript(function () {
     selector = arguments[0];
     return document.querySelector(selector).hasAttribute('aria-expanded');
@@ -78,38 +75,32 @@ ariaTest('"aria-expanded" attribute on menu button', exampleFile, 'button-aria-e
 });
 
 ariaTest('role="menu" on ul element', exampleFile, 'menu-role', async (t) => {
-  t.plan(1);
-  await assertAriaRoles(t, 'ex1', 'menu', 1, 'ul');
+    await assertAriaRoles(t, 'ex1', 'menu', 1, 'ul');
 });
 
 ariaTest('"aria-labelledby" on role="menu"', exampleFile, 'menu-aria-labelledby', async (t) => {
-  t.plan(1);
-  await assertAriaLabelledby(t, ex.menuSelector);
+    await assertAriaLabelledby(t, ex.menuSelector);
 });
 
 // This test fails due to bug: https://github.com/w3c/aria-practices/issues/894
 ariaTest.failing('tabindex="-1" on role="menu"', exampleFile, 'menu-tabindex', async (t) => {
-  t.plan(1);
-  await openMenu(t);
+    await openMenu(t);
   await assertAttributeValues(t, ex.menuSelector, 'tabindex', '-1');
 });
 
 ariaTest('aria-activedescendant on role="menu"', exampleFile, 'menu-aria-activedescendant', async (t) => {
-  t.plan(1);
-  await assertAttributeValues(t, ex.menuSelector, 'aria-activedescendant', ex.defaultAriaActivedescendantVal);
+    await assertAttributeValues(t, ex.menuSelector, 'aria-activedescendant', ex.defaultAriaActivedescendantVal);
 });
 
 ariaTest('role="menuitem" on li element', exampleFile, 'menuitem-role', async (t) => {
-  t.plan(1);
-  await assertAriaRoles(t, 'ex1', 'menuitem', ex.numMenuitems, 'li');
+    await assertAriaRoles(t, 'ex1', 'menuitem', ex.numMenuitems, 'li');
 });
 
 
 // Keys
 
 ariaTest('"enter" on menu button', exampleFile, 'button-down-arrow-or-space-or-enter', async (t) => {
-  t.plan(2);
-
+  
   await t.context.session
     .findElement(By.css(ex.menubuttonSelector))
     .sendKeys(Key.ENTER);
@@ -123,8 +114,7 @@ ariaTest('"enter" on menu button', exampleFile, 'button-down-arrow-or-space-or-e
 });
 
 ariaTest('"down arrow" on menu button', exampleFile, 'button-down-arrow-or-space-or-enter', async (t) => {
-  t.plan(2);
-
+  
   await t.context.session
     .findElement(By.css(ex.menubuttonSelector))
     .sendKeys(Key.ARROW_DOWN);
@@ -138,8 +128,7 @@ ariaTest('"down arrow" on menu button', exampleFile, 'button-down-arrow-or-space
 });
 
 ariaTest('"space" on menu button', exampleFile, 'button-down-arrow-or-space-or-enter', async (t) => {
-  t.plan(2);
-
+  
   await t.context.session
     .findElement(By.css(ex.menubuttonSelector))
     .sendKeys(Key.SPACE);
@@ -153,8 +142,7 @@ ariaTest('"space" on menu button', exampleFile, 'button-down-arrow-or-space-or-e
 });
 
 ariaTest('"up arrow" on menu button', exampleFile, 'button-up-arrow', async (t) => {
-  t.plan(2);
-
+  
   await t.context.session
     .findElement(By.css(ex.menubuttonSelector))
     .sendKeys(Key.ARROW_UP);
@@ -168,10 +156,9 @@ ariaTest('"up arrow" on menu button', exampleFile, 'button-up-arrow', async (t) 
 });
 
 ariaTest('"enter" on role="menu"', exampleFile, 'menu-enter', async (t) => {
-  t.plan(12);
-
+  
   const menu = await t.context.session.findElement(By.css(ex.menuSelector));
-  const items = await t.context.session.findElements(By.css(ex.menuitemSelector));
+  const items = await t.context.queryElements(t, ex.menuitemSelector);
 
   // Select the FIRST item: Send ENTER to the menu while aria-activedescendant is the first item
 
@@ -263,10 +250,9 @@ ariaTest('"enter" on role="menu"', exampleFile, 'menu-enter', async (t) => {
 });
 
 ariaTest('"escape" on role="menu"', exampleFile, 'menu-escape', async (t) => {
-  t.plan(12);
-
+  
   const menu = await t.context.session.findElement(By.css(ex.menuSelector));
-  const items = await t.context.session.findElements(By.css(ex.menuitemSelector));
+  const items = await t.context.queryElements(t, ex.menuitemSelector);
   for (let item of items) {
 
     await openMenu(t);
@@ -292,11 +278,10 @@ ariaTest('"escape" on role="menu"', exampleFile, 'menu-escape', async (t) => {
 });
 
 ariaTest('"down arrow" on role="menu"', exampleFile, 'menu-down-arrow', async (t) => {
-  t.plan(4);
-
+  
   await openMenu(t);
   const menu = await t.context.session.findElement(By.css(ex.menuSelector));
-  const items = await t.context.session.findElements(By.css(ex.menuitemSelector));
+  const items = await t.context.queryElements(t, ex.menuitemSelector);
 
   for (let index = 0; index < items.length - 1; index++) {
 
@@ -309,11 +294,10 @@ ariaTest('"down arrow" on role="menu"', exampleFile, 'menu-down-arrow', async (t
 });
 
 ariaTest('"up arrow" on role="menu"', exampleFile, 'menu-up-arrow', async (t) => {
-  t.plan(4);
-
+  
   await openMenu(t);
   const menu = await t.context.session.findElement(By.css(ex.menuSelector));
-  const items = await t.context.session.findElements(By.css(ex.menuitemSelector));
+  const items = await t.context.queryElements(t, ex.menuitemSelector);
 
   await menu.sendKeys(Key.ARROW_UP);
   await assertAriaActivedescendant(t, ex.menuSelector, ex.menuitemSelector, ex.numMenuitems - 1);
@@ -327,10 +311,9 @@ ariaTest('"up arrow" on role="menu"', exampleFile, 'menu-up-arrow', async (t) =>
 });
 
 ariaTest('"home" on role="menu"', exampleFile, 'menu-home', async (t) => {
-  t.plan(4);
-
+  
   const menu = await t.context.session.findElement(By.css(ex.menuSelector));
-  const items = await t.context.session.findElements(By.css(ex.menuitemSelector));
+  const items = await t.context.queryElements(t, ex.menuitemSelector);
   await openMenu(t);
 
   // Send HOME to the menu while aria-activedescendant is the first item
@@ -355,10 +338,9 @@ ariaTest('"home" on role="menu"', exampleFile, 'menu-home', async (t) => {
 });
 
 ariaTest('"end" on role="menu"', exampleFile, 'menu-end', async (t) => {
-  t.plan(4);
-
+  
   const menu = await t.context.session.findElement(By.css(ex.menuSelector));
-  const items = await t.context.session.findElements(By.css(ex.menuitemSelector));
+  const items = await t.context.queryElements(t, ex.menuitemSelector);
   const last =  ex.numMenuitems - 1;
   await openMenu(t);
 
@@ -384,8 +366,7 @@ ariaTest('"end" on role="menu"', exampleFile, 'menu-end', async (t) => {
 });
 
 ariaTest('"character" on role="menu"', exampleFile, 'menu-character', async (t) => {
-  t.plan(4);
-
+  
   const charIndexTest = [
     { sendChar: 'x', sendIndex: 0, endIndex: 0 },
     { sendChar: 'a', sendIndex: 0, endIndex: 1 },

--- a/test/tests/menu-button_actions.js
+++ b/test/tests/menu-button_actions.js
@@ -34,18 +34,15 @@ const openMenu = async function (t) {
 // Attributes
 
 ariaTest('"aria-haspopup" attribute on menu button', exampleFile, 'menu-button-aria-haspopup', async (t) => {
-  t.plan(1);
-  await assertAttributeValues(t, ex.menubuttonSelector, 'aria-haspopup', 'true');
+    await assertAttributeValues(t, ex.menubuttonSelector, 'aria-haspopup', 'true');
 });
 
 ariaTest('"aria-controls" attribute on menu button', exampleFile, 'menu-button-aria-controls', async (t) => {
-  t.plan(1);
-  await assertAriaControls(t, ex.menubuttonSelector);
+    await assertAriaControls(t, ex.menubuttonSelector);
 });
 
 ariaTest('"aria-expanded" attribute on menu button', exampleFile, 'menu-button-aria-expanded', async (t) => {
-  t.plan(4);
-
+  
   const hasAttribute = await t.context.session.executeScript(function () {
     selector = arguments[0];
     return document.querySelector(selector).hasAttribute('aria-expanded');
@@ -72,31 +69,26 @@ ariaTest('"aria-expanded" attribute on menu button', exampleFile, 'menu-button-a
 });
 
 ariaTest('role="menu" on ul element', exampleFile, 'menu-role', async (t) => {
-  t.plan(1);
-  await assertAriaRoles(t, 'ex1', 'menu', 1, 'ul');
+    await assertAriaRoles(t, 'ex1', 'menu', 1, 'ul');
 });
 
 ariaTest('"aria-labelledby" on role="menu"', exampleFile, 'menu-aria-labelledby', async (t) => {
-  t.plan(1);
-  await assertAriaLabelledby(t, ex.menuSelector);
+    await assertAriaLabelledby(t, ex.menuSelector);
 });
 
 ariaTest('role="menuitem" on li element', exampleFile, 'menuitem-role', async (t) => {
-  t.plan(1);
-  await assertAriaRoles(t, 'ex1', 'menuitem', ex.numMenuitems, 'li');
+    await assertAriaRoles(t, 'ex1', 'menuitem', ex.numMenuitems, 'li');
 });
 
 ariaTest('tabindex="-1" on role="menuitem"', exampleFile, 'menuitem-tabindex', async (t) => {
-  t.plan(1);
-  await assertAttributeValues(t, ex.menuitemSelector, 'tabindex', '-1');
+    await assertAttributeValues(t, ex.menuitemSelector, 'tabindex', '-1');
 });
 
 
 // Keys
 
 ariaTest('"enter" on menu button', exampleFile, 'menu-button-key-open', async (t) => {
-  t.plan(2);
-
+  
   await t.context.session
     .findElement(By.css(ex.menubuttonSelector))
     .sendKeys(Key.ENTER);
@@ -113,8 +105,7 @@ ariaTest('"enter" on menu button', exampleFile, 'menu-button-key-open', async (t
 });
 
 ariaTest('"down arrow" on menu button', exampleFile, 'menu-button-key-open', async (t) => {
-  t.plan(2);
-
+  
   await t.context.session
     .findElement(By.css(ex.menubuttonSelector))
     .sendKeys(Key.ARROW_DOWN);
@@ -131,8 +122,7 @@ ariaTest('"down arrow" on menu button', exampleFile, 'menu-button-key-open', asy
 });
 
 ariaTest('"space" on menu button', exampleFile, 'menu-button-key-open', async (t) => {
-  t.plan(2);
-
+  
   await t.context.session
     .findElement(By.css(ex.menubuttonSelector))
     .sendKeys(Key.SPACE);
@@ -149,8 +139,7 @@ ariaTest('"space" on menu button', exampleFile, 'menu-button-key-open', async (t
 });
 
 ariaTest('"up arrow" on menu button', exampleFile, 'menu-button-key-up-arrow', async (t) => {
-  t.plan(2);
-
+  
   await t.context.session
     .findElement(By.css(ex.menubuttonSelector))
     .sendKeys(Key.ARROW_UP);
@@ -167,9 +156,8 @@ ariaTest('"up arrow" on menu button', exampleFile, 'menu-button-key-up-arrow', a
 });
 
 ariaTest('"enter" on role="menuitem"', exampleFile, 'menu-key-enter', async (t) => {
-  t.plan(12);
-
-  const items = await t.context.session.findElements(By.css(ex.menuitemSelector));
+  
+  const items = await t.context.queryElements(t, ex.menuitemSelector);
   for (let item of items) {
 
     await openMenu(t);
@@ -195,9 +183,8 @@ ariaTest('"enter" on role="menuitem"', exampleFile, 'menu-key-enter', async (t) 
 });
 
 ariaTest('"escape" on role="menuitem"', exampleFile, 'menu-key-escape', async (t) => {
-  t.plan(12);
-
-  const items = await t.context.session.findElements(By.css(ex.menuitemSelector));
+  
+  const items = await t.context.queryElements(t, ex.menuitemSelector);
   for (let item of items) {
 
     await openMenu(t);
@@ -223,11 +210,10 @@ ariaTest('"escape" on role="menuitem"', exampleFile, 'menu-key-escape', async (t
 });
 
 ariaTest('"down arrow" on role="menuitem"', exampleFile, 'menu-key-down-arrow', async (t) => {
-  t.plan(4);
-
+  
   await openMenu(t);
 
-  const items = await t.context.session.findElements(By.css(ex.menuitemSelector));
+  const items = await t.context.queryElements(t, ex.menuitemSelector);
   for (let index = 0; index < items.length - 1; index++) {
 
     await items[index].sendKeys(Key.ARROW_DOWN);
@@ -250,11 +236,10 @@ ariaTest('"down arrow" on role="menuitem"', exampleFile, 'menu-key-down-arrow', 
 });
 
 ariaTest('"up arrow" on role="menuitem"', exampleFile, 'menu-key-up-arrow', async (t) => {
-  t.plan(4);
-
+  
   await openMenu(t);
 
-  const items = await t.context.session.findElements(By.css(ex.menuitemSelector));
+  const items = await t.context.queryElements(t, ex.menuitemSelector);
 
   await items[0].sendKeys(Key.ARROW_UP);
 
@@ -278,11 +263,10 @@ ariaTest('"up arrow" on role="menuitem"', exampleFile, 'menu-key-up-arrow', asyn
 });
 
 ariaTest('"home" on role="menuitem"', exampleFile, 'menu-key-home', async (t) => {
-  t.plan(4);
-
+  
   await openMenu(t);
 
-  const items = await t.context.session.findElements(By.css(ex.menuitemSelector));
+  const items = await t.context.queryElements(t, ex.menuitemSelector);
   for (let index = 0; index < items.length; index++) {
 
     await items[index].sendKeys(Key.HOME);
@@ -297,11 +281,10 @@ ariaTest('"home" on role="menuitem"', exampleFile, 'menu-key-home', async (t) =>
 });
 
 ariaTest('"end" on role="menuitem"', exampleFile, 'menu-key-end', async (t) => {
-  t.plan(4);
-
+  
   await openMenu(t);
 
-  const items = await t.context.session.findElements(By.css(ex.menuitemSelector));
+  const items = await t.context.queryElements(t, ex.menuitemSelector);
   for (let index = 0; index < items.length; index++) {
 
     await items[index].sendKeys(Key.END);
@@ -315,8 +298,7 @@ ariaTest('"end" on role="menuitem"', exampleFile, 'menu-key-end', async (t) => {
 });
 
 ariaTest('"character" on role="menuitem"', exampleFile, 'menu-key-character', async (t) => {
-  t.plan(4);
-
+  
   const charIndexTest = [
     { sendChar: 'x', sendIndex: 0, endIndex: 0 },
     { sendChar: 'a', sendIndex: 0, endIndex: 1 },
@@ -325,7 +307,7 @@ ariaTest('"character" on role="menuitem"', exampleFile, 'menu-key-character', as
   ];
 
   await openMenu(t);
-  const items = await t.context.session.findElements(By.css(ex.menuitemSelector));
+  const items = await t.context.queryElements(t, ex.menuitemSelector);
 
   for (let test of charIndexTest) {
     await items[test.sendIndex].sendKeys(test.sendChar);

--- a/test/tests/menu-button_links.js
+++ b/test/tests/menu-button_links.js
@@ -61,18 +61,15 @@ const waitForNoAriaExpanded = async function (t) {
 // Attributes
 
 ariaTest('"aria-haspopup" attribute on menu button', exampleFile, 'button-aria-haspopup', async (t) => {
-  t.plan(1);
-  await assertAttributeValues(t, ex.menubuttonSelector, 'aria-haspopup', 'true');
+    await assertAttributeValues(t, ex.menubuttonSelector, 'aria-haspopup', 'true');
 });
 
 ariaTest('"aria-controls" attribute on menu button', exampleFile, 'button-aria-controls', async (t) => {
-  t.plan(1);
-  await assertAriaControls(t, ex.menubuttonSelector);
+    await assertAriaControls(t, ex.menubuttonSelector);
 });
 
 ariaTest('"aria-expanded" attribute on menu button', exampleFile, 'button-aria-expanded', async (t) => {
-  t.plan(4);
-
+  
   const hasAttribute = await t.context.session.executeScript(function () {
     selector = arguments[0];
     return document.querySelector(selector).hasAttribute('aria-expanded');
@@ -99,36 +96,30 @@ ariaTest('"aria-expanded" attribute on menu button', exampleFile, 'button-aria-e
 });
 
 ariaTest('role="menu" on ul element', exampleFile, 'menu-role', async (t) => {
-  t.plan(1);
-  await assertAriaRoles(t, 'ex1', 'menu', 1, 'ul');
+    await assertAriaRoles(t, 'ex1', 'menu', 1, 'ul');
 });
 
 ariaTest('"aria-labelledby" on role="menu"', exampleFile, 'menu-aria-labelledby', async (t) => {
-  t.plan(1);
-  await assertAriaLabelledby(t, ex.menuSelector);
+    await assertAriaLabelledby(t, ex.menuSelector);
 });
 
 ariaTest('role="none" on li element', exampleFile, 'none-role', async (t) => {
-  t.plan(1);
-  await assertAriaRoles(t, 'ex1', 'none', ex.numMenuitems, 'li');
+    await assertAriaRoles(t, 'ex1', 'none', ex.numMenuitems, 'li');
 });
 
 ariaTest('role="menuitem" on a element', exampleFile, 'menuitem-role', async (t) => {
-  t.plan(1);
-  await assertAriaRoles(t, 'ex1', 'menuitem', ex.numMenuitems, 'a');
+    await assertAriaRoles(t, 'ex1', 'menuitem', ex.numMenuitems, 'a');
 });
 
 ariaTest('tabindex="-1" on role="menuitem"', exampleFile, 'menuitem-tabindex', async (t) => {
-  t.plan(1);
-  await assertAttributeValues(t, ex.menuitemSelector, 'tabindex', '-1');
+    await assertAttributeValues(t, ex.menuitemSelector, 'tabindex', '-1');
 });
 
 
 // Keys
 
 ariaTest('"enter" on menu button', exampleFile, 'button-down-arrow-or-space-or-enter', async (t) => {
-  t.plan(2);
-
+  
   await t.context.session
     .findElement(By.css(ex.menubuttonSelector))
     .sendKeys(Key.ENTER);
@@ -145,8 +136,7 @@ ariaTest('"enter" on menu button', exampleFile, 'button-down-arrow-or-space-or-e
 });
 
 ariaTest('"down arrow" on menu button', exampleFile, 'button-down-arrow-or-space-or-enter', async (t) => {
-  t.plan(2);
-
+  
   await t.context.session
     .findElement(By.css(ex.menubuttonSelector))
     .sendKeys(Key.ARROW_DOWN);
@@ -163,8 +153,7 @@ ariaTest('"down arrow" on menu button', exampleFile, 'button-down-arrow-or-space
 });
 
 ariaTest('"space" on menu button', exampleFile, 'button-down-arrow-or-space-or-enter', async (t) => {
-  t.plan(2);
-
+  
   await t.context.session
     .findElement(By.css(ex.menubuttonSelector))
     .sendKeys(Key.SPACE);
@@ -181,8 +170,7 @@ ariaTest('"space" on menu button', exampleFile, 'button-down-arrow-or-space-or-e
 });
 
 ariaTest('"up arrow" on menu button', exampleFile, 'button-up-arrow', async (t) => {
-  t.plan(2);
-
+  
   await t.context.session
     .findElement(By.css(ex.menubuttonSelector))
     .sendKeys(Key.ARROW_UP);
@@ -199,13 +187,12 @@ ariaTest('"up arrow" on menu button', exampleFile, 'button-up-arrow', async (t) 
 });
 
 ariaTest('"enter" on role="menuitem"', exampleFile, 'menu-enter', async (t) => {
-  t.plan(6);
-
+  
   for (let index = 0; index < ex.numMenuitems; index++) {
 
     // Return to test page
     await t.context.session.get(t.context.url);
-    const item = (await t.context.session.findElements(By.css(ex.menuitemSelector)))[index];
+    const item = (await t.context.queryElements(t, ex.menuitemSelector))[index];
 
     await openMenu(t);
     await item.sendKeys(Key.ENTER);
@@ -220,9 +207,8 @@ ariaTest('"enter" on role="menuitem"', exampleFile, 'menu-enter', async (t) => {
 });
 
 ariaTest('"escape" on role="menuitem"', exampleFile, 'menu-escape', async (t) => {
-  t.plan(12);
-
-  const items = await t.context.session.findElements(By.css(ex.menuitemSelector));
+  
+  const items = await t.context.queryElements(t, ex.menuitemSelector);
   for (let index = 0; index < ex.numMenuitems; index++) {
     const item = items[index];
 
@@ -244,11 +230,10 @@ ariaTest('"escape" on role="menuitem"', exampleFile, 'menu-escape', async (t) =>
 });
 
 ariaTest('"down arrow" on role="menuitem"', exampleFile, 'menu-down-arrow', async (t) => {
-  t.plan(6);
-
+  
   await openMenu(t);
 
-  const items = await t.context.session.findElements(By.css(ex.menuitemSelector));
+  const items = await t.context.queryElements(t, ex.menuitemSelector);
   for (let index = 0; index < items.length - 1; index++) {
 
     await items[index].sendKeys(Key.ARROW_DOWN);
@@ -271,11 +256,10 @@ ariaTest('"down arrow" on role="menuitem"', exampleFile, 'menu-down-arrow', asyn
 });
 
 ariaTest('"up arrow" on role="menuitem"', exampleFile, 'menu-up-arrow', async (t) => {
-  t.plan(6);
-
+  
   await openMenu(t);
 
-  const items = await t.context.session.findElements(By.css(ex.menuitemSelector));
+  const items = await t.context.queryElements(t, ex.menuitemSelector);
 
   await items[0].sendKeys(Key.ARROW_UP);
 
@@ -299,11 +283,10 @@ ariaTest('"up arrow" on role="menuitem"', exampleFile, 'menu-up-arrow', async (t
 });
 
 ariaTest('"home" on role="menuitem"', exampleFile, 'menu-home', async (t) => {
-  t.plan(6);
-
+  
   await openMenu(t);
 
-  const items = await t.context.session.findElements(By.css(ex.menuitemSelector));
+  const items = await t.context.queryElements(t, ex.menuitemSelector);
   for (let index = 0; index < items.length; index++) {
 
     await items[index].sendKeys(Key.HOME);
@@ -318,11 +301,10 @@ ariaTest('"home" on role="menuitem"', exampleFile, 'menu-home', async (t) => {
 });
 
 ariaTest('"end" on role="menuitem"', exampleFile, 'menu-end', async (t) => {
-  t.plan(6);
-
+  
   await openMenu(t);
 
-  const items = await t.context.session.findElements(By.css(ex.menuitemSelector));
+  const items = await t.context.queryElements(t, ex.menuitemSelector);
   for (let index = 0; index < items.length; index++) {
 
     await items[index].sendKeys(Key.END);
@@ -336,8 +318,7 @@ ariaTest('"end" on role="menuitem"', exampleFile, 'menu-end', async (t) => {
 });
 
 ariaTest('"character" on role="menuitem"', exampleFile, 'menu-character', async (t) => {
-  t.plan(4);
-
+  
   const charIndexTest = [
     { sendChar: 'a', sendIndex: 0, endIndex: 2 },
     { sendChar: 'w', sendIndex: 2, endIndex: 3 },
@@ -346,7 +327,7 @@ ariaTest('"character" on role="menuitem"', exampleFile, 'menu-character', async 
   ];
 
   await openMenu(t);
-  const items = await t.context.session.findElements(By.css(ex.menuitemSelector));
+  const items = await t.context.queryElements(t, ex.menuitemSelector);
 
   for (let test of charIndexTest) {
     await items[test.sendIndex].sendKeys(test.sendChar);

--- a/test/tests/menubar_menubar-1.js
+++ b/test/tests/menubar_menubar-1.js
@@ -58,11 +58,11 @@ const getSubmenuMenuitemSelector = function (menuIndex, menuitemIndex) {
 
 const openSubmenu = async function (t, menuIndex, menuitemIndex) {
   // Send ARROW_DOWN to open menu
-  const menubaritems = await t.context.session.findElements(By.css(ex.menubarMenuitemSelector));
+  const menubaritems = await t.context.queryElements(t, ex.menubarMenuitemSelector);
   await menubaritems[menuIndex].sendKeys(Key.ARROW_DOWN);
 
   // Get the menuitems for that menu and send ARROW_RIGHT to open the submenu
-  const menuitems = await t.context.session.findElements(By.css(ex.menuMenuitemSelectors[menuIndex]));
+  const menuitems = await t.context.queryElements(t, ex.menuMenuitemSelectors[menuIndex]);
   await menuitems[menuitemIndex].sendKeys(Key.ARROW_RIGHT);
   return;
 };
@@ -79,7 +79,7 @@ const exampleInitialized = async function (t) {
   const initializedSelector = ex.menubarMenuitemSelector + '[tabindex="0"]';
 
   await t.context.session.wait(async function () {
-    const els = await t.context.session.findElements(By.css(initializedSelector));
+    const els = await t.context.queryElements(t, initializedSelector);
     return els.length === 1;
   }, t.context.waitTime, 'Timeout waiting for example to initialize');
 };
@@ -108,19 +108,16 @@ const doesMenuitemHaveSubmenu = function (menuIndex, menuitemIndex) {
 // Attributes
 
 ariaTest('Test for role="menubar" on ul', exampleFile, 'menubar-role', async (t) => {
-  t.plan(1);
-  await assertAriaRoles(t, 'ex1', 'menubar', 1, 'ul');
+    await assertAriaRoles(t, 'ex1', 'menubar', 1, 'ul');
 });
 
 ariaTest('Test aria-label on menubar', exampleFile, 'menubar-aria-label', async (t) => {
-  t.plan(1);
-  await assertAriaLabelExists(t, ex.menubarSelector);
+    await assertAriaLabelExists(t, ex.menubarSelector);
 });
 
 ariaTest('Test for role="menuitem" in menubar', exampleFile, 'menuitem-role', async (t) => {
-  t.plan(4);
-
-  const menuitems = await t.context.session.findElements(By.css(ex.menubarMenuitemSelector));
+  
+  const menuitems = await t.context.queryElements(t, ex.menubarMenuitemSelector);
 
   t.is(
     menuitems.length,
@@ -138,8 +135,7 @@ ariaTest('Test for role="menuitem" in menubar', exampleFile, 'menuitem-role', as
 
 ariaTest('Test roving tabindex', exampleFile, 'menuitem-tabindex', async (t) => {
 
-  t.plan(1);
-
+  
   // Wait for roving tabindex to be initialized by the javascript
   await exampleInitialized(t);
 
@@ -149,19 +145,17 @@ ariaTest('Test roving tabindex', exampleFile, 'menuitem-tabindex', async (t) => 
 ariaTest('Test aria-haspopup set to true on menuitems',
   exampleFile, 'menuitem-aria-haspopup', async (t) => {
 
-    t.plan(1);
-
+    
     await assertAttributeValues(t, ex.menubarMenuitemSelector, 'aria-haspopup', 'true');
   });
 
 ariaTest('"aria-expanded" attribute on menubar menuitem', exampleFile, 'menuitem-aria-expanded', async (t) => {
-  t.plan(22);
-
+  
   // Before interating with page, make sure aria-expanded is set to false
   await assertAttributeValues(t, ex.menubarMenuitemSelector, 'aria-expanded', 'false');
 
   // AND make sure no submenus are visible
-  const submenus = await t.context.session.findElements(By.css(ex.menuSelector));
+  const submenus = await t.context.queryElements(t, ex.menuSelector);
   for (let submenu of submenus) {
     t.false(
       await submenu.isDisplayed(),
@@ -169,7 +163,7 @@ ariaTest('"aria-expanded" attribute on menubar menuitem', exampleFile, 'menuitem
     );
   }
 
-  const menuitems = await t.context.session.findElements(By.css(ex.menubarMenuitemSelector));
+  const menuitems = await t.context.queryElements(t, ex.menubarMenuitemSelector);
 
   for (let menuIndex = 0; menuIndex < menuitems.length; menuIndex++) {
 
@@ -202,9 +196,8 @@ ariaTest('"aria-expanded" attribute on menubar menuitem', exampleFile, 'menuitem
 });
 
 ariaTest('Test for role="none" on menubar li', exampleFile, 'none-role', async (t) => {
-  t.plan(3);
-
-  const liElements = await t.context.session.findElements(By.css(ex.menubarSelector + '>li'));
+  
+  const liElements = await t.context.queryElements(t, ex.menubarSelector + '>li');
 
   for (let liElement of liElements) {
     t.is(
@@ -216,20 +209,17 @@ ariaTest('Test for role="none" on menubar li', exampleFile, 'none-role', async (
 });
 
 ariaTest('Test for role="menu" on ul', exampleFile, 'menu-role', async (t) => {
-  t.plan(1);
-  await assertAriaRoles(t, 'ex1', 'menu', ex.numTotalMenus, 'ul');
+    await assertAriaRoles(t, 'ex1', 'menu', ex.numTotalMenus, 'ul');
 });
 
 ariaTest('Test for aria-label on role="menu"', exampleFile, 'menu-aria-label', async (t) => {
-  t.plan(1);
-  await assertAriaLabelExists(t, ex.anyMenuSelector);
+    await assertAriaLabelExists(t, ex.anyMenuSelector);
 });
 
 ariaTest('Test for submenu role="menuitem"s with accessible names', exampleFile, 'sub-menuitem-role', async (t) => {
 
-  t.plan(28);
-
-  const menuitems = await t.context.session.findElements(By.css(ex.anyMenuMenuitemSelector));
+  
+  const menuitems = await t.context.queryElements(t, ex.anyMenuMenuitemSelector);
 
   t.truthy(
     menuitems.length,
@@ -254,17 +244,15 @@ ariaTest('Test for submenu role="menuitem"s with accessible names', exampleFile,
 });
 
 ariaTest('Test tabindex="-1" on submenu role="menuitem"s', exampleFile, 'sub-menuitem-tabindex', async (t) => {
-  t.plan(1);
-  await assertAttributeValues(t, ex.anyMenuMenuitemSelector, 'tabindex', '-1');
+    await assertAttributeValues(t, ex.anyMenuMenuitemSelector, 'tabindex', '-1');
 });
 
 ariaTest('Test aria-haspopup on menuitems with submenus', exampleFile, 'sub-menuitem-aria-haspopup', async (t) => {
-  t.plan(18);
-
-  const menubarMenuitems = await t.context.session.findElements(By.css(ex.menubarMenuitemSelector));
+  
+  const menubarMenuitems = await t.context.queryElements(t, ex.menubarMenuitemSelector);
 
   for (let menuIndex = 0; menuIndex < ex.numMenus; menuIndex++) {
-    const menuItems = await t.context.session.findElements(By.css(ex.menuMenuitemSelectors[menuIndex]));
+    const menuItems = await t.context.queryElements(t, ex.menuMenuitemSelectors[menuIndex]);
 
     for (let menuitemIndex = 0; menuitemIndex < menuItems.length; menuitemIndex++) {
       const menuitemHasSubmenu = doesMenuitemHaveSubmenu(menuIndex, menuitemIndex);
@@ -285,9 +273,8 @@ ariaTest('Test aria-haspopup on menuitems with submenus', exampleFile, 'sub-menu
 });
 
 ariaTest('Test aria-expanded on menuitems with submenus', exampleFile, 'sub-menuitem-aria-expanded', async (t) => {
-  t.plan(12);
-
-  const menubarMenuitems = await t.context.session.findElements(By.css(ex.menubarMenuitemSelector));
+  
+  const menubarMenuitems = await t.context.queryElements(t, ex.menubarMenuitemSelector);
 
   for (let submenuLocation of ex.submenuLocations) {
     const [menuIndex, menuitemIndex] = submenuLocation;
@@ -296,7 +283,7 @@ ariaTest('Test aria-expanded on menuitems with submenus', exampleFile, 'sub-menu
     await menubarMenuitems[menuIndex].sendKeys(Key.ARROW_DOWN);
 
     // Get the menuitems for that menu
-    const menuitems = await t.context.session.findElements(By.css(ex.menuMenuitemSelectors[menuIndex]));
+    const menuitems = await t.context.queryElements(t, ex.menuMenuitemSelectors[menuIndex]);
 
     // Get the submenu associate with the menuitem we are testing
     const submenuSelector = getSubmenuSelector(menuIndex, menuitemIndex);
@@ -332,9 +319,8 @@ ariaTest('Test aria-expanded on menuitems with submenus', exampleFile, 'sub-menu
 });
 
 ariaTest('Test for role="none" on menu lis', exampleFile, 'sub-none-role', async (t) => {
-  t.plan(27);
-
-  const liElements = await t.context.session.findElements(By.css(ex.anyMenuSelector + '>li'));
+  
+  const liElements = await t.context.queryElements(t, ex.anyMenuSelector + '>li');
 
   for (let liElement of liElements) {
     if (await liElement.getAttribute('role') !== 'separator') {
@@ -351,10 +337,9 @@ ariaTest('Test for role="none" on menu lis', exampleFile, 'sub-none-role', async
 // KEYS
 
 ariaTest('Key ENTER open submenu', exampleFile, 'menubar-space-or-enter', async (t) => {
-  t.plan(6);
-
-  const menuitems = await t.context.session.findElements(By.css(ex.menubarMenuitemSelector));
-  const menus = await t.context.session.findElements(By.css(ex.menuSelector));
+  
+  const menuitems = await t.context.queryElements(t, ex.menubarMenuitemSelector);
+  const menus = await t.context.queryElements(t, ex.menuSelector);
   for (let menuIndex = 0; menuIndex < ex.numMenus; menuIndex++) {
 
     // Send the ENTER key
@@ -375,10 +360,9 @@ ariaTest('Key ENTER open submenu', exampleFile, 'menubar-space-or-enter', async 
 
 
 ariaTest('Key SPACE open submenu', exampleFile, 'menubar-space-or-enter', async (t) => {
-  t.plan(6);
-
-  const menubaritems = await t.context.session.findElements(By.css(ex.menubarMenuitemSelector));
-  const menus = await t.context.session.findElements(By.css(ex.menuSelector));
+  
+  const menubaritems = await t.context.queryElements(t, ex.menubarMenuitemSelector);
+  const menus = await t.context.queryElements(t, ex.menuSelector);
   for (let menuIndex = 0; menuIndex < ex.numMenus; menuIndex++) {
 
     // Send the SPACE key
@@ -401,9 +385,8 @@ ariaTest('Key SPACE open submenu', exampleFile, 'menubar-space-or-enter', async 
 ariaTest('Key ARROW_RIGHT moves focus to next menubar item',
   exampleFile, 'menubar-right-arrow', async (t) => {
 
-    t.plan(4);
-
-    const menubaritems = await t.context.session.findElements(By.css(ex.menubarMenuitemSelector));
+    
+    const menubaritems = await t.context.queryElements(t, ex.menubarMenuitemSelector);
 
     for (let menuIndex = 0; menuIndex < ex.numMenus + 1; menuIndex++) {
 
@@ -424,9 +407,8 @@ ariaTest('Key ARROW_RIGHT moves focus to next menubar item',
 ariaTest('Key ARROW_RIGHT moves focus to next menubar item',
   exampleFile, 'menubar-left-arrow', async (t) => {
 
-    t.plan(3);
-
-    const menubaritems = await t.context.session.findElements(By.css(ex.menubarMenuitemSelector));
+    
+    const menubaritems = await t.context.queryElements(t, ex.menubarMenuitemSelector);
 
     // Send the ARROW_LEFT key to the first menuitem
     await menubaritems[0].sendKeys(Key.ARROW_LEFT);
@@ -454,10 +436,9 @@ ariaTest('Key ARROW_RIGHT moves focus to next menubar item',
 ariaTest('Key ARROW_UP opens submenu, focus on last item',
   exampleFile, 'menubar-up-arrow', async (t) => {
 
-    t.plan(6);
-
-    const menubaritems = await t.context.session.findElements(By.css(ex.menubarMenuitemSelector));
-    const menus = await t.context.session.findElements(By.css(ex.menuSelector));
+    
+    const menubaritems = await t.context.queryElements(t, ex.menubarMenuitemSelector);
+    const menus = await t.context.queryElements(t, ex.menuSelector);
     for (let menuIndex = 0; menuIndex < ex.numMenus; menuIndex++) {
 
       // Send the ENTER key
@@ -469,8 +450,7 @@ ariaTest('Key ARROW_UP opens submenu, focus on last item',
         'Sending key "ENTER" to menuitem ' + menuIndex + ' in menubar should display submenu'
       );
 
-      const numSubItems = (await t.context.session
-        .findElements(By.css(ex.menuMenuitemSelectors[menuIndex]))).length;
+      const numSubItems = (await t.context.queryElements(t, ex.menuMenuitemSelectors[menuIndex])).length;
 
       // Test that the focus is on the last item in the list
       t.true(
@@ -482,10 +462,9 @@ ariaTest('Key ARROW_UP opens submenu, focus on last item',
 
 ariaTest('Key ARROW_DOWN opens submenu, focus on first item',
   exampleFile, 'menubar-down-arrow', async (t) => {
-    t.plan(6);
-
-    const menubaritems = await t.context.session.findElements(By.css(ex.menubarMenuitemSelector));
-    const menus = await t.context.session.findElements(By.css(ex.menuSelector));
+    
+    const menubaritems = await t.context.queryElements(t, ex.menubarMenuitemSelector);
+    const menus = await t.context.queryElements(t, ex.menuSelector);
     for (let menuIndex = 0; menuIndex < ex.numMenus; menuIndex++) {
 
       // Send the ENTER key
@@ -506,9 +485,8 @@ ariaTest('Key ARROW_DOWN opens submenu, focus on first item',
   });
 
 ariaTest('Key HOME goes to first item in menubar', exampleFile, 'menubar-home', async (t) => {
-  t.plan(3);
-
-  const menubaritems = await t.context.session.findElements(By.css(ex.menubarMenuitemSelector));
+  
+  const menubaritems = await t.context.queryElements(t, ex.menubarMenuitemSelector);
   for (let menuIndex = 0; menuIndex < ex.numMenus; menuIndex++) {
 
     // Send the ARROW_RIGHT key to move the focus to later menu item for every test
@@ -528,9 +506,8 @@ ariaTest('Key HOME goes to first item in menubar', exampleFile, 'menubar-home', 
 });
 
 ariaTest('Key END goes to last item in menubar', exampleFile, 'menubar-end', async (t) => {
-  t.plan(3);
-
-  const menubaritems = await t.context.session.findElements(By.css(ex.menubarMenuitemSelector));
+  
+  const menubaritems = await t.context.queryElements(t, ex.menubarMenuitemSelector);
   for (let menuIndex = 0; menuIndex < ex.numMenus; menuIndex++) {
 
     // Send the ARROW_RIGHT key to move the focus to later menu item for every test
@@ -552,8 +529,7 @@ ariaTest('Key END goes to last item in menubar', exampleFile, 'menubar-end', asy
 ariaTest('Character sends to menubar changes focus in menubar',
   exampleFile, 'menubar-character', async (t) => {
 
-    t.plan(4);
-
+    
     const charIndexTest = [
       { sendChar: 'z', sendIndex: 0, endIndex: 0 },
       { sendChar: 'a', sendIndex: 0, endIndex: 1 },
@@ -561,7 +537,7 @@ ariaTest('Character sends to menubar changes focus in menubar',
       { sendChar: 'a', sendIndex: 2, endIndex: 0 }
     ];
 
-    const menubaritems = await t.context.session.findElements(By.css(ex.menubarMenuitemSelector));
+    const menubaritems = await t.context.queryElements(t, ex.menubarMenuitemSelector);
     for (let test of charIndexTest) {
 
       // Send character to menuitem
@@ -577,8 +553,7 @@ ariaTest('Character sends to menubar changes focus in menubar',
 
 // This test is failing due to a bug reported in issue: https://github.com/w3c/aria-practices/issues/907
 ariaTest.failing('ENTER in submenu selects item', exampleFile, 'submenu-space-or-enter', async (t) => {
-  t.plan(27);
-
+  
   // Test all the level one menuitems
 
   for (let menuIndex = 0; menuIndex < ex.numMenus; menuIndex++) {
@@ -586,11 +561,11 @@ ariaTest.failing('ENTER in submenu selects item', exampleFile, 'submenu-space-or
 
       await t.context.session.get(t.context.url);
 
-      const menubaritems = await t.context.session.findElements(By.css(ex.menubarMenuitemSelector));
+      const menubaritems = await t.context.queryElements(t, ex.menubarMenuitemSelector);
 
       // Open the submenu
       await menubaritems[menuIndex].sendKeys(Key.ENTER);
-      const items = await t.context.session.findElements(By.css(ex.menuMenuitemSelectors[menuIndex]));
+      const items = await t.context.queryElements(t, ex.menuMenuitemSelectors[menuIndex]);
       const itemText = await items[itemIndex].getText();
 
       // send ENTER to the item
@@ -612,7 +587,7 @@ ariaTest.failing('ENTER in submenu selects item', exampleFile, 'submenu-space-or
 
     // Get the submenu associate with the menuitem we are testing
     const submenuMenuitemSelector = getSubmenuMenuitemSelector(menuIndex, menuitemIndex);
-    const numItems = (await t.context.session.findElements(By.css(submenuMenuitemSelector))).length;
+    const numItems = (await t.context.queryElements(t, submenuMenuitemSelector)).length;
 
     // Test all the items in the submenu
     for (let itemIndex = 0; itemIndex < numItems; itemIndex++) {
@@ -620,7 +595,7 @@ ariaTest.failing('ENTER in submenu selects item', exampleFile, 'submenu-space-or
       await openSubmenu(t, ...submenuLocation);
 
       // send ENTER to the item we are testing
-      const items = await t.context.session.findElements(By.css(submenuMenuitemSelector));
+      const items = await t.context.queryElements(t, submenuMenuitemSelector);
       const itemText = await items[itemIndex].getText();
       await items[itemIndex].sendKeys(Key.ENTER);
       await waitForUrlChange(t);
@@ -638,8 +613,7 @@ ariaTest.failing('ENTER in submenu selects item', exampleFile, 'submenu-space-or
 
 // This test is failing due to a bug reported in issue: https://github.com/w3c/aria-practices/issues/907
 ariaTest.failing('SPACE in submenu selects item', exampleFile, 'submenu-space-or-enter', async (t) => {
-  t.plan(27);
-
+  
   // Test all the level one menuitems
 
   for (let menuIndex = 0; menuIndex < ex.numMenus; menuIndex++) {
@@ -647,11 +621,11 @@ ariaTest.failing('SPACE in submenu selects item', exampleFile, 'submenu-space-or
 
       await t.context.session.get(t.context.url);
 
-      const menubaritems = await t.context.session.findElements(By.css(ex.menubarMenuitemSelector));
+      const menubaritems = await t.context.queryElements(t, ex.menubarMenuitemSelector);
 
       // Open the submenu
       await menubaritems[menuIndex].sendKeys(Key.ENTER);
-      const items = await t.context.session.findElements(By.css(ex.menuMenuitemSelectors[menuIndex]));
+      const items = await t.context.queryElements(t, ex.menuMenuitemSelectors[menuIndex]);
       const itemText = await items[itemIndex].getText();
 
       // send SPACE to the item
@@ -673,7 +647,7 @@ ariaTest.failing('SPACE in submenu selects item', exampleFile, 'submenu-space-or
 
     // Get the submenu associate with the menuitem we are testing
     const submenuMenuitemSelector = getSubmenuMenuitemSelector(menuIndex, menuitemIndex);
-    const numItems = (await t.context.session.findElements(By.css(submenuMenuitemSelector))).length;
+    const numItems = (await t.context.queryElements(t, submenuMenuitemSelector)).length;
 
     // Test all the items in the submenu
     for (let itemIndex = 0; itemIndex < numItems; itemIndex++) {
@@ -681,7 +655,7 @@ ariaTest.failing('SPACE in submenu selects item', exampleFile, 'submenu-space-or
       await openSubmenu(t, ...submenuLocation);
 
       // send SPACE to the item we are testing
-      const items = await t.context.session.findElements(By.css(submenuMenuitemSelector));
+      const items = await t.context.queryElements(t, submenuMenuitemSelector);
       const itemText = await items[itemIndex].getText();
       await items[itemIndex].sendKeys(Key.SPACE);
       await waitForUrlChange(t);
@@ -699,10 +673,9 @@ ariaTest.failing('SPACE in submenu selects item', exampleFile, 'submenu-space-or
 
 
 ariaTest('ESCAPE to submenu closes submenu', exampleFile, 'submenu-escape', async (t) => {
-  t.plan(54);
-
-  const menubaritems = await t.context.session.findElements(By.css(ex.menubarMenuitemSelector));
-  const menus = await t.context.session.findElements(By.css(ex.menuSelector));
+  
+  const menubaritems = await t.context.queryElements(t, ex.menubarMenuitemSelector);
+  const menus = await t.context.queryElements(t, ex.menuSelector);
 
   // Test all the level one menuitems
 
@@ -712,7 +685,7 @@ ariaTest('ESCAPE to submenu closes submenu', exampleFile, 'submenu-escape', asyn
       // Open the submenu
       await menubaritems[menuIndex].sendKeys(Key.ENTER);
 
-      const items = await t.context.session.findElements(By.css(ex.menuMenuitemSelectors[menuIndex]));
+      const items = await t.context.queryElements(t, ex.menuMenuitemSelectors[menuIndex]);
       const itemText = await items[itemIndex].getText();
 
       // send ARROW_RIGHT to the item
@@ -737,7 +710,7 @@ ariaTest('ESCAPE to submenu closes submenu', exampleFile, 'submenu-escape', asyn
 
     // Get the submenu items we are testing
     let submenuMenuitemSelector = getSubmenuMenuitemSelector(menuIndex, menuitemIndex);
-    const items = await t.context.session.findElements(By.css(submenuMenuitemSelector));
+    const items = await t.context.queryElements(t, submenuMenuitemSelector);
     const numItems = items.length;
 
     for (let itemIndex = 0; itemIndex < numItems; itemIndex++) {
@@ -766,10 +739,9 @@ ariaTest('ESCAPE to submenu closes submenu', exampleFile, 'submenu-escape', asyn
 
 ariaTest('ARROW_RIGHT to submenu closes submenu and opens next', exampleFile, 'submenu-right-arrow', async (t) => {
 
-  t.plan(54);
-
-  const menubaritems = await t.context.session.findElements(By.css(ex.menubarMenuitemSelector));
-  const menus = await t.context.session.findElements(By.css(ex.menuSelector));
+  
+  const menubaritems = await t.context.queryElements(t, ex.menubarMenuitemSelector);
+  const menus = await t.context.queryElements(t, ex.menuSelector);
 
   // Test all the level one menuitems
 
@@ -779,7 +751,7 @@ ariaTest('ARROW_RIGHT to submenu closes submenu and opens next', exampleFile, 's
       // Open the submenu
       await menubaritems[menuIndex].sendKeys(Key.ENTER);
 
-      const items = await t.context.session.findElements(By.css(ex.menuMenuitemSelectors[menuIndex]));
+      const items = await t.context.queryElements(t, ex.menuMenuitemSelectors[menuIndex]);
       const itemText = await items[itemIndex].getText();
       const hasSubmenu = await items[itemIndex].getAttribute('aria-haspopup');
 
@@ -828,7 +800,7 @@ ariaTest('ARROW_RIGHT to submenu closes submenu and opens next', exampleFile, 's
 
     // Get the submenu items we are testing
     const submenuMenuitemSelector = getSubmenuMenuitemSelector(menuIndex, menuitemIndex);
-    const items = await t.context.session.findElements(By.css(submenuMenuitemSelector));
+    const items = await t.context.queryElements(t, submenuMenuitemSelector);
     const numItems = items.length;
 
     for (let itemIndex = 0; itemIndex < numItems; itemIndex++) {
@@ -859,10 +831,9 @@ ariaTest('ARROW_RIGHT to submenu closes submenu and opens next', exampleFile, 's
 });
 
 ariaTest('ARROW_LEFT to submenu closes submenu and opens next', exampleFile, 'submenu-left-arrow', async (t) => {
-  t.plan(54);
-
-  const menubaritems = await t.context.session.findElements(By.css(ex.menubarMenuitemSelector));
-  const menus = await t.context.session.findElements(By.css(ex.menuSelector));
+  
+  const menubaritems = await t.context.queryElements(t, ex.menubarMenuitemSelector);
+  const menus = await t.context.queryElements(t, ex.menuSelector);
 
   // Test all the level one menuitems
 
@@ -872,7 +843,7 @@ ariaTest('ARROW_LEFT to submenu closes submenu and opens next', exampleFile, 'su
       // Open the submenu
       await menubaritems[menuIndex].sendKeys(Key.ENTER);
 
-      const items = await t.context.session.findElements(By.css(ex.menuMenuitemSelectors[menuIndex]));
+      const items = await t.context.queryElements(t, ex.menuMenuitemSelectors[menuIndex]);
       const itemText = await items[itemIndex].getText();
 
       // send ARROW_LEFT to the item
@@ -902,7 +873,7 @@ ariaTest('ARROW_LEFT to submenu closes submenu and opens next', exampleFile, 'su
 
     // Get the submenu items we are testing
     const submenuMenuitemSelector = getSubmenuMenuitemSelector(menuIndex, menuitemIndex);
-    const items = await t.context.session.findElements(By.css(submenuMenuitemSelector));
+    const items = await t.context.queryElements(t, submenuMenuitemSelector);
     const numItems = items.length;
 
     for (let itemIndex = 0; itemIndex < numItems; itemIndex++) {
@@ -929,10 +900,9 @@ ariaTest('ARROW_LEFT to submenu closes submenu and opens next', exampleFile, 'su
 });
 
 ariaTest('ARROW_DOWN moves focus in menu', exampleFile, 'submenu-down-arrow', async (t) => {
-  t.plan(27);
-
-  const menubaritems = await t.context.session.findElements(By.css(ex.menubarMenuitemSelector));
-  const menus = await t.context.session.findElements(By.css(ex.menuSelector));
+  
+  const menubaritems = await t.context.queryElements(t, ex.menubarMenuitemSelector);
+  const menus = await t.context.queryElements(t, ex.menuSelector);
 
   // Test all the level one menuitems
 
@@ -942,7 +912,7 @@ ariaTest('ARROW_DOWN moves focus in menu', exampleFile, 'submenu-down-arrow', as
       // Open the submenu
       await menubaritems[menuIndex].sendKeys(Key.ENTER);
 
-      const items = await t.context.session.findElements(By.css(ex.menuMenuitemSelectors[menuIndex]));
+      const items = await t.context.queryElements(t, ex.menuMenuitemSelectors[menuIndex]);
       const itemText = await items[itemIndex].getText();
 
       // send ARROW_DOWN to the item
@@ -968,7 +938,7 @@ ariaTest('ARROW_DOWN moves focus in menu', exampleFile, 'submenu-down-arrow', as
 
     // Get the submenu items we are testing
     const submenuMenuitemSelector = getSubmenuMenuitemSelector(menuIndex, menuitemIndex);
-    const items = await t.context.session.findElements(By.css(submenuMenuitemSelector));
+    const items = await t.context.queryElements(t, submenuMenuitemSelector);
     const numItems = items.length;
 
     for (let itemIndex = 0; itemIndex < numItems; itemIndex++) {
@@ -996,10 +966,9 @@ ariaTest('ARROW_DOWN moves focus in menu', exampleFile, 'submenu-down-arrow', as
 
 
 ariaTest('ARROW_UP moves focus in menu', exampleFile, 'submenu-up-arrow', async (t) => {
-  t.plan(27);
-
-  const menubaritems = await t.context.session.findElements(By.css(ex.menubarMenuitemSelector));
-  const menus = await t.context.session.findElements(By.css(ex.menuSelector));
+  
+  const menubaritems = await t.context.queryElements(t, ex.menubarMenuitemSelector);
+  const menus = await t.context.queryElements(t, ex.menuSelector);
 
   // Test all the level one menuitems
 
@@ -1009,7 +978,7 @@ ariaTest('ARROW_UP moves focus in menu', exampleFile, 'submenu-up-arrow', async 
       // Open the submenu
       await menubaritems[menuIndex].sendKeys(Key.ENTER);
 
-      const items = await t.context.session.findElements(By.css(ex.menuMenuitemSelectors[menuIndex]));
+      const items = await t.context.queryElements(t, ex.menuMenuitemSelectors[menuIndex]);
       const itemText = await items[itemIndex].getText();
 
       // send ARROW_UP to the item
@@ -1035,7 +1004,7 @@ ariaTest('ARROW_UP moves focus in menu', exampleFile, 'submenu-up-arrow', async 
 
     // Get the submenu items we are testing
     const submenuMenuitemSelector = getSubmenuMenuitemSelector(menuIndex, menuitemIndex);
-    const items = await t.context.session.findElements(By.css(submenuMenuitemSelector));
+    const items = await t.context.queryElements(t, submenuMenuitemSelector);
     const numItems = items.length;
 
     for (let itemIndex = 0; itemIndex < numItems; itemIndex++) {
@@ -1062,10 +1031,9 @@ ariaTest('ARROW_UP moves focus in menu', exampleFile, 'submenu-up-arrow', async 
 });
 
 ariaTest('HOME moves focus in menu', exampleFile, 'submenu-home', async (t) => {
-  t.plan(27);
-
-  const menubaritems = await t.context.session.findElements(By.css(ex.menubarMenuitemSelector));
-  const menus = await t.context.session.findElements(By.css(ex.menuSelector));
+  
+  const menubaritems = await t.context.queryElements(t, ex.menubarMenuitemSelector);
+  const menus = await t.context.queryElements(t, ex.menuSelector);
 
   // Test all the level one menuitems
 
@@ -1075,7 +1043,7 @@ ariaTest('HOME moves focus in menu', exampleFile, 'submenu-home', async (t) => {
       // Open the submenu
       await menubaritems[menuIndex].sendKeys(Key.ENTER);
 
-      const items = await t.context.session.findElements(By.css(ex.menuMenuitemSelectors[menuIndex]));
+      const items = await t.context.queryElements(t, ex.menuMenuitemSelectors[menuIndex]);
       const itemText = await items[itemIndex].getText();
 
       // send HOME to the item
@@ -1096,7 +1064,7 @@ ariaTest('HOME moves focus in menu', exampleFile, 'submenu-home', async (t) => {
 
     // Get the submenu items we are testing
     const submenuMenuitemSelector = getSubmenuMenuitemSelector(menuIndex, menuitemIndex);
-    const items = await t.context.session.findElements(By.css(submenuMenuitemSelector));
+    const items = await t.context.queryElements(t, submenuMenuitemSelector);
     const numItems = items.length;
 
     for (let itemIndex = 0; itemIndex < numItems; itemIndex++) {
@@ -1118,10 +1086,9 @@ ariaTest('HOME moves focus in menu', exampleFile, 'submenu-home', async (t) => {
 
 
 ariaTest('END moves focus in menu', exampleFile, 'submenu-end', async (t) => {
-  t.plan(27);
-
-  const menubaritems = await t.context.session.findElements(By.css(ex.menubarMenuitemSelector));
-  const menus = await t.context.session.findElements(By.css(ex.menuSelector));
+  
+  const menubaritems = await t.context.queryElements(t, ex.menubarMenuitemSelector);
+  const menus = await t.context.queryElements(t, ex.menuSelector);
 
   // Test all the level one menuitems
 
@@ -1131,7 +1098,7 @@ ariaTest('END moves focus in menu', exampleFile, 'submenu-end', async (t) => {
       // Open the submenu
       await menubaritems[menuIndex].sendKeys(Key.ENTER);
 
-      const items = await t.context.session.findElements(By.css(ex.menuMenuitemSelectors[menuIndex]));
+      const items = await t.context.queryElements(t, ex.menuMenuitemSelectors[menuIndex]);
       const itemText = await items[itemIndex].getText();
 
       // send END to the item
@@ -1152,7 +1119,7 @@ ariaTest('END moves focus in menu', exampleFile, 'submenu-end', async (t) => {
 
     // Get the submenu items we are testing
     const submenuMenuitemSelector = getSubmenuMenuitemSelector(menuIndex, menuitemIndex);
-    const items = await t.context.session.findElements(By.css(submenuMenuitemSelector));
+    const items = await t.context.queryElements(t, submenuMenuitemSelector);
     const numItems = items.length;
 
     for (let itemIndex = 0; itemIndex < numItems; itemIndex++) {
@@ -1174,8 +1141,7 @@ ariaTest('END moves focus in menu', exampleFile, 'submenu-end', async (t) => {
 
 
 ariaTest('Character sends to menubar changes focus in menubar', exampleFile, 'submenu-character', async (t) => {
-  t.plan(15);
-
+  
   const charIndexTest = [
     [ // Tests for menu dropdown 0
       { sendChar: 'a', sendIndex: 0, endIndex: 1 },
@@ -1193,12 +1159,12 @@ ariaTest('Character sends to menubar changes focus in menubar', exampleFile, 'su
     ]
   ];
 
-  const menubaritems = await t.context.session.findElements(By.css(ex.menubarMenuitemSelector));
+  const menubaritems = await t.context.queryElements(t, ex.menubarMenuitemSelector);
   for (let menuIndex = 0; menuIndex < ex.numMenus; menuIndex++) {
 
     // Open the dropdown
     await menubaritems[menuIndex].sendKeys(Key.ARROW_DOWN);
-    const items = await t.context.session.findElements(By.css(ex.menuMenuitemSelectors[menuIndex]));
+    const items = await t.context.queryElements(t, ex.menuMenuitemSelectors[menuIndex]);
 
     for (let test of charIndexTest[menuIndex]) {
 
@@ -1240,7 +1206,7 @@ ariaTest('Character sends to menubar changes focus in menubar', exampleFile, 'su
 
     // Get the submenu items we are testing
     const submenuMenuitemSelector = getSubmenuMenuitemSelector(menuIndex, menuitemIndex);
-    const items = await t.context.session.findElements(By.css(submenuMenuitemSelector));
+    const items = await t.context.queryElements(t, submenuMenuitemSelector);
 
     for (let test of subCharIndexTest[testIndex]) {
 

--- a/test/tests/menubar_menubar-2.js
+++ b/test/tests/menubar_menubar-2.js
@@ -58,7 +58,7 @@ const exampleInitialized = async function (t) {
   const initializedSelector = ex.menubarMenuitemSelector + '[tabindex="0"]';
 
   await t.context.session.wait(async function () {
-    const els = await t.context.session.findElements(By.css(initializedSelector));
+    const els = await t.context.queryElements(t, initializedSelector);
     return els.length === 1;
   }, t.context.waitTime, 'Timeout waiting for example to initialize');
 };
@@ -88,9 +88,8 @@ const checkFocus = async function (t, selector, index) {
 
 ariaTest('Test for role="menubar" on ul', exampleFile, 'menubar-role', async (t) => {
 
-  t.plan(2);
-
-  const menubars = await t.context.session.findElements(By.css(ex.menubarSelector));
+  
+  const menubars = await t.context.queryElements(t, ex.menubarSelector);
 
   t.is(
     menubars.length,
@@ -106,15 +105,13 @@ ariaTest('Test for role="menubar" on ul', exampleFile, 'menubar-role', async (t)
 });
 
 ariaTest('Test aria-label on menubar', exampleFile, 'menubar-aria-label', async (t) => {
-  t.plan(1);
-  await assertAriaLabelExists(t, ex.menubarSelector);
+    await assertAriaLabelExists(t, ex.menubarSelector);
 });
 
 ariaTest('Test for role="menuitem" on li', exampleFile, 'menubar-menuitem-role', async (t) => {
 
-  t.plan(5);
-
-  const menuitems = await t.context.session.findElements(By.css(ex.menubarMenuitemSelector));
+  
+  const menuitems = await t.context.queryElements(t, ex.menubarMenuitemSelector);
 
   t.is(
     menuitems.length,
@@ -132,8 +129,7 @@ ariaTest('Test for role="menuitem" on li', exampleFile, 'menubar-menuitem-role',
 
 ariaTest('Test roving tabindex', exampleFile, 'menubar-menuitem-tabindex', async (t) => {
 
-  t.plan(1);
-
+  
   // Wait for roving tabindex to be initialized by the javascript
   await exampleInitialized(t);
 
@@ -143,20 +139,18 @@ ariaTest('Test roving tabindex', exampleFile, 'menubar-menuitem-tabindex', async
 ariaTest('Test aria-haspopup set to true on menuitems',
   exampleFile, 'menubar-menuitem-aria-haspopup', async (t) => {
 
-    t.plan(1);
-
+    
     await assertAttributeValues(t, ex.menubarMenuitemSelector, 'aria-haspopup', 'true');
   });
 
 ariaTest('"aria-expanded" attribute on menubar menuitem', exampleFile, 'menubar-menuitem-aria-expanded', async (t) => {
 
-  t.plan(37);
-
+  
   // Before interating with page, make sure aria-expanded is set to false
   await assertAttributeValues(t, ex.menubarMenuitemSelector, 'aria-expanded', 'false');
 
   // AND make sure no submenus are visible
-  const submenus = await t.context.session.findElements(By.css(ex.submenuSelector));
+  const submenus = await t.context.queryElements(t, ex.submenuSelector);
   for (let submenu of submenus) {
     t.false(
       await submenu.isDisplayed(),
@@ -164,7 +158,7 @@ ariaTest('"aria-expanded" attribute on menubar menuitem', exampleFile, 'menubar-
     );
   }
 
-  const menuitems = await t.context.session.findElements(By.css(ex.menubarMenuitemSelector));
+  const menuitems = await t.context.queryElements(t, ex.menubarMenuitemSelector);
 
   for (let menuIndex = 0; menuIndex < menuitems.length; menuIndex++) {
 
@@ -200,9 +194,8 @@ ariaTest('"aria-expanded" attribute on menubar menuitem', exampleFile, 'menubar-
 
 ariaTest('Test for role="menu" on ul', exampleFile, 'menu-role', async (t) => {
 
-  t.plan(6);
-
-  const submenus = await t.context.session.findElements(By.css(ex.submenuSelector));
+  
+  const submenus = await t.context.queryElements(t, ex.submenuSelector);
 
   // Test elements with role="menu" exist
   t.is(
@@ -224,8 +217,7 @@ ariaTest('Test for role="menu" on ul', exampleFile, 'menu-role', async (t) => {
 });
 
 ariaTest('Test for aria-label on role="menu"', exampleFile, 'menu-aria-label', async (t) => {
-  t.plan(4);
-
+  
   const submenusSelectors = [
     '#ex1 li:nth-of-type(1) [role="menu"]',
     '#ex1 li:nth-of-type(2) [role="menu"]',
@@ -240,9 +232,8 @@ ariaTest('Test for aria-label on role="menu"', exampleFile, 'menu-aria-label', a
 
 ariaTest('Test for submenu menuitems with accessible names', exampleFile, 'submenu-menuitem-role', async (t) => {
 
-  t.plan(3);
-
-  const menuitems = await t.context.session.findElements(By.css(ex.submenuMenuitemSelector));
+  
+  const menuitems = await t.context.queryElements(t, ex.submenuMenuitemSelector);
 
   t.truthy(
     menuitems.length,
@@ -270,21 +261,19 @@ ariaTest('Test for submenu menuitems with accessible names', exampleFile, 'subme
 ariaTest('Test tabindex="-1" for all submenu role="menuitem"s',
   exampleFile, 'submenu-menuitem-tabindex', async (t) => {
 
-    t.plan(1);
-    await assertAttributeValues(t, ex.submenuMenuitemSelector, 'tabindex', '-1');
+        await assertAttributeValues(t, ex.submenuMenuitemSelector, 'tabindex', '-1');
   });
 
 ariaTest('Test aria-disabled="false" for all submenu role="menuitem"s',
   exampleFile, 'submenu-menuitem-aria-disabled', async (t) => {
-    t.plan(3);
-
+    
     // "aria-disable" should be set to false by default
     await assertAttributeValues(t, ex.submenuMenuitemSelector, 'aria-disabled', 'false');
 
-    const menus = await t.context.session.findElements(By.css(ex.menubarMenuitemSelector));
+    const menus = await t.context.queryElements(t, ex.menubarMenuitemSelector);
     const sizeMenu = await t.context.session.findElement(By.css('[aria-label="Size"]'));
-    const menuitems = await sizeMenu.findElements(By.css('[role="menuitem"]'));
-    const menuItemRadios = await sizeMenu.findElements(By.css('[role="menuitemradio"]'));
+    const menuitems = await t.context.queryElements(t, '[role="menuitem"]', sizeMenu);
+    const menuItemRadios = await t.context.queryElements(t, '[role="menuitemradio"]', sizeMenu);
 
     // select X-Small size
     await menus[3].sendKeys(Key.ARROW_DOWN);
@@ -314,9 +303,8 @@ ariaTest('Test aria-disabled="false" for all submenu role="menuitem"s',
   });
 
 ariaTest('Test for role="menuitemcheckbox" on li', exampleFile, 'menuitemcheckbox-role', async (t) => {
-  t.plan(3);
-
-  const checkboxes = await t.context.session.findElements(By.css(ex.menuitemcheckboxSelector));
+  
+  const checkboxes = await t.context.queryElements(t, ex.menuitemcheckboxSelector);
 
   t.truthy(
     checkboxes.length,
@@ -341,15 +329,13 @@ ariaTest('Test for role="menuitemcheckbox" on li', exampleFile, 'menuitemcheckbo
 });
 
 ariaTest('Test tabindex="-1" for role="menuitemcheckbox"', exampleFile, 'menuitemcheckbox-tabindex', async (t) => {
-  t.plan(1);
-  await assertAttributeValues(t, ex.menuitemcheckboxSelector, 'tabindex', '-1');
+    await assertAttributeValues(t, ex.menuitemcheckboxSelector, 'tabindex', '-1');
 });
 
 ariaTest('Test "aria-checked" attirbute on role="menuitemcheckbox"',
   exampleFile, 'menuitemcheckbox-aria-checked', async (t) => {
-    t.plan(6);
-
-    const menus = await t.context.session.findElements(By.css(ex.menubarMenuitemSelector));
+    
+    const menus = await t.context.queryElements(t, ex.menubarMenuitemSelector);
 
     // Reveal the menuitemcheckbox elements in the second dropdown
     await menus[1].sendKeys(Key.ARROW_DOWN);
@@ -367,7 +353,7 @@ ariaTest('Test "aria-checked" attirbute on role="menuitemcheckbox"',
     }
 
     // Select both menuitems
-    const checkboxes = await t.context.session.findElements(By.css(ex.menuitemcheckboxSelector));
+    const checkboxes = await t.context.queryElements(t, ex.menuitemcheckboxSelector);
     checkboxes[0].sendKeys(Key.ENTER);
     await menus[1].sendKeys(Key.ARROW_DOWN);
     checkboxes[1].sendKeys(Key.ENTER);
@@ -389,25 +375,21 @@ ariaTest('Test "aria-checked" attirbute on role="menuitemcheckbox"',
 
 
 ariaTest('Test role="separator" exists', exampleFile, 'separator-role', async (t) => {
-  t.plan(1);
-  await assertAriaRoles(t, 'ex1', 'separator', 3, 'li');
+    await assertAriaRoles(t, 'ex1', 'separator', 3, 'li');
 });
 
 ariaTest('Test role="group" exists', exampleFile, 'group-role', async (t) => {
-  t.plan(1);
-  await assertAriaRoles(t, 'ex1', 'group', 4, 'ul');
+    await assertAriaRoles(t, 'ex1', 'group', 4, 'ul');
 });
 
 ariaTest('Test aria-label on group', exampleFile, 'group-aria-label', async (t) => {
-  t.plan(1);
-  await assertAriaLabelExists(t, ex.groupSelector);
+    await assertAriaLabelExists(t, ex.groupSelector);
 });
 
 ariaTest('Test role="menuitemradio" exists with accessible name',
   exampleFile, 'menuitemradio-role', async (t) => {
-    t.plan(22);
-
-    const items = await t.context.session.findElements(By.css(ex.menuitemradioSelector));
+    
+    const items = await t.context.queryElements(t, ex.menuitemradioSelector);
 
     // Test that the elements exist
     t.truthy(
@@ -434,21 +416,20 @@ ariaTest('Test role="menuitemradio" exists with accessible name',
 
 ariaTest('Test tabindex="-1" on role="menuitemradio"',
   exampleFile, 'menuitemradio-tabindex', async (t) => {
-    t.plan(1);
-    await assertAttributeValues(t, ex.menuitemradioSelector, 'tabindex', '-1');
+        await assertAttributeValues(t, ex.menuitemradioSelector, 'tabindex', '-1');
   });
 
 ariaTest('Text "aria-checked" appropriately set on role="menitemradio"',
   exampleFile, 'menuitemradio-aria-checked', async (t) => {
 
-    const menus = await t.context.session.findElements(By.css(ex.menubarMenuitemSelector));
+    const menus = await t.context.queryElements(t, ex.menubarMenuitemSelector);
 
     for (let grouping of ex.radioItemGroupings) {
 
       // Reveal the elements in the dropdown
       await menus[grouping.menuIndex].sendKeys(Key.ARROW_DOWN);
 
-      const items = await t.context.session.findElements(By.css(grouping.itemsSelector));
+      const items = await t.context.queryElements(t, grouping.itemsSelector);
 
       // Test for the initial state of checked/not checked for all radio menuitems
 
@@ -475,10 +456,9 @@ ariaTest('Text "aria-checked" appropriately set on role="menitemradio"',
 // KEYS
 
 ariaTest('Key ENTER open submenu', exampleFile, 'menubar-key-space-and-enter', async (t) => {
-  t.plan(8);
-
-  const menuitems = await t.context.session.findElements(By.css(ex.menubarMenuitemSelector));
-  const submenus = await t.context.session.findElements(By.css(ex.submenuSelector));
+  
+  const menuitems = await t.context.queryElements(t, ex.menubarMenuitemSelector);
+  const submenus = await t.context.queryElements(t, ex.submenuSelector);
   for (let menuIndex = 0; menuIndex < ex.numMenus; menuIndex++) {
 
     // Send the ENTER key
@@ -499,10 +479,9 @@ ariaTest('Key ENTER open submenu', exampleFile, 'menubar-key-space-and-enter', a
 
 
 ariaTest('Key SPACE open submenu', exampleFile, 'menubar-key-space-and-enter', async (t) => {
-  t.plan(8);
-
-  const menuitems = await t.context.session.findElements(By.css(ex.menubarMenuitemSelector));
-  const submenus = await t.context.session.findElements(By.css(ex.submenuSelector));
+  
+  const menuitems = await t.context.queryElements(t, ex.menubarMenuitemSelector);
+  const submenus = await t.context.queryElements(t, ex.submenuSelector);
   for (let menuIndex = 0; menuIndex < ex.numMenus; menuIndex++) {
 
     // Send the SPACE key
@@ -524,10 +503,9 @@ ariaTest('Key SPACE open submenu', exampleFile, 'menubar-key-space-and-enter', a
 
 
 ariaTest('Key ESCAPE closes menubar', exampleFile, 'menubar-key-escape', async (t) => {
-  t.plan(4);
-
-  const menuitems = await t.context.session.findElements(By.css(ex.menubarMenuitemSelector));
-  const submenus = await t.context.session.findElements(By.css(ex.submenuSelector));
+  
+  const menuitems = await t.context.queryElements(t, ex.menubarMenuitemSelector);
+  const submenus = await t.context.queryElements(t, ex.submenuSelector);
   for (let menuIndex = 0; menuIndex < ex.numMenus; menuIndex++) {
 
     // Send the ENTER key, then the ESCAPE
@@ -546,9 +524,8 @@ ariaTest('Key ESCAPE closes menubar', exampleFile, 'menubar-key-escape', async (
 ariaTest('Key ARROW_RIGHT moves focus to next menubar item',
   exampleFile, 'menubar-key-right-arrow', async (t) => {
 
-    t.plan(5);
-
-    const menuitems = await t.context.session.findElements(By.css(ex.menubarMenuitemSelector));
+    
+    const menuitems = await t.context.queryElements(t, ex.menubarMenuitemSelector);
 
     for (let menuIndex = 0; menuIndex < ex.numMenus + 1; menuIndex++) {
 
@@ -569,9 +546,8 @@ ariaTest('Key ARROW_RIGHT moves focus to next menubar item',
 ariaTest('Key ARROW_RIGHT moves focus to next menubar item',
   exampleFile, 'menubar-key-left-arrow', async (t) => {
 
-    t.plan(4);
-
-    const menuitems = await t.context.session.findElements(By.css(ex.menubarMenuitemSelector));
+    
+    const menuitems = await t.context.queryElements(t, ex.menubarMenuitemSelector);
 
     // Send the ARROW_LEFT key to the first menuitem
     await menuitems[0].sendKeys(Key.ARROW_LEFT);
@@ -599,10 +575,9 @@ ariaTest('Key ARROW_RIGHT moves focus to next menubar item',
 ariaTest('Key ARROW_UP opens submenu, focus on last item',
   exampleFile, 'menubar-key-up-arrow', async (t) => {
 
-    t.plan(8);
-
-    const menuitems = await t.context.session.findElements(By.css(ex.menubarMenuitemSelector));
-    const submenus = await t.context.session.findElements(By.css(ex.submenuSelector));
+    
+    const menuitems = await t.context.queryElements(t, ex.menubarMenuitemSelector);
+    const submenus = await t.context.queryElements(t, ex.submenuSelector);
     for (let menuIndex = 0; menuIndex < ex.numMenus; menuIndex++) {
 
       // Send the ENTER key
@@ -614,8 +589,7 @@ ariaTest('Key ARROW_UP opens submenu, focus on last item',
         'Sending key "ENTER" to menuitem ' + menuIndex + ' in menubar should display submenu'
       );
 
-      const numSubItems = (await t.context.session
-        .findElements(By.css(ex.allSubmenuItems[menuIndex]))).length;
+      const numSubItems = (await t.context.queryElements(t, ex.allSubmenuItems[menuIndex])).length;
 
       // Test that the focus is on the last item in the list
       t.true(
@@ -627,10 +601,9 @@ ariaTest('Key ARROW_UP opens submenu, focus on last item',
 
 ariaTest('Key ARROW_DOWN opens submenu, focus on first item',
   exampleFile, 'menubar-key-down-arrow', async (t) => {
-    t.plan(8);
-
-    const menuitems = await t.context.session.findElements(By.css(ex.menubarMenuitemSelector));
-    const submenus = await t.context.session.findElements(By.css(ex.submenuSelector));
+    
+    const menuitems = await t.context.queryElements(t, ex.menubarMenuitemSelector);
+    const submenus = await t.context.queryElements(t, ex.submenuSelector);
     for (let menuIndex = 0; menuIndex < ex.numMenus; menuIndex++) {
 
       // Send the ENTER key
@@ -651,9 +624,8 @@ ariaTest('Key ARROW_DOWN opens submenu, focus on first item',
   });
 
 ariaTest('Key HOME goes to first item in menubar', exampleFile, 'menubar-key-home', async (t) => {
-  t.plan(4);
-
-  const menuitems = await t.context.session.findElements(By.css(ex.menubarMenuitemSelector));
+  
+  const menuitems = await t.context.queryElements(t, ex.menubarMenuitemSelector);
   for (let menuIndex = 0; menuIndex < ex.numMenus; menuIndex++) {
 
     // Send the ARROW_RIGHT key to move the focus to later menu item for every test
@@ -673,9 +645,8 @@ ariaTest('Key HOME goes to first item in menubar', exampleFile, 'menubar-key-hom
 });
 
 ariaTest('Key END goes to last item in menubar', exampleFile, 'menubar-key-end', async (t) => {
-  t.plan(4);
-
-  const menuitems = await t.context.session.findElements(By.css(ex.menubarMenuitemSelector));
+  
+  const menuitems = await t.context.queryElements(t, ex.menubarMenuitemSelector);
   for (let menuIndex = 0; menuIndex < ex.numMenus; menuIndex++) {
 
     // Send the ARROW_RIGHT key to move the focus to later menu item for every test
@@ -697,8 +668,7 @@ ariaTest('Key END goes to last item in menubar', exampleFile, 'menubar-key-end',
 ariaTest('Character sends to menubar changes focus in menubar',
   exampleFile, 'menubar-key-character', async (t) => {
 
-    t.plan(7);
-
+    
     const charIndexTest = [
       { sendChar: 'f', sendIndex: 0, endIndex: 0 },
       { sendChar: 's', sendIndex: 0, endIndex: 1 },
@@ -709,7 +679,7 @@ ariaTest('Character sends to menubar changes focus in menubar',
       { sendChar: 'z', sendIndex: 3, endIndex: 3 }
     ];
 
-    const menuitems = await t.context.session.findElements(By.css(ex.menubarMenuitemSelector));
+    const menuitems = await t.context.queryElements(t, ex.menubarMenuitemSelector);
     for (let test of charIndexTest) {
 
       // Send character to menuitem
@@ -724,10 +694,9 @@ ariaTest('Character sends to menubar changes focus in menubar',
   });
 
 ariaTest('ENTER in submenu selects item', exampleFile, 'submenu-enter', async (t) => {
-  t.plan(75);
-
-  const menuitems = await t.context.session.findElements(By.css(ex.menubarMenuitemSelector));
-  const submenus = await t.context.session.findElements(By.css(ex.submenuSelector));
+  
+  const menuitems = await t.context.queryElements(t, ex.menubarMenuitemSelector);
+  const submenus = await t.context.queryElements(t, ex.submenuSelector);
 
   for (let menuIndex = 0; menuIndex < ex.numMenus; menuIndex++) {
 
@@ -735,7 +704,7 @@ ariaTest('ENTER in submenu selects item', exampleFile, 'submenu-enter', async (t
 
       // Open the submenu
       await menuitems[menuIndex].sendKeys(Key.ENTER);
-      const items = await t.context.session.findElements(By.css(ex.allSubmenuItems[menuIndex]));
+      const items = await t.context.queryElements(t, ex.allSubmenuItems[menuIndex]);
       const item = items[itemIndex];
       const itemText = await item.getText();
 
@@ -781,10 +750,9 @@ ariaTest('ENTER in submenu selects item', exampleFile, 'submenu-enter', async (t
 });
 
 ariaTest('ESCAPE to submenu closes submenu', exampleFile, 'submenu-escape', async (t) => {
-  t.plan(50);
-
-  const menuitems = await t.context.session.findElements(By.css(ex.menubarMenuitemSelector));
-  const submenus = await t.context.session.findElements(By.css(ex.submenuSelector));
+  
+  const menuitems = await t.context.queryElements(t, ex.menubarMenuitemSelector);
+  const submenus = await t.context.queryElements(t, ex.submenuSelector);
 
   for (let menuIndex = 0; menuIndex < ex.numMenus; menuIndex++) {
 
@@ -793,7 +761,7 @@ ariaTest('ESCAPE to submenu closes submenu', exampleFile, 'submenu-escape', asyn
       // Open the submenu
       await menuitems[menuIndex].sendKeys(Key.ENTER);
 
-      const items = await t.context.session.findElements(By.css(ex.allSubmenuItems[menuIndex]));
+      const items = await t.context.queryElements(t, ex.allSubmenuItems[menuIndex]);
       const item = items[itemIndex];
       const itemText = await item.getText();
 
@@ -819,10 +787,9 @@ ariaTest('ESCAPE to submenu closes submenu', exampleFile, 'submenu-escape', asyn
 ariaTest('ARROW_RIGHT to submenu closes submenu and opens next',
   exampleFile, 'submenu-right-arrow', async (t) => {
 
-    t.plan(75);
-
-    const menuitems = await t.context.session.findElements(By.css(ex.menubarMenuitemSelector));
-    const submenus = await t.context.session.findElements(By.css(ex.submenuSelector));
+    
+    const menuitems = await t.context.queryElements(t, ex.menubarMenuitemSelector);
+    const submenus = await t.context.queryElements(t, ex.submenuSelector);
 
     for (let menuIndex = 0; menuIndex < ex.numMenus; menuIndex++) {
 
@@ -831,7 +798,7 @@ ariaTest('ARROW_RIGHT to submenu closes submenu and opens next',
         // Open the submenu
         await menuitems[menuIndex].sendKeys(Key.ENTER);
 
-        const items = await t.context.session.findElements(By.css(ex.allSubmenuItems[menuIndex]));
+        const items = await t.context.queryElements(t, ex.allSubmenuItems[menuIndex]);
         const item = items[itemIndex];
         const itemText = await item.getText();
         const nextMenuIndex = (menuIndex + 1) % ex.numMenus;
@@ -863,10 +830,9 @@ ariaTest('ARROW_RIGHT to submenu closes submenu and opens next',
 ariaTest('ARROW_RIGHT to submenu closes submenu and opens next',
   exampleFile, 'submenu-left-arrow', async (t) => {
 
-    t.plan(75);
-
-    const menuitems = await t.context.session.findElements(By.css(ex.menubarMenuitemSelector));
-    const submenus = await t.context.session.findElements(By.css(ex.submenuSelector));
+    
+    const menuitems = await t.context.queryElements(t, ex.menubarMenuitemSelector);
+    const submenus = await t.context.queryElements(t, ex.submenuSelector);
 
     for (let menuIndex = 0; menuIndex < ex.numMenus; menuIndex++) {
       for (let itemIndex = 0; itemIndex < ex.numSubmenuItems[menuIndex]; itemIndex++) {
@@ -874,7 +840,7 @@ ariaTest('ARROW_RIGHT to submenu closes submenu and opens next',
         // Open the submenu
         await menuitems[menuIndex].sendKeys(Key.ENTER);
 
-        const items = await t.context.session.findElements(By.css(ex.allSubmenuItems[menuIndex]));
+        const items = await t.context.queryElements(t, ex.allSubmenuItems[menuIndex]);
         const item = items[itemIndex];
         const itemText = await item.getText();
         // Account for wrapping (index 0 should go to 3)
@@ -905,15 +871,14 @@ ariaTest('ARROW_RIGHT to submenu closes submenu and opens next',
   });
 
 ariaTest('ARROW_DOWN moves focus to next item', exampleFile, 'submenu-down-arrow', async (t) => {
-  t.plan(25);
-
-  const menuitems = await t.context.session.findElements(By.css(ex.menubarMenuitemSelector));
+  
+  const menuitems = await t.context.queryElements(t, ex.menubarMenuitemSelector);
 
   for (let menuIndex = 0; menuIndex < ex.numMenus; menuIndex++) {
 
     // Open the submenu
     await menuitems[menuIndex].sendKeys(Key.ARROW_DOWN);
-    const items = await t.context.session.findElements(By.css(ex.allSubmenuItems[menuIndex]));
+    const items = await t.context.queryElements(t, ex.allSubmenuItems[menuIndex]);
 
     for (let itemIndex = 0; itemIndex < ex.numSubmenuItems[menuIndex]; itemIndex++) {
       const item = items[itemIndex];
@@ -933,15 +898,14 @@ ariaTest('ARROW_DOWN moves focus to next item', exampleFile, 'submenu-down-arrow
 });
 
 ariaTest('ARROW_DOWN moves focus to previous item', exampleFile, 'submenu-up-arrow', async (t) => {
-  t.plan(25);
-
-  const menuitems = await t.context.session.findElements(By.css(ex.menubarMenuitemSelector));
+  
+  const menuitems = await t.context.queryElements(t, ex.menubarMenuitemSelector);
 
   for (let menuIndex = 0; menuIndex < ex.numMenus; menuIndex++) {
 
     // Open the submenu
     await menuitems[menuIndex].sendKeys(Key.ARROW_DOWN);
-    const items = await t.context.session.findElements(By.css(ex.allSubmenuItems[menuIndex]));
+    const items = await t.context.queryElements(t, ex.allSubmenuItems[menuIndex]);
 
     for (let itemIndex = 0; itemIndex < ex.numSubmenuItems[menuIndex]; itemIndex++) {
       const item = items[itemIndex];
@@ -962,14 +926,13 @@ ariaTest('ARROW_DOWN moves focus to previous item', exampleFile, 'submenu-up-arr
 });
 
 ariaTest('HOME moves focus to first item', exampleFile, 'submenu-home', async (t) => {
-  t.plan(25);
-  const menuitems = await t.context.session.findElements(By.css(ex.menubarMenuitemSelector));
+    const menuitems = await t.context.queryElements(t, ex.menubarMenuitemSelector);
 
   for (let menuIndex = 0; menuIndex < ex.numMenus; menuIndex++) {
 
     // Open the submenu
     await menuitems[menuIndex].sendKeys(Key.ARROW_DOWN);
-    const items = await t.context.session.findElements(By.css(ex.allSubmenuItems[menuIndex]));
+    const items = await t.context.queryElements(t, ex.allSubmenuItems[menuIndex]);
 
     for (let itemIndex = 0; itemIndex < ex.numSubmenuItems[menuIndex]; itemIndex++) {
       const item = items[itemIndex];
@@ -990,14 +953,13 @@ ariaTest('HOME moves focus to first item', exampleFile, 'submenu-home', async (t
 });
 
 ariaTest('END moves focus to last item', exampleFile, 'submenu-end', async (t) => {
-  t.plan(25);
-  const menuitems = await t.context.session.findElements(By.css(ex.menubarMenuitemSelector));
+    const menuitems = await t.context.queryElements(t, ex.menubarMenuitemSelector);
 
   for (let menuIndex = 0; menuIndex < ex.numMenus; menuIndex++) {
 
     // Open the submenu
     await menuitems[menuIndex].sendKeys(Key.ARROW_DOWN);
-    const items = await t.context.session.findElements(By.css(ex.allSubmenuItems[menuIndex]));
+    const items = await t.context.queryElements(t, ex.allSubmenuItems[menuIndex]);
     const lastIndex = items.length - 1;
 
     for (let itemIndex = 0; itemIndex < ex.numSubmenuItems[menuIndex]; itemIndex++) {
@@ -1021,8 +983,7 @@ ariaTest('END moves focus to last item', exampleFile, 'submenu-end', async (t) =
 ariaTest('Character sends to menubar changes focus in menubar',
   exampleFile, 'submenu-character', async (t) => {
 
-    t.plan(9);
-
+    
     const charIndexTest = [
       [ // Tests for menu dropdown 0
         { sendChar: 's', sendIndex: 0, endIndex: 1 },
@@ -1043,12 +1004,12 @@ ariaTest('Character sends to menubar changes focus in menubar',
       ]
     ];
 
-    const menuitems = await t.context.session.findElements(By.css(ex.menubarMenuitemSelector));
+    const menuitems = await t.context.queryElements(t, ex.menubarMenuitemSelector);
     for (let menuIndex = 0; menuIndex < ex.numMenus; menuIndex++) {
 
       // Open the dropdown
       await menuitems[menuIndex].sendKeys(Key.ARROW_DOWN);
-      const items = await t.context.session.findElements(By.css(ex.allSubmenuItems[menuIndex]));
+      const items = await t.context.queryElements(t, ex.allSubmenuItems[menuIndex]);
 
       for (let test of charIndexTest[menuIndex]) {
 

--- a/test/tests/radio_radio-1.js
+++ b/test/tests/radio_radio-1.js
@@ -29,23 +29,19 @@ const checkFocus = async function (t, selector, index) {
 // Attributes
 
 ariaTest('role="radigroup" on div element', exampleFile, 'radiogroup-role', async (t) => {
-  t.plan(1);
-  await assertAriaRoles(t, 'ex1', 'radiogroup', '2', 'div');
+    await assertAriaRoles(t, 'ex1', 'radiogroup', '2', 'div');
 });
 
 ariaTest('"aria-labelledby" attribute on radiogroup', exampleFile, 'radiogroup-aria-labelledby', async (t) => {
-  t.plan(1);
-  await assertAriaLabelledby(t,  ex.radiogroupSelector);
+    await assertAriaLabelledby(t,  ex.radiogroupSelector);
 });
 
 ariaTest('role="radio" on div elements', exampleFile, 'radio-role', async (t) => {
-  t.plan(1);
-  await assertAriaRoles(t, 'ex1', 'radio', '6', 'div');
+    await assertAriaRoles(t, 'ex1', 'radio', '6', 'div');
 });
 
 ariaTest('roving tabindex on radio elements', exampleFile, 'radio-tabindex', async (t) => {
-  t.plan(2);
-
+  
   // Test first radio group
   let radios = ex.radiogroupSelector + ':nth-of-type(1) ' + ex.innerRadioSelector;
   await assertRovingTabindex(t, radios, Key.ARROW_RIGHT);
@@ -56,14 +52,13 @@ ariaTest('roving tabindex on radio elements', exampleFile, 'radio-tabindex', asy
 });
 
 ariaTest('"aria-checked" set on role="radio"', exampleFile, 'radio-aria-checked', async (t) => {
-  t.plan(19);
-
+  
   // The radio groups will be all unchecked on page load
   await assertAttributeValues(t, ex.radioSelector, 'aria-checked', 'false');
 
-  const radiogroups = await t.context.session.findElements(By.css(ex.radiogroupSelector));
+  const radiogroups = await t.context.queryElements(t, ex.radiogroupSelector);
   for (let radiogroup of radiogroups) {
-    let radios = await radiogroup.findElements(By.css(ex.innerRadioSelector));
+    let radios = await t.context.queryElements(t, ex.innerRadioSelector, radiogroup);
 
     for (let checked = 0; checked < radios.length; checked++) {
 
@@ -86,8 +81,7 @@ ariaTest('"aria-checked" set on role="radio"', exampleFile, 'radio-aria-checked'
 // Keys
 
 ariaTest('Moves focus to first or checked item', exampleFile, 'key-tab', async (t) => {
-  t.plan(2);
-
+  
   // On page load, the first item in the radio list should be in tab index
   await assertTabOrder(t, [
     ex.crustRadioSelector + ':nth-of-type(1)',
@@ -108,8 +102,7 @@ ariaTest('Moves focus to first or checked item', exampleFile, 'key-tab', async (
 });
 
 ariaTest('Selects radio item', exampleFile, 'key-space', async (t) => {
-  t.plan(2);
-
+  
   const firstCrustSelector = ex.crustRadioSelector + ':nth-of-type(1)';
   await t.context.session.findElement(By.css(firstCrustSelector)).sendKeys(Key.SPACE);
   await assertAttributeValues(t, firstCrustSelector, 'aria-checked', 'true');
@@ -121,9 +114,8 @@ ariaTest('Selects radio item', exampleFile, 'key-space', async (t) => {
 });
 
 ariaTest('RIGHT ARROW changes focus and checks radio', exampleFile, 'key-right-arrow', async (t) => {
-  t.plan(6);
-
-  let radios = await t.context.session.findElements(By.css(ex.crustRadioSelector));
+  
+  let radios = await t.context.queryElements(t, ex.crustRadioSelector);
 
   // Right arrow moves focus to right
   for (let index = 0; index < radios.length - 1; index++) {
@@ -157,9 +149,8 @@ ariaTest('RIGHT ARROW changes focus and checks radio', exampleFile, 'key-right-a
 });
 
 ariaTest('DOWN ARROW changes focus and checks radio', exampleFile, 'key-down-arrow', async (t) => {
-  t.plan(6);
-
-  let radios = await t.context.session.findElements(By.css(ex.crustRadioSelector));
+  
+  let radios = await t.context.queryElements(t, ex.crustRadioSelector);
 
   // Down arrow moves focus to down
   for (let index = 0; index < radios.length - 1; index++) {
@@ -193,9 +184,8 @@ ariaTest('DOWN ARROW changes focus and checks radio', exampleFile, 'key-down-arr
 });
 
 ariaTest('LEFT ARROW changes focus and checks radio', exampleFile, 'key-left-arrow', async (t) => {
-  t.plan(6);
-
-  let radios = await t.context.session.findElements(By.css(ex.crustRadioSelector));
+  
+  let radios = await t.context.queryElements(t, ex.crustRadioSelector);
 
   // Left arrow should move focus from first item to last, then progressively left
   await radios[0].sendKeys(Key.ARROW_LEFT);
@@ -230,9 +220,8 @@ ariaTest('LEFT ARROW changes focus and checks radio', exampleFile, 'key-left-arr
 });
 
 ariaTest('UP ARROW changes focus and checks radio', exampleFile, 'key-up-arrow', async (t) => {
-  t.plan(6);
-
-  let radios = await t.context.session.findElements(By.css(ex.crustRadioSelector));
+  
+  let radios = await t.context.queryElements(t, ex.crustRadioSelector);
 
   // Up arrow should move focus from first item to last, then progressively up
   await radios[0].sendKeys(Key.ARROW_UP);

--- a/test/tests/radio_radio-2.js
+++ b/test/tests/radio_radio-2.js
@@ -27,40 +27,34 @@ const ex = {
 // Attributes
 
 ariaTest('role="radigroup" on div element', exampleFile, 'radiogroup-role', async (t) => {
-  t.plan(1);
-  await assertAriaRoles(t, 'ex1', 'radiogroup', '2', 'ul');
+    await assertAriaRoles(t, 'ex1', 'radiogroup', '2', 'ul');
 });
 
 ariaTest('"aria-labelledby" attribute on radiogroup', exampleFile, 'radiogroup-aria-labelledby', async (t) => {
-  t.plan(1);
-  await assertAriaLabelledby(t,  ex.radiogroupSelector);
+    await assertAriaLabelledby(t,  ex.radiogroupSelector);
 });
 
 ariaTest('tabindex on radiogroup', exampleFile, 'radiogroup-tabindex', async (t) => {
-  t.plan(1);
-  await assertAttributeValues(t, ex.radiogroupSelector, 'tabindex', '0');
+    await assertAttributeValues(t, ex.radiogroupSelector, 'tabindex', '0');
 });
 
 ariaTest('aria-activedescendant', exampleFile, 'radiogroup-aria-activedescendant', async (t) => {
-  t.plan(2);
-  await assertAttributeValues(t, ex.radiogroupSelectors[0], 'aria-activedescendant', 'rb11');
+    await assertAttributeValues(t, ex.radiogroupSelectors[0], 'aria-activedescendant', 'rb11');
   await assertAttributeValues(t, ex.radiogroupSelectors[1], 'aria-activedescendant', 'rb21');
 });
 
 ariaTest('role="radio" on div elements', exampleFile, 'radio-role', async (t) => {
-  t.plan(1);
-  await assertAriaRoles(t, 'ex1', 'radio', '6', 'li');
+    await assertAriaRoles(t, 'ex1', 'radio', '6', 'li');
 });
 
 ariaTest('"aria-checked" set on role="radio"', exampleFile, 'radio-aria-checked', async (t) => {
-  t.plan(19);
-
+  
   // The radio groups will be all unchecked on page load
   await assertAttributeValues(t, ex.radioSelector, 'aria-checked', 'false');
 
-  const radiogroups = await t.context.session.findElements(By.css(ex.radiogroupSelector));
+  const radiogroups = await t.context.queryElements(t, ex.radiogroupSelector);
   for (let radiogroup of radiogroups) {
-    const radios = await radiogroup.findElements(By.css(ex.innerRadioSelector));
+    const radios = await t.context.queryElements(t, ex.innerRadioSelector, radiogroup);
 
     for (let checked = 0; checked < radios.length; checked++) {
 
@@ -83,8 +77,7 @@ ariaTest('"aria-checked" set on role="radio"', exampleFile, 'radio-aria-checked'
 // Keys
 
 ariaTest('Moves focus to first or checked item', exampleFile, 'key-tab', async (t) => {
-  t.plan(2);
-
+  
   // On page load, the first item in the radio list should be in tab index
   await assertTabOrder(t, [
     ex.radiogroupSelectors[0],
@@ -106,8 +99,7 @@ ariaTest('Moves focus to first or checked item', exampleFile, 'key-tab', async (
 });
 
 ariaTest('Selects radio item', exampleFile, 'key-space', async (t) => {
-  t.plan(2);
-
+  
   await t.context.session.findElement(By.css(ex.radiogroupSelectors[0])).sendKeys(Key.SPACE);
   const firstCrustRadioOption = ex.radioSelectors[0] + ':nth-of-type(1)';
   await assertAttributeValues(t, firstCrustRadioOption, 'aria-checked', 'true');
@@ -118,14 +110,13 @@ ariaTest('Selects radio item', exampleFile, 'key-space', async (t) => {
 });
 
 ariaTest('RIGHT ARROW changes focus and checks radio', exampleFile, 'key-right-arrow', async (t) => {
-  t.plan(12);
-
+  
   for (let groupIndex = 0; groupIndex < 2; groupIndex++) {
 
     const radiogroupSelector = ex.radiogroupSelectors[groupIndex];
     const radioSelector = ex.radioSelectors[groupIndex];
     const radiogroup = await t.context.session.findElement(By.css(radiogroupSelector));
-    const radios = await t.context.session.findElements(By.css(radioSelector));
+    const radios = await t.context.queryElements(t, radioSelector);
 
     // Right arrow moves focus to right
     for (let index = 0; index < radios.length; index++) {
@@ -144,14 +135,13 @@ ariaTest('RIGHT ARROW changes focus and checks radio', exampleFile, 'key-right-a
 });
 
 ariaTest('DOWN ARROW changes focus and checks radio', exampleFile, 'key-down-arrow', async (t) => {
-  t.plan(12);
-
+  
   for (let groupIndex = 0; groupIndex < 2; groupIndex++) {
 
     const radiogroupSelector = ex.radiogroupSelectors[groupIndex];
     const radioSelector = ex.radioSelectors[groupIndex];
     const radiogroup = await t.context.session.findElement(By.css(radiogroupSelector));
-    const radios = await t.context.session.findElements(By.css(radioSelector));
+    const radios = await t.context.queryElements(t, radioSelector);
 
     // Down arrow moves focus to right
     for (let index = 0; index < radios.length; index++) {
@@ -170,14 +160,13 @@ ariaTest('DOWN ARROW changes focus and checks radio', exampleFile, 'key-down-arr
 });
 
 ariaTest('LEFT ARROW changes focus and checks radio', exampleFile, 'key-left-arrow', async (t) => {
-  t.plan(12);
-
+  
   for (let groupIndex = 0; groupIndex < 2; groupIndex++) {
 
     const radiogroupSelector = ex.radiogroupSelectors[groupIndex];
     const radioSelector = ex.radioSelectors[groupIndex];
     const radiogroup = await t.context.session.findElement(By.css(radiogroupSelector));
-    const radios = await t.context.session.findElements(By.css(radioSelector));
+    const radios = await t.context.queryElements(t, radioSelector);
 
     // Left arrow moves focus to left
     for (let index of [0, 2, 1]) {
@@ -196,14 +185,13 @@ ariaTest('LEFT ARROW changes focus and checks radio', exampleFile, 'key-left-arr
 });
 
 ariaTest('UP ARROW changes focus and checks radio', exampleFile, 'key-up-arrow', async (t) => {
-  t.plan(12);
-
+  
   for (let groupIndex = 0; groupIndex < 2; groupIndex++) {
 
     const radiogroupSelector = ex.radiogroupSelectors[groupIndex];
     const radioSelector = ex.radioSelectors[groupIndex];
     const radiogroup = await t.context.session.findElement(By.css(radiogroupSelector));
-    const radios = await t.context.session.findElements(By.css(radioSelector));
+    const radios = await t.context.queryElements(t, radioSelector);
 
     // Up arrow moves focus to up
     for (let index of [0, 2, 1]) {

--- a/test/tests/slider_multithumb.js
+++ b/test/tests/slider_multithumb.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { ariaTest } = require('..');
-const { By, Key } = require('selenium-webdriver');
+const { Key } = require('selenium-webdriver');
 const assertAttributeValues = require('../util/assertAttributeValues');
 const assertAriaLabelExists = require('../util/assertAriaLabelExists');
 const assertAriaRoles = require('../util/assertAriaRoles');
@@ -60,19 +60,16 @@ const verifyAllValues = async function (
 // Attributes
 
 ariaTest('role="slider" on div element', exampleFile, 'slider-role', async (t) => {
-  t.plan(1);
-  await assertAriaRoles(t, 'ex1', 'slider', '4', 'img');
+    await assertAriaRoles(t, 'ex1', 'slider', '4', 'img');
 });
 
 ariaTest('"tabindex" set to "0" on sliders', exampleFile, 'tabindex', async (t) => {
-  t.plan(1);
-  await assertAttributeValues(t, ex.sliderSelector, 'tabindex', '0');
+    await assertAttributeValues(t, ex.sliderSelector, 'tabindex', '0');
 });
 
 ariaTest('"aria-valuemax" set on sliders', exampleFile, 'aria-valuemax', async (t) => {
-  t.plan(4);
-  const hotelSliders = await t.context.session.findElements(By.css(ex.hotelSliderSelector));
-  const flightSliders = await t.context.session.findElements(By.css(ex.flightSliderSelector));
+    const hotelSliders = await t.context.queryElements(t, ex.hotelSliderSelector);
+  const flightSliders = await t.context.queryElements(t, ex.flightSliderSelector);
 
   t.is(
     await hotelSliders[0].getAttribute('aria-valuemax'),
@@ -98,9 +95,8 @@ ariaTest('"aria-valuemax" set on sliders', exampleFile, 'aria-valuemax', async (
 });
 
 ariaTest('"aria-valuemin" set to "0" on sliders', exampleFile, 'aria-valuemin', async (t) => {
-  t.plan(4);
-  const hotelSliders = await t.context.session.findElements(By.css(ex.hotelSliderSelector));
-  const flightSliders = await t.context.session.findElements(By.css(ex.flightSliderSelector));
+    const hotelSliders = await t.context.queryElements(t, ex.hotelSliderSelector);
+  const flightSliders = await t.context.queryElements(t, ex.flightSliderSelector);
 
   t.is(
     await hotelSliders[0].getAttribute('aria-valuemin'),
@@ -125,9 +121,8 @@ ariaTest('"aria-valuemin" set to "0" on sliders', exampleFile, 'aria-valuemin', 
 });
 
 ariaTest('"aria-valuenow" reflects slider value', exampleFile, 'aria-valuenow', async (t) => {
-  t.plan(4);
-  const hotelSliders = await t.context.session.findElements(By.css(ex.hotelSliderSelector));
-  const flightSliders = await t.context.session.findElements(By.css(ex.flightSliderSelector));
+    const hotelSliders = await t.context.queryElements(t, ex.hotelSliderSelector);
+  const flightSliders = await t.context.queryElements(t, ex.flightSliderSelector);
 
   t.is(
     await hotelSliders[0].getAttribute('aria-valuenow'),
@@ -152,9 +147,8 @@ ariaTest('"aria-valuenow" reflects slider value', exampleFile, 'aria-valuenow', 
 });
 
 ariaTest('"aria-valuetext" reflects slider value', exampleFile, 'aria-valuetext', async (t) => {
-  t.plan(4);
-  const hotelSliders = await t.context.session.findElements(By.css(ex.hotelSliderSelector));
-  const flightSliders = await t.context.session.findElements(By.css(ex.flightSliderSelector));
+    const hotelSliders = await t.context.queryElements(t, ex.hotelSliderSelector);
+  const flightSliders = await t.context.queryElements(t, ex.flightSliderSelector);
 
   t.is(
     await hotelSliders[0].getAttribute('aria-valuetext'),
@@ -180,17 +174,15 @@ ariaTest('"aria-valuetext" reflects slider value', exampleFile, 'aria-valuetext'
 
 
 ariaTest('"aria-label" set on sliders', exampleFile, 'aria-label', async (t) => {
-  t.plan(1);
-  await assertAriaLabelExists(t, ex.sliderSelector);
+    await assertAriaLabelExists(t, ex.sliderSelector);
 });
 
 // Keys
 
 ariaTest('Right arrow increases slider value by 1', exampleFile, 'key-right-arrow', async (t) => {
-  t.plan(24);
-
-  const hotelSliders = await t.context.session.findElements(By.css(ex.hotelSliderSelector));
-  const hotelLabels = await t.context.session.findElements(By.css(ex.hotelLabelSelector));
+  
+  const hotelSliders = await t.context.queryElements(t, ex.hotelSliderSelector);
+  const hotelLabels = await t.context.queryElements(t, ex.hotelLabelSelector);
 
   // Send 1 key to lower hotel slider
   await hotelSliders[0].sendKeys(Key.ARROW_RIGHT);
@@ -246,8 +238,8 @@ ariaTest('Right arrow increases slider value by 1', exampleFile, 'key-right-arro
     'after END then one ARROW RIGHT to upper hotel slider'
   );
 
-  const flightSliders = await t.context.session.findElements(By.css(ex.flightSliderSelector));
-  const flightLabels = await t.context.session.findElements(By.css(ex.flightLabelSelector));
+  const flightSliders = await t.context.queryElements(t, ex.flightSliderSelector);
+  const flightLabels = await t.context.queryElements(t, ex.flightLabelSelector);
 
   // Send 1 key to lower flight slider
   await flightSliders[0].sendKeys(Key.ARROW_RIGHT);
@@ -305,10 +297,9 @@ ariaTest('Right arrow increases slider value by 1', exampleFile, 'key-right-arro
 });
 
 ariaTest('Up arrow increases slider value by 1', exampleFile, 'key-up-arrow', async (t) => {
-  t.plan(24);
-
-  const hotelSliders = await t.context.session.findElements(By.css(ex.hotelSliderSelector));
-  const hotelLabels = await t.context.session.findElements(By.css(ex.hotelLabelSelector));
+  
+  const hotelSliders = await t.context.queryElements(t, ex.hotelSliderSelector);
+  const hotelLabels = await t.context.queryElements(t, ex.hotelLabelSelector);
 
   // Send 1 key to lower hotel slider
   await hotelSliders[0].sendKeys(Key.ARROW_UP);
@@ -364,8 +355,8 @@ ariaTest('Up arrow increases slider value by 1', exampleFile, 'key-up-arrow', as
     'after END then one ARROW UP to upper hotel slider'
   );
 
-  const flightSliders = await t.context.session.findElements(By.css(ex.flightSliderSelector));
-  const flightLabels = await t.context.session.findElements(By.css(ex.flightLabelSelector));
+  const flightSliders = await t.context.queryElements(t, ex.flightSliderSelector);
+  const flightLabels = await t.context.queryElements(t, ex.flightLabelSelector);
 
   // Send 1 key to lower flight slider
   await flightSliders[0].sendKeys(Key.ARROW_UP);
@@ -424,10 +415,9 @@ ariaTest('Up arrow increases slider value by 1', exampleFile, 'key-up-arrow', as
 
 
 ariaTest('Page up increases slider value by 10', exampleFile, 'key-page-up', async (t) => {
-  t.plan(24);
-
-  const hotelSliders = await t.context.session.findElements(By.css(ex.hotelSliderSelector));
-  const hotelLabels = await t.context.session.findElements(By.css(ex.hotelLabelSelector));
+  
+  const hotelSliders = await t.context.queryElements(t, ex.hotelSliderSelector);
+  const hotelLabels = await t.context.queryElements(t, ex.hotelLabelSelector);
 
   // Send 1 key to lower hotel slider
   await hotelSliders[0].sendKeys(Key.PAGE_UP);
@@ -483,8 +473,8 @@ ariaTest('Page up increases slider value by 10', exampleFile, 'key-page-up', asy
     'after END then one PAGE UP to upper hotel slider'
   );
 
-  const flightSliders = await t.context.session.findElements(By.css(ex.flightSliderSelector));
-  const flightLabels = await t.context.session.findElements(By.css(ex.flightLabelSelector));
+  const flightSliders = await t.context.queryElements(t, ex.flightSliderSelector);
+  const flightLabels = await t.context.queryElements(t, ex.flightLabelSelector);
 
   // Send 1 key to lower flight slider
   await flightSliders[0].sendKeys(Key.PAGE_UP);
@@ -543,10 +533,9 @@ ariaTest('Page up increases slider value by 10', exampleFile, 'key-page-up', asy
 
 
 ariaTest('left arrow decreases slider value by 1', exampleFile, 'key-left-arrow', async (t) => {
-  t.plan(24);
-
-  const hotelSliders = await t.context.session.findElements(By.css(ex.hotelSliderSelector));
-  const hotelLabels = await t.context.session.findElements(By.css(ex.hotelLabelSelector));
+  
+  const hotelSliders = await t.context.queryElements(t, ex.hotelSliderSelector);
+  const hotelLabels = await t.context.queryElements(t, ex.hotelLabelSelector);
 
   // Send 1 key to lower hotel slider
   await hotelSliders[0].sendKeys(Key.ARROW_LEFT);
@@ -602,8 +591,8 @@ ariaTest('left arrow decreases slider value by 1', exampleFile, 'key-left-arrow'
     'after HOME then one ARROW LEFT to upper hotel slider'
   );
 
-  const flightSliders = await t.context.session.findElements(By.css(ex.flightSliderSelector));
-  const flightLabels = await t.context.session.findElements(By.css(ex.flightLabelSelector));
+  const flightSliders = await t.context.queryElements(t, ex.flightSliderSelector);
+  const flightLabels = await t.context.queryElements(t, ex.flightLabelSelector);
 
   // Send 1 key to lower flight slider
   await flightSliders[0].sendKeys(Key.ARROW_LEFT);
@@ -661,10 +650,9 @@ ariaTest('left arrow decreases slider value by 1', exampleFile, 'key-left-arrow'
 });
 
 ariaTest('down arrow decreases slider value by 1', exampleFile, 'key-down-arrow', async (t) => {
-  t.plan(24);
-
-  const hotelSliders = await t.context.session.findElements(By.css(ex.hotelSliderSelector));
-  const hotelLabels = await t.context.session.findElements(By.css(ex.hotelLabelSelector));
+  
+  const hotelSliders = await t.context.queryElements(t, ex.hotelSliderSelector);
+  const hotelLabels = await t.context.queryElements(t, ex.hotelLabelSelector);
 
   // Send 1 key to lower hotel slider
   await hotelSliders[0].sendKeys(Key.ARROW_DOWN);
@@ -720,8 +708,8 @@ ariaTest('down arrow decreases slider value by 1', exampleFile, 'key-down-arrow'
     'after HOME then one ARROW DOWN to upper hotel slider'
   );
 
-  const flightSliders = await t.context.session.findElements(By.css(ex.flightSliderSelector));
-  const flightLabels = await t.context.session.findElements(By.css(ex.flightLabelSelector));
+  const flightSliders = await t.context.queryElements(t, ex.flightSliderSelector);
+  const flightLabels = await t.context.queryElements(t, ex.flightLabelSelector);
 
   // Send 1 key to lower flight slider
   await flightSliders[0].sendKeys(Key.ARROW_DOWN);
@@ -780,10 +768,9 @@ ariaTest('down arrow decreases slider value by 1', exampleFile, 'key-down-arrow'
 
 
 ariaTest('page down decreases slider value by 10', exampleFile, 'key-page-down', async (t) => {
-  t.plan(24);
-
-  const hotelSliders = await t.context.session.findElements(By.css(ex.hotelSliderSelector));
-  const hotelLabels = await t.context.session.findElements(By.css(ex.hotelLabelSelector));
+  
+  const hotelSliders = await t.context.queryElements(t, ex.hotelSliderSelector);
+  const hotelLabels = await t.context.queryElements(t, ex.hotelLabelSelector);
 
   // Send 1 key to lower hotel slider
   await hotelSliders[0].sendKeys(Key.PAGE_DOWN);
@@ -839,8 +826,8 @@ ariaTest('page down decreases slider value by 10', exampleFile, 'key-page-down',
     'after HOME then one PAGE DOWN to upper hotel slider'
   );
 
-  const flightSliders = await t.context.session.findElements(By.css(ex.flightSliderSelector));
-  const flightLabels = await t.context.session.findElements(By.css(ex.flightLabelSelector));
+  const flightSliders = await t.context.queryElements(t, ex.flightSliderSelector);
+  const flightLabels = await t.context.queryElements(t, ex.flightLabelSelector);
 
   // Send 1 key to lower flight slider
   await flightSliders[0].sendKeys(Key.PAGE_DOWN);
@@ -899,10 +886,9 @@ ariaTest('page down decreases slider value by 10', exampleFile, 'key-page-down',
 
 
 ariaTest('home sends value to minimum', exampleFile, 'key-home', async (t) => {
-  t.plan(12);
-
-  const hotelSliders = await t.context.session.findElements(By.css(ex.hotelSliderSelector));
-  const hotelLabels = await t.context.session.findElements(By.css(ex.hotelLabelSelector));
+  
+  const hotelSliders = await t.context.queryElements(t, ex.hotelSliderSelector);
+  const hotelLabels = await t.context.queryElements(t, ex.hotelLabelSelector);
 
   // Send 1 key to upper hotel slider
   await hotelSliders[1].sendKeys(Key.HOME);
@@ -932,8 +918,8 @@ ariaTest('home sends value to minimum', exampleFile, 'key-home', async (t) => {
     'after one HOME to lower hotel slider'
   );
 
-  const flightSliders = await t.context.session.findElements(By.css(ex.flightSliderSelector));
-  const flightLabels = await t.context.session.findElements(By.css(ex.flightLabelSelector));
+  const flightSliders = await t.context.queryElements(t, ex.flightSliderSelector);
+  const flightLabels = await t.context.queryElements(t, ex.flightLabelSelector);
 
   // Send 1 key to upper flight slider
   await flightSliders[1].sendKeys(Key.HOME);
@@ -966,10 +952,9 @@ ariaTest('home sends value to minimum', exampleFile, 'key-home', async (t) => {
 
 
 ariaTest('end sends value to minimum', exampleFile, 'key-end', async (t) => {
-  t.plan(12);
-
-  const hotelSliders = await t.context.session.findElements(By.css(ex.hotelSliderSelector));
-  const hotelLabels = await t.context.session.findElements(By.css(ex.hotelLabelSelector));
+  
+  const hotelSliders = await t.context.queryElements(t, ex.hotelSliderSelector);
+  const hotelLabels = await t.context.queryElements(t, ex.hotelLabelSelector);
 
   await hotelSliders[0].sendKeys(Key.END);
 
@@ -997,8 +982,8 @@ ariaTest('end sends value to minimum', exampleFile, 'key-end', async (t) => {
     'after one END to upper hotel slider'
   );
 
-  const flightSliders = await t.context.session.findElements(By.css(ex.flightSliderSelector));
-  const flightLabels = await t.context.session.findElements(By.css(ex.flightLabelSelector));
+  const flightSliders = await t.context.queryElements(t, ex.flightSliderSelector);
+  const flightLabels = await t.context.queryElements(t, ex.flightLabelSelector);
 
   await flightSliders[0].sendKeys(Key.END);
 

--- a/test/tests/slider_slider-1.js
+++ b/test/tests/slider_slider-1.js
@@ -50,7 +50,7 @@ const testDisplayMatchesValue = async function (t, rgbString) {
 };
 
 const sendAllSlidersToEnd = async function (t) {
-  const sliders = await t.context.session.findElements(By.css(ex.sliderSelector));
+  const sliders = await t.context.queryElements(t, ex.sliderSelector);
 
   for (let slider of sliders) {
     await slider.sendKeys(Key.END);
@@ -60,41 +60,34 @@ const sendAllSlidersToEnd = async function (t) {
 // Attributes
 
 ariaTest('role="slider" on div element', exampleFile, 'slider-role', async (t) => {
-  t.plan(1);
-  await assertAriaRoles(t, 'ex1', 'slider', '3', 'div');
+    await assertAriaRoles(t, 'ex1', 'slider', '3', 'div');
 });
 
 ariaTest('"tabindex" set to "0" on sliders', exampleFile, 'tabindex', async (t) => {
-  t.plan(1);
-  await assertAttributeValues(t, ex.sliderSelector, 'tabindex', '0');
+    await assertAttributeValues(t, ex.sliderSelector, 'tabindex', '0');
 });
 
 ariaTest('"aria-valuemax" set to "255" on sliders', exampleFile, 'aria-valuemax', async (t) => {
-  t.plan(1);
-  await assertAttributeValues(t, ex.sliderSelector, 'aria-valuemax', '255');
+    await assertAttributeValues(t, ex.sliderSelector, 'aria-valuemax', '255');
 });
 
 ariaTest('"aria-valuemin" set to "0" on sliders', exampleFile, 'aria-valuemin', async (t) => {
-  t.plan(1);
-  await assertAttributeValues(t, ex.sliderSelector, 'aria-valuemin', '0');
+    await assertAttributeValues(t, ex.sliderSelector, 'aria-valuemin', '0');
 });
 
 ariaTest('"aria-valuenow" reflects slider value', exampleFile, 'aria-valuenow', async (t) => {
-  t.plan(1);
-  await assertAttributeValues(t, ex.sliderSelector, 'aria-valuenow', '0');
+    await assertAttributeValues(t, ex.sliderSelector, 'aria-valuenow', '0');
 });
 
 ariaTest('"aria-labelledby" set on sliders', exampleFile, 'aria-labelledby', async (t) => {
-  t.plan(1);
-  await assertAriaLabelledby(t, ex.sliderSelector);
+    await assertAriaLabelledby(t, ex.sliderSelector);
 });
 
 // Keys
 
 ariaTest('Right arrow increases slider value by 1', exampleFile, 'key-right-arrow', async (t) => {
-  t.plan(12);
-
-  const sliders = await t.context.session.findElements(By.css(ex.sliderSelector));
+  
+  const sliders = await t.context.queryElements(t, ex.sliderSelector);
 
   // Send 1 key to red slider
   const redSlider = sliders[0];
@@ -185,9 +178,8 @@ ariaTest('Right arrow increases slider value by 1', exampleFile, 'key-right-arro
 });
 
 ariaTest('up arrow increases slider value by 1', exampleFile, 'key-up-arrow', async (t) => {
-  t.plan(12);
-
-  const sliders = await t.context.session.findElements(By.css(ex.sliderSelector));
+  
+  const sliders = await t.context.queryElements(t, ex.sliderSelector);
 
   // Send 1 key to red slider
   const redSlider = sliders[0];
@@ -279,9 +271,8 @@ ariaTest('up arrow increases slider value by 1', exampleFile, 'key-up-arrow', as
 
 
 ariaTest('page up increases slider value by 10', exampleFile, 'key-page-up', async (t) => {
-  t.plan(12);
-
-  const sliders = await t.context.session.findElements(By.css(ex.sliderSelector));
+  
+  const sliders = await t.context.queryElements(t, ex.sliderSelector);
 
   // Send 1 key to red slider
   const redSlider = sliders[0];
@@ -372,9 +363,8 @@ ariaTest('page up increases slider value by 10', exampleFile, 'key-page-up', asy
 });
 
 ariaTest('key end set slider at max value', exampleFile, 'key-end', async (t) => {
-  t.plan(6);
-
-  const sliders = await t.context.session.findElements(By.css(ex.sliderSelector));
+  
+  const sliders = await t.context.queryElements(t, ex.sliderSelector);
 
   // Send key end to red slider
   const redSlider = sliders[0];
@@ -420,11 +410,10 @@ ariaTest('key end set slider at max value', exampleFile, 'key-end', async (t) =>
 });
 
 ariaTest('left arrow decreases slider value by 1', exampleFile, 'key-left-arrow', async (t) => {
-  t.plan(12);
-
+  
   await sendAllSlidersToEnd(t);
 
-  const sliders = await t.context.session.findElements(By.css(ex.sliderSelector));
+  const sliders = await t.context.queryElements(t, ex.sliderSelector);
 
   // Send 1 key to red slider
   const redSlider = sliders[0];
@@ -515,11 +504,10 @@ ariaTest('left arrow decreases slider value by 1', exampleFile, 'key-left-arrow'
 });
 
 ariaTest('down arrow decreases slider value by 1', exampleFile, 'key-down-arrow', async (t) => {
-  t.plan(12);
-
+  
   await sendAllSlidersToEnd(t);
 
-  const sliders = await t.context.session.findElements(By.css(ex.sliderSelector));
+  const sliders = await t.context.queryElements(t, ex.sliderSelector);
 
   // Send 1 key to red slider
   const redSlider = sliders[0];
@@ -610,11 +598,10 @@ ariaTest('down arrow decreases slider value by 1', exampleFile, 'key-down-arrow'
 });
 
 ariaTest('page down decreases slider value by 10', exampleFile, 'key-page-down', async (t) => {
-  t.plan(12);
-
+  
   await sendAllSlidersToEnd(t);
 
-  const sliders = await t.context.session.findElements(By.css(ex.sliderSelector));
+  const sliders = await t.context.queryElements(t, ex.sliderSelector);
 
   // Send 1 key to red slider
   const redSlider = sliders[0];
@@ -705,9 +692,8 @@ ariaTest('page down decreases slider value by 10', exampleFile, 'key-page-down',
 });
 
 ariaTest('home set slider value to minimum', exampleFile, 'key-home', async (t) => {
-  t.plan(6);
-
-  const sliders = await t.context.session.findElements(By.css(ex.sliderSelector));
+  
+  const sliders = await t.context.queryElements(t, ex.sliderSelector);
 
   await sendAllSlidersToEnd(t);
 

--- a/test/tests/slider_slider-2.js
+++ b/test/tests/slider_slider-2.js
@@ -36,7 +36,7 @@ const ex = {
 };
 
 const sendAllSlidersToEnd = async function (t) {
-  const sliders = await t.context.session.findElements(By.css(ex.sliderSelector));
+  const sliders = await t.context.queryElements(t, ex.sliderSelector);
 
   for (let slider of sliders) {
     await slider.sendKeys(Key.END);
@@ -53,60 +53,51 @@ const getValueAndText = async function (t, selector) {
 // Attributes
 
 ariaTest('role="slider" on div element', exampleFile, 'slider-role', async (t) => {
-  t.plan(1);
-  await assertAriaRoles(t, 'ex1', 'slider', '3', 'div');
+    await assertAriaRoles(t, 'ex1', 'slider', '3', 'div');
 });
 
 ariaTest('"tabindex" set to "0" on sliders', exampleFile, 'tabindex', async (t) => {
-  t.plan(1);
-  await assertAttributeValues(t, ex.sliderSelector, 'tabindex', '0');
+    await assertAttributeValues(t, ex.sliderSelector, 'tabindex', '0');
 });
 
 ariaTest('"aria-orientation" set on sliders', exampleFile, 'aria-orientation', async (t) => {
-  t.plan(3);
-  await assertAttributeValues(t, ex.tempSelector, 'aria-orientation', 'vertical');
+    await assertAttributeValues(t, ex.tempSelector, 'aria-orientation', 'vertical');
   await assertAttributeValues(t, ex.fanSelector, 'aria-orientation', 'horizontal');
   await assertAttributeValues(t, ex.heatSelector, 'aria-orientation', 'horizontal');
 });
 
 ariaTest('"aria-valuemax" set on sliders', exampleFile, 'aria-valuemax', async (t) => {
-  t.plan(3);
-  await assertAttributeValues(t, ex.tempSelector, 'aria-valuemax', ex.tempMax);
+    await assertAttributeValues(t, ex.tempSelector, 'aria-valuemax', ex.tempMax);
   await assertAttributeValues(t, ex.fanSelector, 'aria-valuemax', ex.fanMax);
   await assertAttributeValues(t, ex.heatSelector, 'aria-valuemax', ex.heatMax);
 });
 
 ariaTest('"aria-valuemin" set on sliders', exampleFile, 'aria-valuemin', async (t) => {
-  t.plan(3);
-  await assertAttributeValues(t, ex.tempSelector, 'aria-valuemin', ex.tempMin);
+    await assertAttributeValues(t, ex.tempSelector, 'aria-valuemin', ex.tempMin);
   await assertAttributeValues(t, ex.fanSelector, 'aria-valuemin', ex.fanMin);
   await assertAttributeValues(t, ex.heatSelector, 'aria-valuemin', ex.heatMin);
 });
 
 ariaTest('"aria-valuenow" reflects slider value', exampleFile, 'aria-valuenow', async (t) => {
-  t.plan(3);
-  await assertAttributeValues(t, ex.tempSelector, 'aria-valuenow', ex.tempDefault);
+    await assertAttributeValues(t, ex.tempSelector, 'aria-valuenow', ex.tempDefault);
   await assertAttributeValues(t, ex.fanSelector, 'aria-valuenow', '0');
   await assertAttributeValues(t, ex.heatSelector, 'aria-valuenow', '0');
 });
 
 ariaTest('"aria-valuetext" reflects slider value', exampleFile, 'aria-valuetext', async (t) => {
-  t.plan(2);
-  await assertAttributeValues(t, ex.fanSelector, 'aria-valuetext', ex.fanValues[0]);
+    await assertAttributeValues(t, ex.fanSelector, 'aria-valuetext', ex.fanValues[0]);
   await assertAttributeValues(t, ex.heatSelector, 'aria-valuetext', ex.heatValues[0]);
 });
 
 ariaTest('"aria-labelledby" set on sliders', exampleFile, 'aria-labelledby', async (t) => {
-  t.plan(1);
-  await assertAriaLabelledby(t, ex.sliderSelector);
+    await assertAriaLabelledby(t, ex.sliderSelector);
 });
 
 
 // Keys
 
 ariaTest('Right arrow increases slider value by 1', exampleFile, 'key-right-arrow', async (t) => {
-  t.plan(8);
-
+  
   // Send 1 key to temp slider
   const tempSlider = await t.context.session.findElement(By.css(ex.tempSelector));
   await tempSlider.sendKeys(Key.ARROW_RIGHT);
@@ -184,8 +175,7 @@ ariaTest('Right arrow increases slider value by 1', exampleFile, 'key-right-arro
 });
 
 ariaTest('up arrow increases slider value by 1', exampleFile, 'key-up-arrow', async (t) => {
-  t.plan(8);
-
+  
   // Send 1 key to temp slider
   const tempSlider = await t.context.session.findElement(By.css(ex.tempSelector));
   await tempSlider.sendKeys(Key.ARROW_UP);
@@ -264,8 +254,7 @@ ariaTest('up arrow increases slider value by 1', exampleFile, 'key-up-arrow', as
 
 
 ariaTest('page up increases slider value by 10', exampleFile, 'key-page-up', async (t) => {
-  t.plan(4);
-
+  
   // Send 1 key to temp slider
   const tempSlider = await t.context.session.findElement(By.css(ex.tempSelector));
   await tempSlider.sendKeys(Key.PAGE_UP);
@@ -300,8 +289,7 @@ ariaTest('page up increases slider value by 10', exampleFile, 'key-page-up', asy
 });
 
 ariaTest('key end set slider at max value', exampleFile, 'key-end', async (t) => {
-  t.plan(4);
-
+  
   // Send key end to temp slider
   const tempSlider = await t.context.session.findElement(By.css(ex.tempSelector));
   await tempSlider.sendKeys(Key.END);
@@ -339,8 +327,7 @@ ariaTest('key end set slider at max value', exampleFile, 'key-end', async (t) =>
 });
 
 ariaTest('left arrow decreases slider value by 1', exampleFile, 'key-left-arrow', async (t) => {
-  t.plan(8);
-
+  
   await sendAllSlidersToEnd(t);
 
   // Send 1 key to temp slider
@@ -423,8 +410,7 @@ ariaTest('left arrow decreases slider value by 1', exampleFile, 'key-left-arrow'
 });
 
 ariaTest('down arrow decreases slider value by 1', exampleFile, 'key-down-arrow', async (t) => {
-  t.plan(8);
-
+  
   await sendAllSlidersToEnd(t);
 
   // Send 1 key to temp slider
@@ -507,8 +493,7 @@ ariaTest('down arrow decreases slider value by 1', exampleFile, 'key-down-arrow'
 });
 
 ariaTest('page down decreases slider value by 10', exampleFile, 'key-page-down', async (t) => {
-  t.plan(4);
-
+  
   // Send 1 key to temp slider
   const tempSlider = await t.context.session.findElement(By.css(ex.tempSelector));
   await tempSlider.sendKeys(Key.PAGE_DOWN);
@@ -543,8 +528,7 @@ ariaTest('page down decreases slider value by 10', exampleFile, 'key-page-down',
 });
 
 ariaTest('home set slider value to minimum', exampleFile, 'key-home', async (t) => {
-  t.plan(4);
-
+  
   // Send key home to temp slider
   const tempSlider = await t.context.session.findElement(By.css(ex.tempSelector));
   await tempSlider.sendKeys(Key.HOME);

--- a/test/tests/spinbutton_datepicker.js
+++ b/test/tests/spinbutton_datepicker.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const { ariaTest } = require('..');
-const { By, Key } = require('selenium-webdriver');
 const assertAttributeValues = require('../util/assertAttributeValues');
 const assertAriaLabelledby = require('../util/assertAriaLabelledby');
 const assertAriaRoles = require('../util/assertAriaRoles');
@@ -59,51 +58,43 @@ const ex = {
 // Attributes
 
 ariaTest('role="group" on div element', exampleFile, 'group-role', async (t) => {
-  t.plan(1);
-  await assertAriaRoles(t, 'example', 'group', '1', 'div');
+    await assertAriaRoles(t, 'example', 'group', '1', 'div');
 });
 
 ariaTest('"aria-labelledby" attribute on group', exampleFile, 'group-aria-labelledby', async (t) => {
-  t.plan(1);
-  await assertAriaLabelledby(t,  ex.groupSelector);
+    await assertAriaLabelledby(t,  ex.groupSelector);
 });
 
 ariaTest('role="spinbutton" on div element', exampleFile, 'spinbutton-role', async (t) => {
-  t.plan(1);
-  await assertAriaRoles(t, 'example', 'spinbutton', '3', 'div');
+    await assertAriaRoles(t, 'example', 'spinbutton', '3', 'div');
 });
 
 ariaTest('"aria-valuemax" represetns the minimum value on spinbuttons', exampleFile, 'spinbutton-aria-valuemax', async (t) => {
-  t.plan(3);
-  await assertAttributeValues(t, ex.daySelector, 'aria-valuemax', ex.dayMax);
+    await assertAttributeValues(t, ex.daySelector, 'aria-valuemax', ex.dayMax);
   await assertAttributeValues(t, ex.monthSelector, 'aria-valuemax', ex.monthMax);
   await assertAttributeValues(t, ex.yearSelector, 'aria-valuemax', ex.yearMax);
 });
 
 ariaTest('"aria-valuemin" represents the maximum value on spinbuttons', exampleFile, 'spinbutton-aria-valuemin', async (t) => {
-  t.plan(3);
-  await assertAttributeValues(t, ex.daySelector, 'aria-valuemin', ex.dayMin);
+    await assertAttributeValues(t, ex.daySelector, 'aria-valuemin', ex.dayMin);
   await assertAttributeValues(t, ex.monthSelector, 'aria-valuemin', ex.monthMin);
   await assertAttributeValues(t, ex.yearSelector, 'aria-valuemin', ex.yearMin);
 });
 
 ariaTest('"aria-valuenow" reflects spinbutton value as a number', exampleFile, 'spinbutton-aria-valuenow', async (t) => {
-  t.plan(3);
-  await assertAttributeValues(t, ex.daySelector, 'aria-valuenow', ex.dayNow);
+    await assertAttributeValues(t, ex.daySelector, 'aria-valuenow', ex.dayNow);
   await assertAttributeValues(t, ex.monthSelector, 'aria-valuenow', ex.monthNow);
   await assertAttributeValues(t, ex.yearSelector, 'aria-valuenow', ex.yearNow);
 });
 
 
 ariaTest('"aria-valuetext" reflects spin button value as a text string', exampleFile, 'spinbutton-aria-valuetext', async (t) => {
-  t.plan(2);
-  await assertAttributeValues(t, ex.daySelector, 'aria-valuetext', ex.dayText);
+    await assertAttributeValues(t, ex.daySelector, 'aria-valuetext', ex.dayText);
   await assertAttributeValues(t, ex.monthSelector, 'aria-valuetext', ex.monthText);
 });
 
 ariaTest('"aria-label" provides accessible name for the spin buttons to screen reader users', exampleFile, 'spinbutton-aria-label', async (t) => {
-  t.plan(3);
-
+  
   await assertAttributeValues(t, ex.daySelector, 'aria-label', 'Day');
   await assertAttributeValues(t, ex.monthSelector, 'aria-label', 'Month');
   await assertAttributeValues(t, ex.yearSelector, 'aria-label', 'Year');
@@ -111,8 +102,7 @@ ariaTest('"aria-label" provides accessible name for the spin buttons to screen r
 });
 
 ariaTest('"tabindex=-1" removes previous and next from the tab order of the page', exampleFile, 'button-tabindex', async (t) => {
-  t.plan(6);
-  await assertAttributeValues(t, ex.dayIncreaseSelector, 'tabindex', '-1');
+    await assertAttributeValues(t, ex.dayIncreaseSelector, 'tabindex', '-1');
   await assertAttributeValues(t, ex.dayDecreaseSelector, 'tabindex', '-1');
 
   await assertAttributeValues(t, ex.monthIncreaseSelector, 'tabindex', '-1');
@@ -123,8 +113,7 @@ ariaTest('"tabindex=-1" removes previous and next from the tab order of the page
 });
 
 ariaTest('"aria-label" provides accessible name for the previous and next buttons to screen reader users', exampleFile, 'button-aria-label', async (t) => {
-  t.plan(6);
-  await assertAttributeValues(t, ex.dayIncreaseSelector, 'aria-label', 'next day');
+    await assertAttributeValues(t, ex.dayIncreaseSelector, 'aria-label', 'next day');
   await assertAttributeValues(t, ex.dayDecreaseSelector, 'aria-label', 'previous day');
 
   await assertAttributeValues(t, ex.monthIncreaseSelector, 'aria-label', 'next month');
@@ -135,8 +124,7 @@ ariaTest('"aria-label" provides accessible name for the previous and next button
 });
 
 ariaTest('"aria-hidden" hides decorative and redundant content form screen reader users', exampleFile, 'spinbutton-aria-hidden', async (t) => {
-  t.plan(6);
-  await assertAttributeValues(t, ex.dayHiddenPreviousSelector, 'aria-hidden', 'true');
+    await assertAttributeValues(t, ex.dayHiddenPreviousSelector, 'aria-hidden', 'true');
   await assertAttributeValues(t, ex.dayHiddenNextSelector, 'aria-hidden', 'true');
 
   await assertAttributeValues(t, ex.monthHiddenPreviousSelector, 'aria-hidden', 'true');

--- a/test/tests/table_table.js
+++ b/test/tests/table_table.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const { ariaTest } = require('..');
-const { By, Key } = require('selenium-webdriver');
 const assertAriaDescribedby = require('../util/assertAriaDescribedby');
 const assertAriaLabelExists = require('../util/assertAriaLabelExists');
 const assertAriaRoles = require('../util/assertAriaRoles');
@@ -19,27 +18,21 @@ const ex = {
 // Attributes
 
 ariaTest('role="table" element exists', exampleFile, 'table-role', async (t) => {
-  t.plan(1);
-  await assertAriaRoles(t, 'ex1', 'table', 1, 'div');
+    await assertAriaRoles(t, 'ex1', 'table', 1, 'div');
 });
 
 ariaTest('"aria-label" attribute on table element', exampleFile, 'table-aria-label', async (t) => {
-  t.plan(1);
-  await assertAriaLabelExists(t, ex.tableSelector);
+    await assertAriaLabelExists(t, ex.tableSelector);
 });
 
 ariaTest('"aria-describedby" attribute on table element', exampleFile, 'table-aria-describedby', async (t) => {
-  t.plan(1);
-  await assertAriaDescribedby(t, ex.tableSelector);
+    await assertAriaDescribedby(t, ex.tableSelector);
 });
 
 
 ariaTest('role="rowgroup" exists', exampleFile, 'rowgroup-role', async (t) => {
-  t.plan(1);
-
-  const rowgroups = await t.context.session.findElements(By.css(
-    ex.tableSelector + ' [role="rowgroup"]'
-  ));
+  
+  const rowgroups = await t.context.queryElements(t, ex.tableSelector + ' [role="rowgroup"]');
 
   t.is(
     rowgroups.length,
@@ -50,11 +43,8 @@ ariaTest('role="rowgroup" exists', exampleFile, 'rowgroup-role', async (t) => {
 
 
 ariaTest('role="row" exists', exampleFile, 'row-role', async (t) => {
-  t.plan(1);
-
-  const rows = await t.context.session.findElements(By.css(
-    ex.tableSelector + ' [role="rowgroup"] [role="row"]'
-  ));
+  
+  const rows = await t.context.queryElements(t, ex.tableSelector + ' [role="rowgroup"] [role="row"]');
 
   t.is(
     rows.length,
@@ -65,11 +55,8 @@ ariaTest('role="row" exists', exampleFile, 'row-role', async (t) => {
 
 
 ariaTest('role="columnheader" exists', exampleFile, 'columnheader-role', async (t) => {
-  t.plan(1);
-
-  const columnheaders = await t.context.session.findElements(By.css(
-    ex.tableSelector + ' [role="rowgroup"] [role="row"] [role="columnheader"]'
-  ));
+  
+  const columnheaders = await t.context.queryElements(t, ex.tableSelector + ' [role="rowgroup"] [role="row"] [role="columnheader"]');
 
   t.is(
     columnheaders.length,
@@ -80,11 +67,8 @@ ariaTest('role="columnheader" exists', exampleFile, 'columnheader-role', async (
 });
 
 ariaTest('role="cell" exists', exampleFile, 'cell-role', async (t) => {
-  t.plan(1);
-
-  const cells = await t.context.session.findElements(By.css(
-    ex.tableSelector + ' [role="rowgroup"] [role="row"] [role="cell"]'
-  ));
+  
+  const cells = await t.context.queryElements(t, ex.tableSelector + ' [role="rowgroup"] [role="row"] [role="cell"]');
 
   t.is(
     cells.length,

--- a/test/tests/tabs_tabs-1.js
+++ b/test/tests/tabs_tabs-1.js
@@ -1,3 +1,5 @@
+/* eslint no-restricted-properties: 0 */
+
 'use strict';
 
 const { ariaTest } = require('..');
@@ -62,7 +64,7 @@ ariaTest('role="tab" on button elements', exampleFile, 'tab-role', async (t) => 
 });
 
 ariaTest('"aria-selected" set on role="tab"', exampleFile, 'tab-aria-selected', async (t) => {
-  
+
   let tabs = await t.context.queryElements(t, ex.tabSelector);
   let tabpanels = await t.context.queryElements(t, ex.tabpanelSelector);
 
@@ -95,7 +97,7 @@ ariaTest('"aria-selected" set on role="tab"', exampleFile, 'tab-aria-selected', 
 });
 
 ariaTest('"tabindex" on role="tab"', exampleFile, 'tab-tabindex', async (t) => {
-  
+
   let tabs = await t.context.queryElements(t, ex.tabSelector);
   for (let selectedEl = 0; selectedEl < tabs.length; selectedEl++) {
 
@@ -152,7 +154,7 @@ ariaTest('tabindex="0" on role="tabpanel" elements', exampleFile, 'tabpanel-tabi
 // Keys
 
 ariaTest('TAB key moves focus to open tab and panel', exampleFile, 'key-tab', async (t) => {
-  
+
   for (let index = 0; index < ex.tabCount; index++) {
     await openTabAtIndex(t, index);
 
@@ -161,7 +163,7 @@ ariaTest('TAB key moves focus to open tab and panel', exampleFile, 'key-tab', as
 });
 
 ariaTest('ARROW_RIGHT key moves focus and activates tab', exampleFile, 'key-right-arrow', async (t) => {
-  
+
   // Put focus on first tab
   await openTabAtIndex(t, 0);
 
@@ -208,7 +210,7 @@ ariaTest('ARROW_RIGHT key moves focus and activates tab', exampleFile, 'key-righ
 });
 
 ariaTest('ARROW_LEFT key moves focus and activates tab', exampleFile, 'key-left-arrow', async (t) => {
-  
+
   const tabs = await t.context.queryElements(t, ex.tabSelector);
   const tabpanels = await t.context.queryElements(t, ex.tabpanelSelector);
 
@@ -256,7 +258,7 @@ ariaTest('ARROW_LEFT key moves focus and activates tab', exampleFile, 'key-left-
 
 ariaTest('HOME key moves focus and selects tab', exampleFile, 'key-home', async (t) => {
 
-  
+
   const tabs = await t.context.queryElements(t, ex.tabSelector);
   const tabpanels = await t.context.queryElements(t, ex.tabpanelSelector);
   for (let index = 0; index < tabs.length; index++) {
@@ -284,7 +286,7 @@ ariaTest('HOME key moves focus and selects tab', exampleFile, 'key-home', async 
 });
 
 ariaTest('END key moves focus and selects tab', exampleFile, 'key-end', async (t) => {
-  
+
   const tabs = await t.context.queryElements(t, ex.tabSelector);
   const tabpanels = await t.context.queryElements(t, ex.tabpanelSelector);
   for (let index = 0; index < tabs.length; index++) {
@@ -312,7 +314,7 @@ ariaTest('END key moves focus and selects tab', exampleFile, 'key-end', async (t
 });
 
 ariaTest('DELETE key removes third tab', exampleFile, 'key-delete', async (t) => {
-  
+
   let tabs = await t.context.queryElements(t, ex.tabSelector);
 
   // Put focus on the first tab

--- a/test/tests/tabs_tabs-1.js
+++ b/test/tests/tabs_tabs-1.js
@@ -26,7 +26,7 @@ const ex = {
 };
 
 const openTabAtIndex = async function (t, index) {
-  const tabs = await t.context.session.findElements(By.css(ex.tabSelector));
+  const tabs = await t.context.queryElements(t, ex.tabSelector);
   await tabs[index].click();
 };
 
@@ -42,7 +42,7 @@ const waitAndCheckFocus = async function (t, selector, index) {
 
 const waitAndCheckAriaSelected = async function (t, index) {
   return t.context.session.wait(async function () {
-    const tabs = await t.context.session.findElements(By.css(ex.tabSelector));
+    const tabs = await t.context.queryElements(t, ex.tabSelector);
     return (await tabs[index].getAttribute('aria-selected')) === 'true';
   }, t.context.waitTime, 'Timeout waiting for aria-selected to be set to true.');
 };
@@ -50,25 +50,21 @@ const waitAndCheckAriaSelected = async function (t, index) {
 // Attributes
 
 ariaTest('role="tablist" on div element', exampleFile, 'tablist-role', async (t) => {
-  t.plan(1);
-  await assertAriaRoles(t, 'ex1', 'tablist', '1', 'div');
+    await assertAriaRoles(t, 'ex1', 'tablist', '1', 'div');
 });
 
 ariaTest('"ariaLabel" attribute on role="tablist"', exampleFile, 'tablist-aria-label', async (t) => {
-  t.plan(1);
-  await assertAriaLabelExists(t, ex.tablistSelector);
+    await assertAriaLabelExists(t, ex.tablistSelector);
 });
 
 ariaTest('role="tab" on button elements', exampleFile, 'tab-role', async (t) => {
-  t.plan(1);
-  await assertAriaRoles(t, 'ex1', 'tab', '3', 'button');
+    await assertAriaRoles(t, 'ex1', 'tab', '3', 'button');
 });
 
 ariaTest('"aria-selected" set on role="tab"', exampleFile, 'tab-aria-selected', async (t) => {
-  t.plan(18);
-
-  let tabs = await t.context.session.findElements(By.css(ex.tabSelector));
-  let tabpanels = await t.context.session.findElements(By.css(ex.tabpanelSelector));
+  
+  let tabs = await t.context.queryElements(t, ex.tabSelector);
+  let tabpanels = await t.context.queryElements(t, ex.tabpanelSelector);
 
   for (let selectedEl = 0; selectedEl < tabs.length; selectedEl++) {
 
@@ -99,9 +95,8 @@ ariaTest('"aria-selected" set on role="tab"', exampleFile, 'tab-aria-selected', 
 });
 
 ariaTest('"tabindex" on role="tab"', exampleFile, 'tab-tabindex', async (t) => {
-  t.plan(9);
-
-  let tabs = await t.context.session.findElements(By.css(ex.tabSelector));
+  
+  let tabs = await t.context.queryElements(t, ex.tabSelector);
   for (let selectedEl = 0; selectedEl < tabs.length; selectedEl++) {
 
     // Open the tab
@@ -138,31 +133,26 @@ ariaTest('"tabindex" on role="tab"', exampleFile, 'tab-tabindex', async (t) => {
 });
 
 ariaTest('"aria-control" attribute on role="tab"', exampleFile, 'tab-aria-control', async (t) => {
-  t.plan(1);
-  await assertAriaControls(t, ex.tabSelector);
+    await assertAriaControls(t, ex.tabSelector);
 });
 
 ariaTest('role="tabpanel" on div element', exampleFile, 'tabpanel-role', async (t) => {
-  t.plan(1);
-  await assertAriaRoles(t, 'ex1', 'tabpanel', '3', 'div');
+    await assertAriaRoles(t, 'ex1', 'tabpanel', '3', 'div');
 });
 
 ariaTest('"aria-labelledby" attribute on role="tabpanel" elements', exampleFile, 'tabpanel-aria-labelledby', async (t) => {
-  t.plan(1);
-  await assertAriaLabelledby(t, ex.tabpanelSelector);
+    await assertAriaLabelledby(t, ex.tabpanelSelector);
 });
 
 ariaTest('tabindex="0" on role="tabpanel" elements', exampleFile, 'tabpanel-tabindex', async (t) => {
-  t.plan(1);
-  await assertAttributeValues(t, ex.tabpanelSelector, 'tabindex', '0');
+    await assertAttributeValues(t, ex.tabpanelSelector, 'tabindex', '0');
 });
 
 
 // Keys
 
 ariaTest('TAB key moves focus to open tab and panel', exampleFile, 'key-tab', async (t) => {
-  t.plan(3);
-
+  
   for (let index = 0; index < ex.tabCount; index++) {
     await openTabAtIndex(t, index);
 
@@ -171,13 +161,12 @@ ariaTest('TAB key moves focus to open tab and panel', exampleFile, 'key-tab', as
 });
 
 ariaTest('ARROW_RIGHT key moves focus and activates tab', exampleFile, 'key-right-arrow', async (t) => {
-  t.plan(9);
-
+  
   // Put focus on first tab
   await openTabAtIndex(t, 0);
 
-  const tabs = await t.context.session.findElements(By.css(ex.tabSelector));
-  const tabpanels = await t.context.session.findElements(By.css(ex.tabpanelSelector));
+  const tabs = await t.context.queryElements(t, ex.tabSelector);
+  const tabpanels = await t.context.queryElements(t, ex.tabpanelSelector);
   for (let index = 0; index < tabs.length - 1; index++) {
 
     // Send the arrow right key to move focus
@@ -219,10 +208,9 @@ ariaTest('ARROW_RIGHT key moves focus and activates tab', exampleFile, 'key-righ
 });
 
 ariaTest('ARROW_LEFT key moves focus and activates tab', exampleFile, 'key-left-arrow', async (t) => {
-  t.plan(9);
-
-  const tabs = await t.context.session.findElements(By.css(ex.tabSelector));
-  const tabpanels = await t.context.session.findElements(By.css(ex.tabpanelSelector));
+  
+  const tabs = await t.context.queryElements(t, ex.tabSelector);
+  const tabpanels = await t.context.queryElements(t, ex.tabpanelSelector);
 
   // Put focus on first tab
   await openTabAtIndex(t, 0);
@@ -268,10 +256,9 @@ ariaTest('ARROW_LEFT key moves focus and activates tab', exampleFile, 'key-left-
 
 ariaTest('HOME key moves focus and selects tab', exampleFile, 'key-home', async (t) => {
 
-  t.plan(9);
-
-  const tabs = await t.context.session.findElements(By.css(ex.tabSelector));
-  const tabpanels = await t.context.session.findElements(By.css(ex.tabpanelSelector));
+  
+  const tabs = await t.context.queryElements(t, ex.tabSelector);
+  const tabpanels = await t.context.queryElements(t, ex.tabpanelSelector);
   for (let index = 0; index < tabs.length; index++) {
 
     // Put focus on the tab
@@ -297,10 +284,9 @@ ariaTest('HOME key moves focus and selects tab', exampleFile, 'key-home', async 
 });
 
 ariaTest('END key moves focus and selects tab', exampleFile, 'key-end', async (t) => {
-  t.plan(9);
-
-  const tabs = await t.context.session.findElements(By.css(ex.tabSelector));
-  const tabpanels = await t.context.session.findElements(By.css(ex.tabpanelSelector));
+  
+  const tabs = await t.context.queryElements(t, ex.tabSelector);
+  const tabpanels = await t.context.queryElements(t, ex.tabpanelSelector);
   for (let index = 0; index < tabs.length; index++) {
 
     // Put focus on the tab
@@ -326,9 +312,8 @@ ariaTest('END key moves focus and selects tab', exampleFile, 'key-end', async (t
 });
 
 ariaTest('DELETE key removes third tab', exampleFile, 'key-delete', async (t) => {
-  t.plan(4);
-
-  let tabs = await t.context.session.findElements(By.css(ex.tabSelector));
+  
+  let tabs = await t.context.queryElements(t, ex.tabSelector);
 
   // Put focus on the first tab
   await openTabAtIndex(t, 0);
@@ -337,7 +322,7 @@ ariaTest('DELETE key removes third tab', exampleFile, 'key-delete', async (t) =>
   await tabs[0].sendKeys(Key.DELETE);
 
   t.is(
-    (await t.context.session.findElements(By.css(ex.tabSelector))).length,
+    (await t.context.queryElements(t, ex.tabSelector)).length,
     3,
     'Sending DELETE to first tab should not change number of tabs'
   );
@@ -349,7 +334,7 @@ ariaTest('DELETE key removes third tab', exampleFile, 'key-delete', async (t) =>
   await tabs[1].sendKeys(Key.DELETE);
 
   t.is(
-    (await t.context.session.findElements(By.css(ex.tabSelector))).length,
+    (await t.context.queryElements(t, ex.tabSelector)).length,
     3,
     'Sending DELETE to second tab should not change number of tabs'
   );
@@ -361,7 +346,7 @@ ariaTest('DELETE key removes third tab', exampleFile, 'key-delete', async (t) =>
   await tabs[2].sendKeys(Key.DELETE);
 
   t.is(
-    (await t.context.session.findElements(By.css(ex.tabSelector))).length,
+    (await t.context.queryElements(t, ex.tabSelector)).length,
     2,
     'Sending DELETE to third tab should change number of tabs'
   );

--- a/test/tests/tabs_tabs-1.js
+++ b/test/tests/tabs_tabs-1.js
@@ -1,5 +1,3 @@
-/* eslint no-restricted-properties: 0 */
-
 'use strict';
 
 const { ariaTest } = require('..');

--- a/test/tests/tabs_tabs-1.js
+++ b/test/tests/tabs_tabs-1.js
@@ -9,6 +9,7 @@ const assertAriaControls = require('../util/assertAriaControls');
 const assertAriaLabelledby = require('../util/assertAriaLabelledby');
 const assertAriaLabelExists = require('../util/assertAriaLabelExists');
 const assertAriaRoles = require('../util/assertAriaRoles');
+const assertNoElements = require('../util/assertNoElements');
 const assertTabOrder = require('../util/assertTabOrder');
 
 const exampleFile = 'tabs/tabs-1/tabs.html';
@@ -353,10 +354,5 @@ ariaTest('DELETE key removes third tab', exampleFile, 'key-delete', async (t) =>
     'Sending DELETE to third tab should change number of tabs'
   );
 
-  t.is(
-    (await t.context.session.findElements(By.id(ex.deletableId))).length,
-    0,
-    'Sending DELETE to third tab should have delete tab with id: ' + ex.deletableId
-  );
-
+  assertNoElements(t, `#${ex.deletableId}`, `Sending DELETE to third tab should have delete tab with id: ${ex.deletableId}`);
 });

--- a/test/tests/tabs_tabs-2.js
+++ b/test/tests/tabs_tabs-2.js
@@ -1,5 +1,3 @@
-/* eslint no-restricted-properties: 0 */
-
 'use strict';
 
 const { ariaTest } = require('..');

--- a/test/tests/tabs_tabs-2.js
+++ b/test/tests/tabs_tabs-2.js
@@ -43,7 +43,7 @@ const waitAndCheckFocus = async function (t, selector, index) {
 
 const waitAndCheckAriaSelected = async function (t, index) {
   return t.context.session.wait(async function () {
-    const tabs = await t.context.session.findElements(By.css(ex.tabSelector));
+    const tabs = await t.context.queryElements(t, ex.tabSelector);
     return (await tabs[index].getAttribute('aria-selected')) === 'true';
   }, t.context.waitTime, 'Timeout waiting for aria-selected to be set to true.');
 };
@@ -51,25 +51,21 @@ const waitAndCheckAriaSelected = async function (t, index) {
 // Attributes
 
 ariaTest('role="tablist" on div element', exampleFile, 'tablist-role', async (t) => {
-  t.plan(1);
-  await assertAriaRoles(t, 'ex1', 'tablist', '1', 'div');
+    await assertAriaRoles(t, 'ex1', 'tablist', '1', 'div');
 });
 
 ariaTest('"ariaLabel" attribute on role="tablist"', exampleFile, 'tablist-aria-label', async (t) => {
-  t.plan(1);
-  await assertAriaLabelExists(t, ex.tablistSelector);
+    await assertAriaLabelExists(t, ex.tablistSelector);
 });
 
 ariaTest('role="tab" on button elements', exampleFile, 'tab-role', async (t) => {
-  t.plan(1);
-  await assertAriaRoles(t, 'ex1', 'tab', '3', 'button');
+    await assertAriaRoles(t, 'ex1', 'tab', '3', 'button');
 });
 
 ariaTest('"aria-selected" set on role="tab"', exampleFile, 'tab-aria-selected', async (t) => {
-  t.plan(18);
-
-  const tabs = await t.context.session.findElements(By.css(ex.tabSelector));
-  const tabpanels = await t.context.session.findElements(By.css(ex.tabpanelSelector));
+  
+  const tabs = await t.context.queryElements(t, ex.tabSelector);
+  const tabpanels = await t.context.queryElements(t, ex.tabpanelSelector);
 
   for (let selectedEl = 0; selectedEl < tabs.length; selectedEl++) {
 
@@ -100,9 +96,8 @@ ariaTest('"aria-selected" set on role="tab"', exampleFile, 'tab-aria-selected', 
 });
 
 ariaTest('"tabindex" on role="tab"', exampleFile, 'tab-tabindex', async (t) => {
-  t.plan(9);
-
-  const tabs = await t.context.session.findElements(By.css(ex.tabSelector));
+  
+  const tabs = await t.context.queryElements(t, ex.tabSelector);
   for (let selectedEl = 0; selectedEl < tabs.length; selectedEl++) {
 
     // Open the tab
@@ -140,31 +135,26 @@ ariaTest('"tabindex" on role="tab"', exampleFile, 'tab-tabindex', async (t) => {
 });
 
 ariaTest('"aria-control" attribute on role="tab"', exampleFile, 'tab-aria-controls', async (t) => {
-  t.plan(1);
-  await assertAriaControls(t, ex.tabSelector);
+    await assertAriaControls(t, ex.tabSelector);
 });
 
 ariaTest('role="tabpanel" on div element', exampleFile, 'tabpanel-role', async (t) => {
-  t.plan(1);
-  await assertAriaRoles(t, 'ex1', 'tabpanel', '3', 'div');
+    await assertAriaRoles(t, 'ex1', 'tabpanel', '3', 'div');
 });
 
 ariaTest('"aria-labelledby" attribute on role="tabpanel" elements', exampleFile, 'tabpanel-aria-labelledby', async (t) => {
-  t.plan(1);
-  await assertAriaLabelledby(t, ex.tabpanelSelector);
+    await assertAriaLabelledby(t, ex.tabpanelSelector);
 });
 
 ariaTest('tabindex="0" on role="tabpanel" elements', exampleFile, 'tabpanel-tabindex', async (t) => {
-  t.plan(1);
-  await assertAttributeValues(t, ex.tabpanelSelector, 'tabindex', '0');
+    await assertAttributeValues(t, ex.tabpanelSelector, 'tabindex', '0');
 });
 
 
 // Keys
 
 ariaTest('TAB key moves focus to open tab and panel', exampleFile, 'key-tab', async (t) => {
-  t.plan(3);
-
+  
   for (let index = 0; index < ex.tabCount; index++) {
     await openTabAtIndex(t, index);
 
@@ -173,13 +163,12 @@ ariaTest('TAB key moves focus to open tab and panel', exampleFile, 'key-tab', as
 });
 
 ariaTest('ARROW_RIGHT key moves focus', exampleFile, 'key-right-arrow', async (t) => {
-  t.plan(5);
-
+  
   // Put focus on first tab
   await openTabAtIndex(t, 0);
 
-  const tabs = await t.context.session.findElements(By.css(ex.tabSelector));
-  const tabpanels = await t.context.session.findElements(By.css(ex.tabpanelSelector));
+  const tabs = await t.context.queryElements(t, ex.tabSelector);
+  const tabpanels = await t.context.queryElements(t, ex.tabpanelSelector);
   for (let index = 0; index < tabs.length - 1; index++) {
 
     // Send the arrow right key to move focus
@@ -207,10 +196,9 @@ ariaTest('ARROW_RIGHT key moves focus', exampleFile, 'key-right-arrow', async (t
 });
 
 ariaTest('ENTER activates tab that contains focus', exampleFile, 'key-enter-or-space', async (t) => {
-  t.plan(4);
-
-  const tabs = await t.context.session.findElements(By.css(ex.tabSelector));
-  const tabpanels = await t.context.session.findElements(By.css(ex.tabpanelSelector));
+  
+  const tabs = await t.context.queryElements(t, ex.tabSelector);
+  const tabpanels = await t.context.queryElements(t, ex.tabpanelSelector);
   for (let index = 0; index < tabs.length - 1; index++) {
 
     // Send ENTER to activate tab
@@ -232,10 +220,9 @@ ariaTest('ENTER activates tab that contains focus', exampleFile, 'key-enter-or-s
 });
 
 ariaTest('SPACE activates tab that contains focus', exampleFile, 'key-enter-or-space', async (t) => {
-  t.plan(4);
-
-  const tabs = await t.context.session.findElements(By.css(ex.tabSelector));
-  const tabpanels = await t.context.session.findElements(By.css(ex.tabpanelSelector));
+  
+  const tabs = await t.context.queryElements(t, ex.tabSelector);
+  const tabpanels = await t.context.queryElements(t, ex.tabpanelSelector);
   for (let index = 0; index < tabs.length - 1; index++) {
 
     // Send SPACE to activate tab
@@ -258,10 +245,9 @@ ariaTest('SPACE activates tab that contains focus', exampleFile, 'key-enter-or-s
 
 
 ariaTest('ARROW_LEFT key moves focus', exampleFile, 'key-left-arrow', async (t) => {
-  t.plan(4);
-
-  const tabs = await t.context.session.findElements(By.css(ex.tabSelector));
-  const tabpanels = await t.context.session.findElements(By.css(ex.tabpanelSelector));
+  
+  const tabs = await t.context.queryElements(t, ex.tabSelector);
+  const tabpanels = await t.context.queryElements(t, ex.tabpanelSelector);
 
   // Put focus on first tab
   await openTabAtIndex(t, 0);
@@ -294,10 +280,9 @@ ariaTest('ARROW_LEFT key moves focus', exampleFile, 'key-left-arrow', async (t) 
 
 ariaTest('HOME key moves focus', exampleFile, 'key-home', async (t) => {
 
-  t.plan(3);
-
-  const tabs = await t.context.session.findElements(By.css(ex.tabSelector));
-  const tabpanels = await t.context.session.findElements(By.css(ex.tabpanelSelector));
+  
+  const tabs = await t.context.queryElements(t, ex.tabSelector);
+  const tabpanels = await t.context.queryElements(t, ex.tabpanelSelector);
   for (let index = 0; index < tabs.length; index++) {
 
     // Put focus on the tab
@@ -315,10 +300,9 @@ ariaTest('HOME key moves focus', exampleFile, 'key-home', async (t) => {
 });
 
 ariaTest('END key moves focus', exampleFile, 'key-end', async (t) => {
-  t.plan(3);
-
-  const tabs = await t.context.session.findElements(By.css(ex.tabSelector));
-  const tabpanels = await t.context.session.findElements(By.css(ex.tabpanelSelector));
+  
+  const tabs = await t.context.queryElements(t, ex.tabSelector);
+  const tabpanels = await t.context.queryElements(t, ex.tabpanelSelector);
   for (let index = 0; index < tabs.length; index++) {
 
     // Put focus on the tab
@@ -336,9 +320,8 @@ ariaTest('END key moves focus', exampleFile, 'key-end', async (t) => {
 });
 
 ariaTest('DELETE key removes third tab', exampleFile, 'key-delete', async (t) => {
-  t.plan(4);
-
-  const tabs = await t.context.session.findElements(By.css(ex.tabSelector));
+  
+  const tabs = await t.context.queryElements(t, ex.tabSelector);
 
   // Put focus on the first tab
   await openTabAtIndex(t, 0);
@@ -347,7 +330,7 @@ ariaTest('DELETE key removes third tab', exampleFile, 'key-delete', async (t) =>
   await tabs[0].sendKeys(Key.DELETE);
 
   t.is(
-    (await t.context.session.findElements(By.css(ex.tabSelector))).length,
+    (await t.context.queryElements(t, ex.tabSelector)).length,
     3,
     'Sending DELETE to first tab should not change number of tabs'
   );
@@ -359,7 +342,7 @@ ariaTest('DELETE key removes third tab', exampleFile, 'key-delete', async (t) =>
   await tabs[1].sendKeys(Key.DELETE);
 
   t.is(
-    (await t.context.session.findElements(By.css(ex.tabSelector))).length,
+    (await t.context.queryElements(t, ex.tabSelector)).length,
     3,
     'Sending DELETE to second tab should not change number of tabs'
   );
@@ -371,7 +354,7 @@ ariaTest('DELETE key removes third tab', exampleFile, 'key-delete', async (t) =>
   await tabs[2].sendKeys(Key.DELETE);
 
   t.is(
-    (await t.context.session.findElements(By.css(ex.tabSelector))).length,
+    (await t.context.queryElements(t, ex.tabSelector)).length,
     2,
     'Sending DELETE to third tab should change number of tabs'
   );

--- a/test/tests/tabs_tabs-2.js
+++ b/test/tests/tabs_tabs-2.js
@@ -1,3 +1,5 @@
+/* eslint no-restricted-properties: 0 */
+
 'use strict';
 
 const { ariaTest } = require('..');
@@ -63,7 +65,7 @@ ariaTest('role="tab" on button elements', exampleFile, 'tab-role', async (t) => 
 });
 
 ariaTest('"aria-selected" set on role="tab"', exampleFile, 'tab-aria-selected', async (t) => {
-  
+
   const tabs = await t.context.queryElements(t, ex.tabSelector);
   const tabpanels = await t.context.queryElements(t, ex.tabpanelSelector);
 
@@ -96,7 +98,7 @@ ariaTest('"aria-selected" set on role="tab"', exampleFile, 'tab-aria-selected', 
 });
 
 ariaTest('"tabindex" on role="tab"', exampleFile, 'tab-tabindex', async (t) => {
-  
+
   const tabs = await t.context.queryElements(t, ex.tabSelector);
   for (let selectedEl = 0; selectedEl < tabs.length; selectedEl++) {
 
@@ -154,7 +156,7 @@ ariaTest('tabindex="0" on role="tabpanel" elements', exampleFile, 'tabpanel-tabi
 // Keys
 
 ariaTest('TAB key moves focus to open tab and panel', exampleFile, 'key-tab', async (t) => {
-  
+
   for (let index = 0; index < ex.tabCount; index++) {
     await openTabAtIndex(t, index);
 
@@ -163,7 +165,7 @@ ariaTest('TAB key moves focus to open tab and panel', exampleFile, 'key-tab', as
 });
 
 ariaTest('ARROW_RIGHT key moves focus', exampleFile, 'key-right-arrow', async (t) => {
-  
+
   // Put focus on first tab
   await openTabAtIndex(t, 0);
 
@@ -196,7 +198,7 @@ ariaTest('ARROW_RIGHT key moves focus', exampleFile, 'key-right-arrow', async (t
 });
 
 ariaTest('ENTER activates tab that contains focus', exampleFile, 'key-enter-or-space', async (t) => {
-  
+
   const tabs = await t.context.queryElements(t, ex.tabSelector);
   const tabpanels = await t.context.queryElements(t, ex.tabpanelSelector);
   for (let index = 0; index < tabs.length - 1; index++) {
@@ -220,7 +222,7 @@ ariaTest('ENTER activates tab that contains focus', exampleFile, 'key-enter-or-s
 });
 
 ariaTest('SPACE activates tab that contains focus', exampleFile, 'key-enter-or-space', async (t) => {
-  
+
   const tabs = await t.context.queryElements(t, ex.tabSelector);
   const tabpanels = await t.context.queryElements(t, ex.tabpanelSelector);
   for (let index = 0; index < tabs.length - 1; index++) {
@@ -245,7 +247,7 @@ ariaTest('SPACE activates tab that contains focus', exampleFile, 'key-enter-or-s
 
 
 ariaTest('ARROW_LEFT key moves focus', exampleFile, 'key-left-arrow', async (t) => {
-  
+
   const tabs = await t.context.queryElements(t, ex.tabSelector);
   const tabpanels = await t.context.queryElements(t, ex.tabpanelSelector);
 
@@ -280,7 +282,7 @@ ariaTest('ARROW_LEFT key moves focus', exampleFile, 'key-left-arrow', async (t) 
 
 ariaTest('HOME key moves focus', exampleFile, 'key-home', async (t) => {
 
-  
+
   const tabs = await t.context.queryElements(t, ex.tabSelector);
   const tabpanels = await t.context.queryElements(t, ex.tabpanelSelector);
   for (let index = 0; index < tabs.length; index++) {
@@ -300,7 +302,7 @@ ariaTest('HOME key moves focus', exampleFile, 'key-home', async (t) => {
 });
 
 ariaTest('END key moves focus', exampleFile, 'key-end', async (t) => {
-  
+
   const tabs = await t.context.queryElements(t, ex.tabSelector);
   const tabpanels = await t.context.queryElements(t, ex.tabpanelSelector);
   for (let index = 0; index < tabs.length; index++) {
@@ -320,7 +322,7 @@ ariaTest('END key moves focus', exampleFile, 'key-end', async (t) => {
 });
 
 ariaTest('DELETE key removes third tab', exampleFile, 'key-delete', async (t) => {
-  
+
   const tabs = await t.context.queryElements(t, ex.tabSelector);
 
   // Put focus on the first tab

--- a/test/tests/tabs_tabs-2.js
+++ b/test/tests/tabs_tabs-2.js
@@ -9,6 +9,7 @@ const assertAriaControls = require('../util/assertAriaControls');
 const assertAriaLabelledby = require('../util/assertAriaLabelledby');
 const assertAriaLabelExists = require('../util/assertAriaLabelExists');
 const assertAriaRoles = require('../util/assertAriaRoles');
+const assertNoElements = require('../util/assertNoElements');
 const assertTabOrder = require('../util/assertTabOrder');
 
 const exampleFile = 'tabs/tabs-2/tabs.html';
@@ -361,10 +362,5 @@ ariaTest('DELETE key removes third tab', exampleFile, 'key-delete', async (t) =>
     'Sending DELETE to third tab should change number of tabs'
   );
 
-  t.is(
-    (await t.context.session.findElements(By.id(ex.deletableId))).length,
-    0,
-    'Sending DELETE to third tab should have delete tab with id: ' + ex.deletableId
-  );
-
+  assertNoElements(t, `#${ex.deletableId}`, `Sending DELETE to third tab should have delete tab with id: ${ex.deletableId}`);
 });

--- a/test/tests/toolbar_toolbar.js
+++ b/test/tests/toolbar_toolbar.js
@@ -2,7 +2,6 @@
 
 const { ariaTest } = require('..');
 const { By, Key } = require('selenium-webdriver');
-const assertAttributeValues = require('../util/assertAttributeValues');
 const assertAriaLabelExists = require('../util/assertAriaLabelExists');
 const assertAriaRoles = require('../util/assertAriaRoles');
 const assertRovingTabindex = require('../util/assertRovingTabindex');
@@ -67,19 +66,16 @@ const waitAndCheckTabindex = async function (t, selector) {
 // Attributes
 
 ariaTest('Toolbar element has role="toolbar"', exampleFile, 'toolbar-role', async (t) => {
-  t.plan(1);
-  await assertAriaRoles(t, 'ex1', 'toolbar', '1', 'div');
+    await assertAriaRoles(t, 'ex1', 'toolbar', '1', 'div');
 });
 
 // Test fails from bug in example: fix in issue 847 on w3c/aria-practices
 ariaTest('Toolbar element has "aria-label"', exampleFile, 'toolbar-aria-label', async (t) => {
-  t.plan(1);
-  await assertAriaLabelExists(t, ex.toolbarSelector);
+    await assertAriaLabelExists(t, ex.toolbarSelector);
 });
 
 ariaTest('Toolbar items support roving tabindex on toolbar items (Part 1)', exampleFile, 'toolbar-item-tabindex', async (t) => {
-  t.plan(1);
-
+  
   // Test all the toolbar items with roving tab index
   await assertRovingTabindex(t, ex.itemSelector, Key.ARROW_RIGHT);
 
@@ -87,8 +83,7 @@ ariaTest('Toolbar items support roving tabindex on toolbar items (Part 1)', exam
 
 /*
 ariaTest('Toolbar items support roving tabindex on toolbar items (Part 2)', exampleFile, 'toolbar-item-tabindex', async (t) => {
-  t.plan(1);
-
+  
   // Test the last element in the toolbox, which is a native "link" element
   await clickAndWait(t, ex.linkSelector);
 
@@ -107,8 +102,7 @@ ariaTest.failing('"aria-disabled" on button elements', exampleFile, 'button-aria
 // Keys
 
 ariaTest('key TAB moves focus', exampleFile, 'key-tab', async (t) => {
-  t.plan(6);
-
+  
   let numTools = ex.allToolSelectors.length;
 
   for (let index = 0; index < numTools; index++) {
@@ -130,8 +124,7 @@ ariaTest('key TAB moves focus', exampleFile, 'key-tab', async (t) => {
 
 // This tests fail from bug in example: fix in issue 847 on w3c/aria-practices
 ariaTest.failing('key LEFT ARROW moves focus', exampleFile, 'key-left-arrow', async (t) => {
-  t.plan(12);
-
+  
   // Put focus on the first item in the list
   await clickAndWait(t, ex.allToolSelectors[0]);
 
@@ -183,8 +176,7 @@ ariaTest.failing('key LEFT ARROW moves focus', exampleFile, 'key-left-arrow', as
 
 // This tests fail from bug in example: fix in issue 847 on w3c/aria-practices
 ariaTest.failing('key RIGHT ARROW moves focus', exampleFile, 'key-right-arrow', async (t) => {
-  t.plan(12);
-
+  
   // Put focus on the first item in the list
   await clickAndWait(t, ex.allToolSelectors[0]);
 
@@ -235,8 +227,7 @@ ariaTest.failing('key RIGHT ARROW moves focus', exampleFile, 'key-right-arrow', 
 
 // This tests fail from bug in example: fix in issue 847 on w3c/aria-practices
 ariaTest.failing('key HOME moves focus', exampleFile, 'key-home', async (t) => {
-  t.plan(6);
-
+  
   let numTools = ex.allToolSelectors.length;
 
   // Confirm right moves HOME focus to first item
@@ -259,8 +250,7 @@ ariaTest.failing('key HOME moves focus', exampleFile, 'key-home', async (t) => {
 
 // This tests fail from bug in example: fix in issue 847 on w3c/aria-practices
 ariaTest.failing('key END moves focus', exampleFile, 'key-end', async (t) => {
-  t.plan(6);
-
+  
   let numTools = ex.allToolSelectors.length;
 
   // Confirm right moves HOME focus to first item

--- a/test/tests/treegrid_treegrid-1.js
+++ b/test/tests/treegrid_treegrid-1.js
@@ -37,7 +37,7 @@ const reload = async (t) => {
 const closeAllThreads = async function (t) {
   await openAllThreads(t);
 
-  let threads = await t.context.session.findElements(By.css(ex.threadSelector));
+  let threads = await t.context.queryElements(t, ex.threadSelector);
 
   // Going through all open email thread elements in reverse dom order will close child
   // threads first, therefore all threads will be visible before sending keying
@@ -47,7 +47,7 @@ const closeAllThreads = async function (t) {
 };
 
 const openAllThreads = async function (t) {
-  let closedThreads = await t.context.session.findElements(By.css(ex.closedThreadSelector));
+  let closedThreads = await t.context.queryElements(t, ex.closedThreadSelector);
 
   // Going through all closed email thread elements in dom order will open parent
   // threads first, therefore all child threads will be visible before openning
@@ -146,7 +146,7 @@ const sendKeyToGridcellAndWait = async function (t, rowIndex, gridcellIndex, key
 };
 
 const sendKeyToRowAndWait = async function (t, rowIndex, key) {
-  const emailRows = await t.context.session.findElements(By.css(ex.emailRowSelector));
+  const emailRows = await t.context.queryElements(t, ex.emailRowSelector);
   await emailRows[rowIndex].sendKeys(key);
 
   // Wait for focus to move (this example can be slow to update focus on key press)
@@ -173,7 +173,7 @@ const putFocusOnRow1Gridcell = async function (t, columnindex) {
 };
 
 const putFocusOnLastRowGridcell = async function (t, columnindex) {
-  let rows = await t.context.session.findElements(By.css(ex.emailRowSelector));
+  let rows = await t.context.queryElements(t, ex.emailRowSelector);
   let lastrow = rows.length - 1;
 
   if (columnindex === 0) {
@@ -194,23 +194,19 @@ const putFocusOnLastRowGridcell = async function (t, columnindex) {
 // Attributes
 
 ariaTest('treegrid role on table element', exampleFile, 'treegrid-role', async (t) => {
-  t.plan(1);
-  await assertAriaRoles(t, 'ex1', 'treegrid', 1, 'table');
+    await assertAriaRoles(t, 'ex1', 'treegrid', 1, 'table');
 });
 
 ariaTest('aria-label on treegrid', exampleFile, 'treegrid-aria-label', async (t) => {
-  t.plan(1);
-  await assertAriaLabelExists(t, ex.treegridSelector);
+    await assertAriaLabelExists(t, ex.treegridSelector);
 });
 
 ariaTest('row role on tr element', exampleFile, 'row-role', async (t) => {
-  t.plan(1);
-  await assertAriaRoles(t, 'ex1', 'row', 8, 'tr');
+    await assertAriaRoles(t, 'ex1', 'row', 8, 'tr');
 });
 
 ariaTest('roving tabindex on rows and links', exampleFile, 'row-tabindex', async (t) => {
-  t.plan(2);
-
+  
   await openAllThreadsAndFocusOnFirstRow(t);
 
   // Assert roving tab index on rows
@@ -229,8 +225,7 @@ ariaTest('roving tabindex on rows and links', exampleFile, 'row-tabindex', async
 });
 
 ariaTest('aria-expanded on row elements', exampleFile, 'row-aria-expanded', async (t) => {
-  t.plan(6);
-
+  
   // After page load and after closing the first thread, all threads will be closed
   await t.context.session.findElement(By.css(ex.threadSelector)).sendKeys(Key.ARROW_LEFT);
   await assertAttributeValues(t, ex.threadSelector, 'aria-expanded', 'false');
@@ -243,7 +238,7 @@ ariaTest('aria-expanded on row elements', exampleFile, 'row-aria-expanded', asyn
   await t.context.session.findElement(By.css(ex.threadSelector)).sendKeys(Key.ARROW_LEFT);
 
   // Make sure the first thread is closed
-  const threads = await t.context.session.findElements(By.css(ex.threadSelector));
+  const threads = await t.context.queryElements(t, ex.threadSelector);
   t.is(
     await threads.shift().getAttribute('aria-expanded'),
     'false',
@@ -262,9 +257,8 @@ ariaTest('aria-expanded on row elements', exampleFile, 'row-aria-expanded', asyn
 
 
 ariaTest('aria-level on row elements', exampleFile, 'row-aria-level', async (t) => {
-  t.plan(8);
-
-  let rows = await t.context.session.findElements(By.css(ex.emailRowSelector));
+  
+  let rows = await t.context.queryElements(t, ex.emailRowSelector);
 
   for (let index = 0; index < rows.length; index++) {
     t.is(
@@ -276,9 +270,8 @@ ariaTest('aria-level on row elements', exampleFile, 'row-aria-level', async (t) 
 });
 
 ariaTest('aria-setsize on row elements', exampleFile, 'row-aria-setsize', async (t) => {
-  t.plan(8);
-
-  let rows = await t.context.session.findElements(By.css(ex.emailRowSelector));
+  
+  let rows = await t.context.queryElements(t, ex.emailRowSelector);
 
   for (let index = 0; index < rows.length; index++) {
     t.is(
@@ -291,9 +284,8 @@ ariaTest('aria-setsize on row elements', exampleFile, 'row-aria-setsize', async 
 
 
 ariaTest('aria-posinset on row elementsx', exampleFile, 'row-aria-posinset', async (t) => {
-  t.plan(8);
-
-  let rows = await t.context.session.findElements(By.css(ex.emailRowSelector));
+  
+  let rows = await t.context.queryElements(t, ex.emailRowSelector);
 
   for (let index = 0; index < rows.length; index++) {
     t.is(
@@ -306,21 +298,19 @@ ariaTest('aria-posinset on row elementsx', exampleFile, 'row-aria-posinset', asy
 
 
 ariaTest('gridcell roles on td elements', exampleFile, 'gridcell-role', async (t) => {
-  t.plan(1);
-  await assertAriaRoles(t, 'ex1', 'gridcell', 24, 'td');
+    await assertAriaRoles(t, 'ex1', 'gridcell', 24, 'td');
 });
 
 // Keys
 
 ariaTest('Navigating through rows with right arrow', exampleFile, 'key-right-arrow', async (t) => {
-  t.plan(4);
-
+  
   await closeAllThreads(t);
 
   // Going through all closed email thread elements in dom order will open parent
   // threads first.
 
-  const emailRows = await t.context.session.findElements(By.css(ex.emailRowSelector));
+  const emailRows = await t.context.queryElements(t, ex.emailRowSelector);
   for (let index = 0; index < emailRows.length; index++) {
 
     // Send ARROW RIGHT only to emails that are the start of threads
@@ -336,11 +326,10 @@ ariaTest('Navigating through rows with right arrow', exampleFile, 'key-right-arr
 });
 
 ariaTest('Navigating through gridcells with right arrow', exampleFile, 'key-right-arrow', async (t) => {
-  t.plan(24);
-
+  
   await openAllThreads(t);
 
-  const emailRows = await t.context.session.findElements(By.css(ex.emailRowSelector));
+  const emailRows = await t.context.queryElements(t, ex.emailRowSelector);
   for (let index = 0; index < emailRows.length; index++) {
 
     // Check that arrow right moves focus to the first gridcell of each row if the email
@@ -369,11 +358,10 @@ ariaTest('Navigating through gridcells with right arrow', exampleFile, 'key-righ
 });
 
 ariaTest('Navigating through rows with left arrow', exampleFile, 'key-left-arrow', async (t) => {
-  t.plan(20);
-
+  
   await openAllThreads(t);
 
-  const emailRows = await t.context.session.findElements(By.css(ex.emailRowSelector));
+  const emailRows = await t.context.queryElements(t, ex.emailRowSelector);
   let i = emailRows.length - 1;
   while (i > 0) {
 
@@ -420,11 +408,10 @@ ariaTest('Navigating through rows with left arrow', exampleFile, 'key-left-arrow
 
 
 ariaTest('Navigating through gridcells with left arrow', exampleFile, 'key-left-arrow', async (t) => {
-  t.plan(24);
-
+  
   await openAllThreads(t);
 
-  const emailRows = await t.context.session.findElements(By.css(ex.emailRowSelector));
+  const emailRows = await t.context.queryElements(t, ex.emailRowSelector);
 
   for (let index = 0; index < emailRows.length; index++) {
 
@@ -460,11 +447,10 @@ ariaTest('Navigating through gridcells with left arrow', exampleFile, 'key-left-
 });
 
 ariaTest('Navigating through rows with down arrow', exampleFile, 'key-down-arrow', async (t) => {
-  t.plan(8);
-
+  
   await openAllThreads(t);
 
-  const emailRows = await t.context.session.findElements(By.css(ex.emailRowSelector));
+  const emailRows = await t.context.queryElements(t, ex.emailRowSelector);
   for (let index = 0; index < emailRows.length - 1; index++) {
     // Send ARROW DOWN to email rows
     await emailRows[index].sendKeys(Key.ARROW_DOWN);
@@ -484,10 +470,9 @@ ariaTest('Navigating through rows with down arrow', exampleFile, 'key-down-arrow
 });
 
 ariaTest('Navigating through gridcells with down arrow', exampleFile, 'key-down-arrow', async (t) => {
-  t.plan(24);
-
+  
   await openAllThreads(t);
-  const emailRows = await t.context.session.findElements(By.css(ex.emailRowSelector));
+  const emailRows = await t.context.queryElements(t, ex.emailRowSelector);
 
   for (let columnindex = 0; columnindex < 3; columnindex++) {
     await putFocusOnRow1Gridcell(t, columnindex);
@@ -511,11 +496,10 @@ ariaTest('Navigating through gridcells with down arrow', exampleFile, 'key-down-
 });
 
 ariaTest('Navigating through rows with up arrow', exampleFile, 'key-up-arrow', async (t) => {
-  t.plan(8);
-
+  
   await openAllThreads(t);
 
-  const emailRows = await t.context.session.findElements(By.css(ex.emailRowSelector));
+  const emailRows = await t.context.queryElements(t, ex.emailRowSelector);
   for (let index = emailRows.length - 1; index > 0; index--) {
     // Send ARROW UP to email rows
     await emailRows[index].sendKeys(Key.ARROW_UP);
@@ -534,10 +518,9 @@ ariaTest('Navigating through rows with up arrow', exampleFile, 'key-up-arrow', a
 });
 
 ariaTest('Navigating through gridcells with up arrow', exampleFile, 'key-up-arrow', async (t) => {
-  t.plan(24);
-
+  
   await openAllThreads(t);
-  const emailRows = await t.context.session.findElements(By.css(ex.emailRowSelector));
+  const emailRows = await t.context.queryElements(t, ex.emailRowSelector);
 
   for (let columnindex = 0; columnindex < 3; columnindex++) {
     await putFocusOnLastRowGridcell(t, columnindex);
@@ -563,8 +546,7 @@ ariaTest('Navigating through gridcells with up arrow', exampleFile, 'key-up-arro
 
 
 ariaTest('TAB moves focus from active row to wigets in row', exampleFile, 'key-tab', async (t) => {
-  t.plan(1);
-
+  
   // Send tab to the first row:
   await sendKeyToRowAndWait(t, 0, Key.TAB);
 
@@ -575,8 +557,7 @@ ariaTest('TAB moves focus from active row to wigets in row', exampleFile, 'key-t
 });
 
 ariaTest('SHIFT+TAB moves focus from wigets in row to row', exampleFile, 'key-shift-tab', async (t) => {
-  t.plan(1);
-
+  
   await putFocusOnRow1Gridcell(t, 2);
 
   // Send shift tab to the link in the last gridcell of the first row
@@ -590,10 +571,9 @@ ariaTest('SHIFT+TAB moves focus from wigets in row to row', exampleFile, 'key-sh
 });
 
 ariaTest('HOME moves focus', exampleFile, 'key-home', async (t) => {
-  t.plan(2);
-
+  
   await openAllThreads(t);
-  const emailRows = await t.context.session.findElements(By.css(ex.emailRowSelector));
+  const emailRows = await t.context.queryElements(t, ex.emailRowSelector);
 
   // Send HOME to the second row
   await emailRows[1].sendKeys(Key.HOME);
@@ -612,10 +592,9 @@ ariaTest('HOME moves focus', exampleFile, 'key-home', async (t) => {
 });
 
 ariaTest('END moves focus', exampleFile, 'key-end', async (t) => {
-  t.plan(2);
-
+  
   await openAllThreads(t);
-  const emailRows = await t.context.session.findElements(By.css(ex.emailRowSelector));
+  const emailRows = await t.context.queryElements(t, ex.emailRowSelector);
 
   // Send END to the first row
   await emailRows[0].sendKeys(Key.END);
@@ -635,10 +614,9 @@ ariaTest('END moves focus', exampleFile, 'key-end', async (t) => {
 });
 
 ariaTest('CTRL+HOME moves focus', exampleFile, 'key-control-home', async (t) => {
-  t.plan(2);
-
+  
   await openAllThreads(t);
-  const emailRows = await t.context.session.findElements(By.css(ex.emailRowSelector));
+  const emailRows = await t.context.queryElements(t, ex.emailRowSelector);
 
   // Send CTRL+HOME to the second row
   await emailRows[1].sendKeys(Key.chord(Key.CONTROL, Key.HOME));
@@ -657,10 +635,9 @@ ariaTest('CTRL+HOME moves focus', exampleFile, 'key-control-home', async (t) => 
 });
 
 ariaTest('CTRL+END moves focus', exampleFile, 'key-control-end', async (t) => {
-  t.plan(2);
-
+  
   await openAllThreads(t);
-  const emailRows = await t.context.session.findElements(By.css(ex.emailRowSelector));
+  const emailRows = await t.context.queryElements(t, ex.emailRowSelector);
 
   // Send CTRL+END to the first row
   await emailRows[0].sendKeys(Key.chord(Key.CONTROL, Key.END));
@@ -680,8 +657,7 @@ ariaTest('CTRL+END moves focus', exampleFile, 'key-control-end', async (t) => {
 
 // This test fails due to: https://github.com/w3c/aria-practices/issues/790#issuecomment-422079276
 ariaTest.failing('ENTER actives interactive items item', exampleFile, 'key-enter', async (t) => {
-  t.plan(2);
-
+  
   // INTERACTIVE ITEM 1: Enter sent while focus is on email row should open email alert
 
   const email = await t.context.session.findElement(By.css(ex.emailRowSelector));

--- a/test/tests/treeview_treeview-1a.js
+++ b/test/tests/treeview_treeview-1a.js
@@ -21,7 +21,7 @@ const ex = {
 
 const openAllFolders = async function (t) {
   const closedFoldersSelector = ex.treeitemSelector + '[aria-expanded="false"]';
-  let closedFolders = await t.context.session.findElements(By.css(closedFoldersSelector));
+  let closedFolders = await t.context.queryElements(t, closedFoldersSelector);
 
   // Going through all closed folder elements in dom order will open parent
   // folders first, therefore all child folders will be visible before clicked
@@ -74,9 +74,8 @@ const isClosedFolderTreeitem =  async function (el) {
 
 ariaTest('role="tree" on ul element', exampleFile, 'tree-role', async (t) => {
 
-  t.plan(2);
-
-  const trees = await t.context.session.findElements(By.css(ex.treeSelector));
+  
+  const trees = await t.context.queryElements(t, ex.treeSelector);
 
   t.is(
     trees.length,
@@ -93,16 +92,14 @@ ariaTest('role="tree" on ul element', exampleFile, 'tree-role', async (t) => {
 
 ariaTest('aria-labelledby on role="tree" element', exampleFile, 'tree-aria-labelledby', async (t) => {
 
-  t.plan(1);
-
+  
   await assertAriaLabelledby(t, ex.treeSelector);
 });
 
 ariaTest('role="treeitem" on "ul" element', exampleFile, 'treeitem-role', async (t) => {
 
-  t.plan(46);
-
-  const treeitems = await t.context.session.findElements(By.css(ex.treeitemSelector));
+  
+  const treeitems = await t.context.queryElements(t, ex.treeitemSelector);
 
   t.truthy(
     treeitems.length,
@@ -119,17 +116,15 @@ ariaTest('role="treeitem" on "ul" element', exampleFile, 'treeitem-role', async 
 });
 
 ariaTest('treeitem tabindex set by roving tabindex', exampleFile, 'treeitem-tabindex', async (t) => {
-  t.plan(1);
-  await openAllFolders(t);
+    await openAllFolders(t);
 
   await assertRovingTabindex(t, ex.treeitemSelector, Key.ARROW_DOWN);
 });
 
 ariaTest('aria-expanded attribute on treeitem matches dom', exampleFile, 'treeitem-ariaexpanded', async (t) => {
 
-  t.plan(66);
-
-  const folders = await t.context.session.findElements(By.css(ex.folderSelector));
+  
+  const folders = await t.context.queryElements(t, ex.folderSelector);
 
   for (let folder of folders) {
 
@@ -144,7 +139,7 @@ ariaTest('aria-expanded attribute on treeitem matches dom', exampleFile, 'treeit
         'false'
       );
       t.is(
-        await(await folder.findElements(By.css('[role="treeitem"]')))[0].isDisplayed(),
+        await(await t.context.queryElements(t, '[role="treeitem"]', folder))[0].isDisplayed(),
         false
       );
 
@@ -157,7 +152,7 @@ ariaTest('aria-expanded attribute on treeitem matches dom', exampleFile, 'treeit
         'true'
       );
       t.is(
-        await(await folder.findElements(By.css('[role="treeitem"]')))[0].isDisplayed(),
+        await(await t.context.queryElements(t, '[role="treeitem"]', folder))[0].isDisplayed(),
         true
       );
     }
@@ -180,7 +175,7 @@ ariaTest('aria-expanded attribute on treeitem matches dom', exampleFile, 'treeit
         folderText
       );
       t.is(
-        await(await folders[i].findElements(By.css('[role="treeitem"]')))[0].isDisplayed(),
+        await(await t.context.queryElements(t, '[role="treeitem"]', folders[i]))[0].isDisplayed(),
         false,
         folderText
       );
@@ -191,9 +186,8 @@ ariaTest('aria-expanded attribute on treeitem matches dom', exampleFile, 'treeit
 
 ariaTest('role="group" on "ul" elements', exampleFile, 'group-role', async (t) => {
 
-  t.plan(12);
-
-  const groups = await t.context.session.findElements(By.css(ex.groupSelector));
+  
+  const groups = await t.context.queryElements(t, ex.groupSelector);
 
   t.truthy(
     groups.length,
@@ -212,11 +206,10 @@ ariaTest('role="group" on "ul" elements', exampleFile, 'group-role', async (t) =
 // Keys
 
 ariaTest('Key enter opens folder', exampleFile, 'key-enter-or-space', async (t) => {
-  t.plan(34);
-
+  
   await openAllFolders(t);
 
-  const items = await t.context.session.findElements(By.css(ex.docSelector));
+  const items = await t.context.queryElements(t, ex.docSelector);
 
   for (let item of items) {
 
@@ -236,11 +229,10 @@ ariaTest('Key enter opens folder', exampleFile, 'key-enter-or-space', async (t) 
 });
 
 ariaTest('Key space opens folder', exampleFile, 'key-enter-or-space', async (t) => {
-  t.plan(34);
-
+  
   await openAllFolders(t);
 
-  const items = await t.context.session.findElements(By.css(ex.docSelector));
+  const items = await t.context.queryElements(t, ex.docSelector);
 
   for (let item of items) {
 
@@ -260,10 +252,9 @@ ariaTest('Key space opens folder', exampleFile, 'key-enter-or-space', async (t) 
 });
 
 ariaTest('key down arrow moves focus', exampleFile, 'key-down-arrow', async (t) => {
-  t.plan(51);
-
+  
   // Check that the down arrow does not open folders
-  const topLevelFolders = await t.context.session.findElements(By.css(ex.topLevelFolderSelector));
+  const topLevelFolders = await t.context.queryElements(t, ex.topLevelFolderSelector);
 
   for (let i = 0; i < topLevelFolders.length; i++) {
     await topLevelFolders[i].sendKeys(Key.ARROW_DOWN);
@@ -291,7 +282,7 @@ ariaTest('key down arrow moves focus', exampleFile, 'key-down-arrow', async (t) 
   // Open all folders
   await openAllFolders(t);
 
-  const items = await t.context.session.findElements(By.css(ex.treeitemSelector));
+  const items = await t.context.queryElements(t, ex.treeitemSelector);
 
   for (let i = 0; i < items.length; i++) {
     await items[i].sendKeys(Key.ARROW_DOWN);
@@ -309,10 +300,9 @@ ariaTest('key down arrow moves focus', exampleFile, 'key-down-arrow', async (t) 
 });
 
 ariaTest('key up arrow moves focus', exampleFile, 'key-up-arrow', async (t) => {
-  t.plan(51);
-
+  
   // Check that the down arrow does not open folders
-  const topLevelFolders = await t.context.session.findElements(By.css(ex.topLevelFolderSelector));
+  const topLevelFolders = await t.context.queryElements(t, ex.topLevelFolderSelector);
 
   for (let i = topLevelFolders.length - 1; i >= 0 ; i--) {
     await topLevelFolders[i].sendKeys(Key.ARROW_UP);
@@ -340,7 +330,7 @@ ariaTest('key up arrow moves focus', exampleFile, 'key-up-arrow', async (t) => {
   // Open all folders
   await openAllFolders(t);
 
-  const items = await t.context.session.findElements(By.css(ex.treeitemSelector));
+  const items = await t.context.queryElements(t, ex.treeitemSelector);
 
   for (let i = items.length - 1; i >= 0 ; i--) {
     await items[i].sendKeys(Key.ARROW_UP);
@@ -358,9 +348,8 @@ ariaTest('key up arrow moves focus', exampleFile, 'key-up-arrow', async (t) => {
 });
 
 ariaTest('key right arrow opens folders and moves focus', exampleFile, 'key-right-arrow', async (t) => {
-  t.plan(67);
-
-  const items = await t.context.session.findElements(By.css(ex.treeitemSelector));
+  
+  const items = await t.context.queryElements(t, ex.treeitemSelector);
 
   let i = 0;
   while (i < items.length) {
@@ -409,12 +398,11 @@ ariaTest('key right arrow opens folders and moves focus', exampleFile, 'key-righ
 });
 
 ariaTest('key left arrow closes folders and moves focus', exampleFile, 'key-left-arrow', async (t) => {
-  t.plan(106);
-
+  
   // Open all folders
   await openAllFolders(t);
 
-  const items = await t.context.session.findElements(By.css(ex.treeitemSelector));
+  const items = await t.context.queryElements(t, ex.treeitemSelector);
 
   let i = items.length - 1;
   while (i > 0) {
@@ -475,10 +463,9 @@ ariaTest('key left arrow closes folders and moves focus', exampleFile, 'key-left
 });
 
 ariaTest('key home moves focus', exampleFile, 'key-home', async (t) => {
-  t.plan(51);
-
+  
   // Test that key "home" works when no folder is open
-  const topLevelFolders = await t.context.session.findElements(By.css(ex.topLevelFolderSelector));
+  const topLevelFolders = await t.context.queryElements(t, ex.topLevelFolderSelector);
 
   for (let i = topLevelFolders.length - 1; i >= 0 ; i--) {
     await topLevelFolders[i].sendKeys(Key.HOME);
@@ -502,7 +489,7 @@ ariaTest('key home moves focus', exampleFile, 'key-home', async (t) => {
   // Open all folders
   await openAllFolders(t);
 
-  const items = await t.context.session.findElements(By.css(ex.treeitemSelector));
+  const items = await t.context.queryElements(t, ex.treeitemSelector);
 
   for (let i = items.length - 1; i >= 0 ; i--) {
     await items[i].sendKeys(Key.HOME);
@@ -515,10 +502,9 @@ ariaTest('key home moves focus', exampleFile, 'key-home', async (t) => {
 });
 
 ariaTest('key end moves focus', exampleFile, 'key-end', async (t) => {
-  t.plan(51);
-
+  
   // Test that key "end" works when no folder is open
-  const topLevelFolders = await t.context.session.findElements(By.css(ex.topLevelFolderSelector));
+  const topLevelFolders = await t.context.queryElements(t, ex.topLevelFolderSelector);
 
   for (let i = topLevelFolders.length - 1; i >= 0 ; i--) {
     await topLevelFolders[i].sendKeys(Key.END);
@@ -542,7 +528,7 @@ ariaTest('key end moves focus', exampleFile, 'key-end', async (t) => {
   // Open all folders
   await openAllFolders(t);
 
-  const items = await t.context.session.findElements(By.css(ex.treeitemSelector));
+  const items = await t.context.queryElements(t, ex.treeitemSelector);
 
   for (let i = items.length - 1; i >= 0 ; i--) {
     await items[i].sendKeys(Key.END);
@@ -556,8 +542,7 @@ ariaTest('key end moves focus', exampleFile, 'key-end', async (t) => {
 });
 
 ariaTest('characters move focus', exampleFile, 'key-character', async (t) => {
-  t.plan(15);
-
+  
   const charIndexTestClosed = [
     { sendChar: 'p', sendIndex: 0, endIndex: 0 },
     { sendChar: 'r', sendIndex: 0, endIndex: 1 },
@@ -576,7 +561,7 @@ ariaTest('characters move focus', exampleFile, 'key-character', async (t) => {
     { sendChar: 'l', sendIndex: 30, endIndex: 31 }
   ];
 
-  const topLevelFolders = await t.context.session.findElements(By.css(ex.topLevelFolderSelector));
+  const topLevelFolders = await t.context.queryElements(t, ex.topLevelFolderSelector);
 
   for (let test of charIndexTestClosed) {
 
@@ -598,7 +583,7 @@ ariaTest('characters move focus', exampleFile, 'key-character', async (t) => {
   // Open all folders
   await openAllFolders(t);
 
-  const items = await t.context.session.findElements(By.css(ex.treeitemSelector));
+  const items = await t.context.queryElements(t, ex.treeitemSelector);
 
   for (let test of charIndexTestOpened) {
 
@@ -614,12 +599,11 @@ ariaTest('characters move focus', exampleFile, 'key-character', async (t) => {
 });
 
 ariaTest('asterisk key opens folders', exampleFile, 'key-asterisk', async (t) => {
-  t.plan(10);
-
+  
   /* Test that "*" ONLY opens all top level nodes and no other folders */
 
-  const topLevelFolders = await t.context.session.findElements(By.css(ex.topLevelFolderSelector));
-  const nextLevelFolders = await t.context.session.findElements(By.css(ex.nextLevelFolderSelector));
+  const topLevelFolders = await t.context.queryElements(t, ex.topLevelFolderSelector);
+  const nextLevelFolders = await t.context.queryElements(t, ex.nextLevelFolderSelector);
 
   // Send Key
   await topLevelFolders[0].sendKeys('*');
@@ -634,8 +618,7 @@ ariaTest('asterisk key opens folders', exampleFile, 'key-asterisk', async (t) =>
 
   // The subfolders of first top level folder should all be open
 
-  const subFoldersOfFirstFolder = await topLevelFolders[0]
-    .findElements(By.css(ex.nextLevelFolderSelector));
+  const subFoldersOfFirstFolder = await t.context.queryElements(t, ex.nextLevelFolderSelector, topLevelFolders[0]);
   for (let el of subFoldersOfFirstFolder) {
     t.true(
       await el.getAttribute('aria-expanded') === 'true',
@@ -645,8 +628,7 @@ ariaTest('asterisk key opens folders', exampleFile, 'key-asterisk', async (t) =>
 
   // The subfolders of second top level folder should all be closed
 
-  const subFoldersOfSecondFolder = await topLevelFolders[1]
-    .findElements(By.css(ex.nextLevelFolderSelector));
+  const subFoldersOfSecondFolder = await t.context.queryElements(t, ex.nextLevelFolderSelector, topLevelFolders[1]);
   for (let el of subFoldersOfSecondFolder) {
     t.true(
       await el.getAttribute('aria-expanded') === 'false',
@@ -656,8 +638,7 @@ ariaTest('asterisk key opens folders', exampleFile, 'key-asterisk', async (t) =>
 
   // The subfolders of third top level folder should all be closed
 
-  const subFoldersOfThirdFolder = await topLevelFolders[2]
-    .findElements(By.css(ex.nextLevelFolderSelector));
+  const subFoldersOfThirdFolder = await t.context.queryElements(t, ex.nextLevelFolderSelector, topLevelFolders[2]);
   for (let el of subFoldersOfThirdFolder) {
     t.true(
       await el.getAttribute('aria-expanded') === 'false',

--- a/test/tests/treeview_treeview-1b.js
+++ b/test/tests/treeview_treeview-1b.js
@@ -53,7 +53,7 @@ const ex = {
 
 const openAllFolders = async function (t) {
   const closedFoldersSelector = ex.treeitemSelector + '[aria-expanded="false"]';
-  let closedFolders = await t.context.session.findElements(By.css(closedFoldersSelector));
+  let closedFolders = await t.context.queryElements(t, closedFoldersSelector);
 
   // Going through all closed folder elements in dom order will open parent
   // folders first, therefore all child folders will be visible before clicked
@@ -106,9 +106,8 @@ const isClosedFolderTreeitem =  async function (el) {
 
 ariaTest('role="tree" on ul element', exampleFile, 'tree-role', async (t) => {
 
-  t.plan(2);
-
-  const trees = await t.context.session.findElements(By.css(ex.treeSelector));
+  
+  const trees = await t.context.queryElements(t, ex.treeSelector);
 
   t.is(
     trees.length,
@@ -125,16 +124,14 @@ ariaTest('role="tree" on ul element', exampleFile, 'tree-role', async (t) => {
 
 ariaTest('aria-labelledby on role="tree" element', exampleFile, 'tree-arialabelledby', async (t) => {
 
-  t.plan(1);
-
+  
   await assertAriaLabelledby(t, ex.treeSelector);
 });
 
 ariaTest('role="treeitem" on "ul" element', exampleFile, 'treeitem-role', async (t) => {
 
-  t.plan(46);
-
-  const treeitems = await t.context.session.findElements(By.css(ex.treeitemSelector));
+  
+  const treeitems = await t.context.queryElements(t, ex.treeitemSelector);
 
   t.truthy(
     treeitems.length,
@@ -151,19 +148,17 @@ ariaTest('role="treeitem" on "ul" element', exampleFile, 'treeitem-role', async 
 });
 
 ariaTest('treeitem tabindex set by roving tabindex', exampleFile, 'treeitem-tabindex', async (t) => {
-  t.plan(1);
-  await openAllFolders(t);
+    await openAllFolders(t);
 
   await assertRovingTabindex(t, ex.treeitemSelector, Key.ARROW_DOWN);
 });
 
 ariaTest('"aria-setsize" atrribute on treeitem', exampleFile, 'treeitem-aria-setsize', async (t) => {
-  t.plan(45);
-
+  
   for (const [level, levelSelectors] of Object.entries(ex.treeitemGroupSelectors)) {
     for (const selector of levelSelectors) {
 
-      const treeitems = await t.context.session.findElements(By.css(selector));
+      const treeitems = await t.context.queryElements(t, selector);
       const setsize = treeitems.length;
 
       for (const treeitem of treeitems) {
@@ -179,12 +174,11 @@ ariaTest('"aria-setsize" atrribute on treeitem', exampleFile, 'treeitem-aria-set
 });
 
 ariaTest('"aria-posinset" attribute on treeitem', exampleFile, 'treeitem-aria-posinset', async (t) => {
-  t.plan(45);
-
+  
   for (const [level, levelSelectors] of Object.entries(ex.treeitemGroupSelectors)) {
     for (const selector of levelSelectors) {
 
-      const treeitems = await t.context.session.findElements(By.css(selector));
+      const treeitems = await t.context.queryElements(t, selector);
       let pos = 0;
       for (const treeitem of treeitems) {
         pos++;
@@ -199,12 +193,11 @@ ariaTest('"aria-posinset" attribute on treeitem', exampleFile, 'treeitem-aria-po
 });
 
 ariaTest('"aria-level" attribute on treeitem', exampleFile, 'treeitem-aria-level', async (t) => {
-  t.plan(45);
-
+  
   for (const [level, levelSelectors] of Object.entries(ex.treeitemGroupSelectors)) {
     for (const selector of levelSelectors) {
 
-      const treeitems = await t.context.session.findElements(By.css(selector));
+      const treeitems = await t.context.queryElements(t, selector);
       for (const treeitem of treeitems) {
         t.is(
           await treeitem.getAttribute('aria-level'),
@@ -218,9 +211,8 @@ ariaTest('"aria-level" attribute on treeitem', exampleFile, 'treeitem-aria-level
 
 ariaTest('aria-expanded attribute on treeitem matches dom', exampleFile, 'treeitem-aria-expanded', async (t) => {
 
-  t.plan(66);
-
-  const folders = await t.context.session.findElements(By.css(ex.folderSelector));
+  
+  const folders = await t.context.queryElements(t, ex.folderSelector);
 
   for (let folder of folders) {
 
@@ -235,7 +227,7 @@ ariaTest('aria-expanded attribute on treeitem matches dom', exampleFile, 'treeit
         'false'
       );
       t.is(
-        await(await folder.findElements(By.css('[role="treeitem"]')))[0].isDisplayed(),
+        await(await t.context.queryElements(t, '[role="treeitem"]', folder))[0].isDisplayed(),
         false
       );
 
@@ -248,7 +240,7 @@ ariaTest('aria-expanded attribute on treeitem matches dom', exampleFile, 'treeit
         'true'
       );
       t.is(
-        await(await folder.findElements(By.css('[role="treeitem"]')))[0].isDisplayed(),
+        await(await t.context.queryElements(t, '[role="treeitem"]', folder))[0].isDisplayed(),
         true
       );
     }
@@ -271,7 +263,7 @@ ariaTest('aria-expanded attribute on treeitem matches dom', exampleFile, 'treeit
         folderText
       );
       t.is(
-        await(await folders[i].findElements(By.css('[role="treeitem"]')))[0].isDisplayed(),
+        await(await t.context.queryElements(t, '[role="treeitem"]', folders[i]))[0].isDisplayed(),
         false,
         folderText
       );
@@ -282,9 +274,8 @@ ariaTest('aria-expanded attribute on treeitem matches dom', exampleFile, 'treeit
 
 ariaTest('role="group" on "ul" elements', exampleFile, 'role-group', async (t) => {
 
-  t.plan(12);
-
-  const groups = await t.context.session.findElements(By.css(ex.groupSelector));
+  
+  const groups = await t.context.queryElements(t, ex.groupSelector);
 
   t.truthy(
     groups.length,
@@ -303,11 +294,10 @@ ariaTest('role="group" on "ul" elements', exampleFile, 'role-group', async (t) =
 // Keys
 
 ariaTest('Key enter opens folder', exampleFile, 'key-enter-or-space', async (t) => {
-  t.plan(34);
-
+  
   await openAllFolders(t);
 
-  const items = await t.context.session.findElements(By.css(ex.docSelector));
+  const items = await t.context.queryElements(t, ex.docSelector);
 
   for (let item of items) {
 
@@ -327,11 +317,10 @@ ariaTest('Key enter opens folder', exampleFile, 'key-enter-or-space', async (t) 
 });
 
 ariaTest('Key space opens folder', exampleFile, 'key-enter-or-space', async (t) => {
-  t.plan(34);
-
+  
   await openAllFolders(t);
 
-  const items = await t.context.session.findElements(By.css(ex.docSelector));
+  const items = await t.context.queryElements(t, ex.docSelector);
 
   for (let item of items) {
 
@@ -351,10 +340,9 @@ ariaTest('Key space opens folder', exampleFile, 'key-enter-or-space', async (t) 
 });
 
 ariaTest('key down arrow moves focus', exampleFile, 'key-down-arrow', async (t) => {
-  t.plan(51);
-
+  
   // Check that the down arrow does not open folders
-  const topLevelFolders = await t.context.session.findElements(By.css(ex.topLevelFolderSelector));
+  const topLevelFolders = await t.context.queryElements(t, ex.topLevelFolderSelector);
 
   for (let i = 0; i < topLevelFolders.length; i++) {
     await topLevelFolders[i].sendKeys(Key.ARROW_DOWN);
@@ -382,7 +370,7 @@ ariaTest('key down arrow moves focus', exampleFile, 'key-down-arrow', async (t) 
   // Open all folders
   await openAllFolders(t);
 
-  const items = await t.context.session.findElements(By.css(ex.treeitemSelector));
+  const items = await t.context.queryElements(t, ex.treeitemSelector);
 
   for (let i = 0; i < items.length; i++) {
     await items[i].sendKeys(Key.ARROW_DOWN);
@@ -400,10 +388,9 @@ ariaTest('key down arrow moves focus', exampleFile, 'key-down-arrow', async (t) 
 });
 
 ariaTest('key up arrow moves focus', exampleFile, 'key-up-arrow', async (t) => {
-  t.plan(51);
-
+  
   // Check that the down arrow does not open folders
-  const topLevelFolders = await t.context.session.findElements(By.css(ex.topLevelFolderSelector));
+  const topLevelFolders = await t.context.queryElements(t, ex.topLevelFolderSelector);
 
   for (let i = topLevelFolders.length - 1; i >= 0 ; i--) {
     await topLevelFolders[i].sendKeys(Key.ARROW_UP);
@@ -431,7 +418,7 @@ ariaTest('key up arrow moves focus', exampleFile, 'key-up-arrow', async (t) => {
   // Open all folders
   await openAllFolders(t);
 
-  const items = await t.context.session.findElements(By.css(ex.treeitemSelector));
+  const items = await t.context.queryElements(t, ex.treeitemSelector);
 
   for (let i = items.length - 1; i >= 0 ; i--) {
     await items[i].sendKeys(Key.ARROW_UP);
@@ -449,9 +436,8 @@ ariaTest('key up arrow moves focus', exampleFile, 'key-up-arrow', async (t) => {
 });
 
 ariaTest('key right arrow opens folders and moves focus', exampleFile, 'key-right-arrow', async (t) => {
-  t.plan(67);
-
-  const items = await t.context.session.findElements(By.css(ex.treeitemSelector));
+  
+  const items = await t.context.queryElements(t, ex.treeitemSelector);
 
   let i = 0;
   while (i < items.length) {
@@ -500,12 +486,11 @@ ariaTest('key right arrow opens folders and moves focus', exampleFile, 'key-righ
 });
 
 ariaTest('key left arrow closes folders and moves focus', exampleFile, 'key-left-arrow', async (t) => {
-  t.plan(106);
-
+  
   // Open all folders
   await openAllFolders(t);
 
-  const items = await t.context.session.findElements(By.css(ex.treeitemSelector));
+  const items = await t.context.queryElements(t, ex.treeitemSelector);
 
   let i = items.length - 1;
   while (i > 0) {
@@ -566,10 +551,9 @@ ariaTest('key left arrow closes folders and moves focus', exampleFile, 'key-left
 });
 
 ariaTest('key home moves focus', exampleFile, 'key-home', async (t) => {
-  t.plan(51);
-
+  
   // Test that key "home" works when no folder is open
-  const topLevelFolders = await t.context.session.findElements(By.css(ex.topLevelFolderSelector));
+  const topLevelFolders = await t.context.queryElements(t, ex.topLevelFolderSelector);
 
   for (let i = topLevelFolders.length - 1; i >= 0 ; i--) {
     await topLevelFolders[i].sendKeys(Key.HOME);
@@ -593,7 +577,7 @@ ariaTest('key home moves focus', exampleFile, 'key-home', async (t) => {
   // Open all folders
   await openAllFolders(t);
 
-  const items = await t.context.session.findElements(By.css(ex.treeitemSelector));
+  const items = await t.context.queryElements(t, ex.treeitemSelector);
 
   for (let i = items.length - 1; i >= 0 ; i--) {
     await items[i].sendKeys(Key.HOME);
@@ -606,10 +590,9 @@ ariaTest('key home moves focus', exampleFile, 'key-home', async (t) => {
 });
 
 ariaTest('key end moves focus', exampleFile, 'key-end', async (t) => {
-  t.plan(51);
-
+  
   // Test that key "end" works when no folder is open
-  const topLevelFolders = await t.context.session.findElements(By.css(ex.topLevelFolderSelector));
+  const topLevelFolders = await t.context.queryElements(t, ex.topLevelFolderSelector);
 
   for (let i = topLevelFolders.length - 1; i >= 0 ; i--) {
     await topLevelFolders[i].sendKeys(Key.END);
@@ -633,7 +616,7 @@ ariaTest('key end moves focus', exampleFile, 'key-end', async (t) => {
   // Open all folders
   await openAllFolders(t);
 
-  const items = await t.context.session.findElements(By.css(ex.treeitemSelector));
+  const items = await t.context.queryElements(t, ex.treeitemSelector);
 
   for (let i = items.length - 1; i >= 0 ; i--) {
     await items[i].sendKeys(Key.END);
@@ -647,8 +630,7 @@ ariaTest('key end moves focus', exampleFile, 'key-end', async (t) => {
 });
 
 ariaTest('characters move focus', exampleFile, 'key-character', async (t) => {
-  t.plan(15);
-
+  
   const charIndexTestClosed = [
     { sendChar: 'p', sendIndex: 0, endIndex: 0 },
     { sendChar: 'r', sendIndex: 0, endIndex: 1 },
@@ -667,7 +649,7 @@ ariaTest('characters move focus', exampleFile, 'key-character', async (t) => {
     { sendChar: 'l', sendIndex: 30, endIndex: 31 }
   ];
 
-  const topLevelFolders = await t.context.session.findElements(By.css(ex.topLevelFolderSelector));
+  const topLevelFolders = await t.context.queryElements(t, ex.topLevelFolderSelector);
 
   for (let test of charIndexTestClosed) {
 
@@ -689,7 +671,7 @@ ariaTest('characters move focus', exampleFile, 'key-character', async (t) => {
   // Open all folders
   await openAllFolders(t);
 
-  const items = await t.context.session.findElements(By.css(ex.treeitemSelector));
+  const items = await t.context.queryElements(t, ex.treeitemSelector);
 
   for (let test of charIndexTestOpened) {
 
@@ -705,12 +687,11 @@ ariaTest('characters move focus', exampleFile, 'key-character', async (t) => {
 });
 
 ariaTest('asterisk key opens folders', exampleFile, 'key-asterisk', async (t) => {
-  t.plan(10);
-
+  
   /* Test that "*" ONLY opens all top level nodes and no other folders */
 
-  const topLevelFolders = await t.context.session.findElements(By.css(ex.topLevelFolderSelector));
-  const nextLevelFolders = await t.context.session.findElements(By.css(ex.nextLevelFolderSelector));
+  const topLevelFolders = await t.context.queryElements(t, ex.topLevelFolderSelector);
+  const nextLevelFolders = await t.context.queryElements(t, ex.nextLevelFolderSelector);
 
   // Send Key
   await topLevelFolders[0].sendKeys('*');
@@ -725,8 +706,7 @@ ariaTest('asterisk key opens folders', exampleFile, 'key-asterisk', async (t) =>
 
   // The subfolders of first top level folder should all be open
 
-  const subFoldersOfFirstFolder = await topLevelFolders[0]
-    .findElements(By.css(ex.nextLevelFolderSelector));
+  const subFoldersOfFirstFolder = await t.context.queryElements(t, ex.nextLevelFolderSelector, topLevelFolders[0]);
   for (let el of subFoldersOfFirstFolder) {
     t.true(
       await el.getAttribute('aria-expanded') === 'true',
@@ -736,8 +716,7 @@ ariaTest('asterisk key opens folders', exampleFile, 'key-asterisk', async (t) =>
 
   // The subfolders of second top level folder should all be closed
 
-  const subFoldersOfSecondFolder = await topLevelFolders[1]
-    .findElements(By.css(ex.nextLevelFolderSelector));
+  const subFoldersOfSecondFolder = await t.context.queryElements(t, ex.nextLevelFolderSelector, topLevelFolders[1]);
   for (let el of subFoldersOfSecondFolder) {
     t.true(
       await el.getAttribute('aria-expanded') === 'false',
@@ -747,8 +726,7 @@ ariaTest('asterisk key opens folders', exampleFile, 'key-asterisk', async (t) =>
 
   // The subfolders of third top level folder should all be closed
 
-  const subFoldersOfThirdFolder = await topLevelFolders[2]
-    .findElements(By.css(ex.nextLevelFolderSelector));
+  const subFoldersOfThirdFolder = await t.context.queryElements(t, ex.nextLevelFolderSelector, topLevelFolders[2]);
   for (let el of subFoldersOfThirdFolder) {
     t.true(
       await el.getAttribute('aria-expanded') === 'false',

--- a/test/tests/treeview_treeview-2a.js
+++ b/test/tests/treeview_treeview-2a.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { ariaTest } = require('..');
-const { By, Key } = require('selenium-webdriver');
+const { Key } = require('selenium-webdriver');
 const assertAttributeValues = require('../util/assertAttributeValues');
 const assertAriaLabelledby = require('../util/assertAriaLabelledby');
 const assertRovingTabindex = require('../util/assertRovingTabindex');
@@ -20,7 +20,7 @@ const ex = {
 
 const openAllFolders = async function (t) {
   const closedFoldersSelector = ex.treeitemSelector + '[aria-expanded="false"]';
-  let closedFolders = await t.context.session.findElements(By.css(closedFoldersSelector));
+  let closedFolders = await t.context.queryElements(t, closedFoldersSelector);
 
   // Going through all closed folder elements in dom order will open parent
   // folders first, therefore all child folders will be visible before clicked
@@ -80,9 +80,8 @@ const hasAriaExpandedAttribute = async function (t, el) {
 
 ariaTest('role="tree" on ul element', exampleFile, 'tree-role', async (t) => {
 
-  t.plan(2);
-
-  const trees = await t.context.session.findElements(By.css(ex.treeSelector));
+  
+  const trees = await t.context.queryElements(t, ex.treeSelector);
 
   t.is(
     trees.length,
@@ -99,17 +98,15 @@ ariaTest('role="tree" on ul element', exampleFile, 'tree-role', async (t) => {
 
 ariaTest('aria-labelledby on role="tree" element', exampleFile, 'tree-aria-labelledby', async (t) => {
 
-  t.plan(1);
-
+  
   await assertAriaLabelledby(t, ex.treeSelector);
 });
 
 ariaTest('role="treeitem" on "li" or "a" element', exampleFile, 'treeitem-role', async (t) => {
 
-  t.plan(45);
-
+  
   // Get all the list items in the tree structure
-  const listitems = await t.context.session.findElements(By.css('#ex1 [role="tree"] li'));
+  const listitems = await t.context.queryElements(t, '#ex1 [role="tree"] li');
 
   // Check the role "treeitem" is on the list item (in the case of a directory) or contained link
   for (let item of listitems) {
@@ -125,7 +122,7 @@ ariaTest('role="treeitem" on "li" or "a" element', exampleFile, 'treeitem-role',
       );
     }
     else {
-      const links = await item.findElements(By.css('a'));
+      const links = await t.context.queryElements(t, 'a', item);
       t.is(
         await links[0].getAttribute('role'),
         'treeitem',
@@ -137,10 +134,9 @@ ariaTest('role="treeitem" on "li" or "a" element', exampleFile, 'treeitem-role',
 
 ariaTest('role="none" on "li" element', exampleFile, 'none-role', async (t) => {
 
-  t.plan(34);
-
+  
   // Get all the list items in the tree structure
-  const listitems = await t.context.session.findElements(By.css('#ex1 [role="tree"] li'));
+  const listitems = await t.context.queryElements(t, '#ex1 [role="tree"] li');
 
   for (let item of listitems) {
     const hasAriaExpanded = await hasAriaExpandedAttribute(t, item);
@@ -158,17 +154,15 @@ ariaTest('role="none" on "li" element', exampleFile, 'none-role', async (t) => {
 
 
 ariaTest('treeitem tabindex set by roving tabindex', exampleFile, 'treeitem-tabindex', async (t) => {
-  t.plan(1);
-  await openAllFolders(t);
+    await openAllFolders(t);
 
   await assertRovingTabindex(t, ex.treeitemSelector, Key.ARROW_DOWN);
 });
 
 ariaTest('aria-expanded attribute on treeitem matches dom', exampleFile, 'treeitem-aria-expanded', async (t) => {
 
-  t.plan(66);
-
-  const folders = await t.context.session.findElements(By.css(ex.folderSelector));
+  
+  const folders = await t.context.queryElements(t, ex.folderSelector);
 
   for (let folder of folders) {
 
@@ -183,7 +177,7 @@ ariaTest('aria-expanded attribute on treeitem matches dom', exampleFile, 'treeit
         'false'
       );
       t.is(
-        await(await folder.findElements(By.css('[role="treeitem"]')))[0].isDisplayed(),
+        await(await t.context.queryElements(t, '[role="treeitem"]', folder))[0].isDisplayed(),
         false
       );
 
@@ -196,7 +190,7 @@ ariaTest('aria-expanded attribute on treeitem matches dom', exampleFile, 'treeit
         'true'
       );
       t.is(
-        await(await folder.findElements(By.css('[role="treeitem"]')))[0].isDisplayed(),
+        await(await t.context.queryElements(t, '[role="treeitem"]', folder))[0].isDisplayed(),
         true
       );
     }
@@ -219,7 +213,7 @@ ariaTest('aria-expanded attribute on treeitem matches dom', exampleFile, 'treeit
         folderText
       );
       t.is(
-        await(await folders[i].findElements(By.css('[role="treeitem"]')))[0].isDisplayed(),
+        await(await t.context.queryElements(t, '[role="treeitem"]', folders[i]))[0].isDisplayed(),
         false,
         folderText
       );
@@ -230,9 +224,8 @@ ariaTest('aria-expanded attribute on treeitem matches dom', exampleFile, 'treeit
 
 ariaTest('role="group" on "ul" elements', exampleFile, 'group-role', async (t) => {
 
-  t.plan(12);
-
-  const groups = await t.context.session.findElements(By.css(ex.groupSelector));
+  
+  const groups = await t.context.queryElements(t, ex.groupSelector);
 
   t.truthy(
     groups.length,
@@ -251,9 +244,8 @@ ariaTest('role="group" on "ul" elements', exampleFile, 'group-role', async (t) =
 // Keys
 
 ariaTest('Key enter opens folder and activates link', exampleFile, 'key-enter-or-space', async (t) => {
-  t.plan(2);
-
-  let folders = await t.context.session.findElements(By.css(ex.folderSelector));
+  
+  let folders = await t.context.queryElements(t, ex.folderSelector);
 
   // Going through all closed folder elements in dom order will open parent
   // folders first, therefore all child folders will be visible before sending "enter"
@@ -265,7 +257,7 @@ ariaTest('Key enter opens folder and activates link', exampleFile, 'key-enter-or
   await assertAttributeValues(t, ex.folderSelector, 'aria-expanded', 'true');
 
   // Test a leaf node
-  let leafnodes = await t.context.session.findElements(By.css(ex.linkSelector));
+  let leafnodes = await t.context.queryElements(t, ex.linkSelector);
   await leafnodes[0].sendKeys(Key.ENTER);
 
   await t.context.session.wait(() => {
@@ -284,9 +276,8 @@ ariaTest('Key enter opens folder and activates link', exampleFile, 'key-enter-or
 
 // This test fails due to bug #869.
 ariaTest.failing('Key space opens folder and activates link', exampleFile, 'key-enter-or-space', async (t) => {
-  t.plan(2);
-
-  let folders = await t.context.session.findElements(By.css(ex.folderSelector));
+  
+  let folders = await t.context.queryElements(t, ex.folderSelector);
 
   // Going through all closed folder elements in dom order will open parent
   // folders first, therefore all child folders will be visible before sending "enter"
@@ -298,7 +289,7 @@ ariaTest.failing('Key space opens folder and activates link', exampleFile, 'key-
   await assertAttributeValues(t, ex.folderSelector, 'aria-expanded', 'true');
 
   // Test a leaf node
-  let leafnodes = await t.context.session.findElements(By.css(ex.linkSelector));
+  let leafnodes = await t.context.queryElements(t, ex.linkSelector);
   await leafnodes[0].sendKeys(Key.SPACE);
 
   await t.context.session.wait(() => {
@@ -315,10 +306,9 @@ ariaTest.failing('Key space opens folder and activates link', exampleFile, 'key-
 });
 
 ariaTest('key down arrow moves focus', exampleFile, 'key-down-arrow', async (t) => {
-  t.plan(51);
-
+  
   // Check that the down arrow does not open folders
-  const topLevelFolders = await t.context.session.findElements(By.css(ex.topLevelFolderSelector));
+  const topLevelFolders = await t.context.queryElements(t, ex.topLevelFolderSelector);
 
   for (let i = 0; i < topLevelFolders.length; i++) {
     await topLevelFolders[i].sendKeys(Key.ARROW_DOWN);
@@ -346,7 +336,7 @@ ariaTest('key down arrow moves focus', exampleFile, 'key-down-arrow', async (t) 
   // Open all folders
   await openAllFolders(t);
 
-  const items = await t.context.session.findElements(By.css(ex.treeitemSelector));
+  const items = await t.context.queryElements(t, ex.treeitemSelector);
 
   for (let i = 0; i < items.length; i++) {
     await items[i].sendKeys(Key.ARROW_DOWN);
@@ -364,10 +354,9 @@ ariaTest('key down arrow moves focus', exampleFile, 'key-down-arrow', async (t) 
 });
 
 ariaTest('key up arrow moves focus', exampleFile, 'key-up-arrow', async (t) => {
-  t.plan(51);
-
+  
   // Check that the down arrow does not open folders
-  const topLevelFolders = await t.context.session.findElements(By.css(ex.topLevelFolderSelector));
+  const topLevelFolders = await t.context.queryElements(t, ex.topLevelFolderSelector);
 
   for (let i = topLevelFolders.length - 1; i >= 0 ; i--) {
     await topLevelFolders[i].sendKeys(Key.ARROW_UP);
@@ -395,7 +384,7 @@ ariaTest('key up arrow moves focus', exampleFile, 'key-up-arrow', async (t) => {
   // Open all folders
   await openAllFolders(t);
 
-  const items = await t.context.session.findElements(By.css(ex.treeitemSelector));
+  const items = await t.context.queryElements(t, ex.treeitemSelector);
 
   for (let i = items.length - 1; i >= 0 ; i--) {
     await items[i].sendKeys(Key.ARROW_UP);
@@ -413,9 +402,8 @@ ariaTest('key up arrow moves focus', exampleFile, 'key-up-arrow', async (t) => {
 });
 
 ariaTest('key right arrow opens folders and moves focus', exampleFile, 'key-right-arrow', async (t) => {
-  t.plan(67);
-
-  const items = await t.context.session.findElements(By.css(ex.treeitemSelector));
+  
+  const items = await t.context.queryElements(t, ex.treeitemSelector);
 
   let i = 0;
   while (i < items.length) {
@@ -465,12 +453,11 @@ ariaTest('key right arrow opens folders and moves focus', exampleFile, 'key-righ
 
 // This test fails due to bug #866.
 ariaTest.failing('key left arrow closes folders and moves focus', exampleFile, 'key-left-arrow', async (t) => {
-  t.plan(106);
-
+  
   // Open all folders
   await openAllFolders(t);
 
-  const items = await t.context.session.findElements(By.css(ex.treeitemSelector));
+  const items = await t.context.queryElements(t, ex.treeitemSelector);
 
   let i = items.length - 1;
   while (i > 0) {
@@ -531,10 +518,9 @@ ariaTest.failing('key left arrow closes folders and moves focus', exampleFile, '
 });
 
 ariaTest('key home moves focus', exampleFile, 'key-home', async (t) => {
-  t.plan(51);
-
+  
   // Test that key "home" works when no folder is open
-  const topLevelFolders = await t.context.session.findElements(By.css(ex.topLevelFolderSelector));
+  const topLevelFolders = await t.context.queryElements(t, ex.topLevelFolderSelector);
 
   for (let i = topLevelFolders.length - 1; i >= 0 ; i--) {
     await topLevelFolders[i].sendKeys(Key.HOME);
@@ -558,7 +544,7 @@ ariaTest('key home moves focus', exampleFile, 'key-home', async (t) => {
   // Open all folders
   await openAllFolders(t);
 
-  const items = await t.context.session.findElements(By.css(ex.treeitemSelector));
+  const items = await t.context.queryElements(t, ex.treeitemSelector);
 
   for (let i = items.length - 1; i >= 0 ; i--) {
     await items[i].sendKeys(Key.HOME);
@@ -571,10 +557,9 @@ ariaTest('key home moves focus', exampleFile, 'key-home', async (t) => {
 });
 
 ariaTest('key end moves focus', exampleFile, 'key-end', async (t) => {
-  t.plan(51);
-
+  
   // Test that key "end" works when no folder is open
-  const topLevelFolders = await t.context.session.findElements(By.css(ex.topLevelFolderSelector));
+  const topLevelFolders = await t.context.queryElements(t, ex.topLevelFolderSelector);
 
   for (let i = topLevelFolders.length - 1; i >= 0 ; i--) {
     await topLevelFolders[i].sendKeys(Key.END);
@@ -598,7 +583,7 @@ ariaTest('key end moves focus', exampleFile, 'key-end', async (t) => {
   // Open all folders
   await openAllFolders(t);
 
-  const items = await t.context.session.findElements(By.css(ex.treeitemSelector));
+  const items = await t.context.queryElements(t, ex.treeitemSelector);
 
   for (let i = items.length - 1; i >= 0 ; i--) {
     await items[i].sendKeys(Key.END);
@@ -612,8 +597,7 @@ ariaTest('key end moves focus', exampleFile, 'key-end', async (t) => {
 });
 
 ariaTest('characters move focus', exampleFile, 'key-character', async (t) => {
-  t.plan(12);
-
+  
   const charIndexTestClosed = [
     { sendChar: 'g', sendIndex: 0, endIndex: 2 },
     { sendChar: 'f', sendIndex: 2, endIndex: 0 },
@@ -629,7 +613,7 @@ ariaTest('characters move focus', exampleFile, 'key-character', async (t) => {
     { sendChar: 'o', sendIndex: 41, endIndex: 1 }
   ];
 
-  const topLevelFolders = await t.context.session.findElements(By.css(ex.topLevelFolderSelector));
+  const topLevelFolders = await t.context.queryElements(t, ex.topLevelFolderSelector);
 
   for (let test of charIndexTestClosed) {
 
@@ -651,7 +635,7 @@ ariaTest('characters move focus', exampleFile, 'key-character', async (t) => {
   // Open all folders
   await openAllFolders(t);
 
-  const items = await t.context.session.findElements(By.css(ex.treeitemSelector));
+  const items = await t.context.queryElements(t, ex.treeitemSelector);
 
   for (let test of charIndexTestOpened) {
 
@@ -667,12 +651,11 @@ ariaTest('characters move focus', exampleFile, 'key-character', async (t) => {
 });
 
 ariaTest('asterisk key opens folders', exampleFile, 'key-asterisk', async (t) => {
-  t.plan(10);
-
+  
   /* Test that "*" ONLY opens all top level nodes and no other folders */
 
-  const topLevelFolders = await t.context.session.findElements(By.css(ex.topLevelFolderSelector));
-  const nextLevelFolders = await t.context.session.findElements(By.css(ex.nextLevelFolderSelector));
+  const topLevelFolders = await t.context.queryElements(t, ex.topLevelFolderSelector);
+  const nextLevelFolders = await t.context.queryElements(t, ex.nextLevelFolderSelector);
 
   // Send Key
   await topLevelFolders[0].sendKeys('*');
@@ -687,8 +670,7 @@ ariaTest('asterisk key opens folders', exampleFile, 'key-asterisk', async (t) =>
 
   // The subfolders of first top level folder should all be open
 
-  const subFoldersOfFirstFolder = await topLevelFolders[0]
-    .findElements(By.css(ex.nextLevelFolderSelector));
+  const subFoldersOfFirstFolder = await t.context.queryElements(t, ex.nextLevelFolderSelector, topLevelFolders[0]);
   for (let el of subFoldersOfFirstFolder) {
     t.true(
       await el.getAttribute('aria-expanded') === 'true',
@@ -698,8 +680,7 @@ ariaTest('asterisk key opens folders', exampleFile, 'key-asterisk', async (t) =>
 
   // The subfolders of second top level folder should all be closed
 
-  const subFoldersOfSecondFolder = await topLevelFolders[1]
-    .findElements(By.css(ex.nextLevelFolderSelector));
+  const subFoldersOfSecondFolder = await t.context.queryElements(t, ex.nextLevelFolderSelector, topLevelFolders[1]);
   for (let el of subFoldersOfSecondFolder) {
     t.true(
       await el.getAttribute('aria-expanded') === 'false',
@@ -709,8 +690,7 @@ ariaTest('asterisk key opens folders', exampleFile, 'key-asterisk', async (t) =>
 
   // The subfolders of third top level folder should all be closed
 
-  const subFoldersOfThirdFolder = await topLevelFolders[2]
-    .findElements(By.css(ex.nextLevelFolderSelector));
+  const subFoldersOfThirdFolder = await t.context.queryElements(t, ex.nextLevelFolderSelector, topLevelFolders[2]);
   for (let el of subFoldersOfThirdFolder) {
     t.true(
       await el.getAttribute('aria-expanded') === 'false',

--- a/test/tests/treeview_treeview-2b.js
+++ b/test/tests/treeview_treeview-2b.js
@@ -52,7 +52,7 @@ const ex = {
 
 const openAllFolders = async function (t) {
   const closedFoldersSelector = ex.treeitemSelector + '[aria-expanded="false"]';
-  let closedFolders = await t.context.session.findElements(By.css(closedFoldersSelector));
+  let closedFolders = await t.context.queryElements(t, closedFoldersSelector);
 
   // Going through all closed folder elements in dom order will open parent
   // folders first, therefore all child folders will be visible before clicked
@@ -112,9 +112,8 @@ const hasAriaExpandedAttribute = async function (t, el) {
 
 ariaTest('role="tree" on ul element', exampleFile, 'tree-role', async (t) => {
 
-  t.plan(2);
-
-  const trees = await t.context.session.findElements(By.css(ex.treeSelector));
+  
+  const trees = await t.context.queryElements(t, ex.treeSelector);
 
   t.is(
     trees.length,
@@ -131,17 +130,15 @@ ariaTest('role="tree" on ul element', exampleFile, 'tree-role', async (t) => {
 
 ariaTest('aria-labelledby on role="tree" element', exampleFile, 'tree-aria-labelledby', async (t) => {
 
-  t.plan(1);
-
+  
   await assertAriaLabelledby(t, ex.treeSelector);
 });
 
 ariaTest('role="treeitem" on "li" or "a" element', exampleFile, 'treeitem-role', async (t) => {
 
-  t.plan(45);
-
+  
   // Get all the list items in the tree structure
-  const listitems = await t.context.session.findElements(By.css('#ex1 [role="tree"] li'));
+  const listitems = await t.context.queryElements(t, '#ex1 [role="tree"] li');
 
   // Check the role "treeitem" is on the list item (in the case of a directory) or contained link
   for (let item of listitems) {
@@ -157,7 +154,7 @@ ariaTest('role="treeitem" on "li" or "a" element', exampleFile, 'treeitem-role',
       );
     }
     else {
-      const links = await item.findElements(By.css('a'));
+      const links = await t.context.queryElements(t, 'a', item);
       t.is(
         await links[0].getAttribute('role'),
         'treeitem',
@@ -169,10 +166,9 @@ ariaTest('role="treeitem" on "li" or "a" element', exampleFile, 'treeitem-role',
 
 ariaTest('role="none" on "li" element', exampleFile, 'none-role', async (t) => {
 
-  t.plan(34);
-
+  
   // Get all the list items in the tree structure
-  const listitems = await t.context.session.findElements(By.css('#ex1 [role="tree"] li'));
+  const listitems = await t.context.queryElements(t, '#ex1 [role="tree"] li');
 
   for (let item of listitems) {
     const hasAriaExpanded = await hasAriaExpandedAttribute(t, item);
@@ -190,17 +186,15 @@ ariaTest('role="none" on "li" element', exampleFile, 'none-role', async (t) => {
 
 
 ariaTest('treeitem tabindex set by roving tabindex', exampleFile, 'treeitem-tabindex', async (t) => {
-  t.plan(1);
-  await openAllFolders(t);
+    await openAllFolders(t);
 
   await assertRovingTabindex(t, ex.treeitemSelector, Key.ARROW_DOWN);
 });
 
 ariaTest('aria-expanded attribute on treeitem matches dom', exampleFile, 'treeitem-aria-expanded', async (t) => {
 
-  t.plan(66);
-
-  const folders = await t.context.session.findElements(By.css(ex.folderSelector));
+  
+  const folders = await t.context.queryElements(t, ex.folderSelector);
 
   for (let folder of folders) {
 
@@ -215,7 +209,7 @@ ariaTest('aria-expanded attribute on treeitem matches dom', exampleFile, 'treeit
         'false'
       );
       t.is(
-        await(await folder.findElements(By.css('[role="treeitem"]')))[0].isDisplayed(),
+        await(await t.context.queryElements(t, '[role="treeitem"]', folder))[0].isDisplayed(),
         false
       );
 
@@ -228,7 +222,7 @@ ariaTest('aria-expanded attribute on treeitem matches dom', exampleFile, 'treeit
         'true'
       );
       t.is(
-        await(await folder.findElements(By.css('[role="treeitem"]')))[0].isDisplayed(),
+        await(await t.context.queryElements(t, '[role="treeitem"]', folder))[0].isDisplayed(),
         true
       );
     }
@@ -251,7 +245,7 @@ ariaTest('aria-expanded attribute on treeitem matches dom', exampleFile, 'treeit
         folderText
       );
       t.is(
-        await(await folders[i].findElements(By.css('[role="treeitem"]')))[0].isDisplayed(),
+        await(await t.context.queryElements(t, '[role="treeitem"]', folders[i]))[0].isDisplayed(),
         false,
         folderText
       );
@@ -262,12 +256,11 @@ ariaTest('aria-expanded attribute on treeitem matches dom', exampleFile, 'treeit
 
 
 ariaTest('"aria-setsize" atrribute on treeitem', exampleFile, 'treeitem-aria-setsize', async (t) => {
-  t.plan(45);
-
+  
   for (const [level, levelSelectors] of Object.entries(ex.groupItemSelectors)) {
     for (const selector of levelSelectors) {
 
-      const items = await t.context.session.findElements(By.css(selector));
+      const items = await t.context.queryElements(t, selector);
       const setsize = items.length;
 
       for (const item of items) {
@@ -297,12 +290,11 @@ ariaTest('"aria-setsize" atrribute on treeitem', exampleFile, 'treeitem-aria-set
 });
 
 ariaTest('"aria-posinset" attribute on treeitem', exampleFile, 'treeitem-aria-posinset', async (t) => {
-  t.plan(45);
-
+  
   for (const [level, levelSelectors] of Object.entries(ex.groupItemSelectors)) {
     for (const selector of levelSelectors) {
 
-      const items = await t.context.session.findElements(By.css(selector));
+      const items = await t.context.queryElements(t, selector);
       let pos = 0;
 
       for (const item of items) {
@@ -332,12 +324,11 @@ ariaTest('"aria-posinset" attribute on treeitem', exampleFile, 'treeitem-aria-po
 });
 
 ariaTest('"aria-level" attribute on treeitem', exampleFile, 'treeitem-aria-level', async (t) => {
-  t.plan(45);
-
+  
   for (const [level, levelSelectors] of Object.entries(ex.groupItemSelectors)) {
     for (const selector of levelSelectors) {
 
-      const items = await t.context.session.findElements(By.css(selector));
+      const items = await t.context.queryElements(t, selector);
       for (const item of items) {
 
         // The item is a folder with "treeitem" role and "aria-level" set
@@ -367,9 +358,8 @@ ariaTest('"aria-level" attribute on treeitem', exampleFile, 'treeitem-aria-level
 
 ariaTest('role="group" on "ul" elements', exampleFile, 'group-role', async (t) => {
 
-  t.plan(12);
-
-  const groups = await t.context.session.findElements(By.css(ex.groupSelector));
+  
+  const groups = await t.context.queryElements(t, ex.groupSelector);
 
   t.truthy(
     groups.length,
@@ -388,9 +378,8 @@ ariaTest('role="group" on "ul" elements', exampleFile, 'group-role', async (t) =
 // Keys
 
 ariaTest('Key enter opens folder and activates link', exampleFile, 'key-enter-or-space', async (t) => {
-  t.plan(2);
-
-  let folders = await t.context.session.findElements(By.css(ex.folderSelector));
+  
+  let folders = await t.context.queryElements(t, ex.folderSelector);
 
   // Going through all closed folder elements in dom order will open parent
   // folders first, therefore all child folders will be visible before sending "enter"
@@ -402,7 +391,7 @@ ariaTest('Key enter opens folder and activates link', exampleFile, 'key-enter-or
   await assertAttributeValues(t, ex.folderSelector, 'aria-expanded', 'true');
 
   // Test a leaf node
-  let leafnodes = await t.context.session.findElements(By.css(ex.linkSelector));
+  let leafnodes = await t.context.queryElements(t, ex.linkSelector);
   await leafnodes[0].sendKeys(Key.ENTER);
 
   await t.context.session.wait(() => {
@@ -421,9 +410,8 @@ ariaTest('Key enter opens folder and activates link', exampleFile, 'key-enter-or
 
 // This test fails due to bug #869.
 ariaTest.failing('Key space opens folder and activates link', exampleFile, 'key-enter-or-space', async (t) => {
-  t.plan(2);
-
-  let folders = await t.context.session.findElements(By.css(ex.folderSelector));
+  
+  let folders = await t.context.queryElements(t, ex.folderSelector);
 
   // Going through all closed folder elements in dom order will open parent
   // folders first, therefore all child folders will be visible before sending "enter"
@@ -435,7 +423,7 @@ ariaTest.failing('Key space opens folder and activates link', exampleFile, 'key-
   await assertAttributeValues(t, ex.folderSelector, 'aria-expanded', 'true');
 
   // Test a leaf node
-  let leafnodes = await t.context.session.findElements(By.css(ex.linkSelector));
+  let leafnodes = await t.context.queryElements(t, ex.linkSelector);
   await leafnodes[0].sendKeys(Key.SPACE);
 
   await t.context.session.wait(() => {
@@ -452,10 +440,9 @@ ariaTest.failing('Key space opens folder and activates link', exampleFile, 'key-
 });
 
 ariaTest('key down arrow moves focus', exampleFile, 'key-down-arrow', async (t) => {
-  t.plan(51);
-
+  
   // Check that the down arrow does not open folders
-  const topLevelFolders = await t.context.session.findElements(By.css(ex.topLevelFolderSelector));
+  const topLevelFolders = await t.context.queryElements(t, ex.topLevelFolderSelector);
 
   for (let i = 0; i < topLevelFolders.length; i++) {
     await topLevelFolders[i].sendKeys(Key.ARROW_DOWN);
@@ -483,7 +470,7 @@ ariaTest('key down arrow moves focus', exampleFile, 'key-down-arrow', async (t) 
   // Open all folders
   await openAllFolders(t);
 
-  const items = await t.context.session.findElements(By.css(ex.treeitemSelector));
+  const items = await t.context.queryElements(t, ex.treeitemSelector);
 
   for (let i = 0; i < items.length; i++) {
     await items[i].sendKeys(Key.ARROW_DOWN);
@@ -501,10 +488,9 @@ ariaTest('key down arrow moves focus', exampleFile, 'key-down-arrow', async (t) 
 });
 
 ariaTest('key up arrow moves focus', exampleFile, 'key-up-arrow', async (t) => {
-  t.plan(51);
-
+  
   // Check that the down arrow does not open folders
-  const topLevelFolders = await t.context.session.findElements(By.css(ex.topLevelFolderSelector));
+  const topLevelFolders = await t.context.queryElements(t, ex.topLevelFolderSelector);
 
   for (let i = topLevelFolders.length - 1; i >= 0 ; i--) {
     await topLevelFolders[i].sendKeys(Key.ARROW_UP);
@@ -532,7 +518,7 @@ ariaTest('key up arrow moves focus', exampleFile, 'key-up-arrow', async (t) => {
   // Open all folders
   await openAllFolders(t);
 
-  const items = await t.context.session.findElements(By.css(ex.treeitemSelector));
+  const items = await t.context.queryElements(t, ex.treeitemSelector);
 
   for (let i = items.length - 1; i >= 0 ; i--) {
     await items[i].sendKeys(Key.ARROW_UP);
@@ -550,9 +536,8 @@ ariaTest('key up arrow moves focus', exampleFile, 'key-up-arrow', async (t) => {
 });
 
 ariaTest('key right arrow opens folders and moves focus', exampleFile, 'key-right-arrow', async (t) => {
-  t.plan(67);
-
-  const items = await t.context.session.findElements(By.css(ex.treeitemSelector));
+  
+  const items = await t.context.queryElements(t, ex.treeitemSelector);
 
   let i = 0;
   while (i < items.length) {
@@ -602,12 +587,11 @@ ariaTest('key right arrow opens folders and moves focus', exampleFile, 'key-righ
 
 // This test fails due to bug #866.
 ariaTest.failing('key left arrow closes folders and moves focus', exampleFile, 'key-left-arrow', async (t) => {
-  t.plan(106);
-
+  
   // Open all folders
   await openAllFolders(t);
 
-  const items = await t.context.session.findElements(By.css(ex.treeitemSelector));
+  const items = await t.context.queryElements(t, ex.treeitemSelector);
 
   let i = items.length - 1;
   while (i > 0) {
@@ -668,10 +652,9 @@ ariaTest.failing('key left arrow closes folders and moves focus', exampleFile, '
 });
 
 ariaTest('key home moves focus', exampleFile, 'key-home', async (t) => {
-  t.plan(51);
-
+  
   // Test that key "home" works when no folder is open
-  const topLevelFolders = await t.context.session.findElements(By.css(ex.topLevelFolderSelector));
+  const topLevelFolders = await t.context.queryElements(t, ex.topLevelFolderSelector);
 
   for (let i = topLevelFolders.length - 1; i >= 0 ; i--) {
     await topLevelFolders[i].sendKeys(Key.HOME);
@@ -695,7 +678,7 @@ ariaTest('key home moves focus', exampleFile, 'key-home', async (t) => {
   // Open all folders
   await openAllFolders(t);
 
-  const items = await t.context.session.findElements(By.css(ex.treeitemSelector));
+  const items = await t.context.queryElements(t, ex.treeitemSelector);
 
   for (let i = items.length - 1; i >= 0 ; i--) {
     await items[i].sendKeys(Key.HOME);
@@ -708,10 +691,9 @@ ariaTest('key home moves focus', exampleFile, 'key-home', async (t) => {
 });
 
 ariaTest('key end moves focus', exampleFile, 'key-end', async (t) => {
-  t.plan(51);
-
+  
   // Test that key "end" works when no folder is open
-  const topLevelFolders = await t.context.session.findElements(By.css(ex.topLevelFolderSelector));
+  const topLevelFolders = await t.context.queryElements(t, ex.topLevelFolderSelector);
 
   for (let i = topLevelFolders.length - 1; i >= 0 ; i--) {
     await topLevelFolders[i].sendKeys(Key.END);
@@ -735,7 +717,7 @@ ariaTest('key end moves focus', exampleFile, 'key-end', async (t) => {
   // Open all folders
   await openAllFolders(t);
 
-  const items = await t.context.session.findElements(By.css(ex.treeitemSelector));
+  const items = await t.context.queryElements(t, ex.treeitemSelector);
 
   for (let i = items.length - 1; i >= 0 ; i--) {
     await items[i].sendKeys(Key.END);
@@ -749,8 +731,7 @@ ariaTest('key end moves focus', exampleFile, 'key-end', async (t) => {
 });
 
 ariaTest('characters move focus', exampleFile, 'key-character', async (t) => {
-  t.plan(12);
-
+  
   const charIndexTestClosed = [
     { sendChar: 'g', sendIndex: 0, endIndex: 2 },
     { sendChar: 'f', sendIndex: 2, endIndex: 0 },
@@ -766,7 +747,7 @@ ariaTest('characters move focus', exampleFile, 'key-character', async (t) => {
     { sendChar: 'o', sendIndex: 41, endIndex: 1 }
   ];
 
-  const topLevelFolders = await t.context.session.findElements(By.css(ex.topLevelFolderSelector));
+  const topLevelFolders = await t.context.queryElements(t, ex.topLevelFolderSelector);
 
   for (let test of charIndexTestClosed) {
 
@@ -788,7 +769,7 @@ ariaTest('characters move focus', exampleFile, 'key-character', async (t) => {
   // Open all folders
   await openAllFolders(t);
 
-  const items = await t.context.session.findElements(By.css(ex.treeitemSelector));
+  const items = await t.context.queryElements(t, ex.treeitemSelector);
 
   for (let test of charIndexTestOpened) {
 
@@ -804,12 +785,11 @@ ariaTest('characters move focus', exampleFile, 'key-character', async (t) => {
 });
 
 ariaTest('asterisk key opens folders', exampleFile, 'key-asterisk', async (t) => {
-  t.plan(10);
-
+  
   /* Test that "*" ONLY opens all top level nodes and no other folders */
 
-  const topLevelFolders = await t.context.session.findElements(By.css(ex.topLevelFolderSelector));
-  const nextLevelFolders = await t.context.session.findElements(By.css(ex.nextLevelFolderSelector));
+  const topLevelFolders = await t.context.queryElements(t, ex.topLevelFolderSelector);
+  const nextLevelFolders = await t.context.queryElements(t, ex.nextLevelFolderSelector);
 
   // Send Key
   await topLevelFolders[0].sendKeys('*');
@@ -824,8 +804,7 @@ ariaTest('asterisk key opens folders', exampleFile, 'key-asterisk', async (t) =>
 
   // The subfolders of first top level folder should all be open
 
-  const subFoldersOfFirstFolder = await topLevelFolders[0]
-    .findElements(By.css(ex.nextLevelFolderSelector));
+  const subFoldersOfFirstFolder = await t.context.queryElements(t, ex.nextLevelFolderSelector, topLevelFolders[0]);
   for (let el of subFoldersOfFirstFolder) {
     t.true(
       await el.getAttribute('aria-expanded') === 'true',
@@ -835,8 +814,7 @@ ariaTest('asterisk key opens folders', exampleFile, 'key-asterisk', async (t) =>
 
   // The subfolders of second top level folder should all be closed
 
-  const subFoldersOfSecondFolder = await topLevelFolders[1]
-    .findElements(By.css(ex.nextLevelFolderSelector));
+  const subFoldersOfSecondFolder = await t.context.queryElements(t, ex.nextLevelFolderSelector, topLevelFolders[1]);
   for (let el of subFoldersOfSecondFolder) {
     t.true(
       await el.getAttribute('aria-expanded') === 'false',
@@ -846,8 +824,7 @@ ariaTest('asterisk key opens folders', exampleFile, 'key-asterisk', async (t) =>
 
   // The subfolders of third top level folder should all be closed
 
-  const subFoldersOfThirdFolder = await topLevelFolders[2]
-    .findElements(By.css(ex.nextLevelFolderSelector));
+  const subFoldersOfThirdFolder = await t.context.queryElements(t, ex.nextLevelFolderSelector, topLevelFolders[2]);
   for (let el of subFoldersOfThirdFolder) {
     t.true(
       await el.getAttribute('aria-expanded') === 'false',

--- a/test/util/assertAriaActivedescendant.js
+++ b/test/util/assertAriaActivedescendant.js
@@ -16,8 +16,7 @@ module.exports = async function assertAriaSelectedAndActivedescendant (t, active
 
   // Confirm aria-activedescendant refers to the correct option
 
-  const options = await t.context.session
-    .findElements(By.css(optionsSelector));
+  const options = await t.context.queryElements(t, optionsSelector);
   const optionId = await options[index].getAttribute('id');
 
   assert.strictEqual(

--- a/test/util/assertAriaControls.js
+++ b/test/util/assertAriaControls.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const { By } = require('selenium-webdriver');
 const assert = require('assert');
 
 /**
@@ -11,7 +10,7 @@ const assert = require('assert');
  */
 
 module.exports = async function assertAriaControls (t, elementSelector) {
-  const elements = await t.context.session.findElements(By.css(elementSelector));
+  const elements = await t.context.queryElements(t, elementSelector);
 
   assert.ok(
     elements.length,
@@ -37,7 +36,7 @@ module.exports = async function assertAriaControls (t, elementSelector) {
       '"aria-controls" attribute should have a value on element(s): ' + elementSelector
     );
 
-    const controlEl = await t.context.session.findElements(By.id(controlId));
+    const controlEl = await t.context.queryElements(t, `#${controlId}`);
 
     assert.equal(
       controlEl.length,

--- a/test/util/assertAriaDescribedby.js
+++ b/test/util/assertAriaDescribedby.js
@@ -1,3 +1,5 @@
+/* eslint no-restricted-properties: 0 */
+
 'use strict';
 
 const { By } = require('selenium-webdriver');

--- a/test/util/assertAriaDescribedby.js
+++ b/test/util/assertAriaDescribedby.js
@@ -50,8 +50,7 @@ module.exports = async function assertAriaDescribedby (t, elementSelector) {
         return el.innerText;
       }, descriptionId);
 
-      let descriptionImage = await t.context.session.findElement(By.id(descriptionId))
-        .findElements(By.css('img'));
+      let descriptionImage = await t.context.queryElements(t, `#${descriptionId}`);
 
       assert.ok(
         descriptionText || descriptionImage.length,

--- a/test/util/assertAriaDescribedby.js
+++ b/test/util/assertAriaDescribedby.js
@@ -11,7 +11,7 @@ const assert = require('assert');
  */
 
 module.exports = async function assertAriaDescribedby (t, elementSelector) {
-  const elements = await t.context.session.findElements(By.css(elementSelector));
+  const elements = await t.context.queryElements(t, elementSelector);
 
   assert.ok(
     elements.length,

--- a/test/util/assertAriaDescribedby.js
+++ b/test/util/assertAriaDescribedby.js
@@ -1,5 +1,3 @@
-/* eslint no-restricted-properties: 0 */
-
 'use strict';
 
 const { By } = require('selenium-webdriver');

--- a/test/util/assertAriaLabelExists.js
+++ b/test/util/assertAriaLabelExists.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const { By } = require('selenium-webdriver');
 const assert = require('assert');
 
 /**
@@ -12,7 +11,7 @@ const assert = require('assert');
 
 module.exports = async function assertAriaLabel (t, elementSelector) {
 
-  const elements = await t.context.session.findElements(By.css(elementSelector));
+  const elements = await t.context.queryElements(t, elementSelector);
 
   assert.ok(
     elements.length,

--- a/test/util/assertAriaLabelledby.js
+++ b/test/util/assertAriaLabelledby.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const { By } = require('selenium-webdriver');
 const assert = require('assert');
 
 /**
@@ -11,7 +10,7 @@ const assert = require('assert');
  */
 
 module.exports = async function assertAriaLabelledby (t, elementSelector) {
-  const elements = await t.context.session.findElements(By.css(elementSelector));
+  const elements = await t.context.queryElements(t, elementSelector);
 
   assert.ok(
     elements.length,

--- a/test/util/assertAriaRoles.js
+++ b/test/util/assertAriaRoles.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const { By } = require('selenium-webdriver');
 const assert = require('assert');
 
 /**
@@ -17,7 +16,7 @@ const assert = require('assert');
 module.exports = async function assertAriaRoles (t, exampleId, role, roleCount, elementTag) {
   const elementSelector = '#' + exampleId + ' [role="' + role + '"]';
 
-  const elements = await t.context.session.findElements(By.css(elementSelector));
+  const elements = await t.context.queryElements(t, elementSelector);
 
   assert.equal(
     elements.length,

--- a/test/util/assertAriaSelectedAndActivedescendant.js
+++ b/test/util/assertAriaSelectedAndActivedescendant.js
@@ -16,8 +16,7 @@ module.exports = async function assertAriaSelectedAndActivedescendant (t, active
 
   // Confirm the option at the index has aria-selected set to true
 
-  const options = await t.context.session
-    .findElements(By.css(optionsSelector));
+  const options = await t.context.queryElements(t, optionsSelector);
 
   assert.strictEqual(
     await options[index].getAttribute('aria-selected'),

--- a/test/util/assertAttributeDNE.js
+++ b/test/util/assertAttributeDNE.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const { By } = require('selenium-webdriver');
 const assert = require('assert');
 
 /**
@@ -12,7 +11,7 @@ const assert = require('assert');
  */
 module.exports = async function assertAttributeDNE (t, selector, attribute) {
 
-  const numElements = (await t.context.session.findElements(By.css(selector))).length;
+  const numElements = (await t.context.queryElements(t, selector)).length;
 
   assert.ok(
     numElements,

--- a/test/util/assertAttributeValues.js
+++ b/test/util/assertAttributeValues.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const { By } = require('selenium-webdriver');
 const assert = require('assert');
 
 /**
@@ -12,8 +11,7 @@ const assert = require('assert');
  * @param {String} value           - the value
  */
 module.exports = async function assertAttributeValues (t, elementSelector, attribute, value) {
-  let elementLocator = By.css(elementSelector);
-  let elements = await t.context.session.findElements(elementLocator);
+  let elements = await t.context.queryElements(t, elementSelector);
 
   assert.ok(
     elements.length,

--- a/test/util/assertNoElements.js
+++ b/test/util/assertNoElements.js
@@ -1,0 +1,22 @@
+/* eslint no-restricted-properties: 0 */
+
+'use strict';
+
+const { By } = require('selenium-webdriver');
+
+/**
+ * Return an array of elements by selector. Wraps Selenium's findElements, but with a failing text for empty queries
+ *
+ * @param {ExecutionContext} t - Test execution context
+ * @param {String} selector - CSS selector string
+ * @param {Element} context - Element to query within, defaulting to t.context.session
+ *
+ * @returns {Promise} Resolves to array of elements
+ */
+module.exports = async function assertNoElements(t, selector, message) {
+
+  const elements = await t.context.session.findElements(By.css(selector));
+  const errorMessage = message || 'Should return no results for CSS selector ' + selector;
+
+  t.is(elements.length, 0, errorMessage);
+}

--- a/test/util/assertRovingTabindex.js
+++ b/test/util/assertRovingTabindex.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const { By } = require('selenium-webdriver');
 const assert = require('assert');
 
 /**
@@ -14,7 +13,7 @@ const assert = require('assert');
 module.exports = async function assertRovingTabindex (t, elementsSelector, key) {
 
   // tabindex='0' is expected on the first element
-  let elements = await t.context.session.findElements(By.css(elementsSelector));
+  let elements = await t.context.queryElements(t, elementsSelector);
 
   assert.ok(
     elements.length,

--- a/test/util/queryElements.js
+++ b/test/util/queryElements.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const { By } = require('selenium-webdriver');
+
+/**
+ * Return an array of elements by selector. Wraps Selenium's findElements, but with a failing text for empty queries
+ *
+ * @param {String} selector - CSS selector string
+ * @param {Element} context - Element to query within, defaulting to t.context.session
+ *
+ * @returns {Promise} Resolves to array of elements
+ */
+module.exports = async function queryElements(t, selector, context) {
+  context = context || t.context.session;
+  const result = await context.findElements(By.css(selector));
+  if (result.length === 0) {
+    t.fail(`Element query returned no results: ${selector}`);
+    return [];
+  }
+  else {
+    return result;
+  }
+}

--- a/test/util/queryElements.js
+++ b/test/util/queryElements.js
@@ -1,3 +1,5 @@
+/* eslint no-restricted-properties: 0 */
+
 'use strict';
 
 const { By } = require('selenium-webdriver');

--- a/test/util/queryElements.js
+++ b/test/util/queryElements.js
@@ -7,6 +7,7 @@ const { By } = require('selenium-webdriver');
 /**
  * Return an array of elements by selector. Wraps Selenium's findElements, but with a failing text for empty queries
  *
+ * @param {ExecutionContext} t - Test execution context
  * @param {String} selector - CSS selector string
  * @param {Element} context - Element to query within, defaulting to t.context.session
  *
@@ -17,9 +18,6 @@ module.exports = async function queryElements(t, selector, context) {
   const result = await context.findElements(By.css(selector));
   if (result.length === 0) {
     t.fail(`Element query returned no results: ${selector}`);
-    return [];
   }
-  else {
-    return result;
-  }
+  return result;
 }


### PR DESCRIPTION
Resolves #1312 

Adds `t.context.queryElements` helper function that wraps `t.context.session.findElements`, and fails the test if no elements are found.

Removes `t.plan()`, now that it isn't needed to ensure that tests are run.

Removes some unrelated unused imports caught while updating the above.