### PR TITLE
Select-only combobox

### DIFF
--- a/aria-practices.html
+++ b/aria-practices.html
@@ -790,6 +790,7 @@ Some JavaScript and CSS may not function correctly in Internet Explorer.
       <section class="notoc">
         <h4>Examples</h4>
         <ul>
+          <li><a href="examples/combobox/combobox-select-only.html">Select-Only Combobox</a>: A single-select combobox with no text input that is functionally similar to an HTML <code>select</code> element.</li>
           <li><a href="examples/combobox/combobox-autocomplete-both.html">Editable Combobox with Both List and Inline Autocomplete</a>: An editable combobox that demonstrates the autocomplete behavior known as <q>list with inline autocomplete</q>.</li>
           <li><a href="examples/combobox/combobox-autocomplete-list.html">Editable Combobox with List Autocomplete</a>: An editable combobox that demonstrates the autocomplete behavior known as <q>list with manual selection</q>.</li>
           <li><a href="examples/combobox/combobox-autocomplete-none.html">Editable Combobox Without Autocomplete</a>: An editable combobox that demonstrates the behavior associated with <code>aria-autocomplete=none</code>.</li>

--- a/examples/combobox/combobox-autocomplete-both.html
+++ b/examples/combobox/combobox-autocomplete-both.html
@@ -39,6 +39,7 @@
     </p>
     <p>Similar examples include:</p>
     <ul>
+      <li><a href="examples/combobox/combobox-select-only.html">Select-Only Combobox</a>: A single-select combobox with no text input that is functionally similar to an HTML <code>select</code> element.</li>
       <li><a href="combobox-autocomplete-list.html">Editable Combobox with List Autocomplete</a>: An editable combobox that demonstrates the autocomplete behavior known as <q>list with manual selection</q>.</li>
       <li><a href="combobox-autocomplete-none.html">Editable Combobox Without Autocomplete</a>: An editable combobox that demonstrates the behavior associated with <code>aria-autocomplete=none</code>.</li>
       <li><a href="grid-combo.html">Editable Combobox with Grid Popup</a>: An editable combobox that presents suggestions in a grid, enabling users to navigate descriptive information about each suggestion.</li>

--- a/examples/combobox/combobox-autocomplete-list.html
+++ b/examples/combobox/combobox-autocomplete-list.html
@@ -39,6 +39,7 @@
     </p>
     <p>Similar examples include:</p>
     <ul>
+      <li><a href="examples/combobox/combobox-select-only.html">Select-Only Combobox</a>: A single-select combobox with no text input that is functionally similar to an HTML <code>select</code> element.</li>
       <li><a href="combobox-autocomplete-both.html">Editable Combobox with Both List and Inline Autocomplete</a>: An editable combobox that demonstrates the autocomplete behavior known as <q>list with inline autocomplete</q>.</li>
       <li><a href="combobox-autocomplete-none.html">Editable Combobox Without Autocomplete</a>: An editable combobox that demonstrates the behavior associated with <code>aria-autocomplete=none</code>.</li>
       <li><a href="grid-combo.html">Editable Combobox with Grid Popup</a>: An editable combobox that presents suggestions in a grid, enabling users to navigate descriptive information about each suggestion.</li>

--- a/examples/combobox/combobox-autocomplete-none.html
+++ b/examples/combobox/combobox-autocomplete-none.html
@@ -36,6 +36,7 @@
     </p>
     <p>Similar examples include: </p>
     <ul>
+      <li><a href="examples/combobox/combobox-select-only.html">Select-Only Combobox</a>: A single-select combobox with no text input that is functionally similar to an HTML <code>select</code> element.</li>
       <li><a href="combobox-autocomplete-both.html">Editable Combobox with Both List and Inline Autocomplete</a>: An editable combobox that demonstrates the autocomplete behavior known as <q>list with inline autocomplete</q>.</li>
       <li><a href="combobox-autocomplete-list.html">Editable Combobox with List Autocomplete</a>: An editable combobox that demonstrates the autocomplete behavior known as <q>list with manual selection</q>.</li>
       <li><a href="grid-combo.html">Editable Combobox with Grid Popup</a>: An editable combobox that presents suggestions in a grid, enabling users to navigate descriptive information about each suggestion.</li>

--- a/examples/combobox/combobox-select-only.html
+++ b/examples/combobox/combobox-select-only.html
@@ -1,0 +1,449 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>Select-Only Combobox Example | WAI-ARIA Authoring Practices 1.2</title>
+
+<!--  Core js and css shared by all examples; do not modify when using this template. -->
+<link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/base.css">
+<link rel="stylesheet" href="../css/core.css">
+<script src="../js/examples.js"></script>
+<script src="../js/highlight.pack.js"></script>
+<script src="../js/app.js"></script>
+
+<!--  js and css for this example. -->
+<link href="css/select-only.css" rel="stylesheet">
+<script src="js/select-only.js"  type="text/javascript"></script>
+</head>
+<body>
+  <nav aria-label="Related Links" class="feedback">
+    <ul>
+      <li><a href="../../#browser_and_AT_support">Browser and Assistive Technology Support</a></li>
+      <li><a href="https://github.com/w3c/aria-practices/issues/new">Report Issue</a></li>
+      <li><a href="https://github.com/w3c/aria-practices/projects/7">Related Issues</a></li>
+      <li><a href="../../#combobox">Design Pattern</a></li>
+    </ul>
+  </nav>
+  <main>
+    <h1>Select-Only Combobox Example</h1>
+    <p>The following example implementation of the <a href="../../#combobox">ARIA design pattern for combobox</a>
+    demonstrates a single-select combobox widget that is functionally similar to an HTML <code>select</code> element.
+    Contrary to other combobox examples, this combobox has no <code>&lt;input&gt;</code> element, and does not take freeform user input. Like a <code>&lt;select&gt;</code> a user can still type characters to auto-select matching options, however.
+    </p>
+    <p>Similar examples include: </p>
+    <ul>
+      <li><a href="combobox-autocomplete-both.html">Editable Combobox with Both List and Inline Autocomplete</a>: An editable combobox that demonstrates the autocomplete behavior known as <q>list with inline autocomplete</q>.</li>
+      <li><a href="combobox-autocomplete-list.html">Editable Combobox with List Autocomplete</a>: An editable combobox that demonstrates the autocomplete behavior known as <q>list with manual selection</q>.</li>
+      <li><a href="combobox-autocomplete-none.html">Editable Combobox Without Autocomplete</a>: An editable combobox that demonstrates the behavior associated with <code>aria-autocomplete=none</code>.</li>
+      <li><a href="grid-combo.html">Editable Combobox with Grid Popup</a>: An editable combobox that presents suggestions in a grid, enabling users to navigate descriptive information about each suggestion.</li>
+    </ul>
+
+    <section>
+      <h2 id="ex_label">Example</h2>
+      <div role="separator" id="ex_start_sep" aria-labelledby="ex_start_sep ex_label" aria-label="Start of"></div>
+      <div id="ex1">
+        <label id="combo1-label" class="combo-label">Read-only Select</label>
+        <div class="combo js-select">
+        <div
+            aria-autocomplete="none"
+            aria-controls="listbox1"
+            aria-expanded="false"
+            aria-haspopup="listbox"
+            aria-labelledby="combo1-label"
+            id="combo1"
+            class="combo-input"
+            role="combobox"
+            tabindex="0"
+            >
+            <span class="combo1-value"></span>
+        </div>
+        <div class="combo-menu" role="listbox" id="listbox1">
+            <!-- options are inserted here -->
+            <!-- e.g. <div role="option" id="op1">option text</div>  -->
+        </div>
+        </div>
+      </div>
+      <div role="separator" id="ex_end_sep" aria-labelledby="ex_end_sep ex_label" aria-label="End of"></div>
+    </section>
+
+    <section>
+      <h2 id="kbd_label">Keyboard Support</h2>
+      <p>
+      The example combobox on this page implements the following keyboard interface.
+        Other variations and options for the keyboard interface are described in the
+        <a href="../../#combobox_kbd_interaction">Keyboard Interaction section of the combobox design pattern.</a>
+      </p>
+      <h3 id="kbd_label_textbox">Textbox</h3>
+      <table aria-labelledby="kbd_label_textbox kbd_label" class="def">
+        <thead>
+          <tr>
+            <th>Key</th>
+            <th>Function</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr data-test-id="textbox-key-down-arrow">
+            <th><kbd>Down Arrow</kbd></th>
+            <td>
+              <ul>
+                <li>First opens the listbox if it is not already displayed and then moves visual focus to the first option.</li>
+                <li>DOM focus remains on the textbox.</li>
+              </ul>
+            </td>
+          </tr>
+          <tr data-test-id="textbox-key-alt-down-arrow">
+            <th><kbd>Alt + Down Arrow</kbd></th>
+            <td>
+                Opens the listbox without moving focus or changing selection.
+            </td>
+          </tr>
+          <tr data-test-id="textbox-key-up-arrow">
+            <th><kbd>Up Arrow</kbd></th>
+            <td>
+              <ul>
+                <li>First opens the listbox if it is not already displayed and then moves visual focus to the last option.</li>
+                <li>DOM focus remains on the textbox.</li>
+              </ul>
+            </td>
+          </tr>
+          <tr data-test-id="textbox-key-enter">
+            <th><kbd>Enter</kbd></th>
+            <td>
+              <ul>
+                <li>Sets the textbox value to the content of the selected option.</li>
+                <li>Closes the listbox if it is displayed.</li>
+              </ul>
+            </td>
+          </tr>
+          <tr data-test-id="standard-single-line-editing-keys">
+            <th>Standard single line text editing keys</th>
+            <td>
+              <ul>
+                <li>Keys used for cursor movement and text manipulation, such as <kbd>Delete</kbd> and <kbd>Shift + Right Arrow</kbd>.</li>
+                <li>An HTML <code>input</code> with <code>type="text"</code> is used for the textbox so the browser will provide platform-specific editing keys.</li>
+              </ul>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <h3 id="kbd_label_listbox">Listbox Popup</h3>
+      <p>
+        <strong>NOTE:</strong> When visual focus is in the listbox, DOM focus remains on the textbox and the value of <code>aria-activedescendant</code> on the textbox is set to a value that refers to the listbox option that is visually indicated as focused.
+        Where the following descriptions of keyboard commands mention focus, they are referring to the visual focus indicator.
+        For more information about this focus management technique, see
+        <a href="../../#kbd_focus_activedescendant">Using aria-activedescendant to Manage Focus.</a>
+      </p>
+      <table aria-labelledby="kbd_label_listbox kbd_label" class="def">
+        <thead>
+          <tr>
+            <th>Key</th>
+            <th>Function</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr data-test-id="listbox-key-enter">
+            <th><kbd>Enter</kbd></th>
+            <td>
+              <ul>
+                <li>Sets the textbox value to the content of the focused option in the listbox.</li>
+                <li>Closes the listbox.</li>
+                <li>Sets visual focus on the textbox.</li>
+              </ul>
+            </td>
+          </tr>
+          <tr data-test-id="listbox-key-escape">
+            <th><kbd>Escape</kbd></th>
+            <td>
+              <ul>
+                <li>Closes the listbox.</li>
+                <li>Sets visual focus on the textbox.</li>
+               </ul>
+            </td>
+          </tr>
+          <tr data-test-id="listbox-key-down-arrow">
+            <th><kbd>Down Arrow</kbd></th>
+            <td>
+              <ul>
+                <li>Moves visual focus to the next option.</li>
+                <li>If visual focus is on the last option, moves visual focus to the first option.</li>
+                <li>Note: This wrapping behavior is useful when <kbd>Home</kbd> and <kbd>End</kbd> move the editing cursor as described below.</li>
+              </ul>
+            </td>
+          </tr>
+          <tr data-test-id="listbox-key-up-arrow">
+            <th><kbd>Up Arrow</kbd></th>
+            <td>
+              <ul>
+                <li>Moves visual focus to the previous option.</li>
+                <li>If visual focus is on the first option, moves visual focus to the last option.</li>
+                <li>Note: This wrapping behavior is useful when <kbd>Home</kbd> and <kbd>End</kbd> move the editing cursor as described below.</li>
+              </ul>
+            </td>
+          </tr>
+          <tr data-test-id="listbox-key-right-arrow">
+            <th><kbd>Right Arrow</kbd></th>
+            <td>Moves visual focus to the textbox and moves the editing cursor one character to the right.</td>
+          </tr>
+          <tr data-test-id="listbox-key-left-arrow">
+            <th><kbd>Left Arrow</kbd></th>
+            <td>Moves visual focus to the textbox and moves the editing cursor one character to the left.</td>
+          </tr>
+          <tr data-test-id="listbox-key-home">
+            <th><kbd>Home</kbd></th>
+            <td>Moves visual focus to the textbox and places the editing cursor at the beginning of the field.</td>
+          </tr>
+          <tr data-test-id="listbox-key-end">
+            <th><kbd>End</kbd></th>
+            <td>Moves visual focus to the textbox and places the editing cursor at the end of the field.</td>
+          </tr>
+          <tr data-test-id="listbox-key-char">
+            <th>Printable Characters</th>
+            <td>
+              <ul>
+                <li>Moves visual focus to the textbox.</li>
+                <li>Types the character in the textbox.</li>
+                <li>Options in the listbox are <em>not</em> filtered based on the characters in the textbox.</li>
+              </ul>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <h3 id="kbd_label_button">Button</h3>
+      <p>
+        The button has been removed from the tab sequence of the page, but is still important to assistive technologies for mobile devices that use touch events to open the list of options.
+      </p>
+    </section>
+
+    <section>
+      <h2 id="rps_label">Role, Property, State, and Tabindex Attributes</h2>
+      <p>
+        The example combobox on this page implements the following ARIA roles, states, and properties.
+        Information about other ways of applying ARIA roles, states, and properties is available in the
+        <a href="../../#combobox_roles_states_props">Roles, States, and Properties section of the combobox design pattern.</a>
+      </p>
+      <h3 id="rps_label_textbox">Textbox</h3>
+      <table aria-labelledby="rps_label_textbox rps_label" class="data attributes">
+        <thead>
+          <tr>
+            <th scope="col">Role</th>
+            <th scope="col">Attribute</th>
+            <th scope="col">Element</th>
+            <th scope="col">Usage</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr data-test-id="combobox-role">
+            <th scope="row">
+              <code>combobox</code>
+            </th>
+            <td></td>
+            <td><code>input[type="text"]</code></td>
+            <td>Identifies the input as a combobox.</td>
+          </tr>
+          <tr data-test-id="combobox-aria-autocomplete">
+            <td></td>
+            <th scope="row">
+              <code>aria-autocomplete="none"</code>
+            </th>
+            <td><code>input[type="text"]</code></td>
+            <td>Indicates that the suggestions in the combobox popup are not values that complete the current textbox input.</td>
+          </tr>
+          <tr data-test-id="combobox-aria-controls">
+            <td></td>
+            <th scope="row">
+              <code>aria-controls="#IDREF"</code>
+            </th>
+            <td><code>input[type="text"]</code></td>
+            <td>Identifies the element that serves as the popup.</td>
+          </tr>
+          <tr data-test-id="combobox-aria-expanded">
+            <td></td>
+            <th scope="row">
+              <code>aria-expanded="false"</code>
+            </th>
+            <td><code>input[type="text"]</code></td>
+            <td>Indicates that the popup element <strong>is not</strong> displayed.</td>
+          </tr>
+          <tr data-test-id="combobox-aria-expanded">
+            <td></td>
+            <th scope="row">
+              <code>aria-expanded="true"</code>
+            </th>
+            <td><code>input[type="text"]</code></td>
+            <td>Indicates that the popup element <strong>is</strong> displayed.</td>
+          </tr>
+          <tr data-test-id="combobox-id">
+            <td></td>
+            <th scope="row">
+              <code>id="string"</code>
+            </th>
+            <td><code>input[type="text"]</code></td>
+            <td>
+              <ul>
+                <li>Referenced by <code>for</code> attribute of <code>label</code> element to provide an accessible name.</li>
+                <li>Recommended naming method for HTML input elements because clicking label focuses input.</li>
+              </ul>
+            </td>
+          </tr>
+          <tr data-test-id="combobox-aria-activedescendant">
+            <td></td>
+            <th scope="row">
+              <code>aria-activedescendant="IDREF"</code>
+            </th>
+            <td><code>input[type="text"]</code></td>
+            <td>
+              <ul>
+                <li>When an option in the listbox is visually indicated as having keyboard focus, refers to that option.</li>
+                <li>When navigation keys, such as <kbd>Down Arrow</kbd>, are pressed, the JavaScript changes the value.</li>
+                <li>Enables assistive technologies to know which element the application regards as focused while DOM focus remains on the <code>input</code> element.</li>
+                <li>
+                  For more information about this focus management technique, see
+                  <a href="../../#kbd_focus_activedescendant">Using aria-activedescendant to Manage Focus.</a>
+                </li>
+              </ul>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <h3 id="rps_label_listbox">Listbox Popup</h3>
+      <table aria-labelledby="rps_label_listbox rps_label" class="data attributes">
+        <thead>
+          <tr>
+            <th scope="col">Role</th>
+            <th scope="col">Attribute</th>
+            <th scope="col">Element</th>
+            <th scope="col">Usage</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr data-test-id="listbox-role">
+            <th scope="row">
+              <code>listbox</code>
+            </th>
+            <td></td>
+            <td>
+              <code>ul</code>
+            </td>
+            <td>Identifies the <code>ul</code> element as a <code>listbox</code>.</td>
+          </tr>
+          <tr data-test-id="listbox-aria-label">
+            <td></td>
+            <th scope="row">
+              <code>aria-label="Previous Searches"</code>
+            </th>
+            <td><code>ul</code></td>
+            <td>Provides a label for the <code>listbox</code>.</td>
+          </tr>
+          <tr data-test-id="option-role">
+            <th scope="row">
+              <code>option</code>
+            </th>
+            <td></td>
+            <td><code>li</code></td>
+            <td>
+              <ul>
+                <li>Identifies the element as a <code>listbox</code> <code>option</code>.</li>
+                <li>The text content of the element provides the accessible name of the <code>option</code>.</li>
+              </ul>
+            </td>
+          </tr>
+          <tr data-test-id="option-aria-selected">
+            <td></td>
+            <th scope="row">
+              <code>aria-selected="true"</code>
+            </th>
+            <td><code>li</code></td>
+            <td>
+              <ul>
+                <li>Specified on an option in the listbox when it is visually highlighted as selected.</li>
+                <li>Occurs only when an option in the list is referenced by <code>aria-activedescendant</code>.</li>
+              </ul>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <h3 id="rps_label_button">Button</h3>
+      <table aria-labelledby="rps_label_button rps_label" class="data attributes">
+        <thead>
+          <tr>
+            <th scope="col">Role</th>
+            <th scope="col">Attribute</th>
+            <th scope="col">Element</th>
+            <th scope="col">Usage</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr data-test-id="button-tabindex">
+            <td></td>
+            <th scope="row">
+              <code>tabindex="-1"</code>
+            </th>
+            <td><code>button</code></td>
+            <td>Removes the button from the tab sequence of the page, since it's keyboard function is redundant with the keyboard operation of the textbox to open the listbox.</td>
+          </tr>
+          <tr data-test-id="button-aria-label">
+            <td></td>
+            <th scope="row">
+              <code>aria-label="Previous Searches"</code>
+            </th>
+            <td><code>button</code></td>
+            <td>Provides a label for the <code>button</code>.</td>
+          </tr>
+          <tr data-test-id="button-aria-controls">
+            <td></td>
+            <th scope="row">
+              <code>aria-controls="#IDREF"</code>
+            </th>
+            <td><code>button</code></td>
+            <td>Identifies the element that serves as the popup.</td>
+          </tr>
+          <tr data-test-id="button-aria-expanded">
+            <td></td>
+            <th scope="row">
+              <code>aria-expanded="false"</code>
+            </th>
+            <td><code>button</code></td>
+            <td>Indicates that the popup element <strong>is not</strong> displayed.</td>
+          </tr>
+          <tr data-test-id="button-aria-expanded">
+            <td></td>
+            <th scope="row">
+              <code>aria-expanded="true"</code>
+            </th>
+            <td><code>button</code></td>
+            <td>Indicates that the popup element <strong>is</strong> displayed.</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section>
+      <h2>Javascript and CSS Source Code</h2>
+      <ul>
+        <li>
+          CSS:
+          <a href="css/combobox-autocomplete.css" type="text/css">combobox-autocomplete.css</a>
+        </li>
+        <li>
+          Javascript:
+          <a href="js/combobox-autocomplete.js" type="text/javascript">combobox-autocomplete.js</a>
+        </li>
+      </ul>
+    </section>
+
+    <section>
+      <h2 id="sc1_label">HTML Source Code</h2>
+      <div role="separator" id="sc1_start_sep" aria-labelledby="sc1_start_sep sc1_label" aria-label="Start of"></div>
+      <pre><code id="sc1"></code></pre>
+      <div role="separator" id="sc1_end_sep" aria-labelledby="sc1_end_sep sc1_label" aria-label="End of"></div>
+      <script>
+        sourceCode.add('sc1', 'ex1');
+        sourceCode.make();
+      </script>
+    </section>
+  </main>
+  <nav>
+    <a href="../../#combobox">Combobox Design Pattern in WAI-ARIA Authoring Practices 1.2</a>
+  </nav>
+</body>
+</html>

