### PR TITLE
updated guidance for carousel pattern

### DIFF
--- a/aria-practices.html
+++ b/aria-practices.html
@@ -506,7 +506,7 @@
           </li>
           <li>If the carousel can automatically rotate, it also:
             <ul>
-              <li>Pause auto-rotation on load when operating system settings for reduced motion or disabling animations have been enabled.</li>
+              <li>Pause auto-rotation on load when operating system settings for reduced motion or disabling animations are enabled.</li>
               <li>Has a button for stopping and restarting rotation. This is particularly important for supporting assistive technologies operating in a mode that does not move either keyboard focus or the mouse.</li>
               <li>Stops rotating when keyboard focus enters the carousel, and does not resume until focus leaves the carousel, including slide content.</li>
               <li>Stops rotating whenever the mouse is hovering over the carousel.</li>

--- a/aria-practices.html
+++ b/aria-practices.html
@@ -487,7 +487,7 @@
         A carousel presents a set of items, referred to as slides, by sequentially displaying a subset of one or more slides.
         Typically, one slide is displayed at a time, and users can activate a next or previous slide control that hides the current slide and &quot;rotates&quot; the next or previous slide into view.
         In most implementations, rotation automatically starts when the page loads, and it may also automatically stop once all the slides have been displayed.
-        While a slide may contain any type of content, image carousels where each slide contains nothing more than a single image are common.  In additon to images, carousels often contain content that is overlayed on top of the image, including links, titles, short descriptions and carousel controls.   
+        While a slide may contain any type of content, image carousels where each slide contains nothing more than a single image are common.  In addition to images, carousels often contain content that is overlayed on top of the image, including links, titles, short descriptions and carousel controls.
       </p>
       <section class="notoc">
         <h4>Rotation Control</h4>
@@ -507,14 +507,14 @@
               <li>Stops rotating whenever the mouse is hovering over the carousel.</li>
             </ul>
           </li>
-          <li>Carousels that do not rotate automatically are inheriently more accessible, since users have more control over slide navigation.</li> 
+          <li>Carousels that do not rotate automatically are intermittently more accessible, since users have more control over slide navigation.</li>
         </ul>
-      </section>  
+      </section>
 
       <section class="notoc">
         <h4>Color Contrast</h4>
 
-        <p>The placement of controls and content on top of images affects the ability of people with visual impairments to be able to identify the controls and to read text content.  To ensuring all users can idenitfy carousel controls and the text content associated with each slide requires the author to ensure sufficient color contrast.   Without sufficient color contrast some users will not be able to operate the carousel controls or read the text content of a slide.</p>
+        <p>The placement of controls and content on top of images affects the ability of people with visual impairments to be able to identify the controls and to read text content.  To ensuring all users can identify carousel controls and the text content associated with each slide requires the author to ensure sufficient color contrast.   Without sufficient color contrast some users will not be able to operate the carousel controls or read the text content of a slide.</p>
 
         <p>Features needed to provide sufficient color contrast of text content include:</p>
         <ul>

--- a/aria-practices.html
+++ b/aria-practices.html
@@ -518,7 +518,7 @@
 
         <p>Features needed to provide sufficient color contrast of text content include:</p>
         <ul>
-          <li>When carousel content is overlayed on top of images, ensure the background color of the content provides sufficient color contrast with text and carousel controls.</li>
+          <li>When carousel content is overlayed on top of images, ensure the background color of the content provides sufficient color contrast with text content and carousel controls.</li>
           <li>An alternative to content on top of the image is to move content to before and/or after the image.  The text and controls are easier to identify when outside the image and the surrounding background is more consistent and not dependent on the image content.</li>
         </ul>
       </section>

--- a/aria-practices.html
+++ b/aria-practices.html
@@ -539,7 +539,7 @@
           </thead>
           <tbody>
             <tr>
-              <th>Enabled on load</th>
+              <th scope="row">Enabled on load</th>
               <td>
                 <ul>
                   <li><a href="examples/carousel-1.html">Previous/Next Carousel (Auto, <abbr title="High Contrast Background">HCB</abbr>)</a></li>
@@ -555,7 +555,7 @@
               </td>
             </tr>
             <tr>
-              <th>Paused on load</th>
+              <th scope="row">Paused on load</th>
               <td>
                 <ul>
                   <li><a href="examples/carousel-1.html?paused">Previous/Next Carousel (Paused, <abbr title="High Contrast Background">HCB</abbr>)</a></li>
@@ -570,7 +570,7 @@
               </td>
             </tr>
             <tr>
-              <th>Disabled</th>
+              <th scope="row">Disabled</th>
               <td>
                 <ul>
                   <li><a href="examples/carousel-1.html?noplay">Previous/Next Carousel (No Play, <abbr title="High Contrast Background">HCB</abbr>)</a></li>

--- a/aria-practices.html
+++ b/aria-practices.html
@@ -489,35 +489,39 @@
         In most implementations, rotation automatically starts when the page loads, and it may also automatically stop once all the slides have been displayed.
         While a slide may contain any type of content, image carousels where each slide contains nothing more than a single image are common.  In additon to images, carousels often contain content that is overlayed on top of the image, including links, titles, short descriptions and carousel controls.   
       </p>
