### PR TITLE
DO NOT MERGE: demonstrate Build Linter failure for #1365

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,9 @@ jobs:
       name: Spellcheck
       script: npm run lint:spelling
       env: ALLOW_FAILURE=true
+    - stage: Test
+      name: Build Linting
+      script: npm run lint:build
 
     - stage: Test
       name: AVA Regression Tests

--- a/README.md
+++ b/README.md
@@ -76,6 +76,16 @@ Run locally:
 npm run lint:js
 ```
 
+### Regenerate `examples/index.html`
+
+If you have changed something in `examples/`, the index may need to be regenerated.
+
+Run locally:
+
+```sh
+npm run build
+```
+
 ### Test and fix your code
 
 1. Open a terminal window to the directory that contains the `aria-practices` repository

--- a/examples/accordion/accordion.html
+++ b/examples/accordion/accordion.html
@@ -273,13 +273,13 @@
             <ul>
               <li>Element that serves as an accordion header.</li>
               <li>Each accordion header element contains a button that controls the visibility of its content panel.</li>
-              <li>The example uses heading level 3 so it fits correctly within the outline of the page; the example is contained in a section titled with a level 2 heading.</li> 
+              <li>The example uses heading level 3 so it fits correctly within the outline of the page; the example is contained in a section titled with a level 2 heading.</li>
             </ul>
           </td>
         </tr>
         <tr data-test-id="button-aria-expanded">
           <td> </td>
-          <th scope="row"><code>aria-expanded="true"</code></th>
+          <th scope="row"><code>aria-busy="true"</code></th>
           <td><code>button</code></td>
           <td>
             Set to <code>true</code> when the Accordion panel is expanded, otherwise set to <code>false</code>.

--- a/package.json
+++ b/package.json
@@ -7,13 +7,15 @@
     "example": "examples"
   },
   "scripts": {
+    "build": "node scripts/reference-tables.js",
     "fix": "npm run lint:es -- --fix && npm run lint:css -- --fix",
-    "lint": "npm run lint:es && npm run lint:css && npm run vnu-jar && npm run lint:spelling",
+    "lint": "npm run lint:es && npm run lint:css && npm run vnu-jar && npm run lint:spelling && npm run lint:build",
     "lint:css": "stylelint **/*.css",
     "lint:es": "eslint .",
     "lint:js": "npm run lint:es",
     "lint:html": "npm run vnu-jar",
     "lint:spelling": "cspell \"examples/**/*.html\" \"aria-practices.html\"",
+    "lint:build": "./scripts/lint-build.sh",
     "regression": "ava --timeout=1m",
     "regression-report": "node test/util/report",
     "test": "npm run lint && npm run regression",

--- a/scripts/lint-build.sh
+++ b/scripts/lint-build.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+cp examples/index.html examples/index.tmp.html &&
+npm run build &&
+diff examples/index.html examples/index.tmp.html
+rv=$?
+cp examples/index.tmp.html examples/index.html
+rm examples/index.tmp.html
+[ $rv -ne 0 ] && echo 'Please generate examples/index.html by running: npm run build'
+exit $rv


### PR DESCRIPTION
See #1365. Do not merge this PR.

The second commit here changes `examples/accordion/accordion.html` from `aria-expanded="true"` to `aria-busy="true"`, which would cause a change to the index. The expectation is that the new Build Linter check will fail in Travis CI.