--- a/examples/combobox/combobox-select-only.html
+++ b/examples/combobox/combobox-select-only.html
@@ -56,7 +56,7 @@
                 tabindex="0"
                 >
             </div>
-            <div class="combo-menu" role="listbox" id="listbox1">
+            <div class="combo-menu" role="listbox" id="listbox1" aria-labelledby="combo1-label">
                 <!-- options are inserted here -->
                 <!-- e.g. <div role="option" id="op1">option text</div>  -->
             </div>

--- a/examples/combobox/combobox-select-only.html
+++ b/examples/combobox/combobox-select-only.html
@@ -26,9 +26,11 @@
   </nav>
   <main>
     <h1>Select-Only Combobox Example</h1>
-    <p>The following example implementation of the <a href="../../#combobox">ARIA design pattern for combobox</a>
-    demonstrates a single-select combobox widget that is functionally similar to an HTML <code>select</code> element.
-    Contrary to other combobox examples, this combobox has no <code>&lt;input&gt;</code> element, and does not take freeform user input. Like a <code>&lt;select&gt;</code> a user can still type characters to auto-select matching options, however.
+    <p>
+      The following example implementation of the <a href="../../#combobox">ARIA design pattern for combobox</a>
+      demonstrates a single-select combobox widget that is functionally similar to an HTML <code>select</code> element.
+      Unlike the editable combobox examples, this select-only combobox is not made with a <code>&lt;input&gt;</code> element, and it does not accept freeform user input.
+      However, like an HTML <code>&lt;select&gt;</code>, users can type characters to select matching options.
     </p>
     <p>Similar examples include: </p>
     <ul>

--- a/examples/combobox/combobox-select-only.html
+++ b/examples/combobox/combobox-select-only.html
@@ -71,8 +71,8 @@
         Other variations and options for the keyboard interface are described in the
         <a href="../../#combobox_kbd_interaction">Keyboard Interaction section of the combobox design pattern.</a>
       </p>
-      <h3 id="kbd_label_textbox">Closed Combobox</h3>
-      <table aria-labelledby="kbd_label_textbox kbd_label" class="def">
+      <h3 id="kbd_label_combobox">Closed Combobox</h3>
+      <table aria-labelledby="kbd_label_combobox kbd_label" class="def">
         <thead>
           <tr>
             <th>Key</th>
@@ -80,28 +80,52 @@
           </tr>
         </thead>
         <tbody>
-          <tr data-test-id="textbox-key-down-arrow">
+          <tr data-test-id="combobox-key-down-arrow">
             <th><kbd>Down Arrow</kbd></th>
             <td>
               <ul>
-                <li>First opens the listbox if it is not already displayed and then moves visual focus to the first option.</li>
-                <li>DOM focus remains on the textbox.</li>
+                <li>Opens the listbox if it is not already displayed without moving focus or changing selection.</li>
+                <li>DOM focus remains on the combobox.</li>
               </ul>
             </td>
           </tr>
-          <tr data-test-id="textbox-key-alt-down-arrow">
+          <tr data-test-id="combobox-key-alt-down-arrow">
             <th><kbd>Alt + Down Arrow</kbd></th>
             <td>
                 Opens the listbox without moving focus or changing selection.
             </td>
           </tr>
-          <tr data-test-id="textbox-key-up-arrow">
+          <tr data-test-id="combobox-key-up-arrow">
             <th><kbd>Up Arrow</kbd></th>
             <td>
               <ul>
                 <li>First opens the listbox if it is not already displayed and then moves visual focus to the first option.</li>
-                <li>DOM focus remains on the textbox.</li>
+                <li>DOM focus remains on the combobox.</li>
               </ul>
+            </td>
+          </tr>
+          <tr data-test-id="combobox-key-enter">
+            <th><kbd>Enter</kbd></th>
+            <td>
+                Opens the listbox without moving focus or changing selection.
+            </td>
+          </tr>
+          <tr data-test-id="combobox-key-space">
+            <th><kbd>Space</kbd></th>
+            <td>
+                Opens the listbox without moving focus or changing selection.
+            </td>
+          </tr>
+          <tr data-test-id="combobox-key-home">
+            <th><kbd>Home</kbd></th>
+            <td>
+                Opens the listbox and moves visual focus to the first option.
+            </td>
+          </tr>
+          <tr data-test-id="combobox-key-end">
+            <th><kbd>End</kbd></th>
+            <td>
+                Opens the listbox and moves visual focus to the last option.
             </td>
           </tr>
           <tr data-test-id="standard-single-line-editing-keys">
@@ -118,7 +142,7 @@
       </table>
       <h3 id="kbd_label_listbox">Listbox Popup</h3>
       <p>
-        <strong>NOTE:</strong> When visual focus is in the listbox, DOM focus remains on the textbox and the value of <code>aria-activedescendant</code> on the textbox is set to a value that refers to the listbox option that is visually indicated as focused.
+        <strong>NOTE:</strong> When visual focus is in the listbox, DOM focus remains on the combobox and the value of <code>aria-activedescendant</code> on the combobox is set to a value that refers to the listbox option that is visually indicated as focused.
         Where the following descriptions of keyboard commands mention focus, they are referring to the visual focus indicator.
         For more information about this focus management technique, see
         <a href="../../#kbd_focus_activedescendant">Using aria-activedescendant to Manage Focus.</a>
@@ -138,6 +162,26 @@
                 <li>Sets the value to the content of the focused option in the listbox.</li>
                 <li>Closes the listbox.</li>
                 <li>Sets visual focus on the combobox.</li>
+              </ul>
+            </td>
+          </tr>
+          <tr data-test-id="listbox-key-space">
+            <th><kbd>Space</kbd></th>
+            <td>
+              <ul>
+                <li>Sets the value to the content of the focused option in the listbox.</li>
+                <li>Closes the listbox.</li>
+                <li>Sets visual focus on the combobox.</li>
+              </ul>
+            </td>
+          </tr>
+          <tr data-test-id="listbox-key-tab">
+            <th><kbd>Tab</kbd></th>
+            <td>
+              <ul>
+                <li>Sets the value to the content of the focused option in the listbox.</li>
+                <li>Closes the listbox.</li>
+                <li>Performs the default action, moving focus to the next focusable element.</li>
               </ul>
             </td>
           </tr>
@@ -168,6 +212,16 @@
               </ul>
             </td>
           </tr>
+          <tr data-test-id="listbox-key-alt-up-arrow">
+            <th><kbd>Alt + Up Arrow</kbd></th>
+            <td>
+              <ul>
+                <li>Sets the value to the content of the focused option in the listbox.</li>
+                <li>Closes the listbox.</li>
+                <li>Sets visual focus on the combobox.</li>
+              </ul>
+            </td>
+          </tr>
           <tr data-test-id="listbox-key-home">
             <th><kbd>Home</kbd></th>
             <td>Moves visual focus to the first option.</td>
@@ -175,6 +229,14 @@
           <tr data-test-id="listbox-key-end">
             <th><kbd>End</kbd></th>
             <td>Moves visual focus to the last option.</td>
+          </tr>
+          <tr data-test-id="listbox-key-pageup">
+            <th><kbd>PageUp</kbd></th>
+            <td>Jumps visual focus up 10 options (or to first option).</td>
+          </tr>
+          <tr data-test-id="listbox-key-pagedown">
+            <th><kbd>PageDown</kbd></th>
+            <td>Jumps visual focus down 10 options (or to last option).</td>
           </tr>
           <tr data-test-id="listbox-key-char">
             <th>Printable Characters</th>