-      <h4>Rotation Control</h4>.
-      <p>
-        Ensuring all users can easily control and are not adversely effected by slide rotation is an essential aspect of making carousels accessible.
-        For instance, the screen reader experience can be confusing and disorienting if slides that are not visible on screen are incorrectly hidden, e.g., displayed off-screen.
-        Similarly, if slides rotate automatically and a screen reader user is not aware of the rotation, the user may read an element on slide one, execute the screen reader command for next element, and, instead of hearing the next element on slide one,  hear an element from slide 2 without any knowledge that the element just announced is from an entirely new context.
-      </p>
-      <p>Features needed to provide sufficient rotation control include:</p>
-      <ul>
-        <li>Buttons for displaying the previous and next slides.</li>
-        <li>Optionally, a control, or group of controls, for choosing a specific slide to display. For example, slide picker controls can be marked up as tabs in a tablist with the slide represented by a tabpanel element.</li>
-        <li>If the carousel can automatically rotate, it also:
-          <ul>
-            <li>Has a button for stopping and restarting rotation. This is particularly important for supporting assistive technologies operating in a mode that does not move either keyboard focus or the mouse.</li>
-            <li>Stops rotating when keyboard focus enters the carousel, and does not resume until focus leaves the carousel, including slide content.</li>
-            <li>Stops rotating whenever the mouse is hovering over the carousel.</li>
-          </ul>
-        </li>
-        <li>Carousels that do not rotate automatically are inheriently more accessible, since users have more control over slide navigation.</li> 
-      </ul>
+      <section class="notoc">
+        <h4>Rotation Control</h4>.
+        <p>
+          Ensuring all users can easily control and are not adversely effected by slide rotation is an essential aspect of making carousels accessible.
+          For instance, the screen reader experience can be confusing and disorienting if slides that are not visible on screen are incorrectly hidden, e.g., displayed off-screen.
+          Similarly, if slides rotate automatically and a screen reader user is not aware of the rotation, the user may read an element on slide one, execute the screen reader command for next element, and, instead of hearing the next element on slide one,  hear an element from slide 2 without any knowledge that the element just announced is from an entirely new context.
+        </p>
+        <p>Features needed to provide sufficient rotation control include:</p>
+        <ul>
+          <li>Buttons for displaying the previous and next slides.</li>
+          <li>Optionally, a control, or group of controls, for choosing a specific slide to display. For example, slide picker controls can be marked up as tabs in a tablist with the slide represented by a tabpanel element.</li>
+          <li>If the carousel can automatically rotate, it also:
+            <ul>
+              <li>Has a button for stopping and restarting rotation. This is particularly important for supporting assistive technologies operating in a mode that does not move either keyboard focus or the mouse.</li>
+              <li>Stops rotating when keyboard focus enters the carousel, and does not resume until focus leaves the carousel, including slide content.</li>
+              <li>Stops rotating whenever the mouse is hovering over the carousel.</li>
+            </ul>
+          </li>
+          <li>Carousels that do not rotate automatically are inheriently more accessible, since users have more control over slide navigation.</li> 
+        </ul>
+      </section>  
 
-      <h4>Color Contrast</h4>.
+      <section class="notoc">
+        <h4>Color Contrast</h4>.
 
-      <p>The placement of controls and content on top of the images effects the ability of people with visual impairments to be able to identify the controls and to read text content.  To ensuring all users can idenitfy carousel controls and the text content associated with each slide requires the author to ensure sufficient color contrast.   Without sufficient color contrast some users will not be able to operate the carousel controls or read the text content of a slide.</p>
+        <p>The placement of controls and content on top of the images effects the ability of people with visual impairments to be able to identify the controls and to read text content.  To ensuring all users can idenitfy carousel controls and the text content associated with each slide requires the author to ensure sufficient color contrast.   Without sufficient color contrast some users will not be able to operate the carousel controls or read the text content of a slide.</p>
 
-      <p>Features needed to provide sufficient color contrast of text content include:</p>
-      <ul>
-        <li>When carousel content is overlayed on top of images, ensure the background color of the content provides sufficient color contrast with text and carousel controls.</li>
-        <li>An alternative to content on top of the image is to move content to before and/or after the image.  The text and controls are easier to identify when outside the image and the surrounding background is more consistent and not dependent on the image content.</li>
-      </ul>
+        <p>Features needed to provide sufficient color contrast of text content include:</p>
+        <ul>
+          <li>When carousel content is overlayed on top of images, ensure the background color of the content provides sufficient color contrast with text and carousel controls.</li>
+          <li>An alternative to content on top of the image is to move content to before and/or after the image.  The text and controls are easier to identify when outside the image and the surrounding background is more consistent and not dependent on the image content.</li>
+        </ul>
+      </section>
 
       <section class="notoc">
         <h4>Examples</h4>

--- a/aria-practices.html
+++ b/aria-practices.html
@@ -490,7 +490,7 @@
         While a slide may contain any type of content, image carousels where each slide contains nothing more than a single image are common.  In additon to images, carousels often contain content that is overlayed on top of the image, including links, titles, short descriptions and carousel controls.   
       </p>
       <section class="notoc">
-        <h4>Rotation Control</h4>.
+        <h4>Rotation Control</h4>
         <p>
           Ensuring all users can easily control and are not adversely effected by slide rotation is an essential aspect of making carousels accessible.
           For instance, the screen reader experience can be confusing and disorienting if slides that are not visible on screen are incorrectly hidden, e.g., displayed off-screen.
@@ -512,7 +512,7 @@
       </section>  
 
       <section class="notoc">
-        <h4>Color Contrast</h4>.
+        <h4>Color Contrast</h4>
 
         <p>The placement of controls and content on top of the images effects the ability of people with visual impairments to be able to identify the controls and to read text content.  To ensuring all users can idenitfy carousel controls and the text content associated with each slide requires the author to ensure sufficient color contrast.   Without sufficient color contrast some users will not be able to operate the carousel controls or read the text content of a slide.</p>
 

--- a/aria-practices.html
+++ b/aria-practices.html
@@ -514,11 +514,11 @@
       <section class="notoc">
         <h4>Color Contrast</h4>
 
-        <p>The placement of controls and content on top of the images effects the ability of people with visual impairments to be able to identify the controls and to read text content.  To ensuring all users can idenitfy carousel controls and the text content associated with each slide requires the author to ensure sufficient color contrast.   Without sufficient color contrast some users will not be able to operate the carousel controls or read the text content of a slide.</p>
+        <p>The placement of controls and content on top of images affects the ability of people with visual impairments to be able to identify the controls and to read text content.  To ensuring all users can idenitfy carousel controls and the text content associated with each slide requires the author to ensure sufficient color contrast.   Without sufficient color contrast some users will not be able to operate the carousel controls or read the text content of a slide.</p>
 
         <p>Features needed to provide sufficient color contrast of text content include:</p>
         <ul>
