### PR TITLE
Add file inputs to focusable elements

### DIFF
--- a/examples/js/utils.js
+++ b/examples/js/utils.js
@@ -75,7 +75,7 @@ aria.Utils.isFocusable = function (element) {
     case 'A':
       return !!element.href && element.rel != 'ignore';
     case 'INPUT':
-      return element.type != 'hidden' && element.type != 'file';
+      return element.type != 'hidden';
     case 'BUTTON':
     case 'SELECT':
     case 'TEXTAREA':


### PR DESCRIPTION
Not sure why this was ever skipped. I've tested this by changing the type of the first input field here: https://www.w3.org/TR/wai-aria-practices/examples/dialog-modal/dialog.html

Before: 
![image](https://user-images.githubusercontent.com/11559216/83649994-21ed8080-a5b8-11ea-9c00-618c6aeae4f3.png)

After:
![image](https://user-images.githubusercontent.com/11559216/83650137-4a757a80-a5b8-11ea-84d0-2a7f2f99b991.png)
