### PR TITLE
Fix nested modal dialogs not working on Safari/VoiceOver

### DIFF
--- a/examples/dialog-modal/js/dialog.js
+++ b/examples/dialog-modal/js/dialog.js
@@ -199,7 +199,11 @@ aria.Utils = aria.Utils || {};
     // If this modal is opening on top of one that is already open,
     // get rid of the document focus listener of the open dialog.
     if (aria.OpenDialogList.length > 0) {
-      aria.getCurrentDialog().removeListeners();
+      var topDialog = aria.getCurrentDialog();
+      topDialog.removeListeners();
+      // Safari and VoiceOver don't support multiple aria-modal="true" elements
+      // on the page, so we temporarily remove the parent dialog attribute.
+      topDialog.removeAriaModalAttribute();
     }
 
     this.addListeners();
@@ -244,7 +248,12 @@ aria.Utils = aria.Utils || {};
 
     // If a dialog was open underneath this one, restore its listeners.
     if (aria.OpenDialogList.length > 0) {
-      aria.getCurrentDialog().addListeners();
+      var topDialog = aria.getCurrentDialog();
+      topDialog.addListeners();
+      // Safari and VoiceOver don't support multiple aria-modal="true" elements
+      // on the page. Now that the nested modal is closed, we can restore the
+      // parent modal attribute.
+      topDialog.addAriaModalAttribute();
     }
     else {
       document.body.classList.remove(aria.Utils.dialogOpenClass);
@@ -277,6 +286,14 @@ aria.Utils = aria.Utils || {};
     var focusAfterClosed = newFocusAfterClosed || this.focusAfterClosed;
     var dialog = new aria.Dialog(newDialogId, focusAfterClosed, newFocusFirst);
   }; // end replace
+
+  aria.Dialog.prototype.addAriaModalAttribute = function () {
+    this.dialogNode.setAttribute('aria-modal', 'true');
+  }; // end addAriaModalAttribute
+
+  aria.Dialog.prototype.removeAriaModalAttribute = function () {
+    this.dialogNode.removeAttribute('aria-modal');
+  }; // end removeAriaModalAttribute
 
   aria.Dialog.prototype.addListeners = function () {
     document.addEventListener('focus', this.trapFocus, true);


### PR DESCRIPTION
Fixes #1241

Some tests failed locally, but I couldn't understand how they could be related to these changes.

**Before**

![Example showing the broken nested modal dialog page being used with Safari and VoiceOver where VO doesn't move focus into the nested dialog](https://user-images.githubusercontent.com/3068563/68079387-3e79ce00-fdc7-11e9-94d5-d1087e11579c.gif)

**After**

![Example showing the fixed nested modal dialog page being used with Safari and VoiceOver where VO properly move focus into the nested dialog](https://user-images.githubusercontent.com/3068563/79627194-aec5a300-810c-11ea-805a-dff5ba8f7b95.gif)