-          <li>When carousel content is overlayed on top of images, ensure the background color of the content provides sufficient color contrast with text content and carousel controls.</li>
+          <li>When carousel content is overlayed on top of images, ensure the background color of the content provides sufficient color contrast with text content and carousel controls.  One way to ensure sufficient contrast is to change the opacity or color of the background for text content and control elements.</li>
           <li>An alternative to content on top of the image is to move content to before and/or after the image.  The text and controls are easier to identify when outside the image and the surrounding background is more consistent and not dependent on the image content.</li>
         </ul>
       </section>

--- a/aria-practices.html
+++ b/aria-practices.html
@@ -527,14 +527,13 @@
         <h4>Examples</h4>
         <p>The following table highlights the options for the carousel examples to help authors experience how the placement of text content for each slide and the options for slide rotation change the user experience and accessibility for the examples
         .</p>
-        <table aria-label="Table of the accessibility options for the list and tabbed carousel examples">
+        <table>
+          <caption>Table of the accessibility options for the Previous/Next and Tablist carousel examples</caption>
           <thead>
             <tr>
-              <th >Auto-Rotation</th>
+              <th>Auto-Rotation</th>
               <th style="width: 16em">Content on High Contrast Background (<abbr title="High Contrast Background">HCB</abbr>) on Slide</th>
               <th style="width: 16em">Content Before/After Slide</th>
-            </tr>
-            <tr>
             </tr>
           </thead>
           <tbody>

--- a/aria-practices.html
+++ b/aria-practices.html
@@ -506,6 +506,7 @@
           </li>
           <li>If the carousel can automatically rotate, it also:
             <ul>
+              <li>Pause auto-rotation on load when operating system settings for reduced motion or disabling animations have been enabled.</li>
               <li>Has a button for stopping and restarting rotation. This is particularly important for supporting assistive technologies operating in a mode that does not move either keyboard focus or the mouse.</li>
               <li>Stops rotating when keyboard focus enters the carousel, and does not resume until focus leaves the carousel, including slide content.</li>
               <li>Stops rotating whenever the mouse is hovering over the carousel.</li>
@@ -518,26 +519,27 @@
       <section class="notoc">
         <h4>Color Contrast</h4>
 
-        <p>The placement of controls and content on top of images affects the ability of people with visual impairments to be able to identify the controls and to read text content.  To ensure all users can identify carousel controls and the text content associated with each slide requires the author to provide sufficient color contrast.   Without sufficient color contrast some users will not be able to operate the carousel controls or read the text content of a slide.</p>
+        <p>The placement of controls and text within images affects the ability of people to identify the controls and to read text content.  To ensure all users can identify the controls and text associated with each slide requires the author needs to provide sufficient color contrast.   Without sufficient color contrast some users will not be able to operate the carousel controls or read the text content of a slide.</p>
 
-        <p>Features needed to provide sufficient color contrast of text content include:</p>
+        <p>Features needed to provide sufficient color contrast include:</p>
         <ul>
-          <li>When carousel content is overlayed on top of images, ensure the background color of the content provides sufficient color contrast with text content and carousel controls.  One way to ensure sufficient contrast is to change the opacity or color of the background for text content and control elements.</li>
-          <li>An alternative to content on top of the image is to move controls and text to before and/or after the image.  The text and controls are easier to identify when outside the image and the surrounding background is more consistent and not dependent on the image content.</li>
+          <li>When carousel controls and text are within an image, ensure the background color of the controls and text provide sufficient color contrast.  One way to ensure sufficient contrast is to change the opacity or color of the background for text content and control elements.</li>
+          <li>An alternative to content within the image is to move controls and text to outside the image.  The text and controls are easier to identify when outside the image and the surrounding background is more consistent and not dependent on the image content.</li>
         </ul>
       </section>
 
       <section class="notoc">
         <h4>Examples</h4>
-        <p>The following table highlights the options for the carousel examples to help authors experience how the placement of text content for each slide and the options for slide rotation change the user experience and accessibility for the examples.
+        <p>The following table highlights the options for the carousel examples to help authors experience how the placement of controls and text, and the options for slide rotation change the user experience and accessibility for the examples.</p>
+        <p> Note: If reduced motion or disabling animations has been set on your computer the auto-rotation for the "Enabled on load" options will be initially paused for the examples.
         </p>
         <table>
-          <caption>Table of the accessibility options for the Previous/Next and Tablist carousel examples</caption>
+          <caption>Accessibility view and behavior options for the Previous/Next and Tablist carousel examples</caption>
           <thead>
             <tr>
               <th>Auto-Rotation</th>
-              <th style="width: 16em">Content on High Contrast Background (<abbr title="High Contrast Background">HCB</abbr>) on Slide</th>
-              <th style="width: 16em">Content Before/After Slide</th>
+              <th style="width: 16em">Content on High Contrast Background (<abbr title="High Contrast Background">HCB</abbr>) within Image</th>
+              <th style="width: 16em">Content Outside Image</th>
             </tr>
           </thead>
           <tbody>
@@ -552,8 +554,8 @@
               </td>
               <td>
                 <ul>
-                  <li><a href="examples/carousel-1-prev-next.html?moreaccessible=true">Previous/Next Carousel (Auto, Before/After)</a></li>
-                  <li><a href="examples/carousel-2-tablist.html?moreaccessible=true">Tablist Carousel (Auto, Before/After)</a></li>
+                  <li><a href="examples/carousel-1-prev-next.html?moreaccessible=true">Previous/Next Carousel (Auto, Outside)</a></li>
+                  <li><a href="examples/carousel-2-tablist.html?moreaccessible=true">Tablist Carousel (Auto, Outside)</a></li>
                 </ul>
               </td>
             </tr>
