### PR TITLE
Fixup ReSpec usage issues

### DIFF
--- a/aria-practices.html
+++ b/aria-practices.html
@@ -3,10 +3,10 @@
 <head>
   <meta charset="utf-8" />
   <title>WAI-ARIA Authoring Practices 1.2</title>
-  <script src="https://www.w3.org/Tools/respec/respec-w3c-common" class="remove"></script>
   <script src="common/script/resolveReferences.js" class="remove"></script>
-  <script src="common/biblio.js" class="remove"></script>
   <script src="respec-config.js" class="remove"></script>
+  <script src="common/biblio.js" class="remove"></script>
+  <script src="https://www.w3.org/Tools/respec/respec-w3c-common" class="remove"></script>
   <link href="common/css/common.css" rel="stylesheet" type="text/css" />
 </head>
 <body>
@@ -26,7 +26,7 @@
       of the
       <a href="https://www.w3.org/WAI/">Web Accessibility Initiative</a>.
       It supports the
-      <a href="" class="specref">WAI-ARIA 1.2</a> [<cite><a href="#bib-WAI-ARIA" class="bibref">WAI-ARIA</a></cite>]
+      [[[wai-aria-1.2]]] [[WAI-ARIA-1.2]]
       specification, providing detailed advice and examples beyond what would be appropriate to a technical specification but which are important to understand the specification.
     </p>
     <p> This draft includes only a portion of content planned for WAI-ARIA Authoring Practices 1.2. To see plans for the complete guide, review the <a href="https://github.com/w3c/aria-practices/milestones?direction=asc&amp;sort=due_date&amp;state=open">Authoring Practices Milestone Plan</a>. </p>

--- a/respec-config.js
+++ b/respec-config.js
@@ -8,7 +8,7 @@ var respecConfig = {
   // publishDate: "2013-08-22",
   noRecTrack: true,
 
-  // The specifications short name, as in http://www.w3.org/TR/short-name/
+  // The specifications short name, as in https://www.w3.org/TR/short-name/
   shortName: 'wai-aria-practices-1.2',
 
   // If you wish the publication date to be other than today,
@@ -24,8 +24,8 @@ var respecConfig = {
   // prevRecURI: "",
   // previousDiffURI: "",
 
-  // If there a publicly available Editors Draft, this is the link
-  edDraftURI: 'https://w3c.github.io/aria-practices/',
+  // Github repo
+  github: "w3c/aria-practices",
 
   // If this is a LCWD, uncomment and set the end of its review period
   // lcEnd: "2012-02-21",
@@ -36,7 +36,7 @@ var respecConfig = {
     name: 'Matt King',
     mailto: 'mck@fb.com',
     company: 'Facebook',
-    companyURI: 'http://www.facebook.com/',
+    companyURI: 'https://www.facebook.com/',
     w3cid: 44582
   }, {
     name: 'JaEun Jemma Ku',
@@ -48,7 +48,7 @@ var respecConfig = {
     name: 'James Nurthen',
     mailto: 'nurthen@adobe.com',
     company: 'Adobe',
-    companyURI: 'http://www.adobe.com/',
+    companyURI: 'https://www.adobe.com/',
     w3cid: 37155
   }, {
     name: 'Zoë Bijl',
@@ -65,19 +65,19 @@ var respecConfig = {
   formerEditors: [{
     name: 'Joseph Scheuhammer',
     company: 'Inclusive Design Research Centre, OCAD University',
-    companyURI: 'http://idrc.ocad.ca/',
+    companyURI: 'https://idrc.ocad.ca/',
     w3cid: 42279,
     retiredDate: '2014-10-01'
   }, {
     name: 'Lisa Pappas',
     company: 'SAS',
-    companyURI: 'http://www.sas.com/',
+    companyURI: 'https://www.sas.com/',
     w3cid: 41725,
     retiredDate: '2009-10-01'
   }, {
     name: 'Rich Schwerdtfeger',
     company: 'IBM Corporation',
-    companyURI: 'http://ibm.com/',
+    companyURI: 'https://ibm.com/',
     w3cid: 2460,
     retiredDate: '2014-10-01'
   }],
@@ -89,9 +89,9 @@ var respecConfig = {
   // authors: [
   //   {
   //     name: "Your Name",
-  //     url: "http://example.org/",
+  //     url: "https://example.org/",
   //     company: "Your Company",
-  //     companyURI: "http://example.com/"
+  //     companyURI: "https://example.com/"
   //   },
   // ],
 
@@ -136,7 +136,7 @@ var respecConfig = {
   //   }
   // ],
 
-  // errata: 'http://www.w3.org/2010/02/rdfa/errata.html',
+  // errata: 'https://www.w3.org/2010/02/rdfa/errata.html',
 
   // name of the WG
   wg: 'Accessible Rich Internet Applications Working Group',

--- a/respec-config.js
+++ b/respec-config.js
@@ -1,17 +1,12 @@
 var respecConfig = {
   // Embed RDFa data in the output.
   doRDFa: '1.2',
-  includePermalinks: true,
-  permalinkEdge: true,
-  permalinkHide: false,
   // Specification status (e.g., WD, LC, NOTE, etc.). If in doubt use ED.
   specStatus: 'ED',
   // crEnd: "2012-04-30",
   // perEnd: "2013-07-23",
   // publishDate: "2013-08-22",
   noRecTrack: true,
-  diffTool: 'http://www.aptest.com/standards/htmldiff/htmldiff.pl',
-  license: 'w3c-software-doc',
 
   // The specifications short name, as in http://www.w3.org/TR/short-name/
   shortName: 'wai-aria-practices-1.2',
@@ -72,19 +67,19 @@ var respecConfig = {
     company: 'Inclusive Design Research Centre, OCAD University',
     companyURI: 'http://idrc.ocad.ca/',
     w3cid: 42279,
-    note: 'Editor until October 2014'
+    retiredDate: '2014-10-01'
   }, {
     name: 'Lisa Pappas',
     company: 'SAS',
     companyURI: 'http://www.sas.com/',
     w3cid: 41725,
-    note: 'Editor until October 2009'
+    retiredDate: '2009-10-01'
   }, {
     name: 'Rich Schwerdtfeger',
     company: 'IBM Corporation',
     companyURI: 'http://ibm.com/',
     w3cid: 2460,
-    note: 'Editor until October 2014'
+    retiredDate: '2014-10-01'
   }],
 
   // Authors, add as many as you like.
@@ -160,8 +155,5 @@ var respecConfig = {
   // If in doubt ask your friendly neighbourhood Team Contact.
   wgPatentURI: 'https://www.w3.org/2004/01/pp-impl/83726/status',
   maxTocLevel: 4,
-
-  localBiblio: biblio,
-
   preProcess: [ linkCrossReferences ]
 };


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 504 Gateway Time-out :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Apr 15, 2020, 5:55 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Frawcdn.githack.com%2Fw3c%2Faria-practices%2Fc74e8e46b38c7df5f4c1079f8d3dedf5373af1ab%2Faria-practices.html%3FisPreview%3Dtrue)

```
<html><body><h1>504 Gateway Time-out</h1>
The server didn't respond in time.
</body></html>

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/aria-practices%231376.)._
</details>
