### PR TITLE
Multiple Examples: Add utils to js list

### DIFF
--- a/examples/combobox/grid-combo.html
+++ b/examples/combobox/grid-combo.html
@@ -379,7 +379,7 @@
       <h2>Javascript and CSS Source Code</h2>
       <ul>
         <li> CSS: <a href="css/combobox.css" type="tex/css">combobox.css</a></li>
-        <li>Javascript: <a href="js/grid-combo.js">grid-combo.js</a></li>, <a href="js/grid-combo-example.js">grid-combo-example.js</a>, <a href="../js/utils.js">utils.js</a></li>
+        <li>Javascript: <a href="js/grid-combo.js">grid-combo.js</a>, <a href="js/grid-combo-example.js">grid-combo-example.js</a>, <a href="../js/utils.js">utils.js</a></li>
       </ul>
     </section>
 

--- a/examples/combobox/grid-combo.html
+++ b/examples/combobox/grid-combo.html
@@ -379,8 +379,7 @@
       <h2>Javascript and CSS Source Code</h2>
       <ul>
         <li> CSS: <a href="css/combobox.css" type="tex/css">combobox.css</a></li>
-        <li>Javascript: <a href="js/grid-combo.js">grid-combo.js</a></li>
-        <li>Javascript: <a href="js/grid-combo-example.js">grid-combo-example.js</a></li>
+        <li>Javascript: <a href="js/grid-combo.js">grid-combo.js</a></li>, <a href="js/grid-combo-example.js">grid-combo-example.js</a>, <a href="../js/utils.js">utils.js</a></li>
       </ul>
     </section>
 

--- a/examples/dialog-modal/alertdialog.html
+++ b/examples/dialog-modal/alertdialog.html
@@ -215,7 +215,7 @@
         <h2 id="src_label">Javascript and CSS Source Code</h2>
         <ul>
           <li> CSS: <a href="css/dialog.css" type="text/css">dialog.css</a></li>
-          <li> Javascript: <a href="js/alertdialog.js" type="text/javascript">alertdialog.js</a>, <a href="js/dialog.js" type="text/javascript">dialog.js</a></li>
+          <li> Javascript: <a href="js/alertdialog.js" type="text/javascript">alertdialog.js</a>, <a href="js/dialog.js" type="text/javascript">dialog.js</a>, <a href="../js/utils.js">utils.js</a></li></li>
         </ul>
       </section>
       <section>

--- a/examples/dialog-modal/alertdialog.html
+++ b/examples/dialog-modal/alertdialog.html
@@ -215,7 +215,7 @@
         <h2 id="src_label">Javascript and CSS Source Code</h2>
         <ul>
           <li> CSS: <a href="css/dialog.css" type="text/css">dialog.css</a></li>
-          <li> Javascript: <a href="js/alertdialog.js" type="text/javascript">alertdialog.js</a>, <a href="js/dialog.js" type="text/javascript">dialog.js</a>, <a href="../js/utils.js">utils.js</a></li></li>
+          <li> Javascript: <a href="js/alertdialog.js" type="text/javascript">alertdialog.js</a>, <a href="js/dialog.js" type="text/javascript">dialog.js</a>, <a href="../js/utils.js">utils.js</a></li>
         </ul>
       </section>
       <section>

--- a/examples/dialog-modal/dialog.html
+++ b/examples/dialog-modal/dialog.html
@@ -219,7 +219,7 @@
         </li>
         <li>
           Javascript:
-          <a href="js/dialog.js" type="text/javascript">dialog.js</a>
+          <a href="js/dialog.js" type="text/javascript">dialog.js</a>, <a href="../js/utils.js">utils.js</a>
         </li>
       </ul>
     </section>

--- a/examples/feed/feed.html
+++ b/examples/feed/feed.html
@@ -196,9 +196,7 @@
     <p>The following Javascript and CSS is used by the feedDisplay.html page:</p>
     <ul>
       <li><a href="css/feedDisplay.css" type="tex/css">feedDisplay.css</a></li>
-      <li>Javascript: <a href="js/feed.js" type="text/javascript">feed.js</a></li>
-      <li>Javascript: <a href="js/feedDisplay.js" type="text/javascript">feedDisplay.js</a></li>
-      <li>Javascript: <a href="js/main.js" type="text/javascript">main.js</a></li>
+      <li>Javascript: <a href="js/feed.js" type="text/javascript">feed.js</a>, <a href="js/feedDisplay.js" type="text/javascript">feedDisplay.js</a>, <a href="js/main.js" type="text/javascript">main.js</a>, <a href="../js/utils.js">utils.js</a></li>
     </ul>
   </section>
 

--- a/examples/grid/LayoutGrids.html
+++ b/examples/grid/LayoutGrids.html
@@ -701,6 +701,7 @@
         <ul>
           <li><a href="js/layoutGrids.js" type="text/javascript">layoutGrids.js</a></li>
           <li><a href="js/dataGrid.js" type="text/javascript">dataGrid.js</a></li>