@@ -567,8 +569,8 @@
               </td>
               <td>
                 <ul>
-                  <li><a href="examples/carousel-1-prev-next.html?moreaccessible=true&paused=true">Previous/Next Carousel (Paused, Before/After)</a></li>
-                  <li><a href="examples/carousel-2-tablist.html?moreaccessible=true&paused=true">Tablist Carousel (Paused, Before/After)</a></li>
+                  <li><a href="examples/carousel-1-prev-next.html?moreaccessible=true&paused=true">Previous/Next Carousel (Paused, Outside)</a></li>
+                  <li><a href="examples/carousel-2-tablist.html?moreaccessible=true&paused=true">Tablist Carousel (Paused, Outside)</a></li>
                 </ul>
               </td>
             </tr>
@@ -582,8 +584,8 @@
               </td>
               <td>
                 <ul>
-                  <li><a href="examples/carousel-1-prev-next.html?moreaccessible=true&noplay=true">Previous/Next Carousel (No Play, Before/After)</a></li>
-                  <li><a href="examples/carousel-2-tablist.html?moreaccessible=true&noplay=true">Tablist Carousel (No Play, Before/After)</a></li>
+                  <li><a href="examples/carousel-1-prev-next.html?moreaccessible=true&noplay=true">Previous/Next Carousel (No Play, Outside)</a></li>
+                  <li><a href="examples/carousel-2-tablist.html?moreaccessible=true&noplay=true">Tablist Carousel (No Play, Outside)</a></li>
                 </ul>
                 <em>Most accessible</em>
               </td>

--- a/aria-practices.html
+++ b/aria-practices.html
@@ -548,8 +548,8 @@
               </td>
               <td>
                 <ul>
-                  <li><a href="examples/carousel-1.html?moreaccessible">Previous/Next Carousel (Before/After)</a></li>
-                  <li><a href="examples/carousel-2-tablist.html?moreaccessible">Tablist Carousel (Before/After)</a></li>
+                  <li><a href="examples/carousel-1.html?moreaccessible=true">Previous/Next Carousel (Before/After)</a></li>
+                  <li><a href="examples/carousel-2-tablist.html?moreaccessible=true">Tablist Carousel (Before/After)</a></li>
                 </ul>
               </td>
             </tr>
@@ -557,14 +557,14 @@
               <th scope="row">Paused on load</th>
               <td>
                 <ul>
-                  <li><a href="examples/carousel-1.html?paused">Previous/Next Carousel (Paused, <abbr title="High Contrast Background">HCB</abbr>)</a></li>
-                  <li><a href="examples/carousel-2-tablist.html?paused">Tablist Carousel (Paused, <abbr title="High Contrast Background">HCB</abbr>)</a></li>
+                  <li><a href="examples/carousel-1.html?paused=true">Previous/Next Carousel (Paused, <abbr title="High Contrast Background">HCB</abbr>)</a></li>
+                  <li><a href="examples/carousel-2-tablist.html?paused=true">Tablist Carousel (Paused, <abbr title="High Contrast Background">HCB</abbr>)</a></li>
                 </ul>
               </td>
               <td>
                 <ul>
-                  <li><a href="examples/carousel-1.html?moreaccessiblepaused">Previous/Next Carousel (Paused, Before/After)</a></li>
-                  <li><a href="examples/carousel-2-tablist.html?moreaccessiblepaused">Tablist Carousel (Paused, Before/After)</a></li>
+                  <li><a href="examples/carousel-1.html?moreaccessible=true&paused=true">Previous/Next Carousel (Paused, Before/After)</a></li>
+                  <li><a href="examples/carousel-2-tablist.html?moreaccessible=true&paused=true">Tablist Carousel (Paused, Before/After)</a></li>
                 </ul>
               </td>
             </tr>
@@ -572,14 +572,14 @@
               <th scope="row">Disabled</th>
               <td>
                 <ul>
-                  <li><a href="examples/carousel-1.html?noplay">Previous/Next Carousel (No Play, <abbr title="High Contrast Background">HCB</abbr>)</a></li>
-                  <li><a href="examples/carousel-2-tablist.html?noplay">Tablist Carousel (No Play, <abbr title="High Contrast Background">HCB</abbr>)</a></li>
+                  <li><a href="examples/carousel-1.html?noplay=true">Previous/Next Carousel (No Play, <abbr title="High Contrast Background">HCB</abbr>)</a></li>
+                  <li><a href="examples/carousel-2-tablist.html?noplay=true">Tablist Carousel (No Play, <abbr title="High Contrast Background">HCB</abbr>)</a></li>
                 </ul>
               </td>
               <td>
                 <ul>
-                  <li><a href="examples/carousel-1.html?moreaccessiblenoplay">Previous/Next Carousel (No Play, Before/After)</a></li>
-                  <li><a href="examples/carousel-2-tablist.html?moreaccessiblenoplay">Tablist Carousel (No Play, Before/After)</a></li>
+                  <li><a href="examples/carousel-1.html?moreaccessible=true&noplay=true">Previous/Next Carousel (No Play, Before/After)</a></li>
+                  <li><a href="examples/carousel-2-tablist.html?moreaccessible=true&noplay=true">Tablist Carousel (No Play, Before/After)</a></li>
                 </ul>
                 <em>Most accessible</em>
               </td>

--- a/aria-practices.html
+++ b/aria-practices.html
@@ -498,8 +498,12 @@
         </p>
         <p>Features needed to provide sufficient rotation control include:</p>
         <ul>
