### PR TITLE
Allow ES6 syntax

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,6 +3,9 @@
   "env": {
     "browser": true
   },
+  "parserOptions": {
+    "ecmaVersion": 6
+  },
   "rules": {
     "no-unused-vars": 0,
     "no-undef": 0


### PR DESCRIPTION
Now that we're officially dropping IE11 support, we should update `eslint` to allow ES6/ES2015 features.

Related to #1304, #1305 