@@ -197,8 +259,8 @@
         Information about other ways of applying ARIA roles, states, and properties is available in the
         <a href="../../#combobox_roles_states_props">Roles, States, and Properties section of the combobox design pattern.</a>
       </p>
-      <h3 id="rps_label_textbox">Combobox</h3>
-      <table aria-labelledby="rps_label_textbox rps_label" class="data attributes">
+      <h3 id="rps_label_combobox">Combobox</h3>
+      <table aria-labelledby="rps_label_combobox rps_label" class="data attributes">
         <thead>
           <tr>
             <th scope="col">Role</th>
@@ -215,6 +277,14 @@
             <td></td>
             <td><code>div</code></td>
             <td>Identifies the input as a combobox.</td>
+          </tr>
+          <tr data-test-id="combobox-aria-labelledby">
+            <td></td>
+            <th scope="row">
+              <code>aria-labelledby="#IDREF"</code>
+            </th>
+            <td><code>div</code></td>
+            <td>Identifies the element that labels the combobox.</td>
           </tr>
           <tr data-test-id="combobox-aria-controls">
             <td></td>

--- a/examples/combobox/combobox-select-only.html
+++ b/examples/combobox/combobox-select-only.html
@@ -181,7 +181,9 @@
               <ul>
                 <li>Sets the value to the content of the focused option in the listbox.</li>
                 <li>Closes the listbox.</li>
-                <li>Performs the default action, moving focus to the next focusable element.</li>
+                <li>Performs the default action, moving focus to the next focusable element.
+                  Note: the native <code>&lt;select&gt;</code> element closes the listbox but does not move focus on tab.
+                  This pattern matches the behavior of the other comboboxes rather than the native element in this case.</li>
               </ul>
             </td>
           </tr>

--- a/examples/combobox/combobox-select-only.html
+++ b/examples/combobox/combobox-select-only.html
@@ -128,7 +128,7 @@
                 Opens the listbox and moves visual focus to the last option.
             </td>
           </tr>
-          <tr data-test-id="standard-single-line-editing-keys">
+          <tr data-test-id="printable-chars">
             <th>Printable Characters</th>
             <td>
               <ul>
@@ -240,7 +240,7 @@
             <th><kbd>PageDown</kbd></th>
             <td>Jumps visual focus down 10 options (or to last option).</td>
           </tr>
-          <tr data-test-id="listbox-key-char">
+          <tr data-test-id="printable-chars">
             <th>Printable Characters</th>
             <td>
               <ul>

--- a/examples/combobox/combobox-select-only.html
+++ b/examples/combobox/combobox-select-only.html
@@ -56,7 +56,7 @@
                 tabindex="0"
                 >
             </div>
-            <div class="combo-menu" role="listbox" id="listbox1" aria-labelledby="combo1-label">
+            <div class="combo-menu" role="listbox" id="listbox1" aria-labelledby="combo1-label" tabindex="-1">
                 <!-- options are inserted here -->
                 <!-- e.g. <div role="option" id="op1">option text</div>  -->
             </div>

--- a/examples/combobox/combobox-select-only.html
+++ b/examples/combobox/combobox-select-only.html
@@ -29,7 +29,7 @@
     <p>
       The following example implementation of the <a href="../../#combobox">ARIA design pattern for combobox</a>
       demonstrates a single-select combobox widget that is functionally similar to an HTML <code>select</code> element.
-      Unlike the editable combobox examples, this select-only combobox is not made with a <code>&lt;input&gt;</code> element, and it does not accept freeform user input.
+      Unlike the editable combobox examples, this select-only combobox is not made with an <code>&lt;input&gt;</code> element, and it does not accept freeform user input.
       However, like an HTML <code>&lt;select&gt;</code>, users can type characters to select matching options.
     </p>
     <p>Similar examples include: </p>

--- a/examples/combobox/combobox-select-only.html
+++ b/examples/combobox/combobox-select-only.html
@@ -42,25 +42,24 @@
       <h2 id="ex_label">Example</h2>
       <div role="separator" id="ex_start_sep" aria-labelledby="ex_start_sep ex_label" aria-label="Start of"></div>
       <div id="ex1">
-        <label id="combo1-label" class="combo-label">Read-only Select</label>
+        <label id="combo1-label" class="combo-label">Choose a Fruit</label>
         <div class="combo js-select">
-        <div
-            aria-autocomplete="none"
-            aria-controls="listbox1"
-            aria-expanded="false"
-            aria-haspopup="listbox"
-            aria-labelledby="combo1-label"
-            id="combo1"
-            class="combo-input"
-            role="combobox"
-            tabindex="0"
-            >
-            <span class="combo1-value"></span>
-        </div>
-        <div class="combo-menu" role="listbox" id="listbox1">
-            <!-- options are inserted here -->
-            <!-- e.g. <div role="option" id="op1">option text</div>  -->
-        </div>
+            <div
+                aria-autocomplete="none"
+                aria-controls="listbox1"
+                aria-expanded="false"
+                aria-haspopup="listbox"
+                aria-labelledby="combo1-label"
+                id="combo1"
+                class="combo-input"
+                role="combobox"
+                tabindex="0"
+                >
+            </div>
+            <div class="combo-menu" role="listbox" id="listbox1">
+                <!-- options are inserted here -->
+                <!-- e.g. <div role="option" id="op1">option text</div>  -->
+            </div>
         </div>
       </div>
       <div role="separator" id="ex_end_sep" aria-labelledby="ex_end_sep ex_label" aria-label="End of"></div>
@@ -73,7 +72,7 @@
         Other variations and options for the keyboard interface are described in the
         <a href="../../#combobox_kbd_interaction">Keyboard Interaction section of the combobox design pattern.</a>
       </p>
-      <h3 id="kbd_label_textbox">Textbox</h3>
+      <h3 id="kbd_label_textbox">Closed Combobox</h3>
       <table aria-labelledby="kbd_label_textbox kbd_label" class="def">
         <thead>
           <tr>
@@ -101,26 +100,18 @@
             <th><kbd>Up Arrow</kbd></th>
             <td>
               <ul>
-                <li>First opens the listbox if it is not already displayed and then moves visual focus to the last option.</li>
+                <li>First opens the listbox if it is not already displayed and then moves visual focus to the first option.</li>
                 <li>DOM focus remains on the textbox.</li>
               </ul>
             </td>
           </tr>
-          <tr data-test-id="textbox-key-enter">
-            <th><kbd>Enter</kbd></th>
-            <td>
-              <ul>
-                <li>Sets the textbox value to the content of the selected option.</li>
-                <li>Closes the listbox if it is displayed.</li>
-              </ul>
-            </td>
-          </tr>
           <tr data-test-id="standard-single-line-editing-keys">
-            <th>Standard single line text editing keys</th>
+            <th>Printable Characters</th>
             <td>
               <ul>
-                <li>Keys used for cursor movement and text manipulation, such as <kbd>Delete</kbd> and <kbd>Shift + Right Arrow</kbd>.</li>
-                <li>An HTML <code>input</code> with <code>type="text"</code> is used for the textbox so the browser will provide platform-specific editing keys.</li>
+                <li>First opens the listbox if it is not already displayed and then moves visual focus to the first option that matches the typed character.</li>
+                <li>If multiple keys are typed in quick succession, visual focus moves to the first option that matches the full string.</li>
+                <li>If the same character is typed in succession, visual focus cycles among the options starting with that character</li>
               </ul>
             </td>
           </tr>
@@ -145,9 +136,9 @@
             <th><kbd>Enter</kbd></th>
             <td>
               <ul>
-                <li>Sets the textbox value to the content of the focused option in the listbox.</li>
+                <li>Sets the value to the content of the focused option in the listbox.</li>
                 <li>Closes the listbox.</li>
-                <li>Sets visual focus on the textbox.</li>
+                <li>Sets visual focus on the combobox.</li>
               </ul>
             </td>
           </tr>
@@ -156,7 +147,7 @@
             <td>
               <ul>
                 <li>Closes the listbox.</li>
-                <li>Sets visual focus on the textbox.</li>
+                <li>Sets visual focus on the combobox.</li>
                </ul>
             </td>
           </tr>
@@ -165,8 +156,7 @@
             <td>
               <ul>
                 <li>Moves visual focus to the next option.</li>
-                <li>If visual focus is on the last option, moves visual focus to the first option.</li>
-                <li>Note: This wrapping behavior is useful when <kbd>Home</kbd> and <kbd>End</kbd> move the editing cursor as described below.</li>
+                <li>If visual focus is on the last option, visual focus does not move.</li>
               </ul>
             </td>
           </tr>
@@ -175,43 +165,30 @@
             <td>
               <ul>
                 <li>Moves visual focus to the previous option.</li>
-                <li>If visual focus is on the first option, moves visual focus to the last option.</li>
-                <li>Note: This wrapping behavior is useful when <kbd>Home</kbd> and <kbd>End</kbd> move the editing cursor as described below.</li>
+                <li>If visual focus is on the first option, visual focus does not move.</li>
               </ul>
             </td>
           </tr>
-          <tr data-test-id="listbox-key-right-arrow">
-            <th><kbd>Right Arrow</kbd></th>
-            <td>Moves visual focus to the textbox and moves the editing cursor one character to the right.</td>
-          </tr>
-          <tr data-test-id="listbox-key-left-arrow">
-            <th><kbd>Left Arrow</kbd></th>
-            <td>Moves visual focus to the textbox and moves the editing cursor one character to the left.</td>
-          </tr>
           <tr data-test-id="listbox-key-home">
             <th><kbd>Home</kbd></th>
-            <td>Moves visual focus to the textbox and places the editing cursor at the beginning of the field.</td>
+            <td>Moves visual focus to the first option.</td>
           </tr>
           <tr data-test-id="listbox-key-end">
             <th><kbd>End</kbd></th>
-            <td>Moves visual focus to the textbox and places the editing cursor at the end of the field.</td>
+            <td>Moves visual focus to the last option.</td>
           </tr>
           <tr data-test-id="listbox-key-char">
             <th>Printable Characters</th>
             <td>
               <ul>
-                <li>Moves visual focus to the textbox.</li>
-                <li>Types the character in the textbox.</li>
-                <li>Options in the listbox are <em>not</em> filtered based on the characters in the textbox.</li>
+                <li>First opens the listbox if it is not already displayed and then moves visual focus to the first option that matches the typed character.</li>
+                <li>If multiple keys are typed in quick succession, visual focus moves to the first option that matches the full string.</li>
+                <li>If the same character is typed in succession, visual focus cycles among the options starting with that character</li>
               </ul>
             </td>
           </tr>
         </tbody>
       </table>
-      <h3 id="kbd_label_button">Button</h3>
-      <p>
-        The button has been removed from the tab sequence of the page, but is still important to assistive technologies for mobile devices that use touch events to open the list of options.
-      </p>
     </section>
 
     <section>
@@ -221,7 +198,7 @@
         Information about other ways of applying ARIA roles, states, and properties is available in the
         <a href="../../#combobox_roles_states_props">Roles, States, and Properties section of the combobox design pattern.</a>
       </p>
-      <h3 id="rps_label_textbox">Textbox</h3>
+      <h3 id="rps_label_textbox">Combobox</h3>
       <table aria-labelledby="rps_label_textbox rps_label" class="data attributes">
         <thead>
           <tr>
@@ -237,23 +214,15 @@
               <code>combobox</code>
             </th>
             <td></td>
-            <td><code>input[type="text"]</code></td>
+            <td><code>div</code></td>
             <td>Identifies the input as a combobox.</td>
-          </tr>
-          <tr data-test-id="combobox-aria-autocomplete">
-            <td></td>
-            <th scope="row">
-              <code>aria-autocomplete="none"</code>
-            </th>
-            <td><code>input[type="text"]</code></td>
-            <td>Indicates that the suggestions in the combobox popup are not values that complete the current textbox input.</td>
           </tr>
           <tr data-test-id="combobox-aria-controls">
             <td></td>
             <th scope="row">
               <code>aria-controls="#IDREF"</code>
             </th>
-            <td><code>input[type="text"]</code></td>
+            <td><code>div</code></td>
             <td>Identifies the element that serves as the popup.</td>
           </tr>
           <tr data-test-id="combobox-aria-expanded">
@@ -261,7 +230,7 @@
             <th scope="row">
               <code>aria-expanded="false"</code>
             </th>
-            <td><code>input[type="text"]</code></td>
+            <td><code>div</code></td>
             <td>Indicates that the popup element <strong>is not</strong> displayed.</td>
           </tr>
           <tr data-test-id="combobox-aria-expanded">
@@ -269,28 +238,15 @@
             <th scope="row">
               <code>aria-expanded="true"</code>
             </th>
-            <td><code>input[type="text"]</code></td>
+            <td><code>div</code></td>
             <td>Indicates that the popup element <strong>is</strong> displayed.</td>
-          </tr>
-          <tr data-test-id="combobox-id">
-            <td></td>
-            <th scope="row">
-              <code>id="string"</code>
-            </th>
-            <td><code>input[type="text"]</code></td>
-            <td>
-              <ul>
-                <li>Referenced by <code>for</code> attribute of <code>label</code> element to provide an accessible name.</li>
-                <li>Recommended naming method for HTML input elements because clicking label focuses input.</li>
-              </ul>
-            </td>
           </tr>
           <tr data-test-id="combobox-aria-activedescendant">
             <td></td>
             <th scope="row">
               <code>aria-activedescendant="IDREF"</code>
             </th>
-            <td><code>input[type="text"]</code></td>
+            <td><code>div</code></td>
             <td>
               <ul>
                 <li>When an option in the listbox is visually indicated as having keyboard focus, refers to that option.</li>
@@ -322,24 +278,16 @@
             </th>
             <td></td>
             <td>
-              <code>ul</code>
+              <code>div</code>
             </td>
-            <td>Identifies the <code>ul</code> element as a <code>listbox</code>.</td>
-          </tr>
-          <tr data-test-id="listbox-aria-label">
-            <td></td>
-            <th scope="row">
-              <code>aria-label="Previous Searches"</code>
-            </th>
-            <td><code>ul</code></td>
-            <td>Provides a label for the <code>listbox</code>.</td>
+            <td>Identifies the element as a <code>listbox</code>.</td>
           </tr>
           <tr data-test-id="option-role">
             <th scope="row">
               <code>option</code>
             </th>
             <td></td>
-            <td><code>li</code></td>
+            <td><code>div</code></td>
             <td>
               <ul>
                 <li>Identifies the element as a <code>listbox</code> <code>option</code>.</li>