+          <li><a href="../js/utils.js">utils.js</a></li>
         </ul>
       </li>
     </ul>

--- a/examples/grid/dataGrids.html
+++ b/examples/grid/dataGrids.html
@@ -801,6 +801,7 @@
           <li><a href="js/dataGrid.js" type="text/javascript">dataGrid.js</a></li>
           <li><a href="js/dataGrids.js" type="text/javascript">dataGrids.js</a></li>
           <li><a href="js/menuButton.js" type="text/javascript">menuButton.js</a></li>
+          <li><a href="../js/utils.js">utils.js</a></li>
         </ul>
       </li>
     </ul>

--- a/examples/listbox/listbox-collapsible.html
+++ b/examples/listbox/listbox-collapsible.html
@@ -288,11 +288,7 @@
       </li>
       <li>
         Javascript:
-        <a href="js/listbox.js" type="text/javascript">listbox.js</a>
-      </li>
-      <li>
-        Javascript:
-        <a href="js/listbox-collapsible.js" type="text/javascript">listbox-expandable.js</a>
+        <a href="js/listbox.js" type="text/javascript">listbox.js</a>, <a href="js/listbox-collapsible.js" type="text/javascript">listbox-collapsible</a>, <a href="../js/utils.js">utils.js</a>
       </li>
     </ul>
   </section>

--- a/examples/listbox/listbox-grouped.html
+++ b/examples/listbox/listbox-grouped.html
@@ -218,11 +218,7 @@
       </li>
       <li>
         Javascript:
-        <a href="js/listbox.js" type="text/javascript">listbox.js</a>
-      </li>
-      <li>
-        Javascript:
-        <a href="js/listbox-scrollable.js" type="text/javascript">listbox-scrollable.js</a>
+        <a href="js/listbox.js" type="text/javascript">listbox.js</a>, <a href="js/listbox-scrollable.js" type="text/javascript">listbox-scrollable.js</a>, <a href="../js/utils.js">utils.js</a>
       </li>
     </ul>
   </section>

--- a/examples/listbox/listbox-rearrangeable.html
+++ b/examples/listbox/listbox-rearrangeable.html
@@ -404,15 +404,7 @@ while in the second example, they may select multiple options before activating 
       </li>
       <li>
         Javascript:
-        <a href="js/listbox.js" type="text/javascript">listbox.js</a>
-      </li>
-      <li>
-        Javascript:
-        <a href="js/toolbar.js" type="text/javascript">toolbar.js</a>
-      </li>
-      <li>
-        Javascript:
-        <a href="js/listbox-rearrangeable.js" type="text/javascript">listbox-rearrangeable.js</a>
+        <a href="js/listbox.js" type="text/javascript">listbox.js</a>, <a href="js/toolbar.js" type="text/javascript">toolbar.js</a>, <a href="js/listbox-rearrangeable.js" type="text/javascript">listbox-rearrangeable.js</a>, <a href="../js/utils.js">utils.js</a>
       </li>
     </ul>
   </section>

--- a/examples/listbox/listbox-scrollable.html
+++ b/examples/listbox/listbox-scrollable.html
@@ -213,11 +213,7 @@
       </li>
       <li>
         Javascript:
-        <a href="js/listbox.js" type="text/javascript">listbox.js</a>
-      </li>
-      <li>
-        Javascript:
-        <a href="js/listbox-scrollable.js" type="text/javascript">listbox-scrollable.js</a>
+        <a href="js/listbox.js" type="text/javascript">listbox.js</a>, <a href="js/listbox-scrollable.js" type="text/javascript">listbox-scrollable.js</a>, <a href="../js/utils.js">utils.js</a>
       </li>
     </ul>
   </section>

--- a/examples/toolbar/help.html
+++ b/examples/toolbar/help.html
@@ -11,7 +11,6 @@
 <script src="../js/examples.js"></script>
 <script src="../js/highlight.pack.js"></script>
 <script src="../js/app.js"></script>
-<script src="../js/utils.js" type="text/javascript"></script>
 
 </head>
 

--- a/examples/toolbar/toolbar.html
+++ b/examples/toolbar/toolbar.html
@@ -11,7 +11,6 @@
 <script src="../js/examples.js"></script>
 <script src="../js/highlight.pack.js"></script>
 <script src="../js/app.js"></script>
-<script src="../js/utils.js" type="text/javascript"></script>
 
 <!--  js and css for this example. -->
 


### PR DESCRIPTION
Replaces #1317 because I could not push a rebase to the Bocoup fork.

Resolves #842 by adding examples/js/utils.js to the list of Javascript files in the source code section of the documentation for all example pages that utilize the utils.js..