-          <li>Buttons for displaying the previous and next slides.</li>
-          <li>Optionally, a control, or group of controls, for choosing a specific slide to display. For example, slide picker controls can be marked up as tabs in a tablist with the slide represented by a tabpanel element.</li>
+          <li>Controls for manually moving between slides, for example:
+            <ul>
+              <li>Buttons for displaying the previous and next slides.</li>
+              <li>A set of tabs in a tablist for choosing specific slides to display, with each slide represented by a tabpanel element.</li>
+            </ul>
+          </li>
           <li>If the carousel can automatically rotate, it also:
             <ul>
               <li>Has a button for stopping and restarting rotation. This is particularly important for supporting assistive technologies operating in a mode that does not move either keyboard focus or the mouse.</li>
@@ -514,19 +518,19 @@
       <section class="notoc">
         <h4>Color Contrast</h4>
 
-        <p>The placement of controls and content on top of images affects the ability of people with visual impairments to be able to identify the controls and to read text content.  To ensuring all users can identify carousel controls and the text content associated with each slide requires the author to ensure sufficient color contrast.   Without sufficient color contrast some users will not be able to operate the carousel controls or read the text content of a slide.</p>
+        <p>The placement of controls and content on top of images affects the ability of people with visual impairments to be able to identify the controls and to read text content.  To ensure all users can identify carousel controls and the text content associated with each slide requires the author to provide sufficient color contrast.   Without sufficient color contrast some users will not be able to operate the carousel controls or read the text content of a slide.</p>
 
         <p>Features needed to provide sufficient color contrast of text content include:</p>
         <ul>
           <li>When carousel content is overlayed on top of images, ensure the background color of the content provides sufficient color contrast with text content and carousel controls.  One way to ensure sufficient contrast is to change the opacity or color of the background for text content and control elements.</li>
-          <li>An alternative to content on top of the image is to move content to before and/or after the image.  The text and controls are easier to identify when outside the image and the surrounding background is more consistent and not dependent on the image content.</li>
+          <li>An alternative to content on top of the image is to move controls and text to before and/or after the image.  The text and controls are easier to identify when outside the image and the surrounding background is more consistent and not dependent on the image content.</li>
         </ul>
       </section>
 
       <section class="notoc">
         <h4>Examples</h4>
-        <p>The following table highlights the options for the carousel examples to help authors experience how the placement of text content for each slide and the options for slide rotation change the user experience and accessibility for the examples
-        .</p>
+        <p>The following table highlights the options for the carousel examples to help authors experience how the placement of text content for each slide and the options for slide rotation change the user experience and accessibility for the examples.
+        </p>
         <table>
           <caption>Table of the accessibility options for the Previous/Next and Tablist carousel examples</caption>
           <thead>
@@ -541,15 +545,15 @@
               <th scope="row">Enabled on load</th>
               <td>
                 <ul>
-                  <li><a href="examples/carousel-1.html">Previous/Next Carousel (Auto, <abbr title="High Contrast Background">HCB</abbr>)</a></li>
+                  <li><a href="examples/carousel-1-prev-next.html">Previous/Next Carousel (Auto, <abbr title="High Contrast Background">HCB</abbr>)</a></li>
                   <li><a href="examples/carousel-2-tablist.html">Tablist Carousel (Auto, <abbr title="High Contrast Background">HCB</abbr>)</a></li>
                 </ul>
                 <em>Least accessible</em>
               </td>
               <td>
                 <ul>
-                  <li><a href="examples/carousel-1.html?moreaccessible=true">Previous/Next Carousel (Before/After)</a></li>
-                  <li><a href="examples/carousel-2-tablist.html?moreaccessible=true">Tablist Carousel (Before/After)</a></li>
+                  <li><a href="examples/carousel-1-prev-next.html?moreaccessible=true">Previous/Next Carousel (Auto, Before/After)</a></li>
+                  <li><a href="examples/carousel-2-tablist.html?moreaccessible=true">Tablist Carousel (Auto, Before/After)</a></li>
                 </ul>
               </td>
             </tr>
@@ -557,13 +561,13 @@
               <th scope="row">Paused on load</th>
               <td>
                 <ul>
-                  <li><a href="examples/carousel-1.html?paused=true">Previous/Next Carousel (Paused, <abbr title="High Contrast Background">HCB</abbr>)</a></li>
+                  <li><a href="examples/carousel-1-prev-next.html?paused=true">Previous/Next Carousel (Paused, <abbr title="High Contrast Background">HCB</abbr>)</a></li>
                   <li><a href="examples/carousel-2-tablist.html?paused=true">Tablist Carousel (Paused, <abbr title="High Contrast Background">HCB</abbr>)</a></li>
                 </ul>
               </td>
               <td>
                 <ul>
-                  <li><a href="examples/carousel-1.html?moreaccessible=true&paused=true">Previous/Next Carousel (Paused, Before/After)</a></li>
+                  <li><a href="examples/carousel-1-prev-next.html?moreaccessible=true&paused=true">Previous/Next Carousel (Paused, Before/After)</a></li>
                   <li><a href="examples/carousel-2-tablist.html?moreaccessible=true&paused=true">Tablist Carousel (Paused, Before/After)</a></li>
                 </ul>
               </td>
@@ -572,13 +576,13 @@
               <th scope="row">Disabled</th>
               <td>
                 <ul>
-                  <li><a href="examples/carousel-1.html?noplay=true">Previous/Next Carousel (No Play, <abbr title="High Contrast Background">HCB</abbr>)</a></li>
+                  <li><a href="examples/carousel-1-prev-next.html?noplay=true">Previous/Next Carousel (No Play, <abbr title="High Contrast Background">HCB</abbr>)</a></li>
                   <li><a href="examples/carousel-2-tablist.html?noplay=true">Tablist Carousel (No Play, <abbr title="High Contrast Background">HCB</abbr>)</a></li>
                 </ul>
               </td>
               <td>
                 <ul>