@@ -362,59 +310,6 @@
           </tr>
         </tbody>
       </table>
-      <h3 id="rps_label_button">Button</h3>
-      <table aria-labelledby="rps_label_button rps_label" class="data attributes">
-        <thead>
-          <tr>
-            <th scope="col">Role</th>
-            <th scope="col">Attribute</th>
-            <th scope="col">Element</th>
-            <th scope="col">Usage</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr data-test-id="button-tabindex">
-            <td></td>
-            <th scope="row">
-              <code>tabindex="-1"</code>
-            </th>
-            <td><code>button</code></td>
-            <td>Removes the button from the tab sequence of the page, since it's keyboard function is redundant with the keyboard operation of the textbox to open the listbox.</td>
-          </tr>
-          <tr data-test-id="button-aria-label">
-            <td></td>
-            <th scope="row">
-              <code>aria-label="Previous Searches"</code>
-            </th>
-            <td><code>button</code></td>
-            <td>Provides a label for the <code>button</code>.</td>
-          </tr>
-          <tr data-test-id="button-aria-controls">
-            <td></td>
-            <th scope="row">
-              <code>aria-controls="#IDREF"</code>
-            </th>
-            <td><code>button</code></td>
-            <td>Identifies the element that serves as the popup.</td>
-          </tr>
-          <tr data-test-id="button-aria-expanded">
-            <td></td>
-            <th scope="row">
-              <code>aria-expanded="false"</code>
-            </th>
-            <td><code>button</code></td>
-            <td>Indicates that the popup element <strong>is not</strong> displayed.</td>
-          </tr>
-          <tr data-test-id="button-aria-expanded">
-            <td></td>
-            <th scope="row">
-              <code>aria-expanded="true"</code>
-            </th>
-            <td><code>button</code></td>
-            <td>Indicates that the popup element <strong>is</strong> displayed.</td>
-          </tr>
-        </tbody>
-      </table>
     </section>
 
     <section>
@@ -422,11 +317,11 @@
       <ul>
         <li>
           CSS:
-          <a href="css/combobox-autocomplete.css" type="text/css">combobox-autocomplete.css</a>
+          <a href="css/select-only.css" type="text/css">select-only.css</a>
         </li>
         <li>
           Javascript:
-          <a href="js/combobox-autocomplete.js" type="text/javascript">combobox-autocomplete.js</a>
+          <a href="js/select-only.js" type="text/javascript">select-only.js</a>
         </li>
       </ul>
     </section>

--- a/examples/combobox/combobox-select-only.html
+++ b/examples/combobox/combobox-select-only.html
@@ -45,7 +45,6 @@
         <label id="combo1-label" class="combo-label">Favorite Fruit</label>
         <div class="combo js-select">
             <div
-                aria-autocomplete="none"
                 aria-controls="listbox1"
                 aria-expanded="false"
                 aria-haspopup="listbox"

--- a/examples/combobox/combobox-select-only.html
+++ b/examples/combobox/combobox-select-only.html
@@ -42,7 +42,7 @@
       <h2 id="ex_label">Example</h2>
       <div role="separator" id="ex_start_sep" aria-labelledby="ex_start_sep ex_label" aria-label="Start of"></div>
       <div id="ex1">
-        <label id="combo1-label" class="combo-label">Choose a Fruit</label>
+        <label id="combo1-label" class="combo-label">Favorite Fruit</label>
         <div class="combo js-select">
             <div
                 aria-autocomplete="none"

--- a/examples/combobox/css/select-only.css
+++ b/examples/combobox/css/select-only.css
@@ -1,0 +1,150 @@
+.combo *,
+.combo *::before,
+.combo *::after {
+  box-sizing: border-box;
+}
+
+.combo {
+  display: block;
+  margin-bottom: 1.5em;
+  max-width: 400px;
+  position: relative;
+}
+
+.combo::after {
+  border-bottom: 2px solid rgba(0,0,0,.5);
+  border-right: 2px solid rgba(0,0,0,.5);
+  content: '';
+  display: block;
+  height: 12px;
+  pointer-events: none;
+  position: absolute;
+  right: 16px;
+  top: 50%;
+  transform: translate(0, -65%) rotate(45deg);
+  width: 12px;
+}
+
+.combo-input {
+  background-color: #f5f5f5;
+  border: 2px solid rgba(0,0,0,.5);
+  border-radius: 4px;
+  display: block;
+  font-size: 1em;
+  min-height: calc(1.4em + 26px);
+  padding: 12px 16px 14px;
+  text-align: left;
+  width: 100%;
+}
+
+.open .combo-input {
+  border-radius: 4px 4px 0 0;
+}
+
+.combo-input:focus {
+  border-color: #0067b8;
+  box-shadow: 0 0 4px 2px #0067b8;
+  outline: 5px solid transparent;
+}
+
+.combo-label {
+  display: block;
+  font-size: 20px;
+  font-weight: 100;
+  margin-bottom: 0.25em;
+}
+
+.combo-menu {
+  background-color: #f5f5f5;
+  border: 1px solid rgba(0,0,0,.42);
+  border-radius: 0 0 4px 4px;
+  display: none;
+  max-height: 300px;
+  overflow-y:scroll;
+  left: 0;
+  position: absolute;
+  top: 100%;
+  width: 100%;
+  z-index: 100;
+}
+
+.open .combo-menu {
+  display: block;
+}
+
+.combo-option {
+  padding: 10px 12px 12px;
+}
+
+.combo-option.option-current,
+.combo-option:hover {
+  background-color: rgba(0,0,0,0.1);
+}
+
+.combo-option.option-selected {
+  padding-right: 30px;
+  position: relative;
+}
+
+.combo-option.option-selected::after {
+  border-bottom: 2px solid #000;
+  border-right: 2px solid #000;
+  content: '';
+  height: 16px;
+  position: absolute;
+  right: 15px;
+  top: 50%;
+  transform: translate(0, -50%) rotate(45deg);
+  width: 8px;
+}
+
+/* multiselect list of selected options */
+.selected-options {
+  list-style-type: none;
+  margin: 0;
+  max-width: 400px;
+  padding: 0;
+}
+
+.selected-options li {
+  display: inline-block;
+  margin-bottom: 5px;
+}
+
+.remove-option {
+  background-color: #6200ee;
+  border: 1px solid #6200ee;
+  border-radius: 3px;
+  color: #fff;
+  font-size: 0.75em;
+  font-weight: bold;
+  margin-bottom: 6px;
+  margin-right: 6px;
+  padding: 0.25em 1.75em 0.25em 0.25em;
+  position: relative;
+}
+
+.remove-option:focus {
+  border-color: #baa1dd;
+  box-shadow: 0 0 3px 1px #6200ee;
+  outline: 3px solid transparent;
+}
+
+.remove-option::before,
+.remove-option::after {
+  border-right: 2px solid #fff;
+  content: "";
+  height: 1em;
+  right: 0.75em;
+  position: absolute;
+  top: 50%;
+  width: 0;
+}
+
+.remove-option::before {
+  transform: translate(0, -50%) rotate(45deg);
+}
+
+.remove-option::after {
+  transform: translate(0, -50%) rotate(-45deg);
+}

