### PR TITLE
Listboxes with Rearrangeable Options: Add keyboard commands for multiple selection

### DIFF
--- a/examples/js/utils.js
+++ b/examples/js/utils.js
@@ -12,6 +12,7 @@ aria.KeyCode = {
   BACKSPACE: 8,
   TAB: 9,
   RETURN: 13,
+  SHIFT: 16,
   ESC: 27,
   SPACE: 32,
   PAGE_UP: 33,

--- a/examples/listbox/js/listbox-rearrangeable.js
+++ b/examples/listbox/js/listbox-rearrangeable.js
@@ -11,8 +11,8 @@
 window.addEventListener('load', function () {
   var ex1 = document.getElementById('ex1');
   var ex1ImportantListbox = new aria.Listbox(document.getElementById('ss_imp_list'));
-  var ex1Toolbar = new aria.Toolbar(ex1.querySelector('[role="toolbar"]'));
   var ex1UnimportantListbox = new aria.Listbox(document.getElementById('ss_unimp_list'));
+  new aria.Toolbar(ex1.querySelector('[role="toolbar"]'));
 
   ex1ImportantListbox.enableMoveUpDown(
     document.getElementById('ex1-up'),
@@ -44,7 +44,6 @@ window.addEventListener('load', function () {
   });
   ex1UnimportantListbox.setupMove(document.getElementById('ex1-add'), ex1ImportantListbox);
 
-  var ex2 = document.getElementById('ex2');
   var ex2ImportantListbox = new aria.Listbox(document.getElementById('ms_imp_list'));
   var ex2UnimportantListbox = new aria.Listbox(document.getElementById('ms_unimp_list'));
 

--- a/examples/listbox/js/listbox.js
+++ b/examples/listbox/js/listbox.js
@@ -220,11 +220,12 @@ aria.Listbox.prototype.checkKeyPress = function (evt) {
       break;
     case 65:
       // handle control + A
-      if (evt.ctrlKey) {
+      if (this.multiselectable && evt.ctrlKey) {
         evt.preventDefault();
         this.selectRange(0, allOptions.length - 1);
+        break;
       }
-      break;
+      // fall through
     default:
       var itemToFocus = this.findItemToFocus(key);
       if (itemToFocus) {

--- a/examples/listbox/js/listbox.js
+++ b/examples/listbox/js/listbox.js
@@ -220,7 +220,7 @@ aria.Listbox.prototype.checkKeyPress = function (evt) {
       break;
     case 65:
       // handle control + A
-      if (this.multiselectable && evt.ctrlKey) {
+      if (this.multiselectable && (evt.ctrlKey || evt.metaKey)) {
         evt.preventDefault();
         this.selectRange(0, allOptions.length - 1);
         break;
@@ -269,7 +269,7 @@ aria.Listbox.prototype.findItemToFocus = function (key) {
   return nextMatch;
 };
 
-/* Return the index of the passed elemnt within the passed array, or null if not found */
+/* Return the index of the passed element within the passed array, or null if not found */
 aria.Listbox.prototype.getElementIndex = function (option, options) {
   var allOptions = Array.prototype.slice.call(options); // convert to array
   var optionIndex = allOptions.indexOf(option);

--- a/examples/listbox/listbox-rearrangeable.html
+++ b/examples/listbox/listbox-rearrangeable.html
@@ -291,7 +291,7 @@ while in the second example, they may select multiple options before activating 
         </tr>
         <tr data-test-id="key-control-a">
           <th>
-            <kbd>Control + A</kbd> (except on macOS)<br>
+            <kbd>Control + A</kbd> (All Platforms)<br>
             <kbd>Command-A</kbd> (macOS)
           </th>
           <td>selects all options in the list. If all options are selected, unselects all options.</td>

--- a/examples/listbox/listbox-rearrangeable.html
+++ b/examples/listbox/listbox-rearrangeable.html
@@ -123,7 +123,7 @@ while in the second example, they may select multiple options before activating 
               <li id="ms_opt4" role="option" aria-selected="false">Rear seat warmers</li>
               <li id="ms_opt5" role="option" aria-selected="false">Front sun roof</li>
               <li id="ms_opt6" role="option" aria-selected="false">Rear sun roof</li>
-              <li id="ms_opt7" role="option" aria-selected="false">Privacy cloque</li>
+              <li id="ms_opt7" role="option" aria-selected="false">Cloaking capability</li>
               <li id="ms_opt8" role="option" aria-selected="false">Food synthesizer</li>
               <li id="ms_opt9" role="option" aria-selected="false">Advanced waste recycling system</li>
               <li id="ms_opt10" role="option" aria-selected="false">Turbo vertical take-off capability</li>

--- a/examples/listbox/listbox-rearrangeable.html
+++ b/examples/listbox/listbox-rearrangeable.html
@@ -291,8 +291,8 @@ while in the second example, they may select multiple options before activating 
         </tr>
         <tr data-test-id="key-control-a">
           <th>
-            <kbd>Control + A</kbd> (except on MacOS)<br>
-            <kbd>Command-A</kbd> (Mac OS)
+            <kbd>Control + A</kbd> (except on macOS)<br>
+            <kbd>Command-A</kbd> (macOS)
           </th>
           <td>selects all options in the list. If all options are selected, unselects all options.</td>
         </tr>

--- a/examples/listbox/listbox-rearrangeable.html
+++ b/examples/listbox/listbox-rearrangeable.html
@@ -290,7 +290,10 @@ while in the second example, they may select multiple options before activating 
           <td>Selects from the focused option to the end of the list.</td>
         </tr>
         <tr data-test-id="key-control-a">
-          <th><kbd>Control + A</kbd></th>
+          <th>
+            <kbd>Control + A</kbd> (except on MacOS)<br>
+            <kbd>Command-A</kbd> (Mac OS)
+          </th>
           <td>selects all options in the list. If all options are selected, unselects all options.</td>
         </tr>
       </tbody>

--- a/test/tests/listbox_rearrangeable.js
+++ b/test/tests/listbox_rearrangeable.js
@@ -604,3 +604,47 @@ ariaTest('key control+A selects all options', exampleFile, 'key-control-a', asyn
   }
 });
 
+ariaTest('A without control performs default focus move', exampleFile, 'key-control-a', async (t) => {
+  const listbox = await t.context.session.findElement(By.css(ex[2].listboxSelector));
+  const options = await t.context.session.findElements(By.css(ex[2].optionSelector));
+  
+  // get index of first option that begin with a
+  const matchingOptions = [];
+  for (let index = 0; index < options.length; index++) {
+    const optionText = await options[index].getText();
+    if (optionText && optionText[0].toLowerCase() === 'a') {
+      matchingOptions.push(options[index]);
+    }
+  }
+  const matchingIndex = matchingOptions.length ? options.indexOf(matchingOptions[0]) : null;
+
+  // click inside listbox
+  await t.context.session.findElement(By.css(ex[2].firstOptionSelector)).click();
+  await listbox.sendKeys('a');
+
+  await assertAriaActivedescendant(t, ex[2].listboxSelector, ex[2].optionSelector, matchingIndex);
+
+  // expect only first item to be selected
+  for (let index = options.length - 1; index >= 1 ; index--) {
+    const selected = await options[index].getAttribute('aria-selected');
+    t.is(selected, 'false', 'a character alone should not select options');
+  }
+});
+
+ariaTest('Control + A performs no action on single select listbox', exampleFile, 'key-control-a', async (t) => {
+  const listbox = await t.context.session.findElement(By.css(ex[1].listboxSelector));
+  const options = await t.context.session.findElements(By.css(ex[1].optionSelector));
+
+  // click inside listbox
+  await t.context.session.findElement(By.css(ex[1].firstOptionSelector)).click();
+  await listbox.sendKeys(Key.chord(Key.CONTROL, 'a'));
+
+  await assertAriaActivedescendant(t, ex[1].listboxSelector, ex[1].optionSelector, 0);
+
+  // expect only first item to be selected
+  for (let index = options.length - 1; index >= 1 ; index--) {
+    const selected = await options[index].getAttribute('aria-selected');
+    t.is(selected, null, 'control + a should not affect single select listbox');
+  }
+});
+

--- a/test/tests/listbox_rearrangeable.js
+++ b/test/tests/listbox_rearrangeable.js
@@ -340,33 +340,267 @@ ariaTest('key space selects', exampleFile, 'key-space', async (t) => {
   }
 });
 
-// Bug: https://github.com/w3c/aria-practices/issues/919
-ariaTest.failing('key shift+down arrow moves focus and selects', exampleFile, 'key-shift-down-arrow', async (t) => {
-  t.plan(1);
-  t.fail();
+ariaTest('shift + click selects multiple options', exampleFile, 'key-shift-up-arrow', async (t) => {
+  const listbox = await t.context.session.findElement(By.css(ex[2].listboxSelector));
+  const options = await t.context.session.findElements(By.css(ex[2].optionSelector));
+
+  // Put the focus on the fourth item, and selects item
+  await options[3].click();
+
+  // send shift + click to first option
+  const actions = t.context.session.actions();
+  await actions
+          .keyDown(Key.SHIFT)
+          .click(options[0])
+          .keyUp(Key.SHIFT)
+          .perform();
+  
+  // expect first through fourt option to be selected
+  for (let index = options.length - 1; index >= 0 ; index--) {
+    const selected = await options[index].getAttribute('aria-selected');
+    const shouldBeSelected = index < 4;
+    t.is(
+      selected,
+      `${shouldBeSelected}`,
+      `aria-selected should be ${shouldBeSelected} for option ${index + 1} after using shift + click`
+    );
+  }
 });
 
-// Bug: https://github.com/w3c/aria-practices/issues/919
-ariaTest.failing('key shift+up arrow moves focus and selects', exampleFile, 'key-shift-up-arrow', async (t) => {
-  t.plan(1);
-  t.fail();
+ariaTest('key shift+down arrow moves focus and selects', exampleFile, 'key-shift-down-arrow', async (t) => {
+  const listbox = await t.context.session.findElement(By.css(ex[2].listboxSelector));
+  const options = await t.context.session.findElements(By.css(ex[2].optionSelector));
+
+  // Put the focus on the first item, and selects item
+  await t.context.session.findElement(By.css(ex[2].firstOptionSelector)).click();
+  listbox.sendKeys(Key.chord(Key.SHIFT, Key.ARROW_DOWN));
+
+  // expect first two items to be selected
+  for (let index = options.length - 1; index >= 0 ; index--) {
+    const selected = await options[index].getAttribute('aria-selected');
+    const shouldBeSelected = index < 2;
+    t.is(
+      selected,
+      `${shouldBeSelected}`,
+      `aria-selected should be ${shouldBeSelected} for option ${index + 1} after using shift + down arrow to select first and second options`
+    );
+  }
 });
 
-// Bug: https://github.com/w3c/aria-practices/issues/919
-ariaTest.failing('key control+shift+home moves focus and selects', exampleFile, 'key-control-shift-home', async (t) => {
-  t.plan(1);
-  t.fail();
+ariaTest('key shift+down arrow overwrites previous selection', exampleFile, 'key-shift-down-arrow', async (t) => {
+  const listbox = await t.context.session.findElement(By.css(ex[2].listboxSelector));
+  const options = await t.context.session.findElements(By.css(ex[2].optionSelector));
+
+  // Select first item
+  await t.context.session.findElement(By.css(ex[2].firstOptionSelector)).click();
+
+  // set focus to 3rd item and select
+  await t.context.session.findElement(By.css(`${ex[2].optionSelector}:nth-child(3)`)).click();
+  listbox.sendKeys(Key.chord(Key.SHIFT, Key.ARROW_DOWN));
+
+  // expect only third and fourth items to be selected
+  for (let index = options.length - 1; index >= 0 ; index--) {
+    const selected = await options[index].getAttribute('aria-selected');
+    const shouldBeSelected = index === 2 || index === 3;
+    t.is(
+      selected,
+      `${shouldBeSelected}`,
+      `aria-selected should be ${shouldBeSelected} for option ${index + 1} after using shift + down arrow to select first and second options`
+    );
+  }
 });
 
-// Bug: https://github.com/w3c/aria-practices/issues/919
-ariaTest.failing('key control+shift+end moves focus and selects', exampleFile, 'key-control-shift-end', async (t) => {
-  t.plan(1);
-  t.fail();
+ariaTest('key shift+down arrow cannot move past last option', exampleFile, 'key-shift-down-arrow', async (t) => {
+  const listbox = await t.context.session.findElement(By.css(ex[2].listboxSelector));
+  const options = await t.context.session.findElements(By.css(ex[2].optionSelector));
+
+  // Put the focus on the second to last item, and select item
+  await t.context.session.findElement(By.css(`${ex[2].optionSelector}:nth-child(${options.length - 1})`)).click();
+  await listbox.sendKeys(Key.chord(Key.SHIFT, Key.ARROW_DOWN));
+  await listbox.sendKeys(Key.chord(Key.SHIFT, Key.ARROW_DOWN));
+
+  // expect first two items to be selected
+  for (let index = options.length - 1; index >= 0 ; index--) {
+    const selected = await options[index].getAttribute('aria-selected');
+    const shouldBeSelected = index >= options.length - 2;
+    t.is(
+      selected,
+      `${shouldBeSelected}`,
+      `aria-selected should be ${shouldBeSelected} for option ${index + 1} after using shift + down arrow to select past last option`
+    );
+  }
 });
 
-// Bug: https://github.com/w3c/aria-practices/issues/919
-ariaTest.failing('key control+A selects all options', exampleFile, 'key-control-a', async (t) => {
-  t.plan(1);
-  t.fail();
+ariaTest('key shift+up arrow moves focus and selects', exampleFile, 'key-shift-up-arrow', async (t) => {
+  const listbox = await t.context.session.findElement(By.css(ex[2].listboxSelector));
+  const options = await t.context.session.findElements(By.css(ex[2].optionSelector));
+
+  // Put the focus on the last item, and selects item
+  await t.context.session.findElement(By.css(ex[2].lastOptionSelector)).click();
+  listbox.sendKeys(Key.chord(Key.SHIFT, Key.ARROW_UP));
+
+  // expect last two items to be selected
+  for (let index = options.length - 1; index >= 0 ; index--) {
+    const selected = await options[index].getAttribute('aria-selected');
+    const shouldBeSelected = index >= options.length - 2;
+    t.is(
+      selected,
+      `${shouldBeSelected}`,
+      `aria-selected should be ${shouldBeSelected} for option ${index + 1} after using shift + up arrow to select last and second-to-last options`
+    );
+  }
+});
+
+ariaTest('key shift+up arrow resets previous selection', exampleFile, 'key-shift-up-arrow', async (t) => {
+  const listbox = await t.context.session.findElement(By.css(ex[2].listboxSelector));
+  const options = await t.context.session.findElements(By.css(ex[2].optionSelector));
+
+  // Select first item
+  await t.context.session.findElement(By.css(ex[2].firstOptionSelector)).click();
+
+  // set focus to 3rd item and select
+  await t.context.session.findElement(By.css(`${ex[2].optionSelector}:nth-child(3)`)).click();
+  listbox.sendKeys(Key.chord(Key.SHIFT, Key.ARROW_UP));
+
+  // expect only second and third items to be selected
+  for (let index = options.length - 1; index >= 0 ; index--) {
+    const selected = await options[index].getAttribute('aria-selected');
+    const shouldBeSelected = index === 1 || index === 2;
+    t.is(
+      selected,
+      `${shouldBeSelected}`,
+      `aria-selected should be ${shouldBeSelected} for option ${index + 1} after using shift + up arrow to select third and second options`
+    );
+  }
+});
+
+ariaTest('key shift+up arrow cannot move past first option', exampleFile, 'key-shift-up-arrow', async (t) => {
+  const listbox = await t.context.session.findElement(By.css(ex[2].listboxSelector));
+  const options = await t.context.session.findElements(By.css(ex[2].optionSelector));
+
+  // Put the focus on the second item, and select item
+  await t.context.session.findElement(By.css(`${ex[2].optionSelector}:nth-child(2)`)).click();
+  await listbox.sendKeys(Key.chord(Key.SHIFT, Key.ARROW_UP));
+  await listbox.sendKeys(Key.chord(Key.SHIFT, Key.ARROW_UP));
+
+  // expect first two items to be selected
+  for (let index = options.length - 1; index >= 0 ; index--) {
+    const selected = await options[index].getAttribute('aria-selected');
+    const shouldBeSelected = index <= 1;
+    t.is(
+      selected,
+      `${shouldBeSelected}`,
+      `aria-selected should be ${shouldBeSelected} for option ${index + 1} after using shift + up arrow to select first and second`
+    );
+  }
+});
+
+ariaTest('key control+shift+home moves focus and selects all options', exampleFile, 'key-control-shift-home', async (t) => {
+  const listbox = await t.context.session.findElement(By.css(ex[2].listboxSelector));
+  const options = await t.context.session.findElements(By.css(ex[2].optionSelector));
+
+  // Put the focus on the last item, and selects item
+  await t.context.session.findElement(By.css(ex[2].lastOptionSelector)).click();
+  listbox.sendKeys(Key.chord(Key.SHIFT, Key.CONTROL, Key.HOME));
+
+  for (let index = options.length - 1; index >= 0 ; index--) {
+    const selected = await options[index].getAttribute('aria-selected');
+    t.is(selected, 'true', 'aria-selected should be true for all options after using shift + control + home from last option');
+  }
+});
+
+ariaTest('key control+shift+home moves focus and selects some options', exampleFile, 'key-control-shift-home', async (t) => {
+  const listbox = await t.context.session.findElement(By.css(ex[2].listboxSelector));
+  const options = await t.context.session.findElements(By.css(ex[2].optionSelector));
+
+  // Put the focus on the 5th option, arrow up, then do home
+  await t.context.session.findElement(By.css(`${ex[2].optionSelector}:nth-child(5)`)).click();
+  await listbox.sendKeys(Key.ARROW_UP);
+  await listbox.sendKeys(Key.chord(Key.SHIFT, Key.CONTROL, Key.HOME));
+
+  // expect 1st-4th options to be selected
+  for (let index = options.length - 1; index >= 0 ; index--) {
+    const selected = await options[index].getAttribute('aria-selected');
+    const shouldBeSelected = index < 4;
+    t.is(selected, `${shouldBeSelected}`, 'aria-selected should be true for first through fourth options');
+  }
+});
+
+ariaTest('key shift+home does not change selection', exampleFile, 'key-control-shift-home', async (t) => {
+  const listbox = await t.context.session.findElement(By.css(ex[2].listboxSelector));
+  const options = await t.context.session.findElements(By.css(ex[2].optionSelector));
+
+  // Put the focus on the last option and select it
+  await t.context.session.findElement(By.css(ex[2].lastOptionSelector)).click();
+  await listbox.sendKeys(Key.chord(Key.SHIFT, Key.HOME));
+
+  // expect only last item
+  for (let index = options.length - 1; index >= 0 ; index--) {
+    const selected = await options[index].getAttribute('aria-selected');
+    const shouldBeSelected = index === options.length - 1;
+    t.is(selected, `${shouldBeSelected}`, 'aria-selected should only be true for last option');
+  }
+});
+
+ariaTest('key control+shift+end moves focus and selects all options', exampleFile, 'key-control-shift-end', async (t) => {
+  const listbox = await t.context.session.findElement(By.css(ex[2].listboxSelector));
+  const options = await t.context.session.findElements(By.css(ex[2].optionSelector));
+
+  // Put the focus on the first item, and selects item
+  await t.context.session.findElement(By.css(ex[2].firstOptionSelector)).click();
+  await listbox.sendKeys(Key.chord(Key.SHIFT, Key.CONTROL, Key.END));
+
+  for (let index = options.length - 1; index >= 0 ; index--) {
+    const selected = await options[index].getAttribute('aria-selected');
+    t.is(selected, 'true', 'aria-selected should be true for all options after using shift + control + end from first option');
+  }
+});
+
+ariaTest('key control+shift+end moves focus and selects some options', exampleFile, 'key-control-shift-end', async (t) => {
+  const listbox = await t.context.session.findElement(By.css(ex[2].listboxSelector));
+  const options = await t.context.session.findElements(By.css(ex[2].optionSelector));
+
+  // Put the focus on the 3rd option, arrow down, then do end
+  await t.context.session.findElement(By.css(`${ex[2].optionSelector}:nth-child(3)`)).click();
+  await listbox.sendKeys(Key.ARROW_DOWN);
+  await listbox.sendKeys(Key.chord(Key.SHIFT, Key.CONTROL, Key.END));
+
+  // expect 4th - last options to be selected
+  for (let index = options.length - 1; index >= 0 ; index--) {
+    const selected = await options[index].getAttribute('aria-selected');
+    const shouldBeSelected = index >= 3;
+    t.is(selected, `${shouldBeSelected}`, 'aria-selected should be true for fourth through last options');
+  }
+});
+
+ariaTest('key shift+end does not change selection', exampleFile, 'key-control-shift-end', async (t) => {
+  const listbox = await t.context.session.findElement(By.css(ex[2].listboxSelector));
+  const options = await t.context.session.findElements(By.css(ex[2].optionSelector));
+
+  // Put the focus on the first option and select it
+  await t.context.session.findElement(By.css(ex[2].firstOptionSelector)).click();
+  await listbox.sendKeys(Key.chord(Key.SHIFT, Key.END));
+
+  // expect only first item to be selected
+  for (let index = options.length - 1; index >= 0 ; index--) {
+    const selected = await options[index].getAttribute('aria-selected');
+    const shouldBeSelected = index === 0;
+    t.is(selected, `${shouldBeSelected}`, 'aria-selected should only be true for first option');
+  }
+});
+
+ariaTest('key control+A selects all options', exampleFile, 'key-control-a', async (t) => {
+  const listbox = await t.context.session.findElement(By.css(ex[2].listboxSelector));
+  const options = await t.context.session.findElements(By.css(ex[2].optionSelector));
+
+  // click inside listbox
+  await t.context.session.findElement(By.css(`${ex[2].optionSelector}:nth-child(2)`)).click();
+  await listbox.sendKeys(Key.chord(Key.CONTROL, 'a'));
+
+  // expect all items to be selected
+  for (let index = options.length - 1; index >= 0 ; index--) {
+    const selected = await options[index].getAttribute('aria-selected');
+    t.is(selected, 'true', 'all options should be selected after using control + a');
+  }
 });
 


### PR DESCRIPTION
Resolves #919 

Adds the following functionality:
- Shift + arrow keys
- Control + Shift + home and end
- Control + A
- Shift + Click

Includes tests :)

[Preview link](https://raw.githack.com/w3c/aria-practices/919-listbox-multiselect-keys/examples/listbox/listbox-rearrangeable.html)

### Review checklist

* [x] [Editorial review](https://github.com/w3c/aria-practices/wiki/Pull-Request-Review-Process#editorial_review) by Matt (@mcking65)
* [x] [Functional review](https://github.com/w3c/aria-practices/wiki/Pull-Request-Review-Process#functional_review) by Carolyn (@carmacleod) and Matt (@mcking65)
* [x] [Code review](https://github.com/w3c/aria-practices/wiki/Pull-Request-Review-Process#code_review) by Carolyn (@carmacleod) and Simon (zcorpan)
* [x] [Test review](https://github.com/w3c/aria-practices/wiki/Pull-Request-Review-Process#test_review) by Simon (@zcorpan)