-                  <li><a href="examples/carousel-1.html?moreaccessible=true&noplay=true">Previous/Next Carousel (No Play, Before/After)</a></li>
+                  <li><a href="examples/carousel-1-prev-next.html?moreaccessible=true&noplay=true">Previous/Next Carousel (No Play, Before/After)</a></li>
                   <li><a href="examples/carousel-2-tablist.html?moreaccessible=true&noplay=true">Tablist Carousel (No Play, Before/After)</a></li>
                 </ul>
                 <em>Most accessible</em>
@@ -626,11 +630,11 @@
         <h4>WAI-ARIA Roles, States, and Properties</h4>
         <p>This section describes the element composition for three styles of carousels:</p>
         <ul>
-          <li>Basic: Has rotation, previous slide, and next slide controls but no slide picker controls.</li>
+          <li>Previous/Next: Has rotation, previous slide, and next slide controls but no slide picker controls.</li>
           <li>Tabbed: Has basic controls plus a single tab stop for slide picker controls implemented using the <a href="#tabpanel">tabs pattern.</a></li>
           <li>Grouped: Has basic controls plus a series of tab stops in a group of slide picker controls where each control implements the <a href="#button">button pattern.</a> Because each slide selector button adds an element to the page tab sequence, this style is the least friendly for keyboard users.</li>
         </ul>
-        <h5>Basic carousel elements</h5>
+        <h5>Previous/Next carousel elements</h5>
         <ul>
           <li>
             A carousel container element that encompasses all components of the carousel, including both carousel controls and slides using a <a href="#region" class="role-reference">region</a> role.
@@ -682,7 +686,7 @@
           </li>
         </ul>
         <h5>Tabbed Carousel Elements</h5>
-        <p>The structure of a tabbed carousel is the same as a basic carousel except that:</p>
+        <p>The structure of a tabbed carousel is the same as a previous/next carousel except that:</p>
         <ul>
           <li>
             Each slide container has role <a href="#tabpanel" class="role-reference">tabpanel</a> in lieu of <code>group</code>,
@@ -698,7 +702,7 @@
           </li>
         </ul>
         <h5>Grouped Carousel Elements</h5>
-        <p>A grouped carousel has the same structure as a basic carousel, but it also includes slide picker controls where:</p>
+        <p>A grouped carousel has the same structure as a previous/next carousel, but it also includes slide picker controls where:</p>
         <ul>
           <li>The set of slide picker controls is contained in an element with role <a href="#group" class="role-reference">group</a>.</li>
           <li>The group containing the picker controls has an accessible label provided by the value of <a href="#aria-label" class="property-reference">aria-label</a> that identifies the purpose of the controls, e.g., &quot;Choose slide to display.&quot;</li>

--- a/aria-practices.html
+++ b/aria-practices.html
@@ -530,56 +530,56 @@
         <table aria-label="Table of the accessibility options for the list and tabbed carousel examples">
           <thead>
             <tr>
-              <th scope="column">Auto-Rotation</th>
-              <th scope="column" style="width: 16em">Content on Top of Slide</th>
-              <th scope="column" style="width: 16em">Content Before/After Slide</th>
+              <th >Auto-Rotation</th>
+              <th style="width: 16em">Content on High Contrast Background (<abbr title="High Contrast Background">HCB</abbr>) on Slide</th>
+              <th style="width: 16em">Content Before/After Slide</th>
             </tr>
             <tr>
             </tr>
           </thead>
           <tbody>
             <tr>
-              <th scope="row">Enabled on load</th>
+              <th>Enabled on load</th>
               <td>
                 <ul>
-                  <li><a href="examples/carousel-1.html">Basic Carousel</a></li>
-                  <li><a href="examples/carousel-2-tablist.html">Tablist Carousel</a></li>
+                  <li><a href="examples/carousel-1.html">Previous/Next Carousel (Auto, <abbr title="High Contrast Background">HCB</abbr>)</a></li>
+                  <li><a href="examples/carousel-2-tablist.html">Tablist Carousel (Auto, <abbr title="High Contrast Background">HCB</abbr>)</a></li>
                 </ul>
                 <em>Least accessible</em>
               </td>
               <td>
                 <ul>
-                  <li><a href="examples/carousel-1.html?moreaccessible">Basic Carousel (Before/After)</a></li>
+                  <li><a href="examples/carousel-1.html?moreaccessible">Previous/Next Carousel (Before/After)</a></li>
                   <li><a href="examples/carousel-2-tablist.html?moreaccessible">Tablist Carousel (Before/After)</a></li>
                 </ul>
               </td>
             </tr>
             <tr>
-              <th scope="row">Paused on load</th>
+              <th>Paused on load</th>
               <td>
                 <ul>
-                  <li><a href="examples/carousel-1.html?paused">Basic Carousel (Paused)</a></li>
-                  <li><a href="examples/carousel-2-tablist.html?paused">Tablist Carousel (Paused)</a></li>
+                  <li><a href="examples/carousel-1.html?paused">Previous/Next Carousel (Paused, <abbr title="High Contrast Background">HCB</abbr>)</a></li>
+                  <li><a href="examples/carousel-2-tablist.html?paused">Tablist Carousel (Paused, <abbr title="High Contrast Background">HCB</abbr>)</a></li>
                 </ul>
               </td>
               <td>
                 <ul>
-                  <li><a href="examples/carousel-1.html?moreaccessiblepaused">Basic Carousel (Paused, Before/After)</a></li>
+                  <li><a href="examples/carousel-1.html?moreaccessiblepaused">Previous/Next Carousel (Paused, Before/After)</a></li>
                   <li><a href="examples/carousel-2-tablist.html?moreaccessiblepaused">Tablist Carousel (Paused, Before/After)</a></li>
                 </ul>
               </td>
             </tr>
             <tr>
-              <th scope="row">Disabled</th>
+              <th>Disabled</th>
               <td>
                 <ul>