--- a/examples/combobox/css/select-only.css
+++ b/examples/combobox/css/select-only.css
@@ -12,8 +12,8 @@
 }
 
 .combo::after {
-  border-bottom: 2px solid rgba(0,0,0,.5);
-  border-right: 2px solid rgba(0,0,0,.5);
+  border-bottom: 2px solid rgba(0, 0, 0, 0.75);
+  border-right: 2px solid rgba(0, 0, 0, 0.75);
   content: '';
   display: block;
   height: 12px;
@@ -27,7 +27,7 @@
 
 .combo-input {
   background-color: #f5f5f5;
-  border: 2px solid rgba(0,0,0,.5);
+  border: 2px solid rgba(0, 0, 0, 0.75);
   border-radius: 4px;
   display: block;
   font-size: 1em;
@@ -44,7 +44,7 @@
 .combo-input:focus {
   border-color: #0067b8;
   box-shadow: 0 0 4px 2px #0067b8;
-  outline: 5px solid transparent;
+  outline: 4px solid transparent;
 }
 
 .combo-label {
@@ -56,7 +56,7 @@
 
 .combo-menu {
   background-color: #f5f5f5;
-  border: 1px solid rgba(0,0,0,.42);
+  border: 1px solid rgba(0, 0, 0, 0.75);
   border-radius: 0 0 4px 4px;
   display: none;
   max-height: 300px;
@@ -76,17 +76,21 @@
   padding: 10px 12px 12px;
 }
 
-.combo-option.option-current,
 .combo-option:hover {
-  background-color: rgba(0,0,0,0.1);
+  background-color: rgba(0, 0, 0, 0.1);
 }
 
-.combo-option.option-selected {
+.combo-option.option-current {
+  outline: 3px solid #0067b8;
+  outline-offset: -3px;
+}
+
+.combo-option[aria-selected="true"] {
   padding-right: 30px;
   position: relative;
 }
 
-.combo-option.option-selected::after {
+.combo-option[aria-selected="true"]::after {
   border-bottom: 2px solid #000;
   border-right: 2px solid #000;
   content: '';
@@ -96,55 +100,4 @@
   top: 50%;
   transform: translate(0, -50%) rotate(45deg);
   width: 8px;
-}
-
-/* multiselect list of selected options */
-.selected-options {
-  list-style-type: none;
-  margin: 0;
-  max-width: 400px;
-  padding: 0;
-}
-
-.selected-options li {
-  display: inline-block;
-  margin-bottom: 5px;
-}
-
-.remove-option {
-  background-color: #6200ee;
-  border: 1px solid #6200ee;
-  border-radius: 3px;
-  color: #fff;
-  font-size: 0.75em;
-  font-weight: bold;
-  margin-bottom: 6px;
-  margin-right: 6px;
-  padding: 0.25em 1.75em 0.25em 0.25em;
-  position: relative;
-}
-
-.remove-option:focus {
-  border-color: #baa1dd;
-  box-shadow: 0 0 3px 1px #6200ee;
-  outline: 3px solid transparent;
-}
-
-.remove-option::before,
-.remove-option::after {
-  border-right: 2px solid #fff;
-  content: "";
-  height: 1em;
-  right: 0.75em;
-  position: absolute;
-  top: 50%;
-  width: 0;
-}
-
-.remove-option::before {
-  transform: translate(0, -50%) rotate(45deg);
-}
-
-.remove-option::after {
-  transform: translate(0, -50%) rotate(-45deg);
 }

--- a/examples/combobox/grid-combo.html
+++ b/examples/combobox/grid-combo.html
@@ -44,6 +44,7 @@
     </p>
     <p>Similar examples include: </p>
     <ul>
+      <li><a href="examples/combobox/combobox-select-only.html">Select-Only Combobox</a>: A single-select combobox with no text input that is functionally similar to an HTML <code>select</code> element.</li>
       <li><a href="combobox-autocomplete-both.html">Editable Combobox with Both List and Inline Autocomplete</a>: An editable combobox that demonstrates the autocomplete behavior known as <q>list with inline autocomplete</q>.</li>
       <li><a href="combobox-autocomplete-list.html">Editable Combobox with List Autocomplete</a>: An editable combobox that demonstrates the autocomplete behavior known as <q>list with manual selection</q>.</li>
       <li><a href="combobox-autocomplete-none.html">Editable Combobox Without Autocomplete</a>: An editable combobox that demonstrates the behavior associated with <code>aria-autocomplete=none</code>.</li>

--- a/examples/combobox/js/select-only.js
+++ b/examples/combobox/js/select-only.js
@@ -1,0 +1,278 @@
+const MenuActions = {
+  Close: 0,
+  CloseSelect: 1,
+  First: 2,
+  Last: 3,
+  Next: 4,
+  Open: 5,
+  Previous: 6,
+  Select: 7,
+  Space: 8,
+  Type: 9
+}
+
+/*
+ * Helper functions
+ */
+
+// filter an array of options against an input string
+// returns an array of options that begin with the filter string, case-independent
+function filterOptions(options = [], filter, exclude = []) {
+  return options.filter((option) => {
+    const matches = option.toLowerCase().indexOf(filter.toLowerCase()) === 0;
+    return matches && exclude.indexOf(option) < 0;
+  });
+}
+
+// return a combobox action from a key press
+function getActionFromKey(event, menuOpen) {
+  const { key, altKey, ctrlKey, metaKey } = event;
+  // handle opening when closed
+  if (!menuOpen && (key === 'ArrowDown' || key === 'Enter' || key === ' ')) {
+    return MenuActions.Open;
+  }
+
+  // handle keys when open
+  if (key === 'ArrowDown') {
+    return MenuActions.Next;
+  }
+  else if (key === 'ArrowUp') {
+    return MenuActions.Previous;
+  }
+  else if (key === 'Home') {
+    return MenuActions.First;
+  }
+  else if (key === 'End') {
+    return MenuActions.Last;
+  }
+  else if (key === 'Escape') {
+    return MenuActions.Close;
+  }
+  else if (key === 'Enter') {
+    return MenuActions.CloseSelect;
+  }
+  else if (key === ' ') {
+    return MenuActions.Space;
+  }
+  else if (key === 'Backspace' || key === 'Clear' || (key.length === 1 && !altKey && !ctrlKey && !metaKey)) {
+    return MenuActions.Type;
+  }
+}
+  
+// get index of option that matches a string
+// if the filter is multiple iterations of the same letter (e.g "aaa"),
+// then return the nth match of the single letter
+function getIndexByLetter(options, filter) {
+  const firstMatch = filterOptions(options, filter)[0];
+  const allSameLetter = (array) => array.every((letter) => letter === array[0]);
+  
+  if (firstMatch) {
+    return options.indexOf(firstMatch);
+  }
+  else if (allSameLetter(filter.split(''))) {
+    const matches = filterOptions(options, filter[0]);
+    const matchIndex = (filter.length - 1) % matches.length;
+    return options.indexOf(matches[matchIndex]);
+  }
+  else {
+    return -1;
+  }
+}
+  
+// get updated option index
+function getUpdatedIndex(current, max, action) {
+  switch(action) {
+    case MenuActions.First:
+      return 0;
+    case MenuActions.Last:
+      return max;
+    case MenuActions.Previous:
+      return Math.max(0, current - 1);
+    case MenuActions.Next:
+      return Math.min(max, current + 1);
+    default:
+      return current;
+  }
+}
+  
+// check if an element is currently scrollable
+function isScrollable(element) {
+  return element && element.clientHeight < element.scrollHeight;
+}
+
+// ensure given child element is within the parent's visible scroll area
+function maintainScrollVisibility(activeElement, scrollParent) {
+  const { offsetHeight, offsetTop } = activeElement;
+  const { offsetHeight: parentOffsetHeight, scrollTop } = scrollParent;
+
+  const isAbove = offsetTop < scrollTop;
+  const isBelow = (offsetTop + offsetHeight) > (scrollTop + parentOffsetHeight);
+
+  if (isAbove) {
+    scrollParent.scrollTo(0, offsetTop);
+  }
+  else if (isBelow) {
+    scrollParent.scrollTo(0, offsetTop - parentOffsetHeight + offsetHeight);
+  }
+}
+
+/*
+ * Select Component
+ */
+const Select = function(el, options = []) {
+  // element refs
+  this.el = el;
+  this.comboEl = el.querySelector('[role=combobox]');
+  this.valueEl = this.comboEl.querySelector('span');
+  this.listboxEl = el.querySelector('[role=listbox]');
+
+  // data
+  this.idBase = this.comboEl.id;
+  this.options = options;
+
+  // state
+  this.activeIndex = 0;
+  this.open = false;
+  this.searchString = '';
+  this.searchTimeout = null;
+}
+
+Select.prototype.init = function() {
+  this.valueEl.innerHTML = this.options[0];
+
+  this.comboEl.addEventListener('blur', this.onComboBlur.bind(this));
+  this.comboEl.addEventListener('click', () => this.updateMenuState(true));
+  this.comboEl.addEventListener('keydown', this.onComboKeyDown.bind(this));
+
+  this.options.map((option, index) => {
+    const optionEl = document.createElement('div');
+    optionEl.setAttribute('role', 'option');
+    optionEl.id = `${this.idBase}-${index}`;
+    optionEl.className = index === 0 ? 'combo-option option-current' : 'combo-option';
+    optionEl.setAttribute('aria-selected', `${index === 0}`);
+    optionEl.innerText = option;
+
+    optionEl.addEventListener('click', (event) => {
+      event.stopPropagation();
+      this.onOptionClick(index);
+    });
+    optionEl.addEventListener('mousedown', this.onOptionMouseDown.bind(this));
+
+    this.listboxEl.appendChild(optionEl);
+  });
+}
+
+Select.prototype.getSearchString = function(char) {
+  if (typeof this.searchTimeout === 'number') {
+    window.clearTimeout(this.searchTimeout);
+  }
+  
+  this.searchTimeout = window.setTimeout(() => {
+    this.searchString = '';
+  }, 1000);
+  
+  this.searchString += char;
+  return this.searchString;
+}
+
+Select.prototype.onComboKeyDown = function(event) {
+  const { key } = event;
+  const max = this.options.length - 1;
+
+  const action = getActionFromKey(event, this.open);
+
+  switch(action) {
+      case MenuActions.Next:
+      case MenuActions.Last:
+      case MenuActions.First:
+      case MenuActions.Previous:
+        event.preventDefault();
+        return this.onOptionChange(getUpdatedIndex(this.activeIndex, max, action));
+      case MenuActions.CloseSelect:
+      case MenuActions.Space:
+        event.preventDefault();
+        this.selectOption(this.activeIndex);
+        // intentional fallthrough
+      case MenuActions.Close:
+        event.preventDefault();
+        return this.updateMenuState(false);
+      case MenuActions.Type:
+        this.updateMenuState(true);
+        var searchString = this.getSearchString(key);
+        return this.onOptionChange(Math.max(0, getIndexByLetter(this.options, searchString)));
+      case MenuActions.Open:
+        event.preventDefault();
+        return this.updateMenuState(true);
+    }
+}
+
+Select.prototype.onComboBlur = function() {
+  if (this.ignoreBlur) {
+    this.ignoreBlur = false;
+    return;
+  }
+
+  if (this.open) {
+    this.selectOption(this.activeIndex);
+    this.updateMenuState(false, false);
+  }
+}
+
+Select.prototype.onOptionChange = function(index) {
+  this.activeIndex = index;
+  this.comboEl.setAttribute('aria-activedescendant', `${this.idBase}-${index}`);
+
+  // update active style
+  const options = this.el.querySelectorAll('[role=option]');
+  [...options].forEach((optionEl) => {
+    optionEl.classList.remove('option-current');
+  });
+  options[index].classList.add('option-current');
+
+  if (isScrollable(this.listboxEl)) {
+    maintainScrollVisibility(options[index], this.listboxEl);
+  }
+}
+
+Select.prototype.onOptionClick = function(index) {
+  this.onOptionChange(index);
+  this.selectOption(index);
+  this.updateMenuState(false);
+}
+
+Select.prototype.onOptionMouseDown = function() {
+  this.ignoreBlur = true;
+}
+
+Select.prototype.selectOption = function(index) {
+  const selected = this.options[index];
+  this.valueEl.innerHTML = selected;
+  this.activeIndex = index;
+
+  // update aria-selected
+  const options = this.el.querySelectorAll('[role=option]');
+  [...options].forEach((optionEl) => {
+    optionEl.setAttribute('aria-selected', 'false');
+  });
+  options[index].setAttribute('aria-selected', 'true');
+}
+
+Select.prototype.updateMenuState = function(open, callFocus = true) {
+  this.open = open;
+
+  this.comboEl.setAttribute('aria-expanded', `${open}`);
+  open ? this.el.classList.add('open') : this.el.classList.remove('open');
+  callFocus && this.comboEl.focus();
+  
+  // update activedescendant
+  const activeID = open ? `${this.idBase}-${this.activeIndex}` : this.valueEl.id;
+  this.comboEl.setAttribute('aria-activedescendant', activeID);
+}
+
+// init select
+window.addEventListener('load', function () {
+  const selectEl = document.querySelector('.js-select');
+  const options = ['Apple', 'Banana', 'Blueberry', 'Boysenberry', 'Cherry', 'Durian', 'Eggplant', 'Fig', 'Grape', 'Guava', 'Huckleberry'];
+  const selectComponent = new Select(selectEl, options);
+  selectComponent.init();
+});

--- a/examples/combobox/js/select-only.js
+++ b/examples/combobox/js/select-only.js
@@ -1,3 +1,10 @@
+/*
+*   This content is licensed according to the W3C Software License at
+*   https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document
+*/
+
+'use strict';
+
 // Save a list of named combobox actions, for future readability
 const SelectActions = {
   Close: 0,

--- a/examples/combobox/js/select-only.js
+++ b/examples/combobox/js/select-only.js
@@ -174,7 +174,7 @@ Select.prototype.init = function() {
 
   // add event listeners
   this.comboEl.addEventListener('blur', this.onComboBlur.bind(this));
-  this.comboEl.addEventListener('click', () => this.updateMenuState(true));
+  this.comboEl.addEventListener('click', this.onComboClick.bind(this));
   this.comboEl.addEventListener('keydown', this.onComboKeyDown.bind(this));
 
   // create options
@@ -229,6 +229,10 @@ Select.prototype.onComboBlur = function() {
     this.selectOption(this.activeIndex);
     this.updateMenuState(false, false);
   }
+}
+
+Select.prototype.onComboClick = function() {
+  this.updateMenuState(!this.open, false);
 }
 
 Select.prototype.onComboKeyDown = function(event) {
@@ -356,6 +360,6 @@ window.addEventListener('load', function () {
   const selectEls = document.querySelectorAll('.js-select');
 
   selectEls.forEach((el) => {
-    const selectComponent = new Select(el, options);
+    new Select(el, options);
   });
 });

--- a/examples/combobox/js/select-only.js
+++ b/examples/combobox/js/select-only.js
@@ -42,13 +42,10 @@ function getActionFromKey(event, menuOpen) {
 
   // handle keys when open
   if (menuOpen) {
-    if (key === 'ArrowUp' && event.altKey) {
+    if (key === 'ArrowUp' && altKey) {
       return SelectActions.CloseSelect;
     }
-    if (key === 'ArrowDown' && event.altKey) {
-      return;
-    }
-    if (key === 'ArrowDown') {
+    if (key === 'ArrowDown' && !altKey) {
       return SelectActions.Next;
     }
     else if (key === 'ArrowUp') {

--- a/examples/combobox/js/select-only.js
+++ b/examples/combobox/js/select-only.js
@@ -29,10 +29,18 @@ function filterOptions(options = [], filter, exclude = []) {
 // map a key press to an action
 function getActionFromKey(event, menuOpen) {
   const { key, altKey, ctrlKey, metaKey } = event;
-  const openKeys = ['ArrowDown', 'ArrowUp', 'Enter', ' ', 'Home', 'End']; // all keys that will open the combo
+  const openKeys = ['ArrowDown', 'ArrowUp', 'Enter', ' ']; // all keys that will do the default open action
   // handle opening when closed
   if (!menuOpen && openKeys.includes(key)) {
     return SelectActions.Open;
+  }
+
+  // home and end move the selected option when open or closed
+  if (key === 'Home') {
+    return SelectActions.First;
+  }
+  if (key === 'End') {
+    return SelectActions.Last;
   }
 
   // handle typing characters when open or closed
@@ -45,17 +53,11 @@ function getActionFromKey(event, menuOpen) {
     if (key === 'ArrowUp' && altKey) {
       return SelectActions.CloseSelect;
     }
-    if (key === 'ArrowDown' && !altKey) {
+    else if (key === 'ArrowDown' && !altKey) {
       return SelectActions.Next;
     }
     else if (key === 'ArrowUp') {
       return SelectActions.Previous;
-    }
-    else if (key === 'Home') {
-      return SelectActions.First;
-    }
-    else if (key === 'End') {
-      return SelectActions.Last;
     }
     else if (key === 'PageUp') {
       return SelectActions.PageUp;
@@ -236,27 +238,29 @@ Select.prototype.onComboKeyDown = function(event) {
   const action = getActionFromKey(event, this.open);
 
   switch(action) {
-      case SelectActions.Next:
-      case SelectActions.Last:
-      case SelectActions.First:
-      case SelectActions.Previous:
-      case SelectActions.PageUp:
-      case SelectActions.PageDown:
-        event.preventDefault();
-        return this.onOptionChange(getUpdatedIndex(this.activeIndex, max, action));
-      case SelectActions.CloseSelect:
-        event.preventDefault();
-        this.selectOption(this.activeIndex);
-        // intentional fallthrough
-      case SelectActions.Close:
-        event.preventDefault();
-        return this.updateMenuState(false);
-      case SelectActions.Type:
-        return this.onComboType(key);
-      case SelectActions.Open:
-        event.preventDefault();
-        return this.updateMenuState(true);
-    }
+    case SelectActions.Last:
+    case SelectActions.First:
+      this.updateMenuState(true);
+      // intentional fallthrough
+    case SelectActions.Next:
+    case SelectActions.Previous:
+    case SelectActions.PageUp:
+    case SelectActions.PageDown:
+      event.preventDefault();
+      return this.onOptionChange(getUpdatedIndex(this.activeIndex, max, action));
+    case SelectActions.CloseSelect:
+      event.preventDefault();
+      this.selectOption(this.activeIndex);
+      // intentional fallthrough
+    case SelectActions.Close:
+      event.preventDefault();
+      return this.updateMenuState(false);
+    case SelectActions.Type:
+      return this.onComboType(key);
+    case SelectActions.Open:
+      event.preventDefault();
+      return this.updateMenuState(true);
+  }
 }
 
 Select.prototype.onComboType = function(letter) {

--- a/examples/index.html
+++ b/examples/index.html
@@ -80,6 +80,7 @@
                 <li><a href="combobox/combobox-autocomplete-both.html">Editable Combobox With Both List and Inline Autocomplete</a></li>
                 <li><a href="combobox/combobox-autocomplete-list.html">Editable Combobox With List Autocomplete</a></li>
                 <li><a href="combobox/combobox-autocomplete-none.html">Editable Combobox without Autocomplete</a></li>
+                <li><a href="combobox/combobox-select-only.html">Select-Only Combobox</a></li>
                 <li><a href="combobox/grid-combo.html">Editable Combobox with Grid Popup</a></li>
               </ul>
             </td>
@@ -148,6 +149,7 @@
                 <li><a href="combobox/combobox-autocomplete-both.html">Editable Combobox With Both List and Inline Autocomplete</a></li>
                 <li><a href="combobox/combobox-autocomplete-list.html">Editable Combobox With List Autocomplete</a></li>
                 <li><a href="combobox/combobox-autocomplete-none.html">Editable Combobox without Autocomplete</a></li>
+                <li><a href="combobox/combobox-select-only.html">Select-Only Combobox</a></li>
                 <li><a href="listbox/listbox-collapsible.html">Collapsible Dropdown Listbox</a></li>
                 <li><a href="listbox/listbox-grouped.html">Listbox  with Grouped Options</a></li>
                 <li><a href="listbox/listbox-rearrangeable.html">Listboxes with Rearrangeable Options</a></li>
@@ -225,6 +227,7 @@
                 <li><a href="combobox/combobox-autocomplete-both.html">Editable Combobox With Both List and Inline Autocomplete</a></li>
                 <li><a href="combobox/combobox-autocomplete-list.html">Editable Combobox With List Autocomplete</a></li>
                 <li><a href="combobox/combobox-autocomplete-none.html">Editable Combobox without Autocomplete</a></li>
+                <li><a href="combobox/combobox-select-only.html">Select-Only Combobox</a></li>
               </ul>
             </td>
           </tr>
@@ -298,6 +301,7 @@
             <td><code>tab</code></td>
             <td>
               <ul>
+                <li><a href="carousel/carousel-2-tablist.html">Auto-Rotating Image Carousel with a Tablist</a></li>
                 <li><a href="tabs/tabs-1/tabs.html">Tabs with Automatic Activation</a></li>
                 <li><a href="tabs/tabs-2/tabs.html">Tabs with Manual Activation</a></li>
               </ul>
@@ -311,6 +315,7 @@
             <td><code>tablist</code></td>
             <td>
               <ul>
+                <li><a href="carousel/carousel-2-tablist.html">Auto-Rotating Image Carousel with a Tablist</a></li>
                 <li><a href="tabs/tabs-1/tabs.html">Tabs with Automatic Activation</a></li>
                 <li><a href="tabs/tabs-2/tabs.html">Tabs with Manual Activation</a></li>
               </ul>
@@ -320,6 +325,7 @@
             <td><code>tabpanel</code></td>
             <td>
               <ul>
+                <li><a href="carousel/carousel-2-tablist.html">Auto-Rotating Image Carousel with a Tablist</a></li>
                 <li><a href="tabs/tabs-1/tabs.html">Tabs with Automatic Activation</a></li>
                 <li><a href="tabs/tabs-2/tabs.html">Tabs with Manual Activation</a></li>
               </ul>
@@ -374,6 +380,7 @@
                 <li><a href="combobox/combobox-autocomplete-both.html">Editable Combobox With Both List and Inline Autocomplete</a></li>
                 <li><a href="combobox/combobox-autocomplete-list.html">Editable Combobox With List Autocomplete</a></li>
                 <li><a href="combobox/combobox-autocomplete-none.html">Editable Combobox without Autocomplete</a></li>
+                <li><a href="combobox/combobox-select-only.html">Select-Only Combobox</a></li>
                 <li><a href="combobox/grid-combo.html">Editable Combobox with Grid Popup</a></li>
                 <li><a href="listbox/listbox-collapsible.html">Collapsible Dropdown Listbox</a></li>
                 <li><a href="listbox/listbox-grouped.html">Listbox  with Grouped Options</a></li>
@@ -421,10 +428,12 @@
             <td>
               <ul>
                 <li><a href="accordion/accordion.html">Accordion</a></li>
+                <li><a href="carousel/carousel-2-tablist.html">Auto-Rotating Image Carousel with a Tablist</a></li>
                 <li><a href="checkbox/checkbox-2/checkbox-2.html">Checkbox  (Mixed-State)</a></li>
                 <li><a href="combobox/combobox-autocomplete-both.html">Editable Combobox With Both List and Inline Autocomplete</a></li>
                 <li><a href="combobox/combobox-autocomplete-list.html">Editable Combobox With List Autocomplete</a></li>
                 <li><a href="combobox/combobox-autocomplete-none.html">Editable Combobox without Autocomplete</a></li>
+                <li><a href="combobox/combobox-select-only.html">Select-Only Combobox</a></li>
                 <li><a href="combobox/grid-combo.html">Editable Combobox with Grid Popup</a></li>
                 <li><a href="disclosure/disclosure-faq.html">Disclosure (Show/Hide) for Answers to Frequently Asked Questions</a></li>
                 <li><a href="disclosure/disclosure-img-long-description.html">Disclosure (Show/Hide) for Image Description</a></li>
@@ -471,6 +480,7 @@
                 <li><a href="combobox/combobox-autocomplete-both.html">Editable Combobox With Both List and Inline Autocomplete</a></li>
                 <li><a href="combobox/combobox-autocomplete-list.html">Editable Combobox With List Autocomplete</a></li>
                 <li><a href="combobox/combobox-autocomplete-none.html">Editable Combobox without Autocomplete</a></li>
+                <li><a href="combobox/combobox-select-only.html">Select-Only Combobox</a></li>
                 <li><a href="combobox/grid-combo.html">Editable Combobox with Grid Popup</a></li>
                 <li><a href="disclosure/disclosure-faq.html">Disclosure (Show/Hide) for Answers to Frequently Asked Questions</a></li>
                 <li><a href="disclosure/disclosure-img-long-description.html">Disclosure (Show/Hide) for Image Description</a></li>
@@ -520,6 +530,7 @@
             <td>
               <ul>
                 <li><a href="carousel/carousel-1.html">Auto-Rotating Image Carousel</a></li>
+                <li><a href="carousel/carousel-2-tablist.html">Auto-Rotating Image Carousel with a Tablist</a></li>
                 <li><a href="checkbox/checkbox-1/checkbox-1.html">Checkbox  (Two State)</a></li>
                 <li><a href="combobox/combobox-autocomplete-both.html">Editable Combobox With Both List and Inline Autocomplete</a></li>
                 <li><a href="combobox/combobox-autocomplete-list.html">Editable Combobox With List Autocomplete</a></li>
@@ -609,6 +620,7 @@
               <ul>
                 <li><a href="alert/alert.html">Alert</a></li>
                 <li><a href="carousel/carousel-1.html">Auto-Rotating Image Carousel</a></li>
+                <li><a href="carousel/carousel-2-tablist.html">Auto-Rotating Image Carousel with a Tablist</a></li>
                 <li><a href="dialog-modal/datepicker-dialog.html">Date Picker Dialog</a></li>
               </ul>
             </td>
@@ -654,7 +666,12 @@
           </tr>
           <tr>
             <td><code>aria-roledescription</code></td>
-            <td><a href="carousel/carousel-1.html">Auto-Rotating Image Carousel</a></td>
+            <td>
+              <ul>
+                <li><a href="carousel/carousel-1.html">Auto-Rotating Image Carousel</a></li>
+                <li><a href="carousel/carousel-2-tablist.html">Auto-Rotating Image Carousel with a Tablist</a></li>
+              </ul>
+            </td>
           </tr>
           <tr>
             <td><code>aria-rowcount</code></td>
@@ -678,6 +695,7 @@
             <td><code>aria-selected</code></td>
             <td>
               <ul>
+                <li><a href="carousel/carousel-2-tablist.html">Auto-Rotating Image Carousel with a Tablist</a></li>
                 <li><a href="combobox/combobox-autocomplete-both.html">Editable Combobox With Both List and Inline Autocomplete</a></li>
                 <li><a href="combobox/combobox-autocomplete-list.html">Editable Combobox With List Autocomplete</a></li>
                 <li><a href="combobox/combobox-autocomplete-none.html">Editable Combobox without Autocomplete</a></li>

--- a/test/tests/combobox_select-only.js
+++ b/test/tests/combobox_select-only.js
@@ -97,7 +97,7 @@ ariaTest('Alt + down arrow opens listbox', exampleFile, 'combobox-key-alt-down-a
   t.false(await listbox.isDisplayed(), 'Listbox should be hidden on load');
 
   // Send ALT + ARROW_DOWN to the combo
-  await combobox.sendKeys(Key.ALT, Key.ARROW_DOWN);
+  await combobox.sendKeys(Key.chord(Key.ALT, Key.ARROW_DOWN));
 
   // Check that the listbox is displayed
   t.true(await listbox.isDisplayed(), 'alt + down should show the listbox');
@@ -107,7 +107,27 @@ ariaTest('Alt + down arrow opens listbox', exampleFile, 'combobox-key-alt-down-a
   t.is(await combobox.getAttribute('aria-activedescendant'), firstOptionId, 'Alt + Down should highlight the first option');
 });
 
-ariaTest('Down arrow opens listbox', exampleFile, 'combobox-key-down-arrow', async (t) => {
+ariaTest('Up arrow opens listbox', exampleFile, 'combobox-key-up-arrow', async (t) => {
+  const combobox = await t.context.session.findElement(By.css(ex.comboSelector));
+  const listbox = await t.context.session.findElement(By.css(ex.listboxSelector));
+  const firstOptionId = await t.context.session.findElement(By.css(`${ex.listboxSelector} [role=option]`)).getAttribute('id');
+
+  // listbox starts collapsed
+  t.false(await listbox.isDisplayed(), 'Listbox should be hidden on load');
+
+  // Send ARROW_UP to the combo
+  await combobox.sendKeys(Key.ARROW_UP);
+
+  // Check that the listbox is displayed
+  t.true(await listbox.isDisplayed(), 'arrow up should show the listbox');
+  t.is(await combobox.getAttribute('aria-expanded'), 'true', 'aria-expanded should be true when opened');
+
+  // the first option should be selected
+  t.is(await combobox.getAttribute('aria-activedescendant'), firstOptionId, 'arrow up should highlight the first option');
+});
+
+
+ariaTest(' arrow opens listbox', exampleFile, 'combobox-key-down-arrow', async (t) => {
   const combobox = await t.context.session.findElement(By.css(ex.comboSelector));
   const listbox = await t.context.session.findElement(By.css(ex.listboxSelector));
   const firstOptionId = await t.context.session.findElement(By.css(`${ex.listboxSelector} [role=option]`)).getAttribute('id');
@@ -215,7 +235,7 @@ ariaTest('End opens listbox to last option', exampleFile, 'combobox-key-end', as
   t.is(await combobox.getAttribute('aria-activedescendant'), lastOptionId, 'end should always highlight the last option');
 });
 
-ariaTest('character keys open listbox to matching option', exampleFile, 'listbox-key-char', async (t) => {
+ariaTest('character keys open listbox to matching option', exampleFile, 'printable-chars', async (t) => {
   const combobox = await t.context.session.findElement(By.css(ex.comboSelector));
   const listbox = await t.context.session.findElement(By.css(ex.listboxSelector));
   const secondOptionId = await t.context.session.findElement(By.css(`${ex.listboxSelector} [role=option]:nth-child(2)`)).getAttribute('id');
@@ -290,6 +310,23 @@ ariaTest('Space closes listbox and selects option', exampleFile, 'listbox-key-sp
   t.is(await combobox.getText(), secondOptionText, 'Combobox inner text should match the second option');
   t.is(await secondOption.getAttribute('aria-selected'), 'true', 'Second option has aria-selected set to true');
 });
+
+ariaTest('Space closes listbox and selects option', exampleFile, 'listbox-key-alt-up-arrow', async (t) => {
+  const combobox = await t.context.session.findElement(By.css(ex.comboSelector));
+  const listbox = await t.context.session.findElement(By.css(ex.listboxSelector));
+  const secondOption = await t.context.session.findElement(By.css(`${ex.listboxSelector} [role=option]:nth-child(2)`));
+
+  // Open, move to third option, send ALT+UP ARROW
+  await combobox.sendKeys(Key.ENTER, Key.ARROW_DOWN);
+  const secondOptionText = await secondOption.getText();
+  await combobox.sendKeys(Key.chord(Key.ALT, Key.ARROW_UP));
+
+  // listbox is collapsed and the value is set to the third option
+  t.false(await listbox.isDisplayed(), 'Listbox should be hidden');
+  t.is(await combobox.getText(), secondOptionText, 'Combobox inner text should match the second option');
+  t.is(await secondOption.getAttribute('aria-selected'), 'true', 'Second option has aria-selected set to true');
+});
+
 
 ariaTest('Escape closes listbox without selecting option', exampleFile, 'listbox-key-escape', async (t) => {
   const combobox = await t.context.session.findElement(By.css(ex.comboSelector));
@@ -450,7 +487,7 @@ ariaTest('PageUp moves up 10 options, and does not wrap', exampleFile, 'listbox-
   t.is(await combobox.getAttribute('aria-activedescendant'), optionId, 'aria-activedescendant points to the first option after second pageup');
 });
 
-ariaTest('Multiple single-character presses cycle through options', exampleFile, 'listbox-key-char', async (t) => {
+ariaTest('Multiple single-character presses cycle through options', exampleFile, 'printable-chars', async (t) => {
   const combobox = await t.context.session.findElement(By.css(ex.comboSelector));
   const options = await t.context.queryElements(t, `${ex.listboxSelector} [role=option]`);
 
@@ -484,7 +521,7 @@ ariaTest('Multiple single-character presses cycle through options', exampleFile,
   t.is(await combobox.getAttribute('aria-activedescendant'), `${matchingId}`, 'aria-activedescendant points to the second option beginning with "b"');
 });
 
-ariaTest('Typing multiple characters refines search', exampleFile, 'listbox-key-char', async (t) => {
+ariaTest('Typing multiple characters refines search', exampleFile, 'printable-chars', async (t) => {
   const combobox = await t.context.session.findElement(By.css(ex.comboSelector));
   const options = await t.context.queryElements(t, `${ex.listboxSelector} [role=option]`);
 

--- a/test/tests/combobox_select-only.js
+++ b/test/tests/combobox_select-only.js
@@ -1,0 +1,508 @@
+'use strict';
+
+const { ariaTest } = require('..');
+const { By, Key } = require('selenium-webdriver');
+const assertAttributeValues = require('../util/assertAttributeValues');
+const assertAriaLabelledby = require('../util/assertAriaLabelledby');
+const assertAriaRoles = require('../util/assertAriaRoles');
+
+const exampleFile = 'combobox/combobox-select-only.html';
+
+const ex = {
+  comboSelector: '#combo1',
+  listboxSelector: '#listbox1'
+};
+
+// Attributes
+ariaTest('role="combobox"', exampleFile, 'combobox-role', async (t) => {
+  await assertAriaRoles(t, 'ex1', 'combobox', '1', 'div');
+});
+
+ariaTest('role="listbox"', exampleFile, 'listbox-role', async (t) => {
+  await assertAriaRoles(t, 'ex1', 'listbox', '1', 'div');
+});
+
+ariaTest('role "option"', exampleFile, 'option-role', async (t) => {
+  // open combo
+  await t.context.session.findElement(By.css(ex.comboSelector)).click();
+
+  // query listbox children
+  const options = await t.context.queryElements(t, `${ex.listboxSelector} > div`);
+  await Promise.all(options.map(async (option) => {
+    const role = await option.getAttribute('role');
+    t.is(role, 'option', 'Immediate descendents of the listbox should have role="option"');
+  }));
+});
+
+ariaTest('aria-labelledby on combobox', exampleFile, 'combobox-aria-labelledby', async (t) => {
+  await assertAriaLabelledby(t, ex.comboSelector);
+});
+
+ariaTest('aria-controls on combobox', exampleFile, 'combobox-aria-controls', async (t) => {
+  const controlledId = await t.context.session
+    .findElement(By.css(ex.comboSelector))
+    .getAttribute('aria-controls');
+
+  t.truthy(controlledId, '"aria-controls" should exist on the combobox');
+
+  const controlledRole = await t.context.session.findElement(By.id(controlledId)).getAttribute('role');
+
+  t.is(controlledRole, 'listbox', 'The combobox\'s aria-controls attribute should point to a listbox');
+});
+
+ariaTest('aria-expanded="false" when closed', exampleFile, 'combobox-aria-expanded', async (t) => {
+  const expanded = await t.context.session.findElement(By.css(ex.comboSelector)).getAttribute('aria-expanded');
+
+  t.is(expanded, 'false', 'aria-expanded should be false by default');
+});
+
+ariaTest('click opens combobox and sets aria-expanded="true"', exampleFile, 'combobox-aria-expanded', async (t) => {
+  const combobox = await t.context.session.findElement(By.css(ex.comboSelector));
+
+  await combobox.click();
+  const expanded = await combobox.getAttribute('aria-expanded');
+  const popupDisplayed = await t.context.session.findElement(By.css(ex.listboxSelector)).isDisplayed();
+
+  t.is(expanded, 'true', 'aria-expanded should be true when opened');
+  t.true(popupDisplayed, 'listbox should be present after click');
+});
+
+ariaTest('"aria-activedescendant" on combobox element', exampleFile, 'combobox-aria-activedescendant', async (t) => {
+  const combobox = await t.context.session.findElement(By.css(ex.comboSelector));
+  const firstOption = await t.context.session.findElement(By.css(`${ex.listboxSelector} [role=option]`));
+  const optionId = await firstOption.getAttribute('id');
+
+  await combobox.click();
+  
+  await assertAttributeValues(t, ex.comboSelector, 'aria-activedescendant', optionId);
+});
+
+ariaTest('"aria-selected" attribute on first option', exampleFile, 'option-aria-selected', async (t) => {
+  const firstOption = await t.context.session.findElement(By.css(`${ex.listboxSelector} [role=option]`));
+  const secondOption = await t.context.session.findElement(By.css(`${ex.listboxSelector} [role=option]:nth-child(2)`));
+
+  t.is(await firstOption.getAttribute('aria-selected'), 'true', 'the first option is selected by default');
+  t.is(await secondOption.getAttribute('aria-selected'), 'false', 'other options have aria-selected set to false');
+});
+
+// Behavior
+
+// Open listbox
+ariaTest('Alt + down arrow opens listbox', exampleFile, 'combobox-key-alt-down-arrow', async (t) => {
+  const combobox = await t.context.session.findElement(By.css(ex.comboSelector));
+  const listbox = await t.context.session.findElement(By.css(ex.listboxSelector));
+  const firstOptionId = await t.context.session.findElement(By.css(`${ex.listboxSelector} [role=option]`)).getAttribute('id');
+
+  // listbox starts collapsed
+  t.false(await listbox.isDisplayed(), 'Listbox should be hidden on load');
+
+  // Send ALT + ARROW_DOWN to the combo
+  await combobox.sendKeys(Key.ALT, Key.ARROW_DOWN);
+
+  // Check that the listbox is displayed
+  t.true(await listbox.isDisplayed(), 'alt + down should show the listbox');
+  t.is(await combobox.getAttribute('aria-expanded'), 'true', 'aria-expanded should be true when opened');
+
+  // the first option should be selected
+  t.is(await combobox.getAttribute('aria-activedescendant'), firstOptionId, 'Alt + Down should highlight the first option');
+});
+
+ariaTest('Down arrow opens listbox', exampleFile, 'combobox-key-down-arrow', async (t) => {
+  const combobox = await t.context.session.findElement(By.css(ex.comboSelector));
+  const listbox = await t.context.session.findElement(By.css(ex.listboxSelector));
+  const firstOptionId = await t.context.session.findElement(By.css(`${ex.listboxSelector} [role=option]`)).getAttribute('id');
+
+  // listbox starts collapsed
+  t.false(await listbox.isDisplayed(), 'Listbox should be hidden on load');
+
+  // Send ARROW_DOWN to the combo
+  await combobox.sendKeys(Key.ARROW_DOWN);
+
+  // Check that the listbox is displayed
+  t.true(await listbox.isDisplayed(), 'alt + down should show the listbox');
+  t.is(await combobox.getAttribute('aria-expanded'), 'true', 'aria-expanded should be true when opened');
+
+  // the first option should be selected
+  t.is(await combobox.getAttribute('aria-activedescendant'), firstOptionId, 'Down arrow should highlight the first option');
+});
+
+ariaTest('Enter opens listbox', exampleFile, 'combobox-key-enter', async (t) => {
+  const combobox = await t.context.session.findElement(By.css(ex.comboSelector));
+  const listbox = await t.context.session.findElement(By.css(ex.listboxSelector));
+  const firstOptionId = await t.context.session.findElement(By.css(`${ex.listboxSelector} [role=option]`)).getAttribute('id');
+
+  // listbox starts collapsed
+  t.false(await listbox.isDisplayed(), 'Listbox should be hidden on load');
+
+  // Send ENTER to the combo
+  await combobox.sendKeys(Key.ENTER);
+
+  // Check that the listbox is displayed
+  t.true(await listbox.isDisplayed(), 'enter should show the listbox');
+
+  // the first option should be selected
+  t.is(await combobox.getAttribute('aria-activedescendant'), firstOptionId, 'enter should highlight the first option');
+});
+
+ariaTest('Space opens listbox', exampleFile, 'combobox-key-space', async (t) => {
+  const combobox = await t.context.session.findElement(By.css(ex.comboSelector));
+  const listbox = await t.context.session.findElement(By.css(ex.listboxSelector));
+  const firstOptionId = await t.context.session.findElement(By.css(`${ex.listboxSelector} [role=option]`)).getAttribute('id');
+
+  // listbox starts collapsed
+  t.false(await listbox.isDisplayed(), 'Listbox should be hidden on load');
+
+  // Send space to the combo
+  await combobox.sendKeys(' ');
+
+  // Check that the listbox is displayed
+  t.true(await listbox.isDisplayed(), 'space should show the listbox');
+
+  // the first option should be selected
+  t.is(await combobox.getAttribute('aria-activedescendant'), firstOptionId, 'space should highlight the first option');
+});
+
+ariaTest('combobox opens on last highlighted option', exampleFile, 'combobox-key-down-arrow', async (t) => {
+  const combobox = await t.context.session.findElement(By.css(ex.comboSelector));
+  const listbox = await t.context.session.findElement(By.css(ex.listboxSelector));
+  const secondOptionId = await t.context.session.findElement(By.css(`${ex.listboxSelector} [role=option]:nth-child(2)`)).getAttribute('id');
+
+  // Open, select second option, close
+  await combobox.sendKeys(' ');
+  await combobox.sendKeys(Key.ARROW_DOWN);
+  await combobox.sendKeys(Key.ESCAPE);
+
+  // Open again
+  await combobox.sendKeys(' ');
+
+  // Check that the listbox is displayed and second option is highlighted
+  t.true(await listbox.isDisplayed(), 'space should show the listbox');
+  t.is(await combobox.getAttribute('aria-activedescendant'), secondOptionId, 'second option should be highlighted');
+});
+
+ariaTest('Home opens listbox to first option', exampleFile, 'combobox-key-home', async (t) => {
+  const combobox = await t.context.session.findElement(By.css(ex.comboSelector));
+  const listbox = await t.context.session.findElement(By.css(ex.listboxSelector));
+  const firstOptionId = await t.context.session.findElement(By.css(`${ex.listboxSelector} [role=option]`)).getAttribute('id');
+
+  // Open, select second option, close
+  await combobox.sendKeys(' ');
+  await combobox.sendKeys(Key.ARROW_DOWN);
+  await combobox.sendKeys(Key.ESCAPE);
+
+  // listbox is collapsed
+  t.false(await listbox.isDisplayed(), 'Listbox should be hidden');
+
+  // Send home key to the combo
+  await combobox.sendKeys(Key.HOME);
+
+  // Check that the listbox is displayed and first option is highlighted
+  t.true(await listbox.isDisplayed(), 'home should show the listbox');
+  t.is(await combobox.getAttribute('aria-activedescendant'), firstOptionId, 'home should always highlight the first option');
+});
+
+ariaTest('End opens listbox to last option', exampleFile, 'combobox-key-end', async (t) => {
+  const combobox = await t.context.session.findElement(By.css(ex.comboSelector));
+  const listbox = await t.context.session.findElement(By.css(ex.listboxSelector));
+  const options = await t.context.queryElements(t, `${ex.listboxSelector} [role=option]`);
+  const lastOptionId = await options[options.length - 1].getAttribute('id');
+
+  // Send end key to the combo
+  await combobox.sendKeys(Key.END);
+
+  // Check that the listbox is displayed and first option is highlighted
+  t.true(await listbox.isDisplayed(), 'end should show the listbox');
+  t.is(await combobox.getAttribute('aria-activedescendant'), lastOptionId, 'end should always highlight the last option');
+});
+
+ariaTest('character keys open listbox to matching option', exampleFile, 'listbox-key-char', async (t) => {
+  const combobox = await t.context.session.findElement(By.css(ex.comboSelector));
+  const listbox = await t.context.session.findElement(By.css(ex.listboxSelector));
+  const secondOptionId = await t.context.session.findElement(By.css(`${ex.listboxSelector} [role=option]:nth-child(2)`)).getAttribute('id');
+
+  // type "a"
+  await combobox.sendKeys('a');
+
+  // Check that the listbox is displayed and the second option is highlighted
+  // bit of hard-coding here; we know that the second option begins with "a", since the first is a placeholder
+  t.true(await listbox.isDisplayed(), 'character key should show the listbox');
+  t.is(await combobox.getAttribute('aria-activedescendant'), secondOptionId, 'typing "a" should highlight the first option beginning with "a"');
+});
+
+// Close listbox
+ariaTest('click opens and closes listbox', exampleFile, 'test-additional-behavior', async (t) => {
+  const combobox = await t.context.session.findElement(By.css(ex.comboSelector));
+  const listbox = await t.context.session.findElement(By.css(ex.listboxSelector));
+
+  await combobox.click();
+  t.true(await listbox.isDisplayed(), 'listbox should be present after click');
+
+  await combobox.click();
+  t.false(await listbox.isDisplayed(), 'second click should close listbox');
+  t.is(await combobox.getAttribute('aria-expanded'), 'false', 'aria-expanded should be set to false after second click');
+});
+
+ariaTest('clicking an option selects and closes', exampleFile, 'test-additional-behavior', async (t) => {
+  const combobox = await t.context.session.findElement(By.css(ex.comboSelector));
+  const listbox = await t.context.session.findElement(By.css(ex.listboxSelector));
+  const fourthOption = await t.context.session.findElement(By.css(`${ex.listboxSelector} [role=option]:nth-child(4)`));
+
+  await combobox.click();
+  const fourthOptionText = await fourthOption.getText();
+  t.true(await listbox.isDisplayed(), 'listbox should be present after click');
+
+  await fourthOption.click();
+  t.false(await listbox.isDisplayed(), 'option click should close listbox');
+  t.is(await combobox.getText(), fourthOptionText, 'Combobox inner text should match the clicked option');
+  t.is(await fourthOption.getAttribute('aria-selected'), 'true', 'Clicked option has aria-selected set to true');
+});
+
+ariaTest('Enter closes listbox and selects option', exampleFile, 'listbox-key-enter', async (t) => {
+  const combobox = await t.context.session.findElement(By.css(ex.comboSelector));
+  const listbox = await t.context.session.findElement(By.css(ex.listboxSelector));
+  const thirdOption = await t.context.session.findElement(By.css(`${ex.listboxSelector} [role=option]:nth-child(3)`));
+
+  // Open, move to third option, hit enter
+  await combobox.sendKeys(Key.ENTER, Key.ARROW_DOWN, Key.ARROW_DOWN);
+  const thirdOptionText = await thirdOption.getText();
+  await combobox.sendKeys(Key.ENTER);
+
+
+  // listbox is collapsed and the value is set to the third option
+  t.false(await listbox.isDisplayed(), 'Listbox should be hidden');
+  t.is(await combobox.getAttribute('aria-expanded'), 'false', 'test aria-expanded on combo');
+  t.is(await combobox.getText(), thirdOptionText, 'Combobox inner text should match the third option');
+  t.is(await thirdOption.getAttribute('aria-selected'), 'true', 'Third option has aria-selected set to true');
+});
+
+ariaTest('Space closes listbox and selects option', exampleFile, 'listbox-key-space', async (t) => {
+  const combobox = await t.context.session.findElement(By.css(ex.comboSelector));
+  const listbox = await t.context.session.findElement(By.css(ex.listboxSelector));
+  const secondOption = await t.context.session.findElement(By.css(`${ex.listboxSelector} [role=option]:nth-child(2)`));
+
+  // Open, move to third option, hit space
+  await combobox.sendKeys(Key.ENTER, Key.ARROW_DOWN);
+  const secondOptionText = await secondOption.getText();
+  await combobox.sendKeys(' ');
+
+  // listbox is collapsed and the value is set to the third option
+  t.false(await listbox.isDisplayed(), 'Listbox should be hidden');
+  t.is(await combobox.getText(), secondOptionText, 'Combobox inner text should match the second option');
+  t.is(await secondOption.getAttribute('aria-selected'), 'true', 'Second option has aria-selected set to true');
+});
+
+ariaTest('Escape closes listbox without selecting option', exampleFile, 'listbox-key-escape', async (t) => {
+  const combobox = await t.context.session.findElement(By.css(ex.comboSelector));
+  const listbox = await t.context.session.findElement(By.css(ex.listboxSelector));
+
+  // Open, move to third option, hit enter
+  await combobox.sendKeys(Key.ENTER, Key.ARROW_DOWN, Key.ARROW_DOWN);
+  const firstOptionText = await t.context.session.findElement(By.css(`${ex.listboxSelector} [role=option]`)).getText();
+  await combobox.sendKeys(Key.ESCAPE);
+
+  // listbox is collapsed and the value is still set to the first option
+  t.false(await listbox.isDisplayed(), 'Listbox should be hidden');
+  t.is(await combobox.getText(), firstOptionText, 'Combobox inner text should match the first option');
+});
+
+ariaTest('Tab closes listbox and selects option', exampleFile, 'listbox-key-tab', async (t) => {
+  const combobox = await t.context.session.findElement(By.css(ex.comboSelector));
+  const listbox = await t.context.session.findElement(By.css(ex.listboxSelector));
+  const fourthOption = await t.context.session.findElement(By.css(`${ex.listboxSelector} [role=option]:nth-child(4)`));
+
+  // Open, move to fourth option, hit tab
+  await combobox.sendKeys(Key.ENTER, Key.ARROW_DOWN, Key.ARROW_DOWN, Key.ARROW_DOWN);
+  const fourthOptionText = await fourthOption.getText();
+  await combobox.sendKeys(Key.TAB);
+
+  // listbox is collapsed and the value is set to the fourth option
+  t.false(await listbox.isDisplayed(), 'Listbox should be hidden');
+  t.is(await combobox.getText(), fourthOptionText, 'Combobox inner text should match the second option');
+  t.is(await fourthOption.getAttribute('aria-selected'), 'true', 'Fourth option has aria-selected set to true');
+});
+
+// Changing options
+ariaTest('Down arrow moves to next option', exampleFile, 'listbox-key-down-arrow', async (t) => {
+  const combobox = await t.context.session.findElement(By.css(ex.comboSelector));
+  const thirdOptionId = await t.context.session.findElement(By.css(`${ex.listboxSelector} [role=option]:nth-child(3)`)).getAttribute('id');
+
+  // Open, press down arrow
+  await combobox.click();
+  await combobox.sendKeys(Key.ARROW_DOWN, Key.ARROW_DOWN);
+
+  // Second option is highlighted
+  t.is(await combobox.getAttribute('aria-activedescendant'), thirdOptionId, 'aria-activedescendant points to the third option after two down arrows');
+});
+
+ariaTest('Down arrow does not wrap after last option', exampleFile, 'listbox-key-down-arrow', async (t) => {
+  const combobox = await t.context.session.findElement(By.css(ex.comboSelector));
+  const lastOptionId = await t.context.session.findElement(By.css(`${ex.listboxSelector} [role=option]:last-child`)).getAttribute('id');
+
+  // Open, press end, press down arrow
+  await combobox.click();
+  await combobox.sendKeys(Key.END, Key.ARROW_DOWN);
+
+  // last option is highlighted
+  t.is(await combobox.getAttribute('aria-activedescendant'), lastOptionId, 'aria-activedescendant points to the last option after end + down arrow');
+});
+
+ariaTest('Up arrow does not wrap from first option', exampleFile, 'listbox-key-up-arrow', async (t) => {
+  const combobox = await t.context.session.findElement(By.css(ex.comboSelector));
+  const firstOptionId = await t.context.session.findElement(By.css(`${ex.listboxSelector} [role=option]:first-child`)).getAttribute('id');
+
+  // Open, press up arrow
+  await combobox.click();
+  await combobox.sendKeys(Key.ARROW_UP);
+
+  // first option is highlighted
+  t.is(await combobox.getAttribute('aria-activedescendant'), firstOptionId, 'aria-activedescendant points to the first option after up arrow');
+});
+
+ariaTest('Up arrow moves to previous option', exampleFile, 'listbox-key-up-arrow', async (t) => {
+  const combobox = await t.context.session.findElement(By.css(ex.comboSelector));
+  const options = await t.context.queryElements(t, `${ex.listboxSelector} [role=option]`);
+  const optionId = await options[options.length - 2].getAttribute('id');
+
+  // Open, press end + up arrow
+  await combobox.click();
+  await combobox.sendKeys(Key.END, Key.ARROW_UP);
+
+  // second to last option is highlighted
+  t.is(await combobox.getAttribute('aria-activedescendant'), optionId, 'aria-activedescendant points to the second-to-last option after end + up arrow');
+});
+
+ariaTest('End moves to last option', exampleFile, 'listbox-key-end', async (t) => {
+  const combobox = await t.context.session.findElement(By.css(ex.comboSelector));
+  const lastOptionId = await t.context.session.findElement(By.css(`${ex.listboxSelector} [role=option]:last-child`)).getAttribute('id');
+
+  // Open, press end
+  await combobox.click();
+  await combobox.sendKeys(Key.END);
+
+  // last option is highlighted
+  t.is(await combobox.getAttribute('aria-activedescendant'), lastOptionId, 'aria-activedescendant points to the last option after end');
+});
+
+ariaTest('End scrolls last option into view', exampleFile, 'test-additional-behavior', async (t) => {
+  const combobox = await t.context.session.findElement(By.css(ex.comboSelector));
+  const listbox = await t.context.session.findElement(By.css(ex.listboxSelector));
+  const options = await t.context.queryElements(t, `${ex.listboxSelector} [role=option]`);
+
+  await combobox.click();
+
+  let listboxBounds = await listbox.getRect();
+  let optionBounds = await options[options.length - 1].getRect();
+
+  t.true(listboxBounds.y + listboxBounds.height - optionBounds.y < 0, 'last option is not initially displayed');
+
+  await combobox.sendKeys(Key.END);
+  listboxBounds = await listbox.getRect();
+  optionBounds = await options[options.length - 1].getRect();
+
+  t.true(listboxBounds.y + listboxBounds.height - optionBounds.y >= 0, 'last option is in view after end key');
+});
+
+ariaTest('Home moves to first option', exampleFile, 'listbox-key-home', async (t) => {
+  const combobox = await t.context.session.findElement(By.css(ex.comboSelector));
+  const firstOptionId = await t.context.session.findElement(By.css(`${ex.listboxSelector} [role=option]:first-child`)).getAttribute('id');
+
+  // Open, press down a couple times, then home
+  await combobox.click();
+  await combobox.sendKeys(Key.ARROW_DOWN, Key.ARROW_DOWN, Key.HOME);
+
+  // first option is highlighted
+  t.is(await combobox.getAttribute('aria-activedescendant'), firstOptionId, 'aria-activedescendant points to the first option after home');
+});
+
+ariaTest('PageDown moves 10 options, and does not wrap', exampleFile, 'listbox-key-pagedown', async (t) => {
+  const combobox = await t.context.session.findElement(By.css(ex.comboSelector));
+  const options = await t.context.queryElements(t, `${ex.listboxSelector} [role=option]`);
+
+  // Open, press page down
+  await combobox.click();
+  await combobox.sendKeys(Key.PAGE_DOWN);
+
+  // 11th option is highlighted
+  let optionId = await options[10].getAttribute('id');
+  t.is(await combobox.getAttribute('aria-activedescendant'), optionId, 'aria-activedescendant points to the 10th option after pagedown');
+
+  // last option is highlighted
+  await combobox.sendKeys(Key.PAGE_DOWN);
+  optionId = await options[options.length - 1].getAttribute('id');
+  t.is(await combobox.getAttribute('aria-activedescendant'), optionId, 'aria-activedescendant points to the last option after second pagedown');
+});
+
+ariaTest('PageUp moves up 10 options, and does not wrap', exampleFile, 'listbox-key-pageup', async (t) => {
+  const combobox = await t.context.session.findElement(By.css(ex.comboSelector));
+  const options = await t.context.queryElements(t, `${ex.listboxSelector} [role=option]`);
+
+  // Open, press end then page up
+  await combobox.click();
+  await combobox.sendKeys(Key.END, Key.PAGE_UP);
+
+  // 11th-from-last option is highlighted
+  let optionId = await options[options.length - 11].getAttribute('id');
+  t.is(await combobox.getAttribute('aria-activedescendant'), optionId, 'aria-activedescendant points to the 10th-from-last option after end + pageup');
+
+  // first option is highlighted
+  await combobox.sendKeys(Key.PAGE_UP);
+  optionId = await options[0].getAttribute('id');
+  t.is(await combobox.getAttribute('aria-activedescendant'), optionId, 'aria-activedescendant points to the first option after second pageup');
+});
+
+ariaTest('Multiple single-character presses cycle through options', exampleFile, 'listbox-key-char', async (t) => {
+  const combobox = await t.context.session.findElement(By.css(ex.comboSelector));
+  const options = await t.context.queryElements(t, `${ex.listboxSelector} [role=option]`);
+
+  // Open, then type "a"
+  await combobox.click();
+
+  // get indices of matching options
+  const optionNames = await Promise.all(options.map(async (option) => {
+    return await option.getText();
+  }));
+  const matchingOps = optionNames
+    .filter((name) => name[0].toLowerCase() === 'b')
+    .map((name) => optionNames.indexOf(name));
+
+
+  // type b, check first matching op is highlighted
+  await combobox.sendKeys('b');
+  let matchingId = await options[matchingOps[0]].getAttribute('id');
+  t.is(await combobox.getAttribute('aria-activedescendant'), `${matchingId}`, 'aria-activedescendant points to the first option beginning with "b"');
+
+  // type b again, second matching option is highlighted
+  await combobox.sendKeys('b');
+  matchingId = await options[matchingOps[1]].getAttribute('id');
+  t.is(await combobox.getAttribute('aria-activedescendant'), `${matchingId}`, 'aria-activedescendant points to the second option beginning with "b"');
+
+  // type "b" as many times as there are matching options
+  // focus should wrap and end up on second option again
+  const keys = matchingOps.map((op) => 'b');
+  await combobox.sendKeys(...keys);
+  matchingId = await options[matchingOps[1]].getAttribute('id');
+  t.is(await combobox.getAttribute('aria-activedescendant'), `${matchingId}`, 'aria-activedescendant points to the second option beginning with "b"');
+});
+
+ariaTest('Typing multiple characters refines search', exampleFile, 'listbox-key-char', async (t) => {
+  const combobox = await t.context.session.findElement(By.css(ex.comboSelector));
+  const options = await t.context.queryElements(t, `${ex.listboxSelector} [role=option]`);
+
+  await combobox.click();
+
+  // get info about the fourth option
+  const fourthName = await options[3].getText();
+  const fourthId = await options[3].getAttribute('id');
+
+  // type first letter
+  await combobox.sendKeys(fourthName[0]);
+
+  // fourth op should not be hightlighted after only first letter
+  t.not(await combobox.getAttribute('aria-activedescendant'), fourthId, 'The fourth option is not highlighted after typing only the first letter');
+
+  // type more letters
+  await combobox.sendKeys(...fourthName.slice(1, 4).split(''));
+
+  // now fourth option should be highlighted
+  t.is(await combobox.getAttribute('aria-activedescendant'), fourthId, 'The fourth option is highlighted after typing multiple letters');
+});

--- a/test/util/assertAriaControls.js
+++ b/test/util/assertAriaControls.js
@@ -12,11 +12,6 @@ const assert = require('assert');
 module.exports = async function assertAriaControls (t, elementSelector) {
   const elements = await t.context.queryElements(t, elementSelector);
 
-  assert.ok(
-    elements.length,
-    'CSS elector returned no results: ' + elementSelector
-  );
-
   for (let element of elements) {
     const ariaControlsExists = await t.context.session.executeScript(async function () {
       const selector = arguments[0];

--- a/test/util/assertAriaDescribedby.js
+++ b/test/util/assertAriaDescribedby.js
@@ -13,11 +13,6 @@ const assert = require('assert');
 module.exports = async function assertAriaDescribedby (t, elementSelector) {
   const elements = await t.context.queryElements(t, elementSelector);
 
-  assert.ok(
-    elements.length,
-    'CSS elector returned no results: ' + elementSelector
-  );
-
   for (let index = 0; index < elements.length; index++) {
 
     let ariaDescribedbyExists = await t.context.session.executeScript(async function () {

--- a/test/util/assertAriaLabelExists.js
+++ b/test/util/assertAriaLabelExists.js
@@ -10,13 +10,7 @@ const assert = require('assert');
  */
 
 module.exports = async function assertAriaLabel (t, elementSelector) {
-
   const elements = await t.context.queryElements(t, elementSelector);
-
-  assert.ok(
-    elements.length,
-    'CSS elector returned no results: ' + elementSelector
-  );
 
   for (let index = 0; index < elements.length; index++) {
 

--- a/test/util/assertAriaLabelledby.js
+++ b/test/util/assertAriaLabelledby.js
@@ -12,11 +12,6 @@ const assert = require('assert');
 module.exports = async function assertAriaLabelledby (t, elementSelector) {
   const elements = await t.context.queryElements(t, elementSelector);
 
-  assert.ok(
-    elements.length,
-    'CSS elector returned no results: ' + elementSelector
-  );
-
   for (let index = 0; index < elements.length; index++) {
     const ariaLabelledbyExists = await t.context.session.executeScript(async function () {
       const [selector, index] = arguments;

--- a/test/util/assertAttributeDNE.js
+++ b/test/util/assertAttributeDNE.js
@@ -10,13 +10,7 @@ const assert = require('assert');
  * @param {String} attribute - attribute that should not exist
  */
 module.exports = async function assertAttributeDNE (t, selector, attribute) {
-
   const numElements = (await t.context.queryElements(t, selector)).length;
-
-  assert.ok(
-    numElements,
-    'CSS elector returned no results: ' + selector
-  );
 
   for (let index = 0; index < numElements; index++) {
     const attributeExists = await t.context.session.executeScript(function () {

--- a/test/util/assertAttributeValues.js
+++ b/test/util/assertAttributeValues.js
@@ -13,11 +13,6 @@ const assert = require('assert');
 module.exports = async function assertAttributeValues (t, elementSelector, attribute, value) {
   let elements = await t.context.queryElements(t, elementSelector);
 
-  assert.ok(
-    elements.length,
-    'CSS elector returned no results: ' + elementSelector
-  );
-
   for (let element of elements) {
     assert.strictEqual(
       await element.getAttribute(attribute),

--- a/test/util/assertRovingTabindex.js
+++ b/test/util/assertRovingTabindex.js
@@ -15,11 +15,6 @@ module.exports = async function assertRovingTabindex (t, elementsSelector, key) 
   // tabindex='0' is expected on the first element
   let elements = await t.context.queryElements(t, elementsSelector);
 
-  assert.ok(
-    elements.length,
-    'CSS elector returned no results: ' + elementsSelector
-  );
-
   // test only one element has tabindex="0"
   for (let tabableEl = 0; tabableEl < elements.length; tabableEl++) {
     for (let el = 0; el < elements.length; el++) {


### PR DESCRIPTION
Resolves #1026 by adding a new select-only combobox example.

NOTE: The build is currently expected to fail; this depends on the es6 PR (#1395) for linting to pass.

[Preview link](https://raw.githack.com/w3c/aria-practices/select-only-combo/examples/combobox/combobox-select-only.html)

### Review checklist

* [x] [Editorial review](https://github.com/w3c/aria-practices/wiki/Pull-Request-Review-Process#editorial_review) by @mcking65
* [x] [Functional review](https://github.com/w3c/aria-practices/wiki/Pull-Request-Review-Process#functional_review) by @carmacleod
* [x] [Visual design review](https://github.com/w3c/aria-practices/wiki/Pull-Request-Review-Process#design_review) by @a11ydoer 
* [x] [Accessibility review](https://github.com/w3c/aria-practices/wiki/Pull-Request-Review-Process#accessibility_review) by @charmarkk 
* [x] [Code review](https://github.com/w3c/aria-practices/wiki/Pull-Request-Review-Process#code_review) by @zcorpan
* [x] [Test review](https://github.com/w3c/aria-practices/wiki/Pull-Request-Review-Process#test_review) by @zcorpan


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria-practices/pull/1396.html" title="Last updated on Jun 30, 2020, 8:58 PM UTC (6695e84)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria-practices/1396/162a945...6695e84.html" title="Last updated on Jun 30, 2020, 8:58 PM UTC (6695e84)">Diff</a>