-                  <li><a href="examples/carousel-1.html?noplay">Basic Carousel (No Play)</a></li>
-                  <li><a href="examples/carousel-2-tablist.html?noplay">Tablist Carousel (No Play)</a></li>
+                  <li><a href="examples/carousel-1.html?noplay">Previous/Next Carousel (No Play, <abbr title="High Contrast Background">HCB</abbr>)</a></li>
+                  <li><a href="examples/carousel-2-tablist.html?noplay">Tablist Carousel (No Play, <abbr title="High Contrast Background">HCB</abbr>)</a></li>
                 </ul>
               </td>
               <td>
                 <ul>
-                  <li><a href="examples/carousel-1.html?moreaccessiblenoplay">Basic Carousel (No Play, Before/After)</a></li>
+                  <li><a href="examples/carousel-1.html?moreaccessiblenoplay">Previous/Next Carousel (No Play, Before/After)</a></li>
                   <li><a href="examples/carousel-2-tablist.html?moreaccessiblenoplay">Tablist Carousel (No Play, Before/After)</a></li>
                 </ul>
                 <em>Most accessible</em>

--- a/aria-practices.html
+++ b/aria-practices.html
@@ -486,9 +486,10 @@
       <p>
         A carousel presents a set of items, referred to as slides, by sequentially displaying a subset of one or more slides.
         Typically, one slide is displayed at a time, and users can activate a next or previous slide control that hides the current slide and &quot;rotates&quot; the next or previous slide into view.
-        In some implementations, rotation automatically starts when the page loads, and it may also automatically stop once all the slides have been displayed.
-        While a slide may contain any type of content, image carousels where each slide contains nothing more than a single image are common.
+        In most implementations, rotation automatically starts when the page loads, and it may also automatically stop once all the slides have been displayed.
+        While a slide may contain any type of content, image carousels where each slide contains nothing more than a single image are common.  In additon to images, carousels often contain content that is overlayed on top of the image, including links, titles, short descriptions and carousel controls.   
       </p>
+      <h4>Rotation Control</h4>.
       <p>
         Ensuring all users can easily control and are not adversely effected by slide rotation is an essential aspect of making carousels accessible.
         For instance, the screen reader experience can be confusing and disorienting if slides that are not visible on screen are incorrectly hidden, e.g., displayed off-screen.
@@ -501,17 +502,87 @@
         <li>If the carousel can automatically rotate, it also:
           <ul>
             <li>Has a button for stopping and restarting rotation. This is particularly important for supporting assistive technologies operating in a mode that does not move either keyboard focus or the mouse.</li>
-            <li>Stops rotating when keyboard focus enters the carousel. It does not restart unless the user explicitly requests it to do so.</li>
+            <li>Stops rotating when keyboard focus enters the carousel, and does not resume until focus leaves the carousel, including slide content.</li>
             <li>Stops rotating whenever the mouse is hovering over the carousel.</li>
           </ul>
         </li>
+        <li>Carousels that do not rotate automatically are inheriently more accessible, since users have more control over slide navigation.</li> 
+      </ul>
+
+      <h4>Color Contrast</h4>.
+
+      <p>The placement of controls and content on top of the images effects the ability of people with visual impairments to be able to identify the controls and to read text content.  To ensuring all users can idenitfy carousel controls and the text content associated with each slide requires the author to ensure sufficient color contrast.   Without sufficient color contrast some users will not be able to operate the carousel controls or read the text content of a slide.</p>
+
+      <p>Features needed to provide sufficient color contrast of text content include:</p>
+      <ul>
+        <li>When carousel content is overlayed on top of images, ensure the background color of the content provides sufficient color contrast with text and carousel controls.</li>
+        <li>An alternative to content on top of the image is to move content to before and/or after the image.  The text and controls are easier to identify when outside the image and the surrounding background is more consistent and not dependent on the image content.</li>
       </ul>
 
       <section class="notoc">
-        <h4>Example</h4>
-        <p>
-          <a href="examples/carousel/carousel-1.html">Auto-Rotating Image Carousel Example:</a> A basic image carousel that demonstrates the accessibility features necessary for carousels that rotate automatically on page load.
-        </p>
+        <h4>Examples</h4>
+        <p>The following table highlights the options for the carousel examples to help authors experience how the placement of text content for each slide and the options for slide rotation change the user experience and accessibility for the examples
+        .</p>
+        <table aria-label="Table of the accessibility options for the list and tabbed carousel examples">
+          <thead>
+            <tr>
+              <th scope="column">Auto-Rotation</th>
+              <th scope="column" style="width: 16em">Content on Top of Slide</th>
+              <th scope="column" style="width: 16em">Content Before/After Slide</th>
+            </tr>
+            <tr>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <th scope="row">Enabled on load</th>
+              <td>
+                <ul>
+                  <li><a href="examples/carousel-1.html">Basic Carousel</a></li>
+                  <li><a href="examples/carousel-2-tablist.html">Tablist Carousel</a></li>
+                </ul>
+                <em>Least accessible</em>
+              </td>
+              <td>
+                <ul>
+                  <li><a href="examples/carousel-1.html?moreaccessible">Basic Carousel (Before/After)</a></li>
+                  <li><a href="examples/carousel-2-tablist.html?moreaccessible">Tablist Carousel (Before/After)</a></li>
+                </ul>
+              </td>
+            </tr>
+            <tr>
+              <th scope="row">Paused on load</th>
+              <td>
+                <ul>
+                  <li><a href="examples/carousel-1.html?paused">Basic Carousel (Paused)</a></li>
+                  <li><a href="examples/carousel-2-tablist.html?paused">Tablist Carousel (Paused)</a></li>
+                </ul>
+              </td>
+              <td>
+                <ul>
+                  <li><a href="examples/carousel-1.html?moreaccessiblepaused">Basic Carousel (Paused, Before/After)</a></li>
+                  <li><a href="examples/carousel-2-tablist.html?moreaccessiblepaused">Tablist Carousel (Paused, Before/After)</a></li>
+                </ul>
+              </td>
+            </tr>
+            <tr>
+              <th scope="row">Disabled</th>
+              <td>
+                <ul>
+                  <li><a href="examples/carousel-1.html?noplay">Basic Carousel (No Play)</a></li>
+                  <li><a href="examples/carousel-2-tablist.html?noplay">Tablist Carousel (No Play)</a></li>
+                </ul>
+              </td>
+              <td>
+                <ul>
+                  <li><a href="examples/carousel-1.html?moreaccessiblenoplay">Basic Carousel (No Play, Before/After)</a></li>
+                  <li><a href="examples/carousel-2-tablist.html?moreaccessiblenoplay">Tablist Carousel (No Play, Before/After)</a></li>
+                </ul>
+                <em>Most accessible</em>
+              </td>
+            </tr>
+          </tbody>
+        </table>
       </section>
 
       <section class="notoc">
@@ -536,7 +607,7 @@
         <ul>
           <li>
             If the carousel has an auto-rotate feature, automatic slide rotation stops when any element in the carousel receives keyboard focus.
-            It does not resume unless the user activates the rotation control.
+            It does not resume until focus leaves the carousel, including slide content.
           </li>
           <li><kbd>Tab</kbd> and <kbd>Shift + Tab</kbd>: Move focus through the interactive elements of the carousel as specified by the page tab sequence -- scripting for <kbd>Tab</kbd> is not necessary.</li>
           <li>
@@ -559,11 +630,8 @@
         <h5>Basic carousel elements</h5>
         <ul>
           <li>
-            A carousel container element that encompasses all components of the carousel,  including both carousel controls and slides,
-            has either role <a href="#region" class="role-reference">region</a>
-            or role <a href="#group" class="role-reference">group.</a>
-            The most appropriate role for the carousel container depends on the information architecture of the page.
-            See the <a href="#aria_landmark">landmark regions guidance</a> to determine whether the carousel warrants being designated as a landmark region.
+            A carousel container element that encompasses all components of the carousel, including both carousel controls and slides using a <a href="#region" class="role-reference">region</a> role.
+            The most appropriate landmark role for the carousel container depends on the information architecture of the page, but typically a named <a href="#region" class="role-reference">region</a> or a <a href="#complementary" class="role-reference">complementary</a> role.
           </li>
           <li>The carousel container has the <a href="#aria-roledescription" class="property-reference">aria-roledescription</a> property set to <code>carousel</code>.</li>
           <li>


### PR DESCRIPTION
Updated guidance for Carousel pattern, including a table of the different options available in the two examples.

[Preview of carousel guidance changes](https://raw.githack.com/w3c/aria-practices/update-carousel-guidance/aria-practices.html#carousel)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Apr 22, 2020, 3:53 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Frawcdn.githack.com%2Fw3c%2Faria-practices%2F2016baa0f94ac77fbb6f44a1d51f6ed18d102ba4%2Faria-practices.html%3FisPreview%3Dtrue)

```

😭  Sorry, there was an error generating the HTML. Please report this issue!
[36mSpecification: https://rawcdn.githack.com/w3c/aria-practices/2016baa0f94ac77fbb6f44a1d51f6ed18d102ba4/aria-practices.html?isPreview=true&publishDate=2020-04-22[39m
[36mReSpec version: 25.6.0[39m
[36mFile a bug: https://github.com/w3c/respec/[39m
[36mError: Error: Evaluation failed: Timeout: document.respecIsReady didn't resolve in 26467ms.[39m
[36m    at ExecutionContext._evaluateInternal (/u/spec-generator/node_modules/puppeteer/lib/ExecutionContext.js:122:13)[39m
[36m    at runMicrotasks (<anonymous>)[39m
[36m    at processTicksAndRejections (internal/process/task_queues.js:97:5)[39m
[36m    at async ExecutionContext.evaluate (/u/spec-generator/node_modules/puppeteer/lib/ExecutionContext.js:48:12)[39m
[36m    at async generateHTML (/u/spec-generator/node_modules/respec/tools/respecDocWriter.js:128:12)[39m
[36m    at async fetchAndWrite (/u/spec-generator/node_modules/respec/tools/respecDocWriter.js:95:18)[39m
[36m    at async Object.generate [as respec] (/u/spec-generator/generators/respec.js:14:20)[39m
[36m    at async generate (/u/spec-generator/server.js:91:29)[39m
[36m  -- ASYNC --[39m
[36m    at ExecutionContext.<anonymous> (/u/spec-generator/node_modules/puppeteer/lib/helper.js:111:15)[39m
[36m    at DOMWorld.evaluate (/u/spec-generator/node_modules/puppeteer/lib/DOMWorld.js:112:20)[39m
[36m    at runMicrotasks (<anonymous>)[39m
[36m    at processTicksAndRejections (internal/process/task_queues.js:97:5)[39m
[36m  -- ASYNC --[39m
[36m    at Frame.<anonymous> (/u/spec-generator/node_modules/puppeteer/lib/helper.js:111:15)[39m
[36m    at Page.evaluate (/u/spec-generator/node_modules/puppeteer/lib/Page.js:860:43)[39m
[36m    at Page.<anonymous> (/u/spec-generator/node_modules/puppeteer/lib/helper.js:112:23)[39m
[36m    at generateHTML (/u/spec-generator/node_modules/respec/tools/respecDocWriter.js:128:23)[39m
[36m    at runMicrotasks (<anonymous>)[39m
[36m    at processTicksAndRejections (internal/process/task_queues.js:97:5)[39m
[36m    at async fetchAndWrite (/u/spec-generator/node_modules/respec/tools/respecDocWriter.js:95:18)[39m
[36m    at async Object.generate [as respec] (/u/spec-generator/generators/respec.js:14:20)[39m
[36m    at async generate (/u/spec-generator/server.js:91:29)[39m
[36m[39m
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/aria-practices%231372.)._
</details>
