### PR TITLE
Infrastructure: Add missing test for 6 examples

### DIFF
--- a/test/tests/button_button-idl.js
+++ b/test/tests/button_button-idl.js
@@ -1,0 +1,124 @@
+'use strict';
+
+const { ariaTest } = require('..');
+const { By, Key } = require('selenium-webdriver');
+
+const exampleFile = 'button/button_idl.html';
+const assertDotValue = require('../util/assertDotValue');
+const assertAttributeValues = require('../util/assertAttributeValues');
+
+const ex = {
+  printSelector: '#action',
+  toggleSelector: '#toggle',
+  svg: '#example svg'
+};
+
+// Attributes
+
+ariaTest('Example elements should have role="button" set', exampleFile, 'button-role', async (t) => {
+    await assertDotValue(t, ex.printSelector, 'role', 'button');
+    await assertDotValue(t, ex.toggleSelector, 'role', 'button');
+});
+
+ariaTest('Button examples should have tabindex="0"', exampleFile, 'button-tabindex', async (t) => {
+
+  let printEl = await t.context.session.findElement(By.css(ex.printSelector));
+
+  t.is(
+    await printEl.getAttribute('tabindex'),
+    '0',
+    'tabindex should be set to "0" on button example: ' + ex.printSelector
+  );
+
+  let toggleEl = await t.context.session.findElement(By.css(ex.toggleSelector));
+
+  t.is(
+    await toggleEl.getAttribute('tabindex'),
+    '0',
+    'tabindex should be set to "0" on button example: ' + ex.toggleSelector
+  );
+});
+
+ariaTest('"aria-pressed" reflects button state', exampleFile, 'button-aria-pressed', async (t) => {
+  await assertDotValue(t, ex.toggleSelector, 'ariaPressed', 'false');
+  let toggleButtonEl = await t.context.session.findElement(By.css(ex.toggleSelector));
+  await toggleButtonEl.click();
+  await assertDotValue(t, ex.toggleSelector, 'ariaPressed', 'true');
+  await toggleButtonEl.click();
+  await assertDotValue(t, ex.toggleSelector, 'ariaPressed', 'false');
+});
+
+ariaTest('"aria-hidden" set on SVG', exampleFile, 'svg-aria-hidden', async (t) => {
+    await assertAttributeValues(t, ex.svg, 'aria-hidden', 'true');
+
+});
+
+ariaTest('key ENTER activates button', exampleFile, 'key-enter', async (t) => {
+
+  let toggleButtonEl = await t.context.session.findElement(By.css(ex.toggleSelector));
+
+  // Send ENTER and wait for change of 'aria-pressed'
+  await toggleButtonEl.sendKeys(Key.ENTER);
+  await assertDotValue(t, ex.toggleSelector, 'ariaPressed', 'true');
+  await toggleButtonEl.sendKeys(Key.ENTER);
+  await assertDotValue(t, ex.toggleSelector, 'ariaPressed', 'false');
+
+  let actionButtonEl = await t.context.session.findElement(By.css(ex.printSelector));
+  let oldText = await actionButtonEl.getText();
+  let newText = oldText + ' - Printed!';
+
+  await t.context.session.executeScript(function () {
+    let [selector, newText] = arguments;
+    window.print = function () {
+      document.querySelector(selector).innerText = newText;
+    };
+  }, ex.printSelector, newText);
+
+  // Send ENTER and wait for change of 'aria-pressed'
+  await actionButtonEl.sendKeys(Key.ENTER);
+
+  await t.context.session.wait(async function () {
+    return actionButtonEl.getText('') !== oldText;
+  }, t.context.waitTime, 'window.print was not executed');
+
+  t.is(
+    await actionButtonEl.getText(),
+    newText,
+    'window.print should have been triggered after sending ENTER to example: ' + ex.printSelector
+  );
+});
+
+ariaTest('key SPACE activates button', exampleFile, 'key-space', async (t) => {
+
+  let toggleButtonEl = await t.context.session.findElement(By.css(ex.toggleSelector));
+
+  // Send SPACE and wait for change of 'aria-pressed'
+  await toggleButtonEl.sendKeys(Key.SPACE);
+  await assertDotValue(t, ex.toggleSelector, 'ariaPressed', 'true');
+  await toggleButtonEl.sendKeys(Key.SPACE);
+  await assertDotValue(t, ex.toggleSelector, 'ariaPressed', 'false');
+
+  let actionButtonEl = await t.context.session.findElement(By.css(ex.printSelector));
+  let oldText = await actionButtonEl.getText();
+  let newText = oldText + ' - Printed!';
+
+  await t.context.session.executeScript(function () {
+    let [selector, newText] = arguments;
+    window.print = function () {
+      document.querySelector(selector).innerText = newText;
+    };
+  }, ex.printSelector, newText);
+
+  // Send SPACE and wait for change of 'aria-pressed'
+  await actionButtonEl.sendKeys(Key.SPACE);
+
+  await t.context.session.wait(async function () {
+    return actionButtonEl.getText('') !== oldText;
+  }, t.context.waitTime, 'window.print was not executed');
+
+  t.is(
+    await actionButtonEl.getText(),
+    newText,
+    'window.print should have been triggered after sending SPACE to example: ' + ex.printSelector
+  );
+});

--- a/test/tests/button_button-idl.js
+++ b/test/tests/button_button-idl.js
@@ -8,7 +8,7 @@ const assertAttributeValues = require('../util/assertAttributeValues');
 const ex = {
   printSelector: '#action',
   toggleSelector: '#toggle',
-  svg: '#example svg',
+  svgSelector: '#example svg',
 };
 
 // Attributes
@@ -69,7 +69,7 @@ ariaTest(
   exampleFile,
   'svg-aria-hidden',
   async (t) => {
-    await assertAttributeValues(t, ex.svg, 'aria-hidden', 'true');
+    await assertAttributeValues(t, ex.svgSelector, 'aria-hidden', 'true');
   }
 );
 

--- a/test/tests/button_button-idl.js
+++ b/test/tests/button_button-idl.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { ariaTest } = require('..');
 const { By, Key } = require('selenium-webdriver');
 
@@ -10,52 +8,75 @@ const assertAttributeValues = require('../util/assertAttributeValues');
 const ex = {
   printSelector: '#action',
   toggleSelector: '#toggle',
-  svg: '#example svg'
+  svg: '#example svg',
 };
 
 // Attributes
 
-ariaTest('Example elements should have role="button" set', exampleFile, 'button-role', async (t) => {
+ariaTest(
+  'Example elements should have role="button" set',
+  exampleFile,
+  'button-role',
+  async (t) => {
     await assertDotValue(t, ex.printSelector, 'role', 'button');
     await assertDotValue(t, ex.toggleSelector, 'role', 'button');
-});
+  }
+);
 
-ariaTest('Button examples should have tabindex="0"', exampleFile, 'button-tabindex', async (t) => {
+ariaTest(
+  'Button examples should have tabindex="0"',
+  exampleFile,
+  'button-tabindex',
+  async (t) => {
+    let printEl = await t.context.session.findElement(By.css(ex.printSelector));
 
-  let printEl = await t.context.session.findElement(By.css(ex.printSelector));
+    t.is(
+      await printEl.getAttribute('tabindex'),
+      '0',
+      'tabindex should be set to "0" on button example: ' + ex.printSelector
+    );
 
-  t.is(
-    await printEl.getAttribute('tabindex'),
-    '0',
-    'tabindex should be set to "0" on button example: ' + ex.printSelector
-  );
+    let toggleEl = await t.context.session.findElement(
+      By.css(ex.toggleSelector)
+    );
 
-  let toggleEl = await t.context.session.findElement(By.css(ex.toggleSelector));
+    t.is(
+      await toggleEl.getAttribute('tabindex'),
+      '0',
+      'tabindex should be set to "0" on button example: ' + ex.toggleSelector
+    );
+  }
+);
 
-  t.is(
-    await toggleEl.getAttribute('tabindex'),
-    '0',
-    'tabindex should be set to "0" on button example: ' + ex.toggleSelector
-  );
-});
+ariaTest(
+  '"aria-pressed" reflects button state',
+  exampleFile,
+  'button-aria-pressed',
+  async (t) => {
+    await assertDotValue(t, ex.toggleSelector, 'ariaPressed', 'false');
+    let toggleButtonEl = await t.context.session.findElement(
+      By.css(ex.toggleSelector)
+    );
+    await toggleButtonEl.click();
+    await assertDotValue(t, ex.toggleSelector, 'ariaPressed', 'true');
+    await toggleButtonEl.click();
+    await assertDotValue(t, ex.toggleSelector, 'ariaPressed', 'false');
+  }
+);
 
-ariaTest('"aria-pressed" reflects button state', exampleFile, 'button-aria-pressed', async (t) => {
-  await assertDotValue(t, ex.toggleSelector, 'ariaPressed', 'false');
-  let toggleButtonEl = await t.context.session.findElement(By.css(ex.toggleSelector));
-  await toggleButtonEl.click();
-  await assertDotValue(t, ex.toggleSelector, 'ariaPressed', 'true');
-  await toggleButtonEl.click();
-  await assertDotValue(t, ex.toggleSelector, 'ariaPressed', 'false');
-});
-
-ariaTest('"aria-hidden" set on SVG', exampleFile, 'svg-aria-hidden', async (t) => {
+ariaTest(
+  '"aria-hidden" set on SVG',
+  exampleFile,
+  'svg-aria-hidden',
+  async (t) => {
     await assertAttributeValues(t, ex.svg, 'aria-hidden', 'true');
-
-});
+  }
+);
 
 ariaTest('key ENTER activates button', exampleFile, 'key-enter', async (t) => {
-
-  let toggleButtonEl = await t.context.session.findElement(By.css(ex.toggleSelector));
+  let toggleButtonEl = await t.context.session.findElement(
+    By.css(ex.toggleSelector)
+  );
 
   // Send ENTER and wait for change of 'aria-pressed'
   await toggleButtonEl.sendKeys(Key.ENTER);
@@ -63,34 +84,46 @@ ariaTest('key ENTER activates button', exampleFile, 'key-enter', async (t) => {
   await toggleButtonEl.sendKeys(Key.ENTER);
   await assertDotValue(t, ex.toggleSelector, 'ariaPressed', 'false');
 
-  let actionButtonEl = await t.context.session.findElement(By.css(ex.printSelector));
+  let actionButtonEl = await t.context.session.findElement(
+    By.css(ex.printSelector)
+  );
   let oldText = await actionButtonEl.getText();
   let newText = oldText + ' - Printed!';
 
-  await t.context.session.executeScript(function () {
-    let [selector, newText] = arguments;
-    window.print = function () {
-      document.querySelector(selector).innerText = newText;
-    };
-  }, ex.printSelector, newText);
+  await t.context.session.executeScript(
+    function () {
+      let [selector, newText] = arguments;
+      window.print = function () {
+        document.querySelector(selector).innerText = newText;
+      };
+    },
+    ex.printSelector,
+    newText
+  );
 
   // Send ENTER and wait for change of 'aria-pressed'
   await actionButtonEl.sendKeys(Key.ENTER);
 
-  await t.context.session.wait(async function () {
-    return actionButtonEl.getText('') !== oldText;
-  }, t.context.waitTime, 'window.print was not executed');
+  await t.context.session.wait(
+    async function () {
+      return actionButtonEl.getText('') !== oldText;
+    },
+    t.context.waitTime,
+    'window.print was not executed'
+  );
 
   t.is(
     await actionButtonEl.getText(),
     newText,
-    'window.print should have been triggered after sending ENTER to example: ' + ex.printSelector
+    'window.print should have been triggered after sending ENTER to example: ' +
+      ex.printSelector
   );
 });
 
 ariaTest('key SPACE activates button', exampleFile, 'key-space', async (t) => {
-
-  let toggleButtonEl = await t.context.session.findElement(By.css(ex.toggleSelector));
+  let toggleButtonEl = await t.context.session.findElement(
+    By.css(ex.toggleSelector)
+  );
 
   // Send SPACE and wait for change of 'aria-pressed'
   await toggleButtonEl.sendKeys(Key.SPACE);
@@ -98,27 +131,38 @@ ariaTest('key SPACE activates button', exampleFile, 'key-space', async (t) => {
   await toggleButtonEl.sendKeys(Key.SPACE);
   await assertDotValue(t, ex.toggleSelector, 'ariaPressed', 'false');
 
-  let actionButtonEl = await t.context.session.findElement(By.css(ex.printSelector));
+  let actionButtonEl = await t.context.session.findElement(
+    By.css(ex.printSelector)
+  );
   let oldText = await actionButtonEl.getText();
   let newText = oldText + ' - Printed!';
 
-  await t.context.session.executeScript(function () {
-    let [selector, newText] = arguments;
-    window.print = function () {
-      document.querySelector(selector).innerText = newText;
-    };
-  }, ex.printSelector, newText);
+  await t.context.session.executeScript(
+    function () {
+      let [selector, newText] = arguments;
+      window.print = function () {
+        document.querySelector(selector).innerText = newText;
+      };
+    },
+    ex.printSelector,
+    newText
+  );
 
   // Send SPACE and wait for change of 'aria-pressed'
   await actionButtonEl.sendKeys(Key.SPACE);
 
-  await t.context.session.wait(async function () {
-    return actionButtonEl.getText('') !== oldText;
-  }, t.context.waitTime, 'window.print was not executed');
+  await t.context.session.wait(
+    async function () {
+      return actionButtonEl.getText('') !== oldText;
+    },
+    t.context.waitTime,
+    'window.print was not executed'
+  );
 
   t.is(
     await actionButtonEl.getText(),
     newText,
-    'window.print should have been triggered after sending SPACE to example: ' + ex.printSelector
+    'window.print should have been triggered after sending SPACE to example: ' +
+      ex.printSelector
   );
 });

--- a/test/tests/combobox_autocomplete-both.js
+++ b/test/tests/combobox_autocomplete-both.js
@@ -1,8 +1,10 @@
+'use strict';
+
 const { ariaTest } = require('..');
 const { By, Key } = require('selenium-webdriver');
 const assertAttributeValues = require('../util/assertAttributeValues');
 const assertAriaLabelExists = require('../util/assertAriaLabelExists');
-const assertAttributeDNE = require('../util/assertAttributeDNE');
+const assertAttributeDNE    = require('../util/assertAttributeDNE');
 const assertAriaRoles = require('../util/assertAriaRoles');
 const assertAriaSelectedAndActivedescendant = require('../util/assertAriaSelectedAndActivedescendant');
 
@@ -14,310 +16,233 @@ const ex = {
   optionsSelector: '#ex1 [role="option"]',
   buttonSelector: '#ex1 button',
   numAOptions: 5,
-  secondAOption: 'Alaska',
+  secondAOption: 'Alaska'
+
 };
 
 const waitForFocusChange = async (t, textboxSelector, originalFocus) => {
-  await t.context.session.wait(
-    async function () {
-      let newfocus = await t.context.session
-        .findElement(By.css(textboxSelector))
-        .getAttribute('aria-activedescendant');
-      return newfocus != originalFocus;
-    },
-    t.context.waitTime,
-    'Timeout waiting for "aria-activedescendant" value to change from: ' +
-      originalFocus
-  );
+  await t.context.session.wait(async function () {
+    let newfocus = await t.context.session
+      .findElement(By.css(textboxSelector))
+      .getAttribute('aria-activedescendant');
+    return newfocus != originalFocus;
+  }, t.context.waitTime, 'Timeout waiting for "aria-activedescendant" value to change from: ' + originalFocus);
 };
 
 const confirmCursorIndex = async (t, selector, cursorIndex) => {
-  return t.context.session.executeScript(
-    function () {
-      const [selector, cursorIndex] = arguments;
-      let item = document.querySelector(selector);
-      return item.selectionStart === cursorIndex;
-    },
-    selector,
-    cursorIndex
-  );
+  return t.context.session.executeScript(function () {
+    const [selector, cursorIndex] = arguments;
+    let item = document.querySelector(selector);
+    return item.selectionStart === cursorIndex;
+  }, selector, cursorIndex);
 };
 
 // Attributes
 
-ariaTest(
-  'Test for role="combobox"',
-  exampleFile,
-  'combobox-role',
-  async (t) => {
+ariaTest('Test for role="combobox"', exampleFile, 'combobox-role', async (t) => {
     await assertAriaRoles(t, 'ex1', 'combobox', '1', 'input');
-  }
-);
+});
 
-ariaTest(
-  '"aria-autocomplete" on comboxbox element',
-  exampleFile,
-  'combobox-aria-autocomplete',
-  async (t) => {
-    await assertAttributeValues(
-      t,
-      ex.textboxSelector,
-      'aria-autocomplete',
-      'both'
-    );
-  }
-);
+ariaTest('"aria-autocomplete" on comboxbox element', exampleFile, 'combobox-aria-autocomplete', async (t) => {
+    await assertAttributeValues(t, ex.textboxSelector, 'aria-autocomplete', 'both');
+});
 
-ariaTest(
-  '"aria-controls" attribute on combobox element',
-  exampleFile,
-  'combobox-aria-controls',
-  async (t) => {
-    const popupId = await t.context.session
-      .findElement(By.css(ex.textboxSelector))
-      .getAttribute('aria-controls');
+ariaTest('"aria-controls" attribute on combobox element', exampleFile, 'combobox-aria-controls', async (t) => {
 
-    t.truthy(
-      popupId,
-      '"aria-controls" attribute should exist on: ' + ex.textboxSelector
-    );
+  const popupId = await t.context.session
+    .findElement(By.css(ex.textboxSelector))
+    .getAttribute('aria-controls');
 
-    const popupElements = await t.context.queryElements(t, `#ex1 #${popupId}`);
+  t.truthy(
+    popupId,
+    '"aria-controls" attribute should exist on: ' + ex.textboxSelector
+  );
 
-    t.is(
-      popupElements.length,
-      1,
-      'There should be a element with id "' +
-        popupId +
-        '" as referenced by the aria-controls attribute'
-    );
-  }
-);
+  const popupElements = await t.context.queryElements(t, `#ex1 #${popupId}`);
 
-ariaTest(
-  '"aria-expanded" on combobox element',
-  exampleFile,
-  'combobox-aria-expanded',
-  async (t) => {
-    const combobox = await t.context.session.findElement(
-      By.css(ex.textboxSelector)
-    );
+  t.is(
+    popupElements.length,
+    1,
+    'There should be a element with id "' + popupId + '" as referenced by the aria-controls attribute'
+  );
+});
 
-    // Check that aria-expanded is false and the listbox is not visible before interacting
+ariaTest('"aria-expanded" on combobox element', exampleFile, 'combobox-aria-expanded', async (t) => {
 
-    t.is(
-      await combobox.getAttribute('aria-expanded'),
-      'false',
-      'combobox element should have attribute "aria-expanded" set to false by default.'
-    );
+  const combobox = await t.context.session.findElement(By.css(ex.textboxSelector));
 
-    const popupId = await t.context.session
-      .findElement(By.css(ex.textboxSelector))
-      .getAttribute('aria-controls');
+  // Check that aria-expanded is false and the listbox is not visible before interacting
 
-    const popupElement = await t.context.session
-      .findElement(By.id('ex1'))
-      .findElement(By.id(popupId));
+  t.is(
+    await combobox.getAttribute('aria-expanded'),
+    'false',
+    'combobox element should have attribute "aria-expanded" set to false by default.'
+  );
 
-    t.false(
-      await popupElement.isDisplayed(),
-      "Popup element should not be displayed when 'aria-expanded' is false'"
-    );
+  const popupId = await t.context.session
+    .findElement(By.css(ex.textboxSelector))
+    .getAttribute('aria-controls');
 
-    // Send key "a" to textbox
+  const popupElement = await t.context.session
+    .findElement(By.id('ex1'))
+    .findElement(By.id(popupId));
 
-    await t.context.session
-      .findElement(By.css(ex.textboxSelector))
-      .sendKeys('a');
+  t.false(
+    await popupElement.isDisplayed(),
+    'Popup element should not be displayed when \'aria-expanded\' is false\''
+  );
 
-    // Check that aria-expanded is true and the listbox is visible
+  // Send key "a" to textbox
 
-    t.is(
-      await combobox.getAttribute('aria-expanded'),
-      'true',
-      'combobox element should have attribute "aria-expand" set to true after typing.'
-    );
+  await t.context.session
+    .findElement(By.css(ex.textboxSelector))
+    .sendKeys('a');
 
-    t.true(
-      await popupElement.isDisplayed(),
-      "Popup element should be displayed when 'aria-expanded' is true'"
-    );
-  }
-);
+  // Check that aria-expanded is true and the listbox is visible
 
-ariaTest(
-  '"aria-activedescendant" on combobox element',
-  exampleFile,
-  'combobox-aria-activedescendant',
-  async (t) => {
-    await assertAttributeValues(
-      t,
-      ex.textboxSelector,
-      'aria-activedescendant',
-      null
-    );
-  }
-);
+  t.is(
+    await combobox.getAttribute('aria-expanded'),
+    'true',
+    'combobox element should have attribute "aria-expand" set to true after typing.'
+  );
 
-ariaTest(
-  'role "listbox" on ul element',
-  exampleFile,
-  'listbox-role',
-  async (t) => {
+  t.true(
+    await popupElement.isDisplayed(),
+    'Popup element should be displayed when \'aria-expanded\' is true\''
+  );
+
+});
+
+ariaTest('"aria-activedescendant" on combobox element', exampleFile, 'combobox-aria-activedescendant', async (t) => {
+    await assertAttributeValues(t, ex.textboxSelector, 'aria-activedescendant', null);
+});
+
+ariaTest('"id" attribute on combobox element', exampleFile, 'combobox-id', async (t) => {
+  const combobox = await t.context.session.findElement(By.css(ex.textboxSelector))
+  const id = await combobox.getAttribute('id');
+
+  console.log(id);
+  t.truthy(
+    id,
+    '"id" attribute should exist on combobox'
+  );
+
+  const label = await t.context.queryElements(t, `[for="${id}"]`);
+  t.is(
+    label.length,
+    1,
+    `There should be one element that labels the combobox with: [for="${id}"]`
+  );
+});
+
+ariaTest('role "listbox" on ul element', exampleFile, 'listbox-role', async (t) => {
     await assertAriaRoles(t, 'ex1', 'listbox', '1', 'ul');
-  }
-);
+});
 
-ariaTest(
-  '"aria-label" attribute on listbox element',
-  exampleFile,
-  'listbox-aria-label',
-  async (t) => {
+ariaTest('"aria-label" attribute on listbox element', exampleFile, 'listbox-aria-label', async (t) => {
     await assertAriaLabelExists(t, ex.listboxSelector);
-  }
-);
+});
 
-ariaTest(
-  'role "option" on lu elements',
-  exampleFile,
-  'option-role',
-  async (t) => {
-    // Send arrow down to reveal all options
-    await t.context.session
-      .findElement(By.css(ex.textboxSelector))
-      .sendKeys(Key.ARROW_DOWN);
-    await assertAriaRoles(t, 'ex1', 'option', '56', 'li');
-  }
-);
+ariaTest('role "option" on lu elements', exampleFile, 'option-role', async (t) => {
 
-ariaTest(
-  '"aria-selected" attribute on options element',
-  exampleFile,
-  'option-aria-selected',
-  async (t) => {
-    // Send key "a"
-    await t.context.session
-      .findElement(By.css(ex.textboxSelector))
-      .sendKeys('a');
-    await assertAttributeValues(
-      t,
-      ex.optionsSelector + ':nth-of-type(1)',
-      'aria-selected',
-      'true'
-    );
-  }
-);
+  // Send arrow down to reveal all options
+  await t.context.session.findElement(By.css(ex.textboxSelector)).sendKeys(Key.ARROW_DOWN);
+  await assertAriaRoles(t, 'ex1', 'option', '56', 'li');
+});
 
-ariaTest(
-  'Button should have tabindex="-1"',
-  exampleFile,
-  'button-tabindex',
-  async (t) => {
-    const button = await t.context.session.findElement(
-      By.css(ex.buttonSelector)
-    );
+ariaTest('"aria-selected" attribute on options element', exampleFile, 'option-aria-selected', async (t) => {
 
-    t.is(
-      await button.getAttribute('tabindex'),
-      '-1',
-      'tabindex should be set to "-1" on button'
-    );
-  }
-);
+  // Send key "a"
+  await t.context.session.findElement(By.css(ex.textboxSelector)).sendKeys('a');
+  await assertAttributeValues(t, ex.optionsSelector + ':nth-of-type(1)', 'aria-selected', 'true');
+});
 
-ariaTest(
-  '"aria-label" attribute on button element',
-  exampleFile,
-  'button-aria-label',
-  async (t) => {
-    await assertAriaLabelExists(t, ex.buttonSelector);
-  }
-);
+ariaTest('Button should have tabindex="-1"', exampleFile, 'button-tabindex', async (t) => {
+  const button = await t.context.session.findElement(By.css(ex.buttonSelector))
 
-ariaTest(
-  '"aria-controls" attribute on button element',
-  exampleFile,
-  'button-aria-controls',
-  async (t) => {
-    const popupId = await t.context.session
-      .findElement(By.css(ex.buttonSelector))
-      .getAttribute('aria-controls');
+  t.is(
+    await button.getAttribute('tabindex'),
+    '-1',
+    'tabindex should be set to "-1" on button'
+  );
+});
 
-    t.truthy(
-      popupId,
-      '"aria-controls" attribute should exist on: ' + ex.buttonSelector
-    );
+ariaTest('"aria-label" attribute on button element', exampleFile, 'button-aria-label', async (t) => {
+  await assertAriaLabelExists(t, ex.buttonSelector);
+});
 
-    const popupElements = await t.context.queryElements(t, `#ex1 #${popupId}`);
 
-    t.is(
-      popupElements.length,
-      1,
-      'There should be a element with id "' +
-        popupId +
-        '" as referenced by the aria-controls attribute'
-    );
-  }
-);
+ariaTest('"aria-controls" attribute on button element', exampleFile, 'button-aria-controls', async (t) => {
+  const popupId = await t.context.session
+    .findElement(By.css(ex.buttonSelector))
+    .getAttribute('aria-controls');
 
-ariaTest(
-  '"aria-expanded" on button element',
-  exampleFile,
-  'button-aria-expanded',
-  async (t) => {
-    const button = await t.context.session.findElement(
-      By.css(ex.buttonSelector)
-    );
+  t.truthy(
+    popupId,
+    '"aria-controls" attribute should exist on: ' + ex.buttonSelector
+  );
 
-    // Check that aria-expanded is false and the listbox is not visible before interacting
+  const popupElements = await t.context.queryElements(t, `#ex1 #${popupId}`);
 
-    t.is(
-      await button.getAttribute('aria-expanded'),
-      'false',
-      'button element should have attribute "aria-expanded" set to false by default.'
-    );
+  t.is(
+    popupElements.length,
+    1,
+    'There should be a element with id "' + popupId + '" as referenced by the aria-controls attribute'
+  );
+});
 
-    const popupId = await t.context.session
-      .findElement(By.css(ex.textboxSelector))
-      .getAttribute('aria-controls');
+ariaTest('"aria-expanded" on button element', exampleFile, 'button-aria-expanded', async (t) => {
+  const button = await t.context.session.findElement(By.css(ex.buttonSelector));
 
-    const popupElement = await t.context.session
-      .findElement(By.id('ex1'))
-      .findElement(By.id(popupId));
+  // Check that aria-expanded is false and the listbox is not visible before interacting
 
-    t.false(
-      await popupElement.isDisplayed(),
-      "Popup element should not be displayed when 'aria-expanded' is 'false'"
-    );
+  t.is(
+    await button.getAttribute('aria-expanded'),
+    'false',
+    'button element should have attribute "aria-expanded" set to false by default.'
+  );
 
-    // Send key "a" to textbox
+  const popupId = await t.context.session
+    .findElement(By.css(ex.textboxSelector))
+    .getAttribute('aria-controls');
 
-    await t.context.session
-      .findElement(By.css(ex.textboxSelector))
-      .sendKeys('a');
+  const popupElement = await t.context.session
+    .findElement(By.id('ex1'))
+    .findElement(By.id(popupId));
 
-    // Check that aria-expanded is true and the listbox is visible
+  t.false(
+    await popupElement.isDisplayed(),
+    'Popup element should not be displayed when \'aria-expanded\' is \'false\''
+  );
 
-    t.is(
-      await button.getAttribute('aria-expanded'),
-      'true',
-      'button element should have attribute "aria-expand" set to true after typing.'
-    );
+  // Send key "a" to textbox
 
-    t.true(
-      await popupElement.isDisplayed(),
-      "Popup element should be displayed when 'aria-expanded' is 'true'"
-    );
-  }
-);
+  await t.context.session
+    .findElement(By.css(ex.textboxSelector))
+    .sendKeys('a');
+
+  // Check that aria-expanded is true and the listbox is visible
+
+  t.is(
+    await button.getAttribute('aria-expanded'),
+    'true',
+    'button element should have attribute "aria-expand" set to true after typing.'
+  );
+
+  t.true(
+    await popupElement.isDisplayed(),
+    'Popup element should be displayed when \'aria-expanded\' is \'true\''
+  );
+
+});
+
 
 // Keys
 
-ariaTest(
-  'Test alt + down key press with focus on textbox',
-  exampleFile,
-  'textbox-key-alt-down-arrow',
-  async (t) => {
+ariaTest('Test alt + down key press with focus on textbox',
+  exampleFile, 'textbox-key-alt-down-arrow', async (t) => {
+
+
     // Send ARROW_DOWN to the textbox
     await t.context.session
       .findElement(By.css(ex.textboxSelector))
@@ -325,21 +250,19 @@ ariaTest(
 
     // Check that the listbox is displayed
     t.true(
-      await t.context.session
-        .findElement(By.css(ex.listboxSelector))
-        .isDisplayed(),
+      await t.context.session.findElement(By.css(ex.listboxSelector)).isDisplayed(),
       'In example the list box should display after ALT + ARROW_DOWN keypress'
     );
 
     await assertAttributeDNE(t, ex.optionsSelector, 'aria-selected');
-  }
-);
 
-ariaTest(
-  'Test down key press with focus on textbox',
-  exampleFile,
-  'textbox-key-down-arrow',
-  async (t) => {
+  });
+
+
+ariaTest('Test down key press with focus on textbox',
+  exampleFile, 'textbox-key-down-arrow', async (t) => {
+
+
     // Send ARROW_DOWN to the textbox
     await t.context.session
       .findElement(By.css(ex.textboxSelector))
@@ -347,9 +270,7 @@ ariaTest(
 
     // Check that the listbox is displayed
     t.true(
-      await t.context.session
-        .findElement(By.css(ex.listboxSelector))
-        .isDisplayed(),
+      await t.context.session.findElement(By.css(ex.listboxSelector)).isDisplayed(),
       'In example ex3 listbox should display after ARROW_DOWN keypress'
     );
 
@@ -357,20 +278,15 @@ ariaTest(
     await waitForFocusChange(t, ex.textboxSelector, null);
 
     // Check that the active descendent focus is correct
-    await assertAriaSelectedAndActivedescendant(
-      t,
-      ex.textboxSelector,
-      ex.optionsSelector,
-      0
-    );
-  }
-);
+    await assertAriaSelectedAndActivedescendant(t, ex.textboxSelector, ex.optionsSelector, 0);
 
-ariaTest(
-  'Test down key press with focus on list',
-  exampleFile,
-  'listbox-key-down-arrow',
-  async (t) => {
+  });
+
+
+ariaTest('Test down key press with focus on list',
+  exampleFile, 'listbox-key-down-arrow', async (t) => {
+
+
     // Send 'a' to text box, then send ARROW_DOWN to textbox to set focus on listbox
     await t.context.session
       .findElement(By.css(ex.textboxSelector))
@@ -389,21 +305,16 @@ ariaTest(
       // Account for race condition
       await waitForFocusChange(t, ex.textboxSelector, oldfocus);
 
-      await assertAriaSelectedAndActivedescendant(
-        t,
-        ex.textboxSelector,
-        ex.optionsSelector,
-        i % ex.numAOptions
-      );
+      await assertAriaSelectedAndActivedescendant(t, ex.textboxSelector, ex.optionsSelector, i % ex.numAOptions);
     }
-  }
-);
 
-ariaTest(
-  'Test up key press with focus on textbox',
-  exampleFile,
-  'textbox-key-up-arrow',
-  async (t) => {
+  });
+
+
+ariaTest('Test up key press with focus on textbox',
+  exampleFile, 'textbox-key-up-arrow', async (t) => {
+
+
     // Send ARROW_UP to the textbox
     await t.context.session
       .findElement(By.css(ex.textboxSelector))
@@ -411,9 +322,7 @@ ariaTest(
 
     // Check that the listbox is displayed
     t.true(
-      await t.context.session
-        .findElement(By.css(ex.listboxSelector))
-        .isDisplayed(),
+      await t.context.session.findElement(By.css(ex.listboxSelector)).isDisplayed(),
       'In example ex3 listbox should display after ARROW_UP keypress'
     );
 
@@ -421,22 +330,15 @@ ariaTest(
     await waitForFocusChange(t, ex.textboxSelector, null);
 
     // Check that the active descendent focus is correct
-    let numOptions = (await t.context.queryElements(t, ex.optionsSelector))
-      .length;
-    await assertAriaSelectedAndActivedescendant(
-      t,
-      ex.textboxSelector,
-      ex.optionsSelector,
-      numOptions - 1
-    );
-  }
-);
+    let numOptions = (await t.context.queryElements(t, ex.optionsSelector)).length;
+    await assertAriaSelectedAndActivedescendant(t, ex.textboxSelector, ex.optionsSelector, numOptions - 1);
+  });
 
-ariaTest(
-  'Test up key press with focus on listbox',
-  exampleFile,
-  'listbox-key-up-arrow',
-  async (t) => {
+
+ariaTest('Test up key press with focus on listbox',
+  exampleFile, 'listbox-key-up-arrow', async (t) => {
+
+
     // Send 'a' to text box, then send ARROW_UP to textbox to textbox to put focus in textbox
     // Up arrow should move selection to the last item in the list
     await t.context.session
@@ -445,15 +347,11 @@ ariaTest(
 
     // Account for race condition
     await waitForFocusChange(t, ex.textboxSelector, '');
-    await assertAriaSelectedAndActivedescendant(
-      t,
-      ex.textboxSelector,
-      ex.optionsSelector,
-      ex.numAOptions - 1
-    );
+    await assertAriaSelectedAndActivedescendant(t, ex.textboxSelector, ex.optionsSelector, ex.numAOptions-1);
 
     // Test that ARROW_UP moves active descendant focus up one item in the listbox
-    for (let index = ex.numAOptions - 2; index > 0; index--) {
+    for (let index = ex.numAOptions - 2; index > 0 ; index--) {
+
       let oldfocus = await t.context.session
         .findElement(By.css(ex.textboxSelector))
         .getAttribute('aria-activedescendant');
@@ -465,21 +363,15 @@ ariaTest(
 
       await waitForFocusChange(t, ex.textboxSelector, oldfocus);
 
-      await assertAriaSelectedAndActivedescendant(
-        t,
-        ex.textboxSelector,
-        ex.optionsSelector,
-        index
-      );
+      await assertAriaSelectedAndActivedescendant(t, ex.textboxSelector, ex.optionsSelector, index);
     }
-  }
-);
+  });
 
-ariaTest(
-  'Test enter key press with focus on textbox',
-  exampleFile,
-  'textbox-key-enter',
-  async (t) => {
+
+ariaTest('Test enter key press with focus on textbox',
+  exampleFile, 'textbox-key-enter', async (t) => {
+
+
     // Send key "a" to the textbox
 
     await t.context.session
@@ -488,9 +380,7 @@ ariaTest(
 
     // Get the value of the first option in the listbox
 
-    const firstOption = await t.context.session
-      .findElement(By.css(ex.optionsSelector))
-      .getText();
+    const firstOption = await t.context.session.findElement(By.css(ex.optionsSelector)).getText();
 
     // Send key ENTER
 
@@ -500,12 +390,7 @@ ariaTest(
 
     // Confirm that the listbox is still open
 
-    await assertAttributeValues(
-      t,
-      ex.textboxSelector,
-      'aria-expanded',
-      'false'
-    );
+    await assertAttributeValues(t, ex.textboxSelector, 'aria-expanded', 'false');
 
     // Confirm that the value of the textbox is now set to the first option
 
@@ -516,14 +401,12 @@ ariaTest(
       firstOption,
       'key press "ENTER" should result in first option in textbox'
     );
-  }
-);
+  });
 
-ariaTest(
-  'Test enter key press with focus on listbox',
-  exampleFile,
-  'listbox-key-enter',
-  async (t) => {
+ariaTest('Test enter key press with focus on listbox',
+  exampleFile, 'listbox-key-enter', async (t) => {
+
+
     // Send key "a" to the textbox, then two ARROW_DOWNS
 
     await t.context.session
@@ -532,9 +415,8 @@ ariaTest(
 
     // Get the value of the first option in the listbox
 
-    const secondOption = await (
-      await t.context.queryElements(t, ex.optionsSelector)
-    )[1].getText();
+    const secondOption = await(await t.context.queryElements(t, ex.optionsSelector))[1]
+      .getText();
 
     // Send key ENTER
 
@@ -544,12 +426,7 @@ ariaTest(
 
     // Confirm that the listbox is still open
 
-    await assertAttributeValues(
-      t,
-      ex.textboxSelector,
-      'aria-expanded',
-      'false'
-    );
+    await assertAttributeValues(t, ex.textboxSelector, 'aria-expanded', 'false');
 
     // Confirm that the value of the textbox is now set to the second option
 
@@ -560,14 +437,13 @@ ariaTest(
       secondOption,
       'key press "ENTER" should result in second option in textbox'
     );
-  }
-);
 
-ariaTest(
-  'Test single escape key press with focus on textbox',
-  exampleFile,
-  'textbox-key-escape',
-  async (t) => {
+  });
+
+
+ariaTest('Test single escape key press with focus on textbox',
+  exampleFile, 'textbox-key-escape', async (t) => {
+
     // Send key "a", then key ESCAPE once to the textbox
 
     await t.context.session
@@ -576,12 +452,7 @@ ariaTest(
 
     // Confirm the listbox is closed and the textbox is not cleared
 
-    await assertAttributeValues(
-      t,
-      ex.textboxSelector,
-      'aria-expanded',
-      'false'
-    );
+    await assertAttributeValues(t, ex.textboxSelector, 'aria-expanded', 'false');
     t.is(
       await t.context.session
         .findElement(By.css(ex.textboxSelector))
@@ -589,14 +460,12 @@ ariaTest(
       'Alabama',
       'In key press "ESCAPE" should result in first option in textbox'
     );
-  }
-);
 
-ariaTest(
-  'Test double escape key press with focus on textbox',
-  exampleFile,
-  'textbox-key-escape',
-  async (t) => {
+  });
+
+ariaTest('Test double escape key press with focus on textbox',
+  exampleFile, 'textbox-key-escape', async (t) => {
+
     // Send key "a", then key ESCAPE twice to the textbox
 
     await t.context.session
@@ -605,12 +474,7 @@ ariaTest(
 
     // Confirm the listbox is closed and the textbox is cleared
 
-    await assertAttributeValues(
-      t,
-      ex.textboxSelector,
-      'aria-expanded',
-      'false'
-    );
+    await assertAttributeValues(t, ex.textboxSelector, 'aria-expanded', 'false');
     t.is(
       await t.context.session
         .findElement(By.css(ex.textboxSelector))
@@ -618,14 +482,12 @@ ariaTest(
       '',
       'In key press "ESCAPE" should result in first option in textbox'
     );
-  }
-);
 
-ariaTest(
-  'Test escape key press with focus on textbox',
-  exampleFile,
-  'listbox-key-escape',
-  async (t) => {
+  });
+
+ariaTest('Test escape key press with focus on textbox',
+  exampleFile, 'listbox-key-escape', async (t) => {
+
     // Send key "a" then key "ARROW_DOWN to put the focus on the listbox,
     // then key ESCAPE to the textbox
 
@@ -635,12 +497,7 @@ ariaTest(
 
     // Confirm the listbox is closed and the textboxed is cleared
 
-    await assertAttributeValues(
-      t,
-      ex.textboxSelector,
-      'aria-expanded',
-      'false'
-    );
+    await assertAttributeValues(t, ex.textboxSelector, 'aria-expanded', 'false');
     t.is(
       await t.context.session
         .findElement(By.css(ex.textboxSelector))
@@ -648,51 +505,37 @@ ariaTest(
       ex.secondAOption,
       'In listbox key press "ESCAPE" should result in second option in textbox'
     );
-  }
-);
 
-ariaTest(
-  'left arrow from focus on list puts focus on listbox and moves cursor right',
-  exampleFile,
-  'listbox-key-left-arrow',
-  async (t) => {
+  });
+
+ariaTest('left arrow from focus on list puts focus on listbox and moves cursor right',
+  exampleFile, 'listbox-key-left-arrow', async (t) => {
+
     // Send key "a" then key "ARROW_DOWN" to put the focus on the listbox
-    const textbox = await t.context.session.findElement(
-      By.css(ex.textboxSelector)
-    );
+    const textbox = await t.context.session.findElement(By.css(ex.textboxSelector));
     await textbox.sendKeys('a', Key.ARROW_DOWN);
 
     // Send key "ARROW_LEFT"
     await textbox.sendKeys(Key.ARROW_LEFT);
 
     t.true(
-      await confirmCursorIndex(
-        t,
-        ex.textboxSelector,
-        ex.secondAOption.length - 1
-      ),
-      'Cursor should be at index ' +
-        (ex.secondAOption.length - 1) +
-        ' after one ARROW_LEFT key'
+      await confirmCursorIndex(t, ex.textboxSelector, ex.secondAOption.length - 1),
+      'Cursor should be at index ' + (ex.secondAOption.length - 1) + ' after one ARROW_LEFT key'
     );
 
     t.is(
       await textbox.getAttribute('aria-activedescendant'),
       '',
-      'Focus should be on the textbox after on ARROW_LEFT key'
+      'Focus should be on the textbox after on ARROW_LEFT key',
     );
-  }
-);
+  });
 
-ariaTest(
-  'Right arrow from focus on list puts focus on listbox',
-  exampleFile,
-  'listbox-key-right-arrow',
-  async (t) => {
+
+ariaTest('Right arrow from focus on list puts focus on listbox',
+  exampleFile, 'listbox-key-right-arrow', async (t) => {
+
     // Send key "a" then key "ARROW_DOWN" to put the focus on the listbox
-    const textbox = await t.context.session.findElement(
-      By.css(ex.textboxSelector)
-    );
+    const textbox = await t.context.session.findElement(By.css(ex.textboxSelector));
     await textbox.sendKeys('a', Key.ARROW_DOWN);
 
     // Send key "RIGHT_ARROW"
@@ -700,28 +543,21 @@ ariaTest(
 
     t.true(
       await confirmCursorIndex(t, ex.textboxSelector, ex.secondAOption.length),
-      'Cursor should be at index ' +
-        ex.secondAOption.length +
-        ' after one ARROW_RIGHT key'
+      'Cursor should be at index ' + ex.secondAOption.length + ' after one ARROW_RIGHT key'
     );
 
     t.is(
       await textbox.getAttribute('aria-activedescendant'),
       '',
-      'Focus should be on the textbox after on ARROW_RIGHT key'
+      'Focus should be on the textbox after on ARROW_RIGHT key',
     );
-  }
-);
+  });
 
-ariaTest(
-  'Home from focus on list puts focus on listbox and moves cursor',
-  exampleFile,
-  'listbox-key-home',
-  async (t) => {
+ariaTest('Home from focus on list puts focus on listbox and moves cursor',
+  exampleFile, 'listbox-key-home', async (t) => {
+
     // Send key "a" then key "ARROW_DOWN" to put the focus on the listbox
-    const textbox = await t.context.session.findElement(
-      By.css(ex.textboxSelector)
-    );
+    const textbox = await t.context.session.findElement(By.css(ex.textboxSelector));
     await textbox.sendKeys('a', Key.ARROW_DOWN);
 
     // Send key "ARROW_HOME"
@@ -735,20 +571,15 @@ ariaTest(
     t.is(
       await textbox.getAttribute('aria-activedescendant'),
       '',
-      'Focus should be on the textbox after one ARROW_HOME key'
+      'Focus should be on the textbox after one ARROW_HOME key',
     );
-  }
-);
+  });
 
-ariaTest(
-  'End from focus on list puts focus on listbox',
-  exampleFile,
-  'listbox-key-end',
-  async (t) => {
+ariaTest('End from focus on list puts focus on listbox',
+  exampleFile, 'listbox-key-end', async (t) => {
+
     // Send key "a" then key "ARROW_DOWN" to put the focus on the listbox
-    const textbox = await t.context.session.findElement(
-      By.css(ex.textboxSelector)
-    );
+    const textbox = await t.context.session.findElement(By.css(ex.textboxSelector));
     await textbox.sendKeys('a', Key.ARROW_DOWN);
 
     // Send key "END_ARROW"
@@ -756,37 +587,28 @@ ariaTest(
 
     t.true(
       await confirmCursorIndex(t, ex.textboxSelector, ex.secondAOption.length),
-      'Cursor should be at index ' +
-        ex.secondAOption.length +
-        ' after one ARROW_END key'
+      'Cursor should be at index ' + ex.secondAOption.length + ' after one ARROW_END key'
     );
 
     t.is(
       await textbox.getAttribute('aria-activedescendant'),
       '',
-      'Focus should be on the textbox after on ARROW_END key'
+      'Focus should be on the textbox after on ARROW_END key',
     );
-  }
-);
+  });
 
-ariaTest(
-  'Sending character keys while focus is on listbox moves focus',
-  exampleFile,
-  'listbox-characters',
-  async (t) => {
+ariaTest('Sending character keys while focus is on listbox moves focus',
+  exampleFile, 'listbox-characters', async (t) => {
+
     // Send key "ARROW_DOWN" to put the focus on the listbox
-    const textbox = await t.context.session.findElement(
-      By.css(ex.textboxSelector)
-    );
+    const textbox = await t.context.session.findElement(By.css(ex.textboxSelector));
     await textbox.sendKeys(Key.ARROW_DOWN);
 
     // Send key "a"
     await textbox.sendKeys('a');
 
     // Get the value of the first option in the listbox
-    const firstOption = await t.context.session
-      .findElement(By.css(ex.optionsSelector))
-      .getText();
+    const firstOption = await t.context.session.findElement(By.css(ex.optionsSelector)).getText();
 
     t.is(
       await textbox.getAttribute('value'),
@@ -798,20 +620,16 @@ ariaTest(
     t.is(
       await textbox.getAttribute('aria-activedescendant'),
       '',
-      'Focus should be on the textbox after sending a character key while the focus is on the listbox'
+      'Focus should be on the textbox after sending a character key while the focus is on the listbox',
     );
-  }
-);
 
-ariaTest(
-  'Expected behavior for all other standard single line editing keys',
-  exampleFile,
-  'standard-single-line-editing-keys',
-  async (t) => {
+  });
+
+ariaTest('Expected behavior for all other standard single line editing keys',
+  exampleFile, 'standard-single-line-editing-keys', async (t) => {
+
     // Send key "a"
-    const textbox = await t.context.session.findElement(
-      By.css(ex.textboxSelector)
-    );
+    const textbox = await t.context.session.findElement(By.css(ex.textboxSelector));
     await textbox.sendKeys('a');
 
     t.is(
@@ -819,5 +637,4 @@ ariaTest(
       ex.numAOptions,
       'Sending standard editing keys should filter results'
     );
-  }
-);
+  });

--- a/test/tests/combobox_autocomplete-both.js
+++ b/test/tests/combobox_autocomplete-both.js
@@ -1,10 +1,8 @@
-'use strict';
-
 const { ariaTest } = require('..');
 const { By, Key } = require('selenium-webdriver');
 const assertAttributeValues = require('../util/assertAttributeValues');
 const assertAriaLabelExists = require('../util/assertAriaLabelExists');
-const assertAttributeDNE    = require('../util/assertAttributeDNE');
+const assertAttributeDNE = require('../util/assertAttributeDNE');
 const assertAriaRoles = require('../util/assertAriaRoles');
 const assertAriaSelectedAndActivedescendant = require('../util/assertAriaSelectedAndActivedescendant');
 
@@ -16,233 +14,332 @@ const ex = {
   optionsSelector: '#ex1 [role="option"]',
   buttonSelector: '#ex1 button',
   numAOptions: 5,
-  secondAOption: 'Alaska'
-
+  secondAOption: 'Alaska',
 };
 
 const waitForFocusChange = async (t, textboxSelector, originalFocus) => {
-  await t.context.session.wait(async function () {
-    let newfocus = await t.context.session
-      .findElement(By.css(textboxSelector))
-      .getAttribute('aria-activedescendant');
-    return newfocus != originalFocus;
-  }, t.context.waitTime, 'Timeout waiting for "aria-activedescendant" value to change from: ' + originalFocus);
+  await t.context.session.wait(
+    async function () {
+      let newfocus = await t.context.session
+        .findElement(By.css(textboxSelector))
+        .getAttribute('aria-activedescendant');
+      return newfocus != originalFocus;
+    },
+    t.context.waitTime,
+    'Timeout waiting for "aria-activedescendant" value to change from: ' +
+      originalFocus
+  );
 };
 
 const confirmCursorIndex = async (t, selector, cursorIndex) => {
-  return t.context.session.executeScript(function () {
-    const [selector, cursorIndex] = arguments;
-    let item = document.querySelector(selector);
-    return item.selectionStart === cursorIndex;
-  }, selector, cursorIndex);
+  return t.context.session.executeScript(
+    function () {
+      const [selector, cursorIndex] = arguments;
+      let item = document.querySelector(selector);
+      return item.selectionStart === cursorIndex;
+    },
+    selector,
+    cursorIndex
+  );
 };
 
 // Attributes
 
-ariaTest('Test for role="combobox"', exampleFile, 'combobox-role', async (t) => {
+ariaTest(
+  'Test for role="combobox"',
+  exampleFile,
+  'combobox-role',
+  async (t) => {
     await assertAriaRoles(t, 'ex1', 'combobox', '1', 'input');
-});
+  }
+);
 
-ariaTest('"aria-autocomplete" on comboxbox element', exampleFile, 'combobox-aria-autocomplete', async (t) => {
-    await assertAttributeValues(t, ex.textboxSelector, 'aria-autocomplete', 'both');
-});
+ariaTest(
+  '"aria-autocomplete" on comboxbox element',
+  exampleFile,
+  'combobox-aria-autocomplete',
+  async (t) => {
+    await assertAttributeValues(
+      t,
+      ex.textboxSelector,
+      'aria-autocomplete',
+      'both'
+    );
+  }
+);
 
-ariaTest('"aria-controls" attribute on combobox element', exampleFile, 'combobox-aria-controls', async (t) => {
+ariaTest(
+  '"aria-controls" attribute on combobox element',
+  exampleFile,
+  'combobox-aria-controls',
+  async (t) => {
+    const popupId = await t.context.session
+      .findElement(By.css(ex.textboxSelector))
+      .getAttribute('aria-controls');
 
-  const popupId = await t.context.session
-    .findElement(By.css(ex.textboxSelector))
-    .getAttribute('aria-controls');
+    t.truthy(
+      popupId,
+      '"aria-controls" attribute should exist on: ' + ex.textboxSelector
+    );
 
-  t.truthy(
-    popupId,
-    '"aria-controls" attribute should exist on: ' + ex.textboxSelector
-  );
+    const popupElements = await t.context.queryElements(t, `#ex1 #${popupId}`);
 
-  const popupElements = await t.context.queryElements(t, `#ex1 #${popupId}`);
+    t.is(
+      popupElements.length,
+      1,
+      'There should be a element with id "' +
+        popupId +
+        '" as referenced by the aria-controls attribute'
+    );
+  }
+);
 
-  t.is(
-    popupElements.length,
-    1,
-    'There should be a element with id "' + popupId + '" as referenced by the aria-controls attribute'
-  );
-});
+ariaTest(
+  '"aria-expanded" on combobox element',
+  exampleFile,
+  'combobox-aria-expanded',
+  async (t) => {
+    const combobox = await t.context.session.findElement(
+      By.css(ex.textboxSelector)
+    );
 
-ariaTest('"aria-expanded" on combobox element', exampleFile, 'combobox-aria-expanded', async (t) => {
+    // Check that aria-expanded is false and the listbox is not visible before interacting
 
-  const combobox = await t.context.session.findElement(By.css(ex.textboxSelector));
+    t.is(
+      await combobox.getAttribute('aria-expanded'),
+      'false',
+      'combobox element should have attribute "aria-expanded" set to false by default.'
+    );
 
-  // Check that aria-expanded is false and the listbox is not visible before interacting
+    const popupId = await t.context.session
+      .findElement(By.css(ex.textboxSelector))
+      .getAttribute('aria-controls');
 
-  t.is(
-    await combobox.getAttribute('aria-expanded'),
-    'false',
-    'combobox element should have attribute "aria-expanded" set to false by default.'
-  );
+    const popupElement = await t.context.session
+      .findElement(By.id('ex1'))
+      .findElement(By.id(popupId));
 
-  const popupId = await t.context.session
-    .findElement(By.css(ex.textboxSelector))
-    .getAttribute('aria-controls');
+    t.false(
+      await popupElement.isDisplayed(),
+      "Popup element should not be displayed when 'aria-expanded' is false'"
+    );
 
-  const popupElement = await t.context.session
-    .findElement(By.id('ex1'))
-    .findElement(By.id(popupId));
+    // Send key "a" to textbox
 
-  t.false(
-    await popupElement.isDisplayed(),
-    'Popup element should not be displayed when \'aria-expanded\' is false\''
-  );
+    await t.context.session
+      .findElement(By.css(ex.textboxSelector))
+      .sendKeys('a');
 
-  // Send key "a" to textbox
+    // Check that aria-expanded is true and the listbox is visible
 
-  await t.context.session
-    .findElement(By.css(ex.textboxSelector))
-    .sendKeys('a');
+    t.is(
+      await combobox.getAttribute('aria-expanded'),
+      'true',
+      'combobox element should have attribute "aria-expand" set to true after typing.'
+    );
 
-  // Check that aria-expanded is true and the listbox is visible
+    t.true(
+      await popupElement.isDisplayed(),
+      "Popup element should be displayed when 'aria-expanded' is true'"
+    );
+  }
+);
 
-  t.is(
-    await combobox.getAttribute('aria-expanded'),
-    'true',
-    'combobox element should have attribute "aria-expand" set to true after typing.'
-  );
+ariaTest(
+  '"aria-activedescendant" on combobox element',
+  exampleFile,
+  'combobox-aria-activedescendant',
+  async (t) => {
+    await assertAttributeValues(
+      t,
+      ex.textboxSelector,
+      'aria-activedescendant',
+      null
+    );
+  }
+);
 
-  t.true(
-    await popupElement.isDisplayed(),
-    'Popup element should be displayed when \'aria-expanded\' is true\''
-  );
+ariaTest(
+  '"id" attribute on combobox element',
+  exampleFile,
+  'combobox-id',
+  async (t) => {
+    const combobox = await t.context.session.findElement(
+      By.css(ex.textboxSelector)
+    );
+    const id = await combobox.getAttribute('id');
 
-});
+    console.log(id);
+    t.truthy(id, '"id" attribute should exist on combobox');
 
-ariaTest('"aria-activedescendant" on combobox element', exampleFile, 'combobox-aria-activedescendant', async (t) => {
-    await assertAttributeValues(t, ex.textboxSelector, 'aria-activedescendant', null);
-});
+    const label = await t.context.queryElements(t, `[for="${id}"]`);
+    t.is(
+      label.length,
+      1,
+      `There should be one element that labels the combobox with: [for="${id}"]`
+    );
+  }
+);
 
-ariaTest('"id" attribute on combobox element', exampleFile, 'combobox-id', async (t) => {
-  const combobox = await t.context.session.findElement(By.css(ex.textboxSelector))
-  const id = await combobox.getAttribute('id');
-
-  console.log(id);
-  t.truthy(
-    id,
-    '"id" attribute should exist on combobox'
-  );
-
-  const label = await t.context.queryElements(t, `[for="${id}"]`);
-  t.is(
-    label.length,
-    1,
-    `There should be one element that labels the combobox with: [for="${id}"]`
-  );
-});
-
-ariaTest('role "listbox" on ul element', exampleFile, 'listbox-role', async (t) => {
+ariaTest(
+  'role "listbox" on ul element',
+  exampleFile,
+  'listbox-role',
+  async (t) => {
     await assertAriaRoles(t, 'ex1', 'listbox', '1', 'ul');
-});
+  }
+);
 
-ariaTest('"aria-label" attribute on listbox element', exampleFile, 'listbox-aria-label', async (t) => {
+ariaTest(
+  '"aria-label" attribute on listbox element',
+  exampleFile,
+  'listbox-aria-label',
+  async (t) => {
     await assertAriaLabelExists(t, ex.listboxSelector);
-});
+  }
+);
 
-ariaTest('role "option" on lu elements', exampleFile, 'option-role', async (t) => {
+ariaTest(
+  'role "option" on lu elements',
+  exampleFile,
+  'option-role',
+  async (t) => {
+    // Send arrow down to reveal all options
+    await t.context.session
+      .findElement(By.css(ex.textboxSelector))
+      .sendKeys(Key.ARROW_DOWN);
+    await assertAriaRoles(t, 'ex1', 'option', '56', 'li');
+  }
+);
 
-  // Send arrow down to reveal all options
-  await t.context.session.findElement(By.css(ex.textboxSelector)).sendKeys(Key.ARROW_DOWN);
-  await assertAriaRoles(t, 'ex1', 'option', '56', 'li');
-});
+ariaTest(
+  '"aria-selected" attribute on options element',
+  exampleFile,
+  'option-aria-selected',
+  async (t) => {
+    // Send key "a"
+    await t.context.session
+      .findElement(By.css(ex.textboxSelector))
+      .sendKeys('a');
+    await assertAttributeValues(
+      t,
+      ex.optionsSelector + ':nth-of-type(1)',
+      'aria-selected',
+      'true'
+    );
+  }
+);
 
-ariaTest('"aria-selected" attribute on options element', exampleFile, 'option-aria-selected', async (t) => {
+ariaTest(
+  'Button should have tabindex="-1"',
+  exampleFile,
+  'button-tabindex',
+  async (t) => {
+    const button = await t.context.session.findElement(
+      By.css(ex.buttonSelector)
+    );
 
-  // Send key "a"
-  await t.context.session.findElement(By.css(ex.textboxSelector)).sendKeys('a');
-  await assertAttributeValues(t, ex.optionsSelector + ':nth-of-type(1)', 'aria-selected', 'true');
-});
+    t.is(
+      await button.getAttribute('tabindex'),
+      '-1',
+      'tabindex should be set to "-1" on button'
+    );
+  }
+);
 
-ariaTest('Button should have tabindex="-1"', exampleFile, 'button-tabindex', async (t) => {
-  const button = await t.context.session.findElement(By.css(ex.buttonSelector))
+ariaTest(
+  '"aria-label" attribute on button element',
+  exampleFile,
+  'button-aria-label',
+  async (t) => {
+    await assertAriaLabelExists(t, ex.buttonSelector);
+  }
+);
 
-  t.is(
-    await button.getAttribute('tabindex'),
-    '-1',
-    'tabindex should be set to "-1" on button'
-  );
-});
+ariaTest(
+  '"aria-controls" attribute on button element',
+  exampleFile,
+  'button-aria-controls',
+  async (t) => {
+    const popupId = await t.context.session
+      .findElement(By.css(ex.buttonSelector))
+      .getAttribute('aria-controls');
 
-ariaTest('"aria-label" attribute on button element', exampleFile, 'button-aria-label', async (t) => {
-  await assertAriaLabelExists(t, ex.buttonSelector);
-});
+    t.truthy(
+      popupId,
+      '"aria-controls" attribute should exist on: ' + ex.buttonSelector
+    );
 
+    const popupElements = await t.context.queryElements(t, `#ex1 #${popupId}`);
 
-ariaTest('"aria-controls" attribute on button element', exampleFile, 'button-aria-controls', async (t) => {
-  const popupId = await t.context.session
-    .findElement(By.css(ex.buttonSelector))
-    .getAttribute('aria-controls');
+    t.is(
+      popupElements.length,
+      1,
+      'There should be a element with id "' +
+        popupId +
+        '" as referenced by the aria-controls attribute'
+    );
+  }
+);
 
-  t.truthy(
-    popupId,
-    '"aria-controls" attribute should exist on: ' + ex.buttonSelector
-  );
+ariaTest(
+  '"aria-expanded" on button element',
+  exampleFile,
+  'button-aria-expanded',
+  async (t) => {
+    const button = await t.context.session.findElement(
+      By.css(ex.buttonSelector)
+    );
 
-  const popupElements = await t.context.queryElements(t, `#ex1 #${popupId}`);
+    // Check that aria-expanded is false and the listbox is not visible before interacting
 
-  t.is(
-    popupElements.length,
-    1,
-    'There should be a element with id "' + popupId + '" as referenced by the aria-controls attribute'
-  );
-});
+    t.is(
+      await button.getAttribute('aria-expanded'),
+      'false',
+      'button element should have attribute "aria-expanded" set to false by default.'
+    );
 
-ariaTest('"aria-expanded" on button element', exampleFile, 'button-aria-expanded', async (t) => {
-  const button = await t.context.session.findElement(By.css(ex.buttonSelector));
+    const popupId = await t.context.session
+      .findElement(By.css(ex.textboxSelector))
+      .getAttribute('aria-controls');
 
-  // Check that aria-expanded is false and the listbox is not visible before interacting
+    const popupElement = await t.context.session
+      .findElement(By.id('ex1'))
+      .findElement(By.id(popupId));
 
-  t.is(
-    await button.getAttribute('aria-expanded'),
-    'false',
-    'button element should have attribute "aria-expanded" set to false by default.'
-  );
+    t.false(
+      await popupElement.isDisplayed(),
+      "Popup element should not be displayed when 'aria-expanded' is 'false'"
+    );
 
-  const popupId = await t.context.session
-    .findElement(By.css(ex.textboxSelector))
-    .getAttribute('aria-controls');
+    // Send key "a" to textbox
 
-  const popupElement = await t.context.session
-    .findElement(By.id('ex1'))
-    .findElement(By.id(popupId));
+    await t.context.session
+      .findElement(By.css(ex.textboxSelector))
+      .sendKeys('a');
 
-  t.false(
-    await popupElement.isDisplayed(),
-    'Popup element should not be displayed when \'aria-expanded\' is \'false\''
-  );
+    // Check that aria-expanded is true and the listbox is visible
 
-  // Send key "a" to textbox
+    t.is(
+      await button.getAttribute('aria-expanded'),
+      'true',
+      'button element should have attribute "aria-expand" set to true after typing.'
+    );
 
-  await t.context.session
-    .findElement(By.css(ex.textboxSelector))
-    .sendKeys('a');
-
-  // Check that aria-expanded is true and the listbox is visible
-
-  t.is(
-    await button.getAttribute('aria-expanded'),
-    'true',
-    'button element should have attribute "aria-expand" set to true after typing.'
-  );
-
-  t.true(
-    await popupElement.isDisplayed(),
-    'Popup element should be displayed when \'aria-expanded\' is \'true\''
-  );
-
-});
-
+    t.true(
+      await popupElement.isDisplayed(),
+      "Popup element should be displayed when 'aria-expanded' is 'true'"
+    );
+  }
+);
 
 // Keys
 
-ariaTest('Test alt + down key press with focus on textbox',
-  exampleFile, 'textbox-key-alt-down-arrow', async (t) => {
-
-
+ariaTest(
+  'Test alt + down key press with focus on textbox',
+  exampleFile,
+  'textbox-key-alt-down-arrow',
+  async (t) => {
     // Send ARROW_DOWN to the textbox
     await t.context.session
       .findElement(By.css(ex.textboxSelector))
@@ -250,19 +347,21 @@ ariaTest('Test alt + down key press with focus on textbox',
 
     // Check that the listbox is displayed
     t.true(
-      await t.context.session.findElement(By.css(ex.listboxSelector)).isDisplayed(),
+      await t.context.session
+        .findElement(By.css(ex.listboxSelector))
+        .isDisplayed(),
       'In example the list box should display after ALT + ARROW_DOWN keypress'
     );
 
     await assertAttributeDNE(t, ex.optionsSelector, 'aria-selected');
+  }
+);
 
-  });
-
-
-ariaTest('Test down key press with focus on textbox',
-  exampleFile, 'textbox-key-down-arrow', async (t) => {
-
-
+ariaTest(
+  'Test down key press with focus on textbox',
+  exampleFile,
+  'textbox-key-down-arrow',
+  async (t) => {
     // Send ARROW_DOWN to the textbox
     await t.context.session
       .findElement(By.css(ex.textboxSelector))
@@ -270,7 +369,9 @@ ariaTest('Test down key press with focus on textbox',
 
     // Check that the listbox is displayed
     t.true(
-      await t.context.session.findElement(By.css(ex.listboxSelector)).isDisplayed(),
+      await t.context.session
+        .findElement(By.css(ex.listboxSelector))
+        .isDisplayed(),
       'In example ex3 listbox should display after ARROW_DOWN keypress'
     );
 
@@ -278,15 +379,20 @@ ariaTest('Test down key press with focus on textbox',
     await waitForFocusChange(t, ex.textboxSelector, null);
 
     // Check that the active descendent focus is correct
-    await assertAriaSelectedAndActivedescendant(t, ex.textboxSelector, ex.optionsSelector, 0);
+    await assertAriaSelectedAndActivedescendant(
+      t,
+      ex.textboxSelector,
+      ex.optionsSelector,
+      0
+    );
+  }
+);
 
-  });
-
-
-ariaTest('Test down key press with focus on list',
-  exampleFile, 'listbox-key-down-arrow', async (t) => {
-
-
+ariaTest(
+  'Test down key press with focus on list',
+  exampleFile,
+  'listbox-key-down-arrow',
+  async (t) => {
     // Send 'a' to text box, then send ARROW_DOWN to textbox to set focus on listbox
     await t.context.session
       .findElement(By.css(ex.textboxSelector))
@@ -305,16 +411,21 @@ ariaTest('Test down key press with focus on list',
       // Account for race condition
       await waitForFocusChange(t, ex.textboxSelector, oldfocus);
 
-      await assertAriaSelectedAndActivedescendant(t, ex.textboxSelector, ex.optionsSelector, i % ex.numAOptions);
+      await assertAriaSelectedAndActivedescendant(
+        t,
+        ex.textboxSelector,
+        ex.optionsSelector,
+        i % ex.numAOptions
+      );
     }
+  }
+);
 
-  });
-
-
-ariaTest('Test up key press with focus on textbox',
-  exampleFile, 'textbox-key-up-arrow', async (t) => {
-
-
+ariaTest(
+  'Test up key press with focus on textbox',
+  exampleFile,
+  'textbox-key-up-arrow',
+  async (t) => {
     // Send ARROW_UP to the textbox
     await t.context.session
       .findElement(By.css(ex.textboxSelector))
@@ -322,7 +433,9 @@ ariaTest('Test up key press with focus on textbox',
 
     // Check that the listbox is displayed
     t.true(
-      await t.context.session.findElement(By.css(ex.listboxSelector)).isDisplayed(),
+      await t.context.session
+        .findElement(By.css(ex.listboxSelector))
+        .isDisplayed(),
       'In example ex3 listbox should display after ARROW_UP keypress'
     );
 
@@ -330,15 +443,22 @@ ariaTest('Test up key press with focus on textbox',
     await waitForFocusChange(t, ex.textboxSelector, null);
 
     // Check that the active descendent focus is correct
-    let numOptions = (await t.context.queryElements(t, ex.optionsSelector)).length;
-    await assertAriaSelectedAndActivedescendant(t, ex.textboxSelector, ex.optionsSelector, numOptions - 1);
-  });
+    let numOptions = (await t.context.queryElements(t, ex.optionsSelector))
+      .length;
+    await assertAriaSelectedAndActivedescendant(
+      t,
+      ex.textboxSelector,
+      ex.optionsSelector,
+      numOptions - 1
+    );
+  }
+);
 
-
-ariaTest('Test up key press with focus on listbox',
-  exampleFile, 'listbox-key-up-arrow', async (t) => {
-
-
+ariaTest(
+  'Test up key press with focus on listbox',
+  exampleFile,
+  'listbox-key-up-arrow',
+  async (t) => {
     // Send 'a' to text box, then send ARROW_UP to textbox to textbox to put focus in textbox
     // Up arrow should move selection to the last item in the list
     await t.context.session
@@ -347,11 +467,15 @@ ariaTest('Test up key press with focus on listbox',
 
     // Account for race condition
     await waitForFocusChange(t, ex.textboxSelector, '');
-    await assertAriaSelectedAndActivedescendant(t, ex.textboxSelector, ex.optionsSelector, ex.numAOptions-1);
+    await assertAriaSelectedAndActivedescendant(
+      t,
+      ex.textboxSelector,
+      ex.optionsSelector,
+      ex.numAOptions - 1
+    );
 
     // Test that ARROW_UP moves active descendant focus up one item in the listbox
-    for (let index = ex.numAOptions - 2; index > 0 ; index--) {
-
+    for (let index = ex.numAOptions - 2; index > 0; index--) {
       let oldfocus = await t.context.session
         .findElement(By.css(ex.textboxSelector))
         .getAttribute('aria-activedescendant');
@@ -363,15 +487,21 @@ ariaTest('Test up key press with focus on listbox',
 
       await waitForFocusChange(t, ex.textboxSelector, oldfocus);
 
-      await assertAriaSelectedAndActivedescendant(t, ex.textboxSelector, ex.optionsSelector, index);
+      await assertAriaSelectedAndActivedescendant(
+        t,
+        ex.textboxSelector,
+        ex.optionsSelector,
+        index
+      );
     }
-  });
+  }
+);
 
-
-ariaTest('Test enter key press with focus on textbox',
-  exampleFile, 'textbox-key-enter', async (t) => {
-
-
+ariaTest(
+  'Test enter key press with focus on textbox',
+  exampleFile,
+  'textbox-key-enter',
+  async (t) => {
     // Send key "a" to the textbox
 
     await t.context.session
@@ -380,42 +510,8 @@ ariaTest('Test enter key press with focus on textbox',
 
     // Get the value of the first option in the listbox
 
-    const firstOption = await t.context.session.findElement(By.css(ex.optionsSelector)).getText();
-
-    // Send key ENTER
-
-    await t.context.session
-      .findElement(By.css(ex.textboxSelector))
-      .sendKeys(Key.ENTER);
-
-    // Confirm that the listbox is still open
-
-    await assertAttributeValues(t, ex.textboxSelector, 'aria-expanded', 'false');
-
-    // Confirm that the value of the textbox is now set to the first option
-
-    t.is(
-      await t.context.session
-        .findElement(By.css(ex.textboxSelector))
-        .getAttribute('value'),
-      firstOption,
-      'key press "ENTER" should result in first option in textbox'
-    );
-  });
-
-ariaTest('Test enter key press with focus on listbox',
-  exampleFile, 'listbox-key-enter', async (t) => {
-
-
-    // Send key "a" to the textbox, then two ARROW_DOWNS
-
-    await t.context.session
-      .findElement(By.css(ex.textboxSelector))
-      .sendKeys('a', Key.ARROW_DOWN);
-
-    // Get the value of the first option in the listbox
-
-    const secondOption = await(await t.context.queryElements(t, ex.optionsSelector))[1]
+    const firstOption = await t.context.session
+      .findElement(By.css(ex.optionsSelector))
       .getText();
 
     // Send key ENTER
@@ -426,7 +522,56 @@ ariaTest('Test enter key press with focus on listbox',
 
     // Confirm that the listbox is still open
 
-    await assertAttributeValues(t, ex.textboxSelector, 'aria-expanded', 'false');
+    await assertAttributeValues(
+      t,
+      ex.textboxSelector,
+      'aria-expanded',
+      'false'
+    );
+
+    // Confirm that the value of the textbox is now set to the first option
+
+    t.is(
+      await t.context.session
+        .findElement(By.css(ex.textboxSelector))
+        .getAttribute('value'),
+      firstOption,
+      'key press "ENTER" should result in first option in textbox'
+    );
+  }
+);
+
+ariaTest(
+  'Test enter key press with focus on listbox',
+  exampleFile,
+  'listbox-key-enter',
+  async (t) => {
+    // Send key "a" to the textbox, then two ARROW_DOWNS
+
+    await t.context.session
+      .findElement(By.css(ex.textboxSelector))
+      .sendKeys('a', Key.ARROW_DOWN);
+
+    // Get the value of the first option in the listbox
+
+    const secondOption = await (
+      await t.context.queryElements(t, ex.optionsSelector)
+    )[1].getText();
+
+    // Send key ENTER
+
+    await t.context.session
+      .findElement(By.css(ex.textboxSelector))
+      .sendKeys(Key.ENTER);
+
+    // Confirm that the listbox is still open
+
+    await assertAttributeValues(
+      t,
+      ex.textboxSelector,
+      'aria-expanded',
+      'false'
+    );
 
     // Confirm that the value of the textbox is now set to the second option
 
@@ -437,13 +582,14 @@ ariaTest('Test enter key press with focus on listbox',
       secondOption,
       'key press "ENTER" should result in second option in textbox'
     );
+  }
+);
 
-  });
-
-
-ariaTest('Test single escape key press with focus on textbox',
-  exampleFile, 'textbox-key-escape', async (t) => {
-
+ariaTest(
+  'Test single escape key press with focus on textbox',
+  exampleFile,
+  'textbox-key-escape',
+  async (t) => {
     // Send key "a", then key ESCAPE once to the textbox
 
     await t.context.session
@@ -452,7 +598,12 @@ ariaTest('Test single escape key press with focus on textbox',
 
     // Confirm the listbox is closed and the textbox is not cleared
 
-    await assertAttributeValues(t, ex.textboxSelector, 'aria-expanded', 'false');
+    await assertAttributeValues(
+      t,
+      ex.textboxSelector,
+      'aria-expanded',
+      'false'
+    );
     t.is(
       await t.context.session
         .findElement(By.css(ex.textboxSelector))
@@ -460,12 +611,14 @@ ariaTest('Test single escape key press with focus on textbox',
       'Alabama',
       'In key press "ESCAPE" should result in first option in textbox'
     );
+  }
+);
 
-  });
-
-ariaTest('Test double escape key press with focus on textbox',
-  exampleFile, 'textbox-key-escape', async (t) => {
-
+ariaTest(
+  'Test double escape key press with focus on textbox',
+  exampleFile,
+  'textbox-key-escape',
+  async (t) => {
     // Send key "a", then key ESCAPE twice to the textbox
 
     await t.context.session
@@ -474,7 +627,12 @@ ariaTest('Test double escape key press with focus on textbox',
 
     // Confirm the listbox is closed and the textbox is cleared
 
-    await assertAttributeValues(t, ex.textboxSelector, 'aria-expanded', 'false');
+    await assertAttributeValues(
+      t,
+      ex.textboxSelector,
+      'aria-expanded',
+      'false'
+    );
     t.is(
       await t.context.session
         .findElement(By.css(ex.textboxSelector))
@@ -482,12 +640,14 @@ ariaTest('Test double escape key press with focus on textbox',
       '',
       'In key press "ESCAPE" should result in first option in textbox'
     );
+  }
+);
 
-  });
-
-ariaTest('Test escape key press with focus on textbox',
-  exampleFile, 'listbox-key-escape', async (t) => {
-
+ariaTest(
+  'Test escape key press with focus on textbox',
+  exampleFile,
+  'listbox-key-escape',
+  async (t) => {
     // Send key "a" then key "ARROW_DOWN to put the focus on the listbox,
     // then key ESCAPE to the textbox
 
@@ -497,7 +657,12 @@ ariaTest('Test escape key press with focus on textbox',
 
     // Confirm the listbox is closed and the textboxed is cleared
 
-    await assertAttributeValues(t, ex.textboxSelector, 'aria-expanded', 'false');
+    await assertAttributeValues(
+      t,
+      ex.textboxSelector,
+      'aria-expanded',
+      'false'
+    );
     t.is(
       await t.context.session
         .findElement(By.css(ex.textboxSelector))
@@ -505,37 +670,51 @@ ariaTest('Test escape key press with focus on textbox',
       ex.secondAOption,
       'In listbox key press "ESCAPE" should result in second option in textbox'
     );
+  }
+);
 
-  });
-
-ariaTest('left arrow from focus on list puts focus on listbox and moves cursor right',
-  exampleFile, 'listbox-key-left-arrow', async (t) => {
-
+ariaTest(
+  'left arrow from focus on list puts focus on listbox and moves cursor right',
+  exampleFile,
+  'listbox-key-left-arrow',
+  async (t) => {
     // Send key "a" then key "ARROW_DOWN" to put the focus on the listbox
-    const textbox = await t.context.session.findElement(By.css(ex.textboxSelector));
+    const textbox = await t.context.session.findElement(
+      By.css(ex.textboxSelector)
+    );
     await textbox.sendKeys('a', Key.ARROW_DOWN);
 
     // Send key "ARROW_LEFT"
     await textbox.sendKeys(Key.ARROW_LEFT);
 
     t.true(
-      await confirmCursorIndex(t, ex.textboxSelector, ex.secondAOption.length - 1),
-      'Cursor should be at index ' + (ex.secondAOption.length - 1) + ' after one ARROW_LEFT key'
+      await confirmCursorIndex(
+        t,
+        ex.textboxSelector,
+        ex.secondAOption.length - 1
+      ),
+      'Cursor should be at index ' +
+        (ex.secondAOption.length - 1) +
+        ' after one ARROW_LEFT key'
     );
 
     t.is(
       await textbox.getAttribute('aria-activedescendant'),
       '',
-      'Focus should be on the textbox after on ARROW_LEFT key',
+      'Focus should be on the textbox after on ARROW_LEFT key'
     );
-  });
+  }
+);
 
-
-ariaTest('Right arrow from focus on list puts focus on listbox',
-  exampleFile, 'listbox-key-right-arrow', async (t) => {
-
+ariaTest(
+  'Right arrow from focus on list puts focus on listbox',
+  exampleFile,
+  'listbox-key-right-arrow',
+  async (t) => {
     // Send key "a" then key "ARROW_DOWN" to put the focus on the listbox
-    const textbox = await t.context.session.findElement(By.css(ex.textboxSelector));
+    const textbox = await t.context.session.findElement(
+      By.css(ex.textboxSelector)
+    );
     await textbox.sendKeys('a', Key.ARROW_DOWN);
 
     // Send key "RIGHT_ARROW"
@@ -543,21 +722,28 @@ ariaTest('Right arrow from focus on list puts focus on listbox',
 
     t.true(
       await confirmCursorIndex(t, ex.textboxSelector, ex.secondAOption.length),
-      'Cursor should be at index ' + ex.secondAOption.length + ' after one ARROW_RIGHT key'
+      'Cursor should be at index ' +
+        ex.secondAOption.length +
+        ' after one ARROW_RIGHT key'
     );
 
     t.is(
       await textbox.getAttribute('aria-activedescendant'),
       '',
-      'Focus should be on the textbox after on ARROW_RIGHT key',
+      'Focus should be on the textbox after on ARROW_RIGHT key'
     );
-  });
+  }
+);
 
-ariaTest('Home from focus on list puts focus on listbox and moves cursor',
-  exampleFile, 'listbox-key-home', async (t) => {
-
+ariaTest(
+  'Home from focus on list puts focus on listbox and moves cursor',
+  exampleFile,
+  'listbox-key-home',
+  async (t) => {
     // Send key "a" then key "ARROW_DOWN" to put the focus on the listbox
-    const textbox = await t.context.session.findElement(By.css(ex.textboxSelector));
+    const textbox = await t.context.session.findElement(
+      By.css(ex.textboxSelector)
+    );
     await textbox.sendKeys('a', Key.ARROW_DOWN);
 
     // Send key "ARROW_HOME"
@@ -571,15 +757,20 @@ ariaTest('Home from focus on list puts focus on listbox and moves cursor',
     t.is(
       await textbox.getAttribute('aria-activedescendant'),
       '',
-      'Focus should be on the textbox after one ARROW_HOME key',
+      'Focus should be on the textbox after one ARROW_HOME key'
     );
-  });
+  }
+);
 
-ariaTest('End from focus on list puts focus on listbox',
-  exampleFile, 'listbox-key-end', async (t) => {
-
+ariaTest(
+  'End from focus on list puts focus on listbox',
+  exampleFile,
+  'listbox-key-end',
+  async (t) => {
     // Send key "a" then key "ARROW_DOWN" to put the focus on the listbox
-    const textbox = await t.context.session.findElement(By.css(ex.textboxSelector));
+    const textbox = await t.context.session.findElement(
+      By.css(ex.textboxSelector)
+    );
     await textbox.sendKeys('a', Key.ARROW_DOWN);
 
     // Send key "END_ARROW"
@@ -587,28 +778,37 @@ ariaTest('End from focus on list puts focus on listbox',
 
     t.true(
       await confirmCursorIndex(t, ex.textboxSelector, ex.secondAOption.length),
-      'Cursor should be at index ' + ex.secondAOption.length + ' after one ARROW_END key'
+      'Cursor should be at index ' +
+        ex.secondAOption.length +
+        ' after one ARROW_END key'
     );
 
     t.is(
       await textbox.getAttribute('aria-activedescendant'),
       '',
-      'Focus should be on the textbox after on ARROW_END key',
+      'Focus should be on the textbox after on ARROW_END key'
     );
-  });
+  }
+);
 
-ariaTest('Sending character keys while focus is on listbox moves focus',
-  exampleFile, 'listbox-characters', async (t) => {
-
+ariaTest(
+  'Sending character keys while focus is on listbox moves focus',
+  exampleFile,
+  'listbox-characters',
+  async (t) => {
     // Send key "ARROW_DOWN" to put the focus on the listbox
-    const textbox = await t.context.session.findElement(By.css(ex.textboxSelector));
+    const textbox = await t.context.session.findElement(
+      By.css(ex.textboxSelector)
+    );
     await textbox.sendKeys(Key.ARROW_DOWN);
 
     // Send key "a"
     await textbox.sendKeys('a');
 
     // Get the value of the first option in the listbox
-    const firstOption = await t.context.session.findElement(By.css(ex.optionsSelector)).getText();
+    const firstOption = await t.context.session
+      .findElement(By.css(ex.optionsSelector))
+      .getText();
 
     t.is(
       await textbox.getAttribute('value'),
@@ -620,16 +820,20 @@ ariaTest('Sending character keys while focus is on listbox moves focus',
     t.is(
       await textbox.getAttribute('aria-activedescendant'),
       '',
-      'Focus should be on the textbox after sending a character key while the focus is on the listbox',
+      'Focus should be on the textbox after sending a character key while the focus is on the listbox'
     );
+  }
+);
 
-  });
-
-ariaTest('Expected behavior for all other standard single line editing keys',
-  exampleFile, 'standard-single-line-editing-keys', async (t) => {
-
+ariaTest(
+  'Expected behavior for all other standard single line editing keys',
+  exampleFile,
+  'standard-single-line-editing-keys',
+  async (t) => {
     // Send key "a"
-    const textbox = await t.context.session.findElement(By.css(ex.textboxSelector));
+    const textbox = await t.context.session.findElement(
+      By.css(ex.textboxSelector)
+    );
     await textbox.sendKeys('a');
 
     t.is(
@@ -637,4 +841,5 @@ ariaTest('Expected behavior for all other standard single line editing keys',
       ex.numAOptions,
       'Sending standard editing keys should filter results'
     );
-  });
+  }
+);

--- a/test/tests/combobox_autocomplete-list.js
+++ b/test/tests/combobox_autocomplete-list.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { ariaTest } = require('..');
 const { By, Key } = require('selenium-webdriver');
 const assertAttributeValues = require('../util/assertAttributeValues');
@@ -15,7 +13,7 @@ const ex = {
   listboxSelector: '#ex1 [role="listbox"]',
   optionsSelector: '#ex1 [role="option"]',
   buttonSelector: '#ex1 button',
-  numAOptions: 5
+  numAOptions: 5,
 };
 
 const waitForFocusChange = async (t, textboxSelector, originalFocus) => {
@@ -27,227 +25,330 @@ const waitForFocusChange = async (t, textboxSelector, originalFocus) => {
       return newfocus != originalFocus;
     },
     t.context.waitTime,
-    'Error waiting for "aria-activedescendant" value to change from "' + originalFocus + '". '
+    'Error waiting for "aria-activedescendant" value to change from "' +
+      originalFocus +
+      '". '
   );
 };
 
 const confirmCursorIndex = async (t, selector, cursorIndex) => {
-  return t.context.session.executeScript(function () {
-    const [selector, cursorIndex] = arguments;
-    let item = document.querySelector(selector);
-    return item.selectionStart === cursorIndex;
-  }, selector, cursorIndex);
+  return t.context.session.executeScript(
+    function () {
+      const [selector, cursorIndex] = arguments;
+      let item = document.querySelector(selector);
+      return item.selectionStart === cursorIndex;
+    },
+    selector,
+    cursorIndex
+  );
 };
 
 // Attributes
-ariaTest('Test for role="combobox"', exampleFile, 'combobox-role', async (t) => {
+ariaTest(
+  'Test for role="combobox"',
+  exampleFile,
+  'combobox-role',
+  async (t) => {
     await assertAriaRoles(t, 'ex1', 'combobox', '1', 'input');
-});
+  }
+);
 
-ariaTest('"aria-autocomplete" on comboxbox element', exampleFile, 'combobox-aria-autocomplete', async (t) => {
-    await assertAttributeValues(t, ex.textboxSelector, 'aria-autocomplete', 'list');
-});
+ariaTest(
+  '"aria-autocomplete" on comboxbox element',
+  exampleFile,
+  'combobox-aria-autocomplete',
+  async (t) => {
+    await assertAttributeValues(
+      t,
+      ex.textboxSelector,
+      'aria-autocomplete',
+      'list'
+    );
+  }
+);
 
-ariaTest('"aria-controls" attribute on combobox element', exampleFile, 'combobox-aria-controls', async (t) => {
+ariaTest(
+  '"aria-controls" attribute on combobox element',
+  exampleFile,
+  'combobox-aria-controls',
+  async (t) => {
+    const popupId = await t.context.session
+      .findElement(By.css(ex.textboxSelector))
+      .getAttribute('aria-controls');
 
-  const popupId = await t.context.session
-    .findElement(By.css(ex.textboxSelector))
-    .getAttribute('aria-controls');
+    t.truthy(
+      popupId,
+      '"aria-controls" attribute should exist on: ' + ex.textboxSelector
+    );
 
-  t.truthy(
-    popupId,
-    '"aria-controls" attribute should exist on: ' + ex.textboxSelector
-  );
+    const popupElements = await t.context.queryElements(t, `#ex1 #${popupId}`);
 
-  const popupElements = await t.context.queryElements(t, `#ex1 #${popupId}`);
+    t.is(
+      popupElements.length,
+      1,
+      'There should be a element with id "' +
+        popupId +
+        '" as referenced by the aria-controls attribute'
+    );
+  }
+);
 
-  t.is(
-    popupElements.length,
-    1,
-    'There should be a element with id "' + popupId + '" as referenced by the aria-controls attribute'
-  );
-});
+ariaTest(
+  '"aria-expanded" on combobox element',
+  exampleFile,
+  'combobox-aria-expanded',
+  async (t) => {
+    const combobox = await t.context.session.findElement(
+      By.css(ex.textboxSelector)
+    );
 
-ariaTest('"aria-expanded" on combobox element', exampleFile, 'combobox-aria-expanded', async (t) => {
+    // Check that aria-expanded is false and the listbox is not visible before interacting
 
-  const combobox = await t.context.session.findElement(By.css(ex.textboxSelector));
+    t.is(
+      await combobox.getAttribute('aria-expanded'),
+      'false',
+      'combobox element should have attribute "aria-expanded" set to false by default.'
+    );
 
-  // Check that aria-expanded is false and the listbox is not visible before interacting
+    const popupId = await t.context.session
+      .findElement(By.css(ex.textboxSelector))
+      .getAttribute('aria-controls');
 
-  t.is(
-    await combobox.getAttribute('aria-expanded'),
-    'false',
-    'combobox element should have attribute "aria-expanded" set to false by default.'
-  );
+    const popupElement = await t.context.session
+      .findElement(By.id('ex1'))
+      .findElement(By.id(popupId));
 
-  const popupId = await t.context.session
-    .findElement(By.css(ex.textboxSelector))
-    .getAttribute('aria-controls');
+    t.false(
+      await popupElement.isDisplayed(),
+      "Popup element should not be displayed when 'aria-expanded' is false'"
+    );
 
-  const popupElement = await t.context.session
-    .findElement(By.id('ex1'))
-    .findElement(By.id(popupId));
+    // Send key "a" to textbox
 
-  t.false(
-    await popupElement.isDisplayed(),
-    'Popup element should not be displayed when \'aria-expanded\' is false\''
-  );
+    await t.context.session
+      .findElement(By.css(ex.textboxSelector))
+      .sendKeys('a');
 
-  // Send key "a" to textbox
+    // Check that aria-expanded is true and the listbox is visible
 
-  await t.context.session
-    .findElement(By.css(ex.textboxSelector))
-    .sendKeys('a');
+    t.is(
+      await combobox.getAttribute('aria-expanded'),
+      'true',
+      'combobox element should have attribute "aria-expand" set to true after typing.'
+    );
 
-  // Check that aria-expanded is true and the listbox is visible
+    t.true(
+      await popupElement.isDisplayed(),
+      "Popup element should be displayed when 'aria-expanded' is true'"
+    );
+  }
+);
 
-  t.is(
-    await combobox.getAttribute('aria-expanded'),
-    'true',
-    'combobox element should have attribute "aria-expand" set to true after typing.'
-  );
+ariaTest(
+  '"aria-activedescendant" on combobox element',
+  exampleFile,
+  'combobox-aria-activedescendant',
+  async (t) => {
+    await assertAttributeValues(
+      t,
+      ex.textboxSelector,
+      'aria-activedescendant',
+      null
+    );
+  }
+);
 
-  t.true(
-    await popupElement.isDisplayed(),
-    'Popup element should be displayed when \'aria-expanded\' is true\''
-  );
+ariaTest(
+  '"id" attribute on combobox element',
+  exampleFile,
+  'combobox-id',
+  async (t) => {
+    const combobox = await t.context.session.findElement(
+      By.css(ex.textboxSelector)
+    );
+    const id = await combobox.getAttribute('id');
 
-});
+    console.log(id);
+    t.truthy(id, '"id" attribute should exist on combobox');
 
-ariaTest('"aria-activedescendant" on combobox element', exampleFile, 'combobox-aria-activedescendant', async (t) => {
-    await assertAttributeValues(t, ex.textboxSelector, 'aria-activedescendant', null);
-});
+    const label = await t.context.queryElements(t, `[for="${id}"]`);
+    t.is(
+      label.length,
+      1,
+      `There should be one element that labels the combobox with: [for="${id}"]`
+    );
+  }
+);
 
-ariaTest('"id" attribute on combobox element', exampleFile, 'combobox-id', async (t) => {
-  const combobox = await t.context.session.findElement(By.css(ex.textboxSelector))
-  const id = await combobox.getAttribute('id');
-
-  console.log(id);
-  t.truthy(
-    id,
-    '"id" attribute should exist on combobox'
-  );
-
-  const label = await t.context.queryElements(t, `[for="${id}"]`);
-  t.is(
-    label.length,
-    1,
-    `There should be one element that labels the combobox with: [for="${id}"]`
-  );
-});
-
-ariaTest('role "listbox" on ul element', exampleFile, 'listbox-role', async (t) => {
+ariaTest(
+  'role "listbox" on ul element',
+  exampleFile,
+  'listbox-role',
+  async (t) => {
     await assertAriaRoles(t, 'ex1', 'listbox', '1', 'ul');
-});
+  }
+);
 
-ariaTest('"aria-label" attribute on listbox element', exampleFile, 'listbox-aria-label', async (t) => {
+ariaTest(
+  '"aria-label" attribute on listbox element',
+  exampleFile,
+  'listbox-aria-label',
+  async (t) => {
     await assertAriaLabelExists(t, ex.listboxSelector);
-});
+  }
+);
 
-ariaTest('role "option" on lu elements', exampleFile, 'option-role', async (t) => {
+ariaTest(
+  'role "option" on lu elements',
+  exampleFile,
+  'option-role',
+  async (t) => {
+    // Send arrow down to reveal all options
+    await t.context.session
+      .findElement(By.css(ex.textboxSelector))
+      .sendKeys(Key.ARROW_DOWN);
+    await assertAriaRoles(t, 'ex1', 'option', '56', 'li');
+  }
+);
 
-  // Send arrow down to reveal all options
-  await t.context.session.findElement(By.css(ex.textboxSelector)).sendKeys(Key.ARROW_DOWN);
-  await assertAriaRoles(t, 'ex1', 'option', '56', 'li');
-});
+ariaTest(
+  '"aria-selected" attribute on options element',
+  exampleFile,
+  'option-aria-selected',
+  async (t) => {
+    // Send key "a"
+    await t.context.session
+      .findElement(By.css(ex.textboxSelector))
+      .sendKeys('a');
+    await assertAttributeDNE(
+      t,
+      ex.optionsSelector + ':nth-of-type(1)',
+      'aria-selected'
+    );
 
-ariaTest('"aria-selected" attribute on options element', exampleFile, 'option-aria-selected', async (t) => {
+    // Send key ARROW_DOWN to selected first option
+    await t.context.session
+      .findElement(By.css(ex.textboxSelector))
+      .sendKeys(Key.ARROW_DOWN);
+    await assertAttributeValues(
+      t,
+      ex.optionsSelector + ':nth-of-type(1)',
+      'aria-selected',
+      'true'
+    );
+  }
+);
 
-  // Send key "a"
-  await t.context.session.findElement(By.css(ex.textboxSelector)).sendKeys('a');
-  await assertAttributeDNE(t, ex.optionsSelector + ':nth-of-type(1)', 'aria-selected');
+ariaTest(
+  'Button should have tabindex="-1"',
+  exampleFile,
+  'button-tabindex',
+  async (t) => {
+    const button = await t.context.session.findElement(
+      By.css(ex.buttonSelector)
+    );
 
-  // Send key ARROW_DOWN to selected first option
-  await t.context.session.findElement(By.css(ex.textboxSelector)).sendKeys(Key.ARROW_DOWN);
-  await assertAttributeValues(t, ex.optionsSelector + ':nth-of-type(1)', 'aria-selected', 'true');
-});
+    t.is(
+      await button.getAttribute('tabindex'),
+      '-1',
+      'tabindex should be set to "-1" on button'
+    );
+  }
+);
 
-ariaTest('Button should have tabindex="-1"', exampleFile, 'button-tabindex', async (t) => {
-  const button = await t.context.session.findElement(By.css(ex.buttonSelector))
+ariaTest(
+  '"aria-label" attribute on button element',
+  exampleFile,
+  'button-aria-label',
+  async (t) => {
+    await assertAriaLabelExists(t, ex.buttonSelector);
+  }
+);
 
-  t.is(
-    await button.getAttribute('tabindex'),
-    '-1',
-    'tabindex should be set to "-1" on button'
-  );
-});
+ariaTest(
+  '"aria-controls" attribute on button element',
+  exampleFile,
+  'button-aria-controls',
+  async (t) => {
+    const popupId = await t.context.session
+      .findElement(By.css(ex.buttonSelector))
+      .getAttribute('aria-controls');
 
-ariaTest('"aria-label" attribute on button element', exampleFile, 'button-aria-label', async (t) => {
-  await assertAriaLabelExists(t, ex.buttonSelector);
-});
+    t.truthy(
+      popupId,
+      '"aria-controls" attribute should exist on: ' + ex.buttonSelector
+    );
 
-ariaTest('"aria-controls" attribute on button element', exampleFile, 'button-aria-controls', async (t) => {
-  const popupId = await t.context.session
-    .findElement(By.css(ex.buttonSelector))
-    .getAttribute('aria-controls');
+    const popupElements = await t.context.queryElements(t, `#ex1 #${popupId}`);
 
-  t.truthy(
-    popupId,
-    '"aria-controls" attribute should exist on: ' + ex.buttonSelector
-  );
+    t.is(
+      popupElements.length,
+      1,
+      'There should be a element with id "' +
+        popupId +
+        '" as referenced by the aria-controls attribute'
+    );
+  }
+);
 
-  const popupElements = await t.context.queryElements(t, `#ex1 #${popupId}`);
+ariaTest(
+  '"aria-expanded" on button element',
+  exampleFile,
+  'button-aria-expanded',
+  async (t) => {
+    const button = await t.context.session.findElement(
+      By.css(ex.buttonSelector)
+    );
 
-  t.is(
-    popupElements.length,
-    1,
-    'There should be a element with id "' + popupId + '" as referenced by the aria-controls attribute'
-  );
-});
+    // Check that aria-expanded is false and the listbox is not visible before interacting
 
+    t.is(
+      await button.getAttribute('aria-expanded'),
+      'false',
+      'button element should have attribute "aria-expanded" set to false by default.'
+    );
 
-ariaTest('"aria-expanded" on button element', exampleFile, 'button-aria-expanded', async (t) => {
-  const button = await t.context.session.findElement(By.css(ex.buttonSelector));
+    const popupId = await t.context.session
+      .findElement(By.css(ex.textboxSelector))
+      .getAttribute('aria-controls');
 
-  // Check that aria-expanded is false and the listbox is not visible before interacting
+    const popupElement = await t.context.session
+      .findElement(By.id('ex1'))
+      .findElement(By.id(popupId));
 
-  t.is(
-    await button.getAttribute('aria-expanded'),
-    'false',
-    'button element should have attribute "aria-expanded" set to false by default.'
-  );
+    t.false(
+      await popupElement.isDisplayed(),
+      "Popup element should not be displayed when 'aria-expanded' is false'"
+    );
 
-  const popupId = await t.context.session
-    .findElement(By.css(ex.textboxSelector))
-    .getAttribute('aria-controls');
+    // Send key "a" to textbox
 
-  const popupElement = await t.context.session
-    .findElement(By.id('ex1'))
-    .findElement(By.id(popupId));
+    await t.context.session
+      .findElement(By.css(ex.textboxSelector))
+      .sendKeys('a');
 
-  t.false(
-    await popupElement.isDisplayed(),
-    'Popup element should not be displayed when \'aria-expanded\' is false\''
-  );
+    // Check that aria-expanded is true and the listbox is visible
 
-  // Send key "a" to textbox
+    t.is(
+      await button.getAttribute('aria-expanded'),
+      'true',
+      'button element should have attribute "aria-expand" set to true after typing.'
+    );
 
-  await t.context.session
-    .findElement(By.css(ex.textboxSelector))
-    .sendKeys('a');
-
-  // Check that aria-expanded is true and the listbox is visible
-
-  t.is(
-    await button.getAttribute('aria-expanded'),
-    'true',
-    'button element should have attribute "aria-expand" set to true after typing.'
-  );
-
-  t.true(
-    await popupElement.isDisplayed(),
-    'Popup element should be displayed when \'aria-expanded\' is true\''
-  );
-
-});
-
+    t.true(
+      await popupElement.isDisplayed(),
+      "Popup element should be displayed when 'aria-expanded' is true'"
+    );
+  }
+);
 
 // Keys
 
-ariaTest('Test alt + down key press with focus on textbox',
-  exampleFile, 'textbox-key-alt-down-arrow', async (t) => {
-
-
+ariaTest(
+  'Test alt + down key press with focus on textbox',
+  exampleFile,
+  'textbox-key-alt-down-arrow',
+  async (t) => {
     // Send ARROW_DOWN to the textbox
     await t.context.session
       .findElement(By.css(ex.textboxSelector))
@@ -255,19 +356,22 @@ ariaTest('Test alt + down key press with focus on textbox',
 
     // Check that the listbox is displayed
     t.true(
-      await t.context.session.findElement(By.css(ex.listboxSelector)).isDisplayed(),
+      await t.context.session
+        .findElement(By.css(ex.listboxSelector))
+        .isDisplayed(),
       'In example the list box should display after ALT + ARROW_DOWN keypress'
     );
 
     // aria-selected should not be on any options
     await assertAttributeDNE(t, ex.optionsSelector, 'aria-selected');
+  }
+);
 
-  });
-
-ariaTest('Test down key press with focus on textbox',
-  exampleFile, 'textbox-key-down-arrow', async (t) => {
-
-
+ariaTest(
+  'Test down key press with focus on textbox',
+  exampleFile,
+  'textbox-key-down-arrow',
+  async (t) => {
     // Send ARROW_DOWN to the textbox
     await t.context.session
       .findElement(By.css(ex.textboxSelector))
@@ -275,28 +379,36 @@ ariaTest('Test down key press with focus on textbox',
 
     // Check that the listbox is displayed
     t.true(
-      await t.context.session.findElement(By.css(ex.listboxSelector)).isDisplayed(),
+      await t.context.session
+        .findElement(By.css(ex.listboxSelector))
+        .isDisplayed(),
       'In example ex3 listbox should display after ARROW_DOWN keypress'
     );
 
     await waitForFocusChange(t, ex.textboxSelector, null);
 
     // Check that the active descendent focus is correct
-    await assertAriaSelectedAndActivedescendant(t, ex.textboxSelector, ex.optionsSelector, 0);
+    await assertAriaSelectedAndActivedescendant(
+      t,
+      ex.textboxSelector,
+      ex.optionsSelector,
+      0
+    );
+  }
+);
 
-  });
-
-ariaTest('Test down key press with focus on list',
-  exampleFile, 'listbox-key-down-arrow', async (t) => {
-
-
+ariaTest(
+  'Test down key press with focus on list',
+  exampleFile,
+  'listbox-key-down-arrow',
+  async (t) => {
     // Send 'a' to text box, then send ARROW_DOWN to textbox to set focus on listbox
     await t.context.session
       .findElement(By.css(ex.textboxSelector))
       .sendKeys('a', Key.ARROW_DOWN);
 
     // Test that ARROW_DOWN moves active descendant focus on item in listbox
-    for (let i = 1; i <  ex.numAOptions; i++) {
+    for (let i = 1; i < ex.numAOptions; i++) {
       let oldfocus = await t.context.session
         .findElement(By.css(ex.textboxSelector))
         .getAttribute('aria-activedescendant');
@@ -308,7 +420,12 @@ ariaTest('Test down key press with focus on list',
       // Account for race condition
       await waitForFocusChange(t, ex.textboxSelector, oldfocus);
 
-      await assertAriaSelectedAndActivedescendant(t, ex.textboxSelector, ex.optionsSelector, i);
+      await assertAriaSelectedAndActivedescendant(
+        t,
+        ex.textboxSelector,
+        ex.optionsSelector,
+        i
+      );
     }
 
     // Sending ARROW_DOWN to the last item should put focus on the first
@@ -323,15 +440,20 @@ ariaTest('Test down key press with focus on list',
     await waitForFocusChange(t, ex.textboxSelector, oldfocus);
 
     // Focus should be on the first item
-    await assertAriaSelectedAndActivedescendant(t, ex.textboxSelector, ex.optionsSelector, 0);
+    await assertAriaSelectedAndActivedescendant(
+      t,
+      ex.textboxSelector,
+      ex.optionsSelector,
+      0
+    );
+  }
+);
 
-  });
-
-
-ariaTest('Test up key press with focus on textbox',
-  exampleFile, 'textbox-key-up-arrow', async (t) => {
-
-
+ariaTest(
+  'Test up key press with focus on textbox',
+  exampleFile,
+  'textbox-key-up-arrow',
+  async (t) => {
     // Send ARROW_UP to the textbox
     await t.context.session
       .findElement(By.css(ex.textboxSelector))
@@ -339,21 +461,31 @@ ariaTest('Test up key press with focus on textbox',
 
     // Check that the listbox is displayed
     t.true(
-      await t.context.session.findElement(By.css(ex.listboxSelector)).isDisplayed(),
+      await t.context.session
+        .findElement(By.css(ex.listboxSelector))
+        .isDisplayed(),
       'In example ex3 listbox should display after ARROW_UP keypress'
     );
 
     await waitForFocusChange(t, ex.textboxSelector, null);
 
     // Check that the active descendent focus is correct
-    let numOptions = (await t.context.queryElements(t, ex.optionsSelector)).length;
-    await assertAriaSelectedAndActivedescendant(t, ex.textboxSelector, ex.optionsSelector, numOptions - 1);
-  });
+    let numOptions = (await t.context.queryElements(t, ex.optionsSelector))
+      .length;
+    await assertAriaSelectedAndActivedescendant(
+      t,
+      ex.textboxSelector,
+      ex.optionsSelector,
+      numOptions - 1
+    );
+  }
+);
 
-ariaTest('Test up key press with focus on listbox',
-  exampleFile, 'listbox-key-up-arrow', async (t) => {
-
-
+ariaTest(
+  'Test up key press with focus on listbox',
+  exampleFile,
+  'listbox-key-up-arrow',
+  async (t) => {
     // Send 'a' to text box, then send ARROW_UP to textbox to textbox to put focus in textbox
     // Up arrow should move selection to the last item in the list
     await t.context.session
@@ -361,7 +493,7 @@ ariaTest('Test up key press with focus on listbox',
       .sendKeys('a', Key.ARROW_UP);
 
     // Test that ARROW_UP moves active descendant focus up one item in the listbox
-    for (let index = ex.numAOptions - 2; index > 0 ; index--) {
+    for (let index = ex.numAOptions - 2; index > 0; index--) {
       let oldfocus = await t.context.session
         .findElement(By.css(ex.textboxSelector))
         .getAttribute('aria-activedescendant');
@@ -373,14 +505,21 @@ ariaTest('Test up key press with focus on listbox',
 
       await waitForFocusChange(t, ex.textboxSelector, oldfocus);
 
-      await assertAriaSelectedAndActivedescendant(t, ex.textboxSelector, ex.optionsSelector, index);
+      await assertAriaSelectedAndActivedescendant(
+        t,
+        ex.textboxSelector,
+        ex.optionsSelector,
+        index
+      );
     }
-  });
+  }
+);
 
-ariaTest('Test enter key press with focus on textbox',
-  exampleFile, 'textbox-key-enter', async (t) => {
-
-
+ariaTest(
+  'Test enter key press with focus on textbox',
+  exampleFile,
+  'textbox-key-enter',
+  async (t) => {
     // Send key "a" to the textbox, then key ARROW_DOWN to select the first item
 
     await t.context.session
@@ -395,7 +534,12 @@ ariaTest('Test enter key press with focus on textbox',
 
     // Confirm that the listbox is closed
 
-    await assertAttributeValues(t, ex.textboxSelector, 'aria-expanded', 'false');
+    await assertAttributeValues(
+      t,
+      ex.textboxSelector,
+      'aria-expanded',
+      'false'
+    );
 
     // Confirm that the value of the textbox is the same as the characters set to the listbox
 
@@ -406,13 +550,14 @@ ariaTest('Test enter key press with focus on textbox',
       'a',
       'key press "ENTER" should not result in selecting an option'
     );
+  }
+);
 
-  });
-
-ariaTest('Test enter key press with focus on listbox',
-  exampleFile, 'listbox-key-enter', async (t) => {
-
-
+ariaTest(
+  'Test enter key press with focus on listbox',
+  exampleFile,
+  'listbox-key-enter',
+  async (t) => {
     // Send key "a" to the textbox, then key ARROW_DOWN to select the first item
 
     await t.context.session
@@ -421,7 +566,9 @@ ariaTest('Test enter key press with focus on listbox',
 
     // Get the value of the first option in the listbox
 
-    const firstOption = await t.context.session.findElement(By.css(ex.optionsSelector)).getText();
+    const firstOption = await t.context.session
+      .findElement(By.css(ex.optionsSelector))
+      .getText();
 
     // Send key ENTER
 
@@ -431,7 +578,12 @@ ariaTest('Test enter key press with focus on listbox',
 
     // Confirm that the listbox is closed
 
-    await assertAttributeValues(t, ex.textboxSelector, 'aria-expanded', 'false');
+    await assertAttributeValues(
+      t,
+      ex.textboxSelector,
+      'aria-expanded',
+      'false'
+    );
 
     // Confirm that the value of the textbox is now set to the first option
 
@@ -442,12 +594,14 @@ ariaTest('Test enter key press with focus on listbox',
       firstOption,
       'key press "ENTER" should result in first option in textbox'
     );
+  }
+);
 
-  });
-
-ariaTest('Test single escape key press with focus on textbox',
-  exampleFile, 'textbox-key-escape', async (t) => {
-
+ariaTest(
+  'Test single escape key press with focus on textbox',
+  exampleFile,
+  'textbox-key-escape',
+  async (t) => {
     // Send key "a", then key ESCAPE once to the textbox
 
     await t.context.session
@@ -456,7 +610,12 @@ ariaTest('Test single escape key press with focus on textbox',
 
     // Confirm the listbox is closed and the textbox is not cleared
 
-    await assertAttributeValues(t, ex.textboxSelector, 'aria-expanded', 'false');
+    await assertAttributeValues(
+      t,
+      ex.textboxSelector,
+      'aria-expanded',
+      'false'
+    );
     t.is(
       await t.context.session
         .findElement(By.css(ex.textboxSelector))
@@ -464,12 +623,14 @@ ariaTest('Test single escape key press with focus on textbox',
       'a',
       'In key press "ESCAPE" should result in first option in textbox'
     );
+  }
+);
 
-  });
-
-ariaTest('Test double escape key press with focus on textbox',
-  exampleFile, 'textbox-key-escape', async (t) => {
-
+ariaTest(
+  'Test double escape key press with focus on textbox',
+  exampleFile,
+  'textbox-key-escape',
+  async (t) => {
     // Send key "a", then key ESCAPE twice to the textbox
 
     await t.context.session
@@ -478,7 +639,12 @@ ariaTest('Test double escape key press with focus on textbox',
 
     // Confirm the listbox is closed and the textbox is cleared
 
-    await assertAttributeValues(t, ex.textboxSelector, 'aria-expanded', 'false');
+    await assertAttributeValues(
+      t,
+      ex.textboxSelector,
+      'aria-expanded',
+      'false'
+    );
     t.is(
       await t.context.session
         .findElement(By.css(ex.textboxSelector))
@@ -486,12 +652,14 @@ ariaTest('Test double escape key press with focus on textbox',
       '',
       'In key press "ESCAPE" should result in first option in textbox'
     );
+  }
+);
 
-  });
-
-ariaTest('Test escape key press with focus on textbox',
-  exampleFile, 'listbox-key-escape', async (t) => {
-
+ariaTest(
+  'Test escape key press with focus on textbox',
+  exampleFile,
+  'listbox-key-escape',
+  async (t) => {
     // Send key "a" then key "ARROW_DOWN to put the focus on the listbox,
     // then key ESCAPE to the textbox
 
@@ -501,7 +669,12 @@ ariaTest('Test escape key press with focus on textbox',
 
     // Confirm the listbox is closed and the textboxed is cleared
 
-    await assertAttributeValues(t, ex.textboxSelector, 'aria-expanded', 'false');
+    await assertAttributeValues(
+      t,
+      ex.textboxSelector,
+      'aria-expanded',
+      'false'
+    );
     t.is(
       await t.context.session
         .findElement(By.css(ex.textboxSelector))
@@ -509,14 +682,18 @@ ariaTest('Test escape key press with focus on textbox',
       'a',
       'In listbox key press "ESCAPE" should result in first option in textbox'
     );
+  }
+);
 
-  });
-
-ariaTest('left arrow from focus on list puts focus on listbox and moves cursor right',
-  exampleFile, 'listbox-key-left-arrow', async (t) => {
-
+ariaTest(
+  'left arrow from focus on list puts focus on listbox and moves cursor right',
+  exampleFile,
+  'listbox-key-left-arrow',
+  async (t) => {
     // Send key "a" then key "ARROW_DOWN" to put the focus on the listbox
-    const textbox = await t.context.session.findElement(By.css(ex.textboxSelector));
+    const textbox = await t.context.session.findElement(
+      By.css(ex.textboxSelector)
+    );
     await textbox.sendKeys('a', Key.ARROW_DOWN);
 
     // Send key "ARROW_LEFT"
@@ -530,16 +707,20 @@ ariaTest('left arrow from focus on list puts focus on listbox and moves cursor r
     t.is(
       await textbox.getAttribute('aria-activedescendant'),
       '',
-      'Focus should be on the textbox after on ARROW_LEFT key',
+      'Focus should be on the textbox after on ARROW_LEFT key'
     );
-  });
+  }
+);
 
-
-ariaTest('Right arrow from focus on list puts focus on listbox',
-  exampleFile, 'listbox-key-right-arrow', async (t) => {
-
+ariaTest(
+  'Right arrow from focus on list puts focus on listbox',
+  exampleFile,
+  'listbox-key-right-arrow',
+  async (t) => {
     // Send key "a" then key "ARROW_DOWN" to put the focus on the listbox
-    const textbox = await t.context.session.findElement(By.css(ex.textboxSelector));
+    const textbox = await t.context.session.findElement(
+      By.css(ex.textboxSelector)
+    );
     await textbox.sendKeys('a', Key.ARROW_DOWN);
 
     // Send key "RIGHT_ARROW"
@@ -553,15 +734,20 @@ ariaTest('Right arrow from focus on list puts focus on listbox',
     t.is(
       await textbox.getAttribute('aria-activedescendant'),
       '',
-      'Focus should be on the textbox after on ARROW_RIGHT key',
+      'Focus should be on the textbox after on ARROW_RIGHT key'
     );
-  });
+  }
+);
 
-ariaTest('Home from focus on list puts focus on listbox and moves cursor',
-  exampleFile, 'listbox-key-home', async (t) => {
-
+ariaTest(
+  'Home from focus on list puts focus on listbox and moves cursor',
+  exampleFile,
+  'listbox-key-home',
+  async (t) => {
     // Send key "a" then key "ARROW_DOWN" to put the focus on the listbox
-    const textbox = await t.context.session.findElement(By.css(ex.textboxSelector));
+    const textbox = await t.context.session.findElement(
+      By.css(ex.textboxSelector)
+    );
     await textbox.sendKeys('a', Key.ARROW_DOWN);
 
     // Send key "ARROW_HOME"
@@ -575,15 +761,20 @@ ariaTest('Home from focus on list puts focus on listbox and moves cursor',
     t.is(
       await textbox.getAttribute('aria-activedescendant'),
       '',
-      'Focus should be on the textbox after one ARROW_HOME key',
+      'Focus should be on the textbox after one ARROW_HOME key'
     );
-  });
+  }
+);
 
-ariaTest('End from focus on list puts focus on listbox',
-  exampleFile, 'listbox-key-end', async (t) => {
-
+ariaTest(
+  'End from focus on list puts focus on listbox',
+  exampleFile,
+  'listbox-key-end',
+  async (t) => {
     // Send key "a" then key "ARROW_DOWN" to put the focus on the listbox
-    const textbox = await t.context.session.findElement(By.css(ex.textboxSelector));
+    const textbox = await t.context.session.findElement(
+      By.css(ex.textboxSelector)
+    );
     await textbox.sendKeys('a', Key.ARROW_DOWN);
 
     // Send key "END_ARROW"
@@ -597,15 +788,20 @@ ariaTest('End from focus on list puts focus on listbox',
     t.is(
       await textbox.getAttribute('aria-activedescendant'),
       '',
-      'Focus should be on the textbox after on ARROW_END key',
+      'Focus should be on the textbox after on ARROW_END key'
     );
-  });
+  }
+);
 
-ariaTest('Sending character keys while focus is on listbox moves focus',
-  exampleFile, 'listbox-key-char', async (t) => {
-
+ariaTest(
+  'Sending character keys while focus is on listbox moves focus',
+  exampleFile,
+  'listbox-key-char',
+  async (t) => {
     // Send key "ARROW_DOWN" to put the focus on the listbox
-    const textbox = await t.context.session.findElement(By.css(ex.textboxSelector));
+    const textbox = await t.context.session.findElement(
+      By.css(ex.textboxSelector)
+    );
     await textbox.sendKeys(Key.ARROW_DOWN);
 
     // Send key "a"
@@ -621,16 +817,20 @@ ariaTest('Sending character keys while focus is on listbox moves focus',
     t.is(
       await textbox.getAttribute('aria-activedescendant'),
       '',
-      'Focus should be on the textbox after sending a character key while the focus is on the listbox',
+      'Focus should be on the textbox after sending a character key while the focus is on the listbox'
     );
+  }
+);
 
-  });
-
-ariaTest('Expected behavior for all other standard single line editing keys',
-  exampleFile, 'standard-single-line-editing-keys', async (t) => {
-
+ariaTest(
+  'Expected behavior for all other standard single line editing keys',
+  exampleFile,
+  'standard-single-line-editing-keys',
+  async (t) => {
     // Send key "a"
-    const textbox = await t.context.session.findElement(By.css(ex.textboxSelector));
+    const textbox = await t.context.session.findElement(
+      By.css(ex.textboxSelector)
+    );
     await textbox.sendKeys('a');
 
     t.is(
@@ -638,5 +838,5 @@ ariaTest('Expected behavior for all other standard single line editing keys',
       ex.numAOptions,
       'Sending standard editing keys should filter results'
     );
-  });
-
+  }
+);

--- a/test/tests/combobox_autocomplete-list.js
+++ b/test/tests/combobox_autocomplete-list.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const { ariaTest } = require('..');
 const { By, Key } = require('selenium-webdriver');
 const assertAttributeValues = require('../util/assertAttributeValues');
@@ -13,7 +15,7 @@ const ex = {
   listboxSelector: '#ex1 [role="listbox"]',
   optionsSelector: '#ex1 [role="option"]',
   buttonSelector: '#ex1 button',
-  numAOptions: 5,
+  numAOptions: 5
 };
 
 const waitForFocusChange = async (t, textboxSelector, originalFocus) => {
@@ -25,308 +27,227 @@ const waitForFocusChange = async (t, textboxSelector, originalFocus) => {
       return newfocus != originalFocus;
     },
     t.context.waitTime,
-    'Error waiting for "aria-activedescendant" value to change from "' +
-      originalFocus +
-      '". '
+    'Error waiting for "aria-activedescendant" value to change from "' + originalFocus + '". '
   );
 };
 
 const confirmCursorIndex = async (t, selector, cursorIndex) => {
-  return t.context.session.executeScript(
-    function () {
-      const [selector, cursorIndex] = arguments;
-      let item = document.querySelector(selector);
-      return item.selectionStart === cursorIndex;
-    },
-    selector,
-    cursorIndex
-  );
+  return t.context.session.executeScript(function () {
+    const [selector, cursorIndex] = arguments;
+    let item = document.querySelector(selector);
+    return item.selectionStart === cursorIndex;
+  }, selector, cursorIndex);
 };
 
 // Attributes
-ariaTest(
-  'Test for role="combobox"',
-  exampleFile,
-  'combobox-role',
-  async (t) => {
+ariaTest('Test for role="combobox"', exampleFile, 'combobox-role', async (t) => {
     await assertAriaRoles(t, 'ex1', 'combobox', '1', 'input');
-  }
-);
+});
 
-ariaTest(
-  '"aria-autocomplete" on comboxbox element',
-  exampleFile,
-  'combobox-aria-autocomplete',
-  async (t) => {
-    await assertAttributeValues(
-      t,
-      ex.textboxSelector,
-      'aria-autocomplete',
-      'list'
-    );
-  }
-);
+ariaTest('"aria-autocomplete" on comboxbox element', exampleFile, 'combobox-aria-autocomplete', async (t) => {
+    await assertAttributeValues(t, ex.textboxSelector, 'aria-autocomplete', 'list');
+});
 
-ariaTest(
-  '"aria-controls" attribute on combobox element',
-  exampleFile,
-  'combobox-aria-controls',
-  async (t) => {
-    const popupId = await t.context.session
-      .findElement(By.css(ex.textboxSelector))
-      .getAttribute('aria-controls');
+ariaTest('"aria-controls" attribute on combobox element', exampleFile, 'combobox-aria-controls', async (t) => {
 
-    t.truthy(
-      popupId,
-      '"aria-controls" attribute should exist on: ' + ex.textboxSelector
-    );
+  const popupId = await t.context.session
+    .findElement(By.css(ex.textboxSelector))
+    .getAttribute('aria-controls');
 
-    const popupElements = await t.context.queryElements(t, `#ex1 #${popupId}`);
+  t.truthy(
+    popupId,
+    '"aria-controls" attribute should exist on: ' + ex.textboxSelector
+  );
 
-    t.is(
-      popupElements.length,
-      1,
-      'There should be a element with id "' +
-        popupId +
-        '" as referenced by the aria-controls attribute'
-    );
-  }
-);
+  const popupElements = await t.context.queryElements(t, `#ex1 #${popupId}`);
 
-ariaTest(
-  '"aria-expanded" on combobox element',
-  exampleFile,
-  'combobox-aria-expanded',
-  async (t) => {
-    const combobox = await t.context.session.findElement(
-      By.css(ex.textboxSelector)
-    );
+  t.is(
+    popupElements.length,
+    1,
+    'There should be a element with id "' + popupId + '" as referenced by the aria-controls attribute'
+  );
+});
 
-    // Check that aria-expanded is false and the listbox is not visible before interacting
+ariaTest('"aria-expanded" on combobox element', exampleFile, 'combobox-aria-expanded', async (t) => {
 
-    t.is(
-      await combobox.getAttribute('aria-expanded'),
-      'false',
-      'combobox element should have attribute "aria-expanded" set to false by default.'
-    );
+  const combobox = await t.context.session.findElement(By.css(ex.textboxSelector));
 
-    const popupId = await t.context.session
-      .findElement(By.css(ex.textboxSelector))
-      .getAttribute('aria-controls');
+  // Check that aria-expanded is false and the listbox is not visible before interacting
 
-    const popupElement = await t.context.session
-      .findElement(By.id('ex1'))
-      .findElement(By.id(popupId));
+  t.is(
+    await combobox.getAttribute('aria-expanded'),
+    'false',
+    'combobox element should have attribute "aria-expanded" set to false by default.'
+  );
 
-    t.false(
-      await popupElement.isDisplayed(),
-      "Popup element should not be displayed when 'aria-expanded' is false'"
-    );
+  const popupId = await t.context.session
+    .findElement(By.css(ex.textboxSelector))
+    .getAttribute('aria-controls');
 
-    // Send key "a" to textbox
+  const popupElement = await t.context.session
+    .findElement(By.id('ex1'))
+    .findElement(By.id(popupId));
 
-    await t.context.session
-      .findElement(By.css(ex.textboxSelector))
-      .sendKeys('a');
+  t.false(
+    await popupElement.isDisplayed(),
+    'Popup element should not be displayed when \'aria-expanded\' is false\''
+  );
 
-    // Check that aria-expanded is true and the listbox is visible
+  // Send key "a" to textbox
 
-    t.is(
-      await combobox.getAttribute('aria-expanded'),
-      'true',
-      'combobox element should have attribute "aria-expand" set to true after typing.'
-    );
+  await t.context.session
+    .findElement(By.css(ex.textboxSelector))
+    .sendKeys('a');
 
-    t.true(
-      await popupElement.isDisplayed(),
-      "Popup element should be displayed when 'aria-expanded' is true'"
-    );
-  }
-);
+  // Check that aria-expanded is true and the listbox is visible
 
-ariaTest(
-  '"aria-activedescendant" on combobox element',
-  exampleFile,
-  'combobox-aria-activedescendant',
-  async (t) => {
-    await assertAttributeValues(
-      t,
-      ex.textboxSelector,
-      'aria-activedescendant',
-      null
-    );
-  }
-);
+  t.is(
+    await combobox.getAttribute('aria-expanded'),
+    'true',
+    'combobox element should have attribute "aria-expand" set to true after typing.'
+  );
 
-ariaTest(
-  'role "listbox" on ul element',
-  exampleFile,
-  'listbox-role',
-  async (t) => {
+  t.true(
+    await popupElement.isDisplayed(),
+    'Popup element should be displayed when \'aria-expanded\' is true\''
+  );
+
+});
+
+ariaTest('"aria-activedescendant" on combobox element', exampleFile, 'combobox-aria-activedescendant', async (t) => {
+    await assertAttributeValues(t, ex.textboxSelector, 'aria-activedescendant', null);
+});
+
+ariaTest('"id" attribute on combobox element', exampleFile, 'combobox-id', async (t) => {
+  const combobox = await t.context.session.findElement(By.css(ex.textboxSelector))
+  const id = await combobox.getAttribute('id');
+
+  console.log(id);
+  t.truthy(
+    id,
+    '"id" attribute should exist on combobox'
+  );
+
+  const label = await t.context.queryElements(t, `[for="${id}"]`);
+  t.is(
+    label.length,
+    1,
+    `There should be one element that labels the combobox with: [for="${id}"]`
+  );
+});
+
+ariaTest('role "listbox" on ul element', exampleFile, 'listbox-role', async (t) => {
     await assertAriaRoles(t, 'ex1', 'listbox', '1', 'ul');
-  }
-);
+});
 
-ariaTest(
-  '"aria-label" attribute on listbox element',
-  exampleFile,
-  'listbox-aria-label',
-  async (t) => {
+ariaTest('"aria-label" attribute on listbox element', exampleFile, 'listbox-aria-label', async (t) => {
     await assertAriaLabelExists(t, ex.listboxSelector);
-  }
-);
+});
 
-ariaTest(
-  'role "option" on lu elements',
-  exampleFile,
-  'option-role',
-  async (t) => {
-    // Send arrow down to reveal all options
-    await t.context.session
-      .findElement(By.css(ex.textboxSelector))
-      .sendKeys(Key.ARROW_DOWN);
-    await assertAriaRoles(t, 'ex1', 'option', '56', 'li');
-  }
-);
+ariaTest('role "option" on lu elements', exampleFile, 'option-role', async (t) => {
 
-ariaTest(
-  '"aria-selected" attribute on options element',
-  exampleFile,
-  'option-aria-selected',
-  async (t) => {
-    // Send key "a"
-    await t.context.session
-      .findElement(By.css(ex.textboxSelector))
-      .sendKeys('a');
-    await assertAttributeDNE(
-      t,
-      ex.optionsSelector + ':nth-of-type(1)',
-      'aria-selected'
-    );
+  // Send arrow down to reveal all options
+  await t.context.session.findElement(By.css(ex.textboxSelector)).sendKeys(Key.ARROW_DOWN);
+  await assertAriaRoles(t, 'ex1', 'option', '56', 'li');
+});
 
-    // Send key ARROW_DOWN to selected first option
-    await t.context.session
-      .findElement(By.css(ex.textboxSelector))
-      .sendKeys(Key.ARROW_DOWN);
-    await assertAttributeValues(
-      t,
-      ex.optionsSelector + ':nth-of-type(1)',
-      'aria-selected',
-      'true'
-    );
-  }
-);
+ariaTest('"aria-selected" attribute on options element', exampleFile, 'option-aria-selected', async (t) => {
 
-ariaTest(
-  'Button should have tabindex="-1"',
-  exampleFile,
-  'button-tabindex',
-  async (t) => {
-    const button = await t.context.session.findElement(
-      By.css(ex.buttonSelector)
-    );
+  // Send key "a"
+  await t.context.session.findElement(By.css(ex.textboxSelector)).sendKeys('a');
+  await assertAttributeDNE(t, ex.optionsSelector + ':nth-of-type(1)', 'aria-selected');
 
-    t.is(
-      await button.getAttribute('tabindex'),
-      '-1',
-      'tabindex should be set to "-1" on button'
-    );
-  }
-);
+  // Send key ARROW_DOWN to selected first option
+  await t.context.session.findElement(By.css(ex.textboxSelector)).sendKeys(Key.ARROW_DOWN);
+  await assertAttributeValues(t, ex.optionsSelector + ':nth-of-type(1)', 'aria-selected', 'true');
+});
 
-ariaTest(
-  '"aria-label" attribute on button element',
-  exampleFile,
-  'button-aria-label',
-  async (t) => {
-    await assertAriaLabelExists(t, ex.buttonSelector);
-  }
-);
+ariaTest('Button should have tabindex="-1"', exampleFile, 'button-tabindex', async (t) => {
+  const button = await t.context.session.findElement(By.css(ex.buttonSelector))
 
-ariaTest(
-  '"aria-controls" attribute on button element',
-  exampleFile,
-  'button-aria-controls',
-  async (t) => {
-    const popupId = await t.context.session
-      .findElement(By.css(ex.buttonSelector))
-      .getAttribute('aria-controls');
+  t.is(
+    await button.getAttribute('tabindex'),
+    '-1',
+    'tabindex should be set to "-1" on button'
+  );
+});
 
-    t.truthy(
-      popupId,
-      '"aria-controls" attribute should exist on: ' + ex.buttonSelector
-    );
+ariaTest('"aria-label" attribute on button element', exampleFile, 'button-aria-label', async (t) => {
+  await assertAriaLabelExists(t, ex.buttonSelector);
+});
 
-    const popupElements = await t.context.queryElements(t, `#ex1 #${popupId}`);
+ariaTest('"aria-controls" attribute on button element', exampleFile, 'button-aria-controls', async (t) => {
+  const popupId = await t.context.session
+    .findElement(By.css(ex.buttonSelector))
+    .getAttribute('aria-controls');
 
-    t.is(
-      popupElements.length,
-      1,
-      'There should be a element with id "' +
-        popupId +
-        '" as referenced by the aria-controls attribute'
-    );
-  }
-);
+  t.truthy(
+    popupId,
+    '"aria-controls" attribute should exist on: ' + ex.buttonSelector
+  );
 
-ariaTest(
-  '"aria-expanded" on button element',
-  exampleFile,
-  'button-aria-expanded',
-  async (t) => {
-    const button = await t.context.session.findElement(
-      By.css(ex.buttonSelector)
-    );
+  const popupElements = await t.context.queryElements(t, `#ex1 #${popupId}`);
 
-    // Check that aria-expanded is false and the listbox is not visible before interacting
+  t.is(
+    popupElements.length,
+    1,
+    'There should be a element with id "' + popupId + '" as referenced by the aria-controls attribute'
+  );
+});
 
-    t.is(
-      await button.getAttribute('aria-expanded'),
-      'false',
-      'button element should have attribute "aria-expanded" set to false by default.'
-    );
 
-    const popupId = await t.context.session
-      .findElement(By.css(ex.textboxSelector))
-      .getAttribute('aria-controls');
+ariaTest('"aria-expanded" on button element', exampleFile, 'button-aria-expanded', async (t) => {
+  const button = await t.context.session.findElement(By.css(ex.buttonSelector));
 
-    const popupElement = await t.context.session
-      .findElement(By.id('ex1'))
-      .findElement(By.id(popupId));
+  // Check that aria-expanded is false and the listbox is not visible before interacting
 
-    t.false(
-      await popupElement.isDisplayed(),
-      "Popup element should not be displayed when 'aria-expanded' is false'"
-    );
+  t.is(
+    await button.getAttribute('aria-expanded'),
+    'false',
+    'button element should have attribute "aria-expanded" set to false by default.'
+  );
 
-    // Send key "a" to textbox
+  const popupId = await t.context.session
+    .findElement(By.css(ex.textboxSelector))
+    .getAttribute('aria-controls');
 
-    await t.context.session
-      .findElement(By.css(ex.textboxSelector))
-      .sendKeys('a');
+  const popupElement = await t.context.session
+    .findElement(By.id('ex1'))
+    .findElement(By.id(popupId));
 
-    // Check that aria-expanded is true and the listbox is visible
+  t.false(
+    await popupElement.isDisplayed(),
+    'Popup element should not be displayed when \'aria-expanded\' is false\''
+  );
 
-    t.is(
-      await button.getAttribute('aria-expanded'),
-      'true',
-      'button element should have attribute "aria-expand" set to true after typing.'
-    );
+  // Send key "a" to textbox
 
-    t.true(
-      await popupElement.isDisplayed(),
-      "Popup element should be displayed when 'aria-expanded' is true'"
-    );
-  }
-);
+  await t.context.session
+    .findElement(By.css(ex.textboxSelector))
+    .sendKeys('a');
+
+  // Check that aria-expanded is true and the listbox is visible
+
+  t.is(
+    await button.getAttribute('aria-expanded'),
+    'true',
+    'button element should have attribute "aria-expand" set to true after typing.'
+  );
+
+  t.true(
+    await popupElement.isDisplayed(),
+    'Popup element should be displayed when \'aria-expanded\' is true\''
+  );
+
+});
+
 
 // Keys
 
-ariaTest(
-  'Test alt + down key press with focus on textbox',
-  exampleFile,
-  'textbox-key-alt-down-arrow',
-  async (t) => {
+ariaTest('Test alt + down key press with focus on textbox',
+  exampleFile, 'textbox-key-alt-down-arrow', async (t) => {
+
+
     // Send ARROW_DOWN to the textbox
     await t.context.session
       .findElement(By.css(ex.textboxSelector))
@@ -334,22 +255,19 @@ ariaTest(
 
     // Check that the listbox is displayed
     t.true(
-      await t.context.session
-        .findElement(By.css(ex.listboxSelector))
-        .isDisplayed(),
+      await t.context.session.findElement(By.css(ex.listboxSelector)).isDisplayed(),
       'In example the list box should display after ALT + ARROW_DOWN keypress'
     );
 
     // aria-selected should not be on any options
     await assertAttributeDNE(t, ex.optionsSelector, 'aria-selected');
-  }
-);
 
-ariaTest(
-  'Test down key press with focus on textbox',
-  exampleFile,
-  'textbox-key-down-arrow',
-  async (t) => {
+  });
+
+ariaTest('Test down key press with focus on textbox',
+  exampleFile, 'textbox-key-down-arrow', async (t) => {
+
+
     // Send ARROW_DOWN to the textbox
     await t.context.session
       .findElement(By.css(ex.textboxSelector))
@@ -357,36 +275,28 @@ ariaTest(
 
     // Check that the listbox is displayed
     t.true(
-      await t.context.session
-        .findElement(By.css(ex.listboxSelector))
-        .isDisplayed(),
+      await t.context.session.findElement(By.css(ex.listboxSelector)).isDisplayed(),
       'In example ex3 listbox should display after ARROW_DOWN keypress'
     );
 
     await waitForFocusChange(t, ex.textboxSelector, null);
 
     // Check that the active descendent focus is correct
-    await assertAriaSelectedAndActivedescendant(
-      t,
-      ex.textboxSelector,
-      ex.optionsSelector,
-      0
-    );
-  }
-);
+    await assertAriaSelectedAndActivedescendant(t, ex.textboxSelector, ex.optionsSelector, 0);
 
-ariaTest(
-  'Test down key press with focus on list',
-  exampleFile,
-  'listbox-key-down-arrow',
-  async (t) => {
+  });
+
+ariaTest('Test down key press with focus on list',
+  exampleFile, 'listbox-key-down-arrow', async (t) => {
+
+
     // Send 'a' to text box, then send ARROW_DOWN to textbox to set focus on listbox
     await t.context.session
       .findElement(By.css(ex.textboxSelector))
       .sendKeys('a', Key.ARROW_DOWN);
 
     // Test that ARROW_DOWN moves active descendant focus on item in listbox
-    for (let i = 1; i < ex.numAOptions; i++) {
+    for (let i = 1; i <  ex.numAOptions; i++) {
       let oldfocus = await t.context.session
         .findElement(By.css(ex.textboxSelector))
         .getAttribute('aria-activedescendant');
@@ -398,12 +308,7 @@ ariaTest(
       // Account for race condition
       await waitForFocusChange(t, ex.textboxSelector, oldfocus);
 
-      await assertAriaSelectedAndActivedescendant(
-        t,
-        ex.textboxSelector,
-        ex.optionsSelector,
-        i
-      );
+      await assertAriaSelectedAndActivedescendant(t, ex.textboxSelector, ex.optionsSelector, i);
     }
 
     // Sending ARROW_DOWN to the last item should put focus on the first
@@ -418,20 +323,15 @@ ariaTest(
     await waitForFocusChange(t, ex.textboxSelector, oldfocus);
 
     // Focus should be on the first item
-    await assertAriaSelectedAndActivedescendant(
-      t,
-      ex.textboxSelector,
-      ex.optionsSelector,
-      0
-    );
-  }
-);
+    await assertAriaSelectedAndActivedescendant(t, ex.textboxSelector, ex.optionsSelector, 0);
 
-ariaTest(
-  'Test up key press with focus on textbox',
-  exampleFile,
-  'textbox-key-up-arrow',
-  async (t) => {
+  });
+
+
+ariaTest('Test up key press with focus on textbox',
+  exampleFile, 'textbox-key-up-arrow', async (t) => {
+
+
     // Send ARROW_UP to the textbox
     await t.context.session
       .findElement(By.css(ex.textboxSelector))
@@ -439,31 +339,21 @@ ariaTest(
 
     // Check that the listbox is displayed
     t.true(
-      await t.context.session
-        .findElement(By.css(ex.listboxSelector))
-        .isDisplayed(),
+      await t.context.session.findElement(By.css(ex.listboxSelector)).isDisplayed(),
       'In example ex3 listbox should display after ARROW_UP keypress'
     );
 
     await waitForFocusChange(t, ex.textboxSelector, null);
 
     // Check that the active descendent focus is correct
-    let numOptions = (await t.context.queryElements(t, ex.optionsSelector))
-      .length;
-    await assertAriaSelectedAndActivedescendant(
-      t,
-      ex.textboxSelector,
-      ex.optionsSelector,
-      numOptions - 1
-    );
-  }
-);
+    let numOptions = (await t.context.queryElements(t, ex.optionsSelector)).length;
+    await assertAriaSelectedAndActivedescendant(t, ex.textboxSelector, ex.optionsSelector, numOptions - 1);
+  });
 
-ariaTest(
-  'Test up key press with focus on listbox',
-  exampleFile,
-  'listbox-key-up-arrow',
-  async (t) => {
+ariaTest('Test up key press with focus on listbox',
+  exampleFile, 'listbox-key-up-arrow', async (t) => {
+
+
     // Send 'a' to text box, then send ARROW_UP to textbox to textbox to put focus in textbox
     // Up arrow should move selection to the last item in the list
     await t.context.session
@@ -471,7 +361,7 @@ ariaTest(
       .sendKeys('a', Key.ARROW_UP);
 
     // Test that ARROW_UP moves active descendant focus up one item in the listbox
-    for (let index = ex.numAOptions - 2; index > 0; index--) {
+    for (let index = ex.numAOptions - 2; index > 0 ; index--) {
       let oldfocus = await t.context.session
         .findElement(By.css(ex.textboxSelector))
         .getAttribute('aria-activedescendant');
@@ -483,21 +373,14 @@ ariaTest(
 
       await waitForFocusChange(t, ex.textboxSelector, oldfocus);
 
-      await assertAriaSelectedAndActivedescendant(
-        t,
-        ex.textboxSelector,
-        ex.optionsSelector,
-        index
-      );
+      await assertAriaSelectedAndActivedescendant(t, ex.textboxSelector, ex.optionsSelector, index);
     }
-  }
-);
+  });
 
-ariaTest(
-  'Test enter key press with focus on textbox',
-  exampleFile,
-  'textbox-key-enter',
-  async (t) => {
+ariaTest('Test enter key press with focus on textbox',
+  exampleFile, 'textbox-key-enter', async (t) => {
+
+
     // Send key "a" to the textbox, then key ARROW_DOWN to select the first item
 
     await t.context.session
@@ -512,12 +395,7 @@ ariaTest(
 
     // Confirm that the listbox is closed
 
-    await assertAttributeValues(
-      t,
-      ex.textboxSelector,
-      'aria-expanded',
-      'false'
-    );
+    await assertAttributeValues(t, ex.textboxSelector, 'aria-expanded', 'false');
 
     // Confirm that the value of the textbox is the same as the characters set to the listbox
 
@@ -528,14 +406,13 @@ ariaTest(
       'a',
       'key press "ENTER" should not result in selecting an option'
     );
-  }
-);
 
-ariaTest(
-  'Test enter key press with focus on listbox',
-  exampleFile,
-  'listbox-key-enter',
-  async (t) => {
+  });
+
+ariaTest('Test enter key press with focus on listbox',
+  exampleFile, 'listbox-key-enter', async (t) => {
+
+
     // Send key "a" to the textbox, then key ARROW_DOWN to select the first item
 
     await t.context.session
@@ -544,9 +421,7 @@ ariaTest(
 
     // Get the value of the first option in the listbox
 
-    const firstOption = await t.context.session
-      .findElement(By.css(ex.optionsSelector))
-      .getText();
+    const firstOption = await t.context.session.findElement(By.css(ex.optionsSelector)).getText();
 
     // Send key ENTER
 
@@ -556,12 +431,7 @@ ariaTest(
 
     // Confirm that the listbox is closed
 
-    await assertAttributeValues(
-      t,
-      ex.textboxSelector,
-      'aria-expanded',
-      'false'
-    );
+    await assertAttributeValues(t, ex.textboxSelector, 'aria-expanded', 'false');
 
     // Confirm that the value of the textbox is now set to the first option
 
@@ -572,14 +442,12 @@ ariaTest(
       firstOption,
       'key press "ENTER" should result in first option in textbox'
     );
-  }
-);
 
-ariaTest(
-  'Test single escape key press with focus on textbox',
-  exampleFile,
-  'textbox-key-escape',
-  async (t) => {
+  });
+
+ariaTest('Test single escape key press with focus on textbox',
+  exampleFile, 'textbox-key-escape', async (t) => {
+
     // Send key "a", then key ESCAPE once to the textbox
 
     await t.context.session
@@ -588,12 +456,7 @@ ariaTest(
 
     // Confirm the listbox is closed and the textbox is not cleared
 
-    await assertAttributeValues(
-      t,
-      ex.textboxSelector,
-      'aria-expanded',
-      'false'
-    );
+    await assertAttributeValues(t, ex.textboxSelector, 'aria-expanded', 'false');
     t.is(
       await t.context.session
         .findElement(By.css(ex.textboxSelector))
@@ -601,14 +464,12 @@ ariaTest(
       'a',
       'In key press "ESCAPE" should result in first option in textbox'
     );
-  }
-);
 
-ariaTest(
-  'Test double escape key press with focus on textbox',
-  exampleFile,
-  'textbox-key-escape',
-  async (t) => {
+  });
+
+ariaTest('Test double escape key press with focus on textbox',
+  exampleFile, 'textbox-key-escape', async (t) => {
+
     // Send key "a", then key ESCAPE twice to the textbox
 
     await t.context.session
@@ -617,12 +478,7 @@ ariaTest(
 
     // Confirm the listbox is closed and the textbox is cleared
 
-    await assertAttributeValues(
-      t,
-      ex.textboxSelector,
-      'aria-expanded',
-      'false'
-    );
+    await assertAttributeValues(t, ex.textboxSelector, 'aria-expanded', 'false');
     t.is(
       await t.context.session
         .findElement(By.css(ex.textboxSelector))
@@ -630,14 +486,12 @@ ariaTest(
       '',
       'In key press "ESCAPE" should result in first option in textbox'
     );
-  }
-);
 
-ariaTest(
-  'Test escape key press with focus on textbox',
-  exampleFile,
-  'listbox-key-escape',
-  async (t) => {
+  });
+
+ariaTest('Test escape key press with focus on textbox',
+  exampleFile, 'listbox-key-escape', async (t) => {
+
     // Send key "a" then key "ARROW_DOWN to put the focus on the listbox,
     // then key ESCAPE to the textbox
 
@@ -647,12 +501,7 @@ ariaTest(
 
     // Confirm the listbox is closed and the textboxed is cleared
 
-    await assertAttributeValues(
-      t,
-      ex.textboxSelector,
-      'aria-expanded',
-      'false'
-    );
+    await assertAttributeValues(t, ex.textboxSelector, 'aria-expanded', 'false');
     t.is(
       await t.context.session
         .findElement(By.css(ex.textboxSelector))
@@ -660,18 +509,14 @@ ariaTest(
       'a',
       'In listbox key press "ESCAPE" should result in first option in textbox'
     );
-  }
-);
 
-ariaTest(
-  'left arrow from focus on list puts focus on listbox and moves cursor right',
-  exampleFile,
-  'listbox-key-left-arrow',
-  async (t) => {
+  });
+
+ariaTest('left arrow from focus on list puts focus on listbox and moves cursor right',
+  exampleFile, 'listbox-key-left-arrow', async (t) => {
+
     // Send key "a" then key "ARROW_DOWN" to put the focus on the listbox
-    const textbox = await t.context.session.findElement(
-      By.css(ex.textboxSelector)
-    );
+    const textbox = await t.context.session.findElement(By.css(ex.textboxSelector));
     await textbox.sendKeys('a', Key.ARROW_DOWN);
 
     // Send key "ARROW_LEFT"
@@ -685,20 +530,16 @@ ariaTest(
     t.is(
       await textbox.getAttribute('aria-activedescendant'),
       '',
-      'Focus should be on the textbox after on ARROW_LEFT key'
+      'Focus should be on the textbox after on ARROW_LEFT key',
     );
-  }
-);
+  });
 
-ariaTest(
-  'Right arrow from focus on list puts focus on listbox',
-  exampleFile,
-  'listbox-key-right-arrow',
-  async (t) => {
+
+ariaTest('Right arrow from focus on list puts focus on listbox',
+  exampleFile, 'listbox-key-right-arrow', async (t) => {
+
     // Send key "a" then key "ARROW_DOWN" to put the focus on the listbox
-    const textbox = await t.context.session.findElement(
-      By.css(ex.textboxSelector)
-    );
+    const textbox = await t.context.session.findElement(By.css(ex.textboxSelector));
     await textbox.sendKeys('a', Key.ARROW_DOWN);
 
     // Send key "RIGHT_ARROW"
@@ -712,20 +553,15 @@ ariaTest(
     t.is(
       await textbox.getAttribute('aria-activedescendant'),
       '',
-      'Focus should be on the textbox after on ARROW_RIGHT key'
+      'Focus should be on the textbox after on ARROW_RIGHT key',
     );
-  }
-);
+  });
 
-ariaTest(
-  'Home from focus on list puts focus on listbox and moves cursor',
-  exampleFile,
-  'listbox-key-home',
-  async (t) => {
+ariaTest('Home from focus on list puts focus on listbox and moves cursor',
+  exampleFile, 'listbox-key-home', async (t) => {
+
     // Send key "a" then key "ARROW_DOWN" to put the focus on the listbox
-    const textbox = await t.context.session.findElement(
-      By.css(ex.textboxSelector)
-    );
+    const textbox = await t.context.session.findElement(By.css(ex.textboxSelector));
     await textbox.sendKeys('a', Key.ARROW_DOWN);
 
     // Send key "ARROW_HOME"
@@ -739,20 +575,15 @@ ariaTest(
     t.is(
       await textbox.getAttribute('aria-activedescendant'),
       '',
-      'Focus should be on the textbox after one ARROW_HOME key'
+      'Focus should be on the textbox after one ARROW_HOME key',
     );
-  }
-);
+  });
 
-ariaTest(
-  'End from focus on list puts focus on listbox',
-  exampleFile,
-  'listbox-key-end',
-  async (t) => {
+ariaTest('End from focus on list puts focus on listbox',
+  exampleFile, 'listbox-key-end', async (t) => {
+
     // Send key "a" then key "ARROW_DOWN" to put the focus on the listbox
-    const textbox = await t.context.session.findElement(
-      By.css(ex.textboxSelector)
-    );
+    const textbox = await t.context.session.findElement(By.css(ex.textboxSelector));
     await textbox.sendKeys('a', Key.ARROW_DOWN);
 
     // Send key "END_ARROW"
@@ -766,20 +597,15 @@ ariaTest(
     t.is(
       await textbox.getAttribute('aria-activedescendant'),
       '',
-      'Focus should be on the textbox after on ARROW_END key'
+      'Focus should be on the textbox after on ARROW_END key',
     );
-  }
-);
+  });
 
-ariaTest(
-  'Sending character keys while focus is on listbox moves focus',
-  exampleFile,
-  'listbox-key-char',
-  async (t) => {
+ariaTest('Sending character keys while focus is on listbox moves focus',
+  exampleFile, 'listbox-key-char', async (t) => {
+
     // Send key "ARROW_DOWN" to put the focus on the listbox
-    const textbox = await t.context.session.findElement(
-      By.css(ex.textboxSelector)
-    );
+    const textbox = await t.context.session.findElement(By.css(ex.textboxSelector));
     await textbox.sendKeys(Key.ARROW_DOWN);
 
     // Send key "a"
@@ -795,20 +621,16 @@ ariaTest(
     t.is(
       await textbox.getAttribute('aria-activedescendant'),
       '',
-      'Focus should be on the textbox after sending a character key while the focus is on the listbox'
+      'Focus should be on the textbox after sending a character key while the focus is on the listbox',
     );
-  }
-);
 
-ariaTest(
-  'Expected behavior for all other standard single line editing keys',
-  exampleFile,
-  'standard-single-line-editing-keys',
-  async (t) => {
+  });
+
+ariaTest('Expected behavior for all other standard single line editing keys',
+  exampleFile, 'standard-single-line-editing-keys', async (t) => {
+
     // Send key "a"
-    const textbox = await t.context.session.findElement(
-      By.css(ex.textboxSelector)
-    );
+    const textbox = await t.context.session.findElement(By.css(ex.textboxSelector));
     await textbox.sendKeys('a');
 
     t.is(
@@ -816,5 +638,5 @@ ariaTest(
       ex.numAOptions,
       'Sending standard editing keys should filter results'
     );
-  }
-);
+  });
+

--- a/test/tests/combobox_autocomplete-none.js
+++ b/test/tests/combobox_autocomplete-none.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { ariaTest } = require('..');
 const { By, Key } = require('selenium-webdriver');
 const assertAttributeValues = require('../util/assertAttributeValues');
@@ -15,7 +13,7 @@ const ex = {
   listboxSelector: '#ex1 [role="listbox"]',
   optionsSelector: '#ex1 [role="option"]',
   buttonSelector: '#ex1 button',
-  numOptions: 11
+  numOptions: 11,
 };
 
 const waitForFocusChange = async (t, textboxSelector, originalFocus) => {
@@ -27,226 +25,330 @@ const waitForFocusChange = async (t, textboxSelector, originalFocus) => {
       return newfocus != originalFocus;
     },
     t.context.waitTime,
-    'Timeout waiting for "aria-activedescendant" value to change from "' + originalFocus + '". '
+    'Timeout waiting for "aria-activedescendant" value to change from "' +
+      originalFocus +
+      '". '
   );
 };
 
 const confirmCursorIndex = async (t, selector, cursorIndex) => {
-  return t.context.session.executeScript(function () {
-    const [selector, cursorIndex] = arguments;
-    let item = document.querySelector(selector);
-    return item.selectionStart === cursorIndex;
-  }, selector, cursorIndex);
+  return t.context.session.executeScript(
+    function () {
+      const [selector, cursorIndex] = arguments;
+      let item = document.querySelector(selector);
+      return item.selectionStart === cursorIndex;
+    },
+    selector,
+    cursorIndex
+  );
 };
 
 // Attributes
-ariaTest('Test for role="combobox"', exampleFile, 'combobox-role', async (t) => {
+ariaTest(
+  'Test for role="combobox"',
+  exampleFile,
+  'combobox-role',
+  async (t) => {
     await assertAriaRoles(t, 'ex1', 'combobox', '1', 'input');
-});
+  }
+);
 
-ariaTest('"aria-autocomplete" on comboxbox element', exampleFile, 'combobox-aria-autocomplete', async (t) => {
-    await assertAttributeValues(t, ex.textboxSelector, 'aria-autocomplete', 'none');
-});
+ariaTest(
+  '"aria-autocomplete" on comboxbox element',
+  exampleFile,
+  'combobox-aria-autocomplete',
+  async (t) => {
+    await assertAttributeValues(
+      t,
+      ex.textboxSelector,
+      'aria-autocomplete',
+      'none'
+    );
+  }
+);
 
-ariaTest('"aria-controls" attribute on combobox element', exampleFile, 'combobox-aria-controls', async (t) => {
+ariaTest(
+  '"aria-controls" attribute on combobox element',
+  exampleFile,
+  'combobox-aria-controls',
+  async (t) => {
+    const popupId = await t.context.session
+      .findElement(By.css(ex.textboxSelector))
+      .getAttribute('aria-controls');
 
-  const popupId = await t.context.session
-    .findElement(By.css(ex.textboxSelector))
-    .getAttribute('aria-controls');
+    t.truthy(
+      popupId,
+      '"aria-controls" attribute should exist on: ' + ex.textboxSelector
+    );
 
-  t.truthy(
-    popupId,
-    '"aria-controls" attribute should exist on: ' + ex.textboxSelector
-  );
+    const popupElements = await t.context.queryElements(t, `#ex1 #${popupId}`);
 
-  const popupElements = await t.context.queryElements(t, `#ex1 #${popupId}`);
+    t.is(
+      popupElements.length,
+      1,
+      'There should be a element with id "' +
+        popupId +
+        '" as referenced by the aria-controls attribute'
+    );
+  }
+);
 
-  t.is(
-    popupElements.length,
-    1,
-    'There should be a element with id "' + popupId + '" as referenced by the aria-controls attribute'
-  );
-});
+ariaTest(
+  '"aria-expanded" on combobox element',
+  exampleFile,
+  'combobox-aria-expanded',
+  async (t) => {
+    const combobox = await t.context.session.findElement(
+      By.css(ex.textboxSelector)
+    );
 
-ariaTest('"aria-expanded" on combobox element', exampleFile, 'combobox-aria-expanded', async (t) => {
+    // Check that aria-expanded is false and the listbox is not visible before interacting
 
-  const combobox = await t.context.session.findElement(By.css(ex.textboxSelector));
+    t.is(
+      await combobox.getAttribute('aria-expanded'),
+      'false',
+      'combobox element should have attribute "aria-expanded" set to false by default.'
+    );
 
-  // Check that aria-expanded is false and the listbox is not visible before interacting
+    const popupId = await t.context.session
+      .findElement(By.css(ex.textboxSelector))
+      .getAttribute('aria-controls');
 
-  t.is(
-    await combobox.getAttribute('aria-expanded'),
-    'false',
-    'combobox element should have attribute "aria-expanded" set to false by default.'
-  );
+    const popupElement = await t.context.session
+      .findElement(By.id('ex1'))
+      .findElement(By.id(popupId));
 
-  const popupId = await t.context.session
-    .findElement(By.css(ex.textboxSelector))
-    .getAttribute('aria-controls');
+    t.false(
+      await popupElement.isDisplayed(),
+      "Popup element should not be displayed when 'aria-expanded' is false'"
+    );
 
-  const popupElement = await t.context.session
-    .findElement(By.id('ex1'))
-    .findElement(By.id(popupId));
+    // Send key "a" to textbox
 
-  t.false(
-    await popupElement.isDisplayed(),
-    'Popup element should not be displayed when \'aria-expanded\' is false\''
-  );
+    await t.context.session
+      .findElement(By.css(ex.textboxSelector))
+      .sendKeys('a');
 
-  // Send key "a" to textbox
+    // Check that aria-expanded is true and the listbox is visible
 
-  await t.context.session
-    .findElement(By.css(ex.textboxSelector))
-    .sendKeys('a');
+    t.is(
+      await combobox.getAttribute('aria-expanded'),
+      'true',
+      'combobox element should have attribute "aria-expand" set to true after typing.'
+    );
 
-  // Check that aria-expanded is true and the listbox is visible
+    t.true(
+      await popupElement.isDisplayed(),
+      "Popup element should be displayed when 'aria-expanded' is true'"
+    );
+  }
+);
 
-  t.is(
-    await combobox.getAttribute('aria-expanded'),
-    'true',
-    'combobox element should have attribute "aria-expand" set to true after typing.'
-  );
+ariaTest(
+  '"aria-activedescendant" on combobox element',
+  exampleFile,
+  'combobox-aria-activedescendant',
+  async (t) => {
+    await assertAttributeValues(
+      t,
+      ex.textboxSelector,
+      'aria-activedescendant',
+      null
+    );
+  }
+);
 
-  t.true(
-    await popupElement.isDisplayed(),
-    'Popup element should be displayed when \'aria-expanded\' is true\''
-  );
-
-});
-
-ariaTest('"aria-activedescendant" on combobox element', exampleFile, 'combobox-aria-activedescendant', async (t) => {
-    await assertAttributeValues(t, ex.textboxSelector, 'aria-activedescendant', null);
-});
-
-ariaTest('role "listbox" on ul element', exampleFile, 'listbox-role', async (t) => {
+ariaTest(
+  'role "listbox" on ul element',
+  exampleFile,
+  'listbox-role',
+  async (t) => {
     await assertAriaRoles(t, 'ex1', 'listbox', '1', 'ul');
-});
+  }
+);
 
+ariaTest(
+  '"id" attribute on combobox element',
+  exampleFile,
+  'combobox-id',
+  async (t) => {
+    const combobox = await t.context.session.findElement(
+      By.css(ex.textboxSelector)
+    );
+    const id = await combobox.getAttribute('id');
 
-ariaTest('"id" attribute on combobox element', exampleFile, 'combobox-id', async (t) => {
-  const combobox = await t.context.session.findElement(By.css(ex.textboxSelector))
-  const id = await combobox.getAttribute('id');
+    console.log(id);
+    t.truthy(id, '"id" attribute should exist on combobox');
 
-  console.log(id);
-  t.truthy(
-    id,
-    '"id" attribute should exist on combobox'
-  );
+    const label = await t.context.queryElements(t, `[for="${id}"]`);
+    t.is(
+      label.length,
+      1,
+      `There should be one element that labels the combobox with: [for="${id}"]`
+    );
+  }
+);
 
-  const label = await t.context.queryElements(t, `[for="${id}"]`);
-  t.is(
-    label.length,
-    1,
-    `There should be one element that labels the combobox with: [for="${id}"]`
-  );
-});
-
-ariaTest('"aria-label" attribute on listbox element', exampleFile, 'listbox-aria-label', async (t) => {
+ariaTest(
+  '"aria-label" attribute on listbox element',
+  exampleFile,
+  'listbox-aria-label',
+  async (t) => {
     await assertAriaLabelExists(t, ex.listboxSelector);
-});
+  }
+);
 
-ariaTest('role "option" on lu elements', exampleFile, 'option-role', async (t) => {
+ariaTest(
+  'role "option" on lu elements',
+  exampleFile,
+  'option-role',
+  async (t) => {
+    // Send arrow down to reveal all options
+    await t.context.session
+      .findElement(By.css(ex.textboxSelector))
+      .sendKeys(Key.ARROW_DOWN);
+    await assertAriaRoles(t, 'ex1', 'option', ex.numOptions, 'li');
+  }
+);
 
-  // Send arrow down to reveal all options
-  await t.context.session.findElement(By.css(ex.textboxSelector)).sendKeys(Key.ARROW_DOWN);
-  await assertAriaRoles(t, 'ex1', 'option', ex.numOptions, 'li');
-});
+ariaTest(
+  '"aria-selected" attribute on options element',
+  exampleFile,
+  'option-aria-selected',
+  async (t) => {
+    // Send key "a"
+    await t.context.session
+      .findElement(By.css(ex.textboxSelector))
+      .sendKeys('a');
+    await assertAttributeDNE(
+      t,
+      ex.optionsSelector + ':nth-of-type(1)',
+      'aria-selected'
+    );
 
-ariaTest('"aria-selected" attribute on options element', exampleFile, 'option-aria-selected', async (t) => {
+    // Send key ARROW_DOWN to selected first option
+    await t.context.session
+      .findElement(By.css(ex.textboxSelector))
+      .sendKeys(Key.ARROW_DOWN);
+    await assertAttributeValues(
+      t,
+      ex.optionsSelector + ':nth-of-type(1)',
+      'aria-selected',
+      'true'
+    );
+  }
+);
 
-  // Send key "a"
-  await t.context.session.findElement(By.css(ex.textboxSelector)).sendKeys('a');
-  await assertAttributeDNE(t, ex.optionsSelector + ':nth-of-type(1)', 'aria-selected');
+ariaTest(
+  'Button should have tabindex="-1"',
+  exampleFile,
+  'button-tabindex',
+  async (t) => {
+    const button = await t.context.session.findElement(
+      By.css(ex.buttonSelector)
+    );
 
-  // Send key ARROW_DOWN to selected first option
-  await t.context.session.findElement(By.css(ex.textboxSelector)).sendKeys(Key.ARROW_DOWN);
-  await assertAttributeValues(t, ex.optionsSelector + ':nth-of-type(1)', 'aria-selected', 'true');
-});
+    t.is(
+      await button.getAttribute('tabindex'),
+      '-1',
+      'tabindex should be set to "-1" on button'
+    );
+  }
+);
 
-ariaTest('Button should have tabindex="-1"', exampleFile, 'button-tabindex', async (t) => {
-  const button = await t.context.session.findElement(By.css(ex.buttonSelector))
+ariaTest(
+  '"aria-label" attribute on button element',
+  exampleFile,
+  'button-aria-label',
+  async (t) => {
+    await assertAriaLabelExists(t, ex.buttonSelector);
+  }
+);
 
-  t.is(
-    await button.getAttribute('tabindex'),
-    '-1',
-    'tabindex should be set to "-1" on button'
-  );
-});
+ariaTest(
+  '"aria-controls" attribute on button element',
+  exampleFile,
+  'button-aria-controls',
+  async (t) => {
+    const popupId = await t.context.session
+      .findElement(By.css(ex.buttonSelector))
+      .getAttribute('aria-controls');
 
-ariaTest('"aria-label" attribute on button element', exampleFile, 'button-aria-label', async (t) => {
-  await assertAriaLabelExists(t, ex.buttonSelector);
-});
+    t.truthy(
+      popupId,
+      '"aria-controls" attribute should exist on: ' + ex.buttonSelector
+    );
 
-ariaTest('"aria-controls" attribute on button element', exampleFile, 'button-aria-controls', async (t) => {
-  const popupId = await t.context.session
-    .findElement(By.css(ex.buttonSelector))
-    .getAttribute('aria-controls');
+    const popupElements = await t.context.queryElements(t, `#ex1 #${popupId}`);
 
-  t.truthy(
-    popupId,
-    '"aria-controls" attribute should exist on: ' + ex.buttonSelector
-  );
+    t.is(
+      popupElements.length,
+      1,
+      'There should be a element with id "' +
+        popupId +
+        '" as referenced by the aria-controls attribute'
+    );
+  }
+);
 
-  const popupElements = await t.context.queryElements(t, `#ex1 #${popupId}`);
+ariaTest(
+  '"aria-expanded" on button element',
+  exampleFile,
+  'button-aria-expanded',
+  async (t) => {
+    const button = await t.context.session.findElement(
+      By.css(ex.buttonSelector)
+    );
 
-  t.is(
-    popupElements.length,
-    1,
-    'There should be a element with id "' + popupId + '" as referenced by the aria-controls attribute'
-  );
-});
+    // Check that aria-expanded is false and the listbox is not visible before interacting
 
-ariaTest('"aria-expanded" on button element', exampleFile, 'button-aria-expanded', async (t) => {
-  const button = await t.context.session.findElement(By.css(ex.buttonSelector));
+    t.is(
+      await button.getAttribute('aria-expanded'),
+      'false',
+      'button element should have attribute "aria-expanded" set to false by default.'
+    );
 
-  // Check that aria-expanded is false and the listbox is not visible before interacting
+    const popupId = await t.context.session
+      .findElement(By.css(ex.textboxSelector))
+      .getAttribute('aria-controls');
 
-  t.is(
-    await button.getAttribute('aria-expanded'),
-    'false',
-    'button element should have attribute "aria-expanded" set to false by default.'
-  );
+    const popupElement = await t.context.session
+      .findElement(By.id('ex1'))
+      .findElement(By.id(popupId));
 
-  const popupId = await t.context.session
-    .findElement(By.css(ex.textboxSelector))
-    .getAttribute('aria-controls');
+    t.false(
+      await popupElement.isDisplayed(),
+      "Popup element should not be displayed when 'aria-expanded' is 'false'"
+    );
 
-  const popupElement = await t.context.session
-    .findElement(By.id('ex1'))
-    .findElement(By.id(popupId));
+    // Send key "a" to textbox
 
-  t.false(
-    await popupElement.isDisplayed(),
-    'Popup element should not be displayed when \'aria-expanded\' is \'false\''
-  );
+    await t.context.session
+      .findElement(By.css(ex.textboxSelector))
+      .sendKeys('a');
 
-  // Send key "a" to textbox
+    // Check that aria-expanded is true and the listbox is visible
 
-  await t.context.session
-    .findElement(By.css(ex.textboxSelector))
-    .sendKeys('a');
+    t.is(
+      await button.getAttribute('aria-expanded'),
+      'true',
+      'button element should have attribute "aria-expand" set to true after typing.'
+    );
 
-  // Check that aria-expanded is true and the listbox is visible
-
-  t.is(
-    await button.getAttribute('aria-expanded'),
-    'true',
-    'button element should have attribute "aria-expand" set to true after typing.'
-  );
-
-  t.true(
-    await popupElement.isDisplayed(),
-    'Popup element should be displayed when \'aria-expanded\' is \'true\''
-  );
-
-});
+    t.true(
+      await popupElement.isDisplayed(),
+      "Popup element should be displayed when 'aria-expanded' is 'true'"
+    );
+  }
+);
 
 // Keys
 
-ariaTest('Test alt + down key press with focus on textbox',
-  exampleFile, 'textbox-key-alt-down-arrow', async (t) => {
-
-
+ariaTest(
+  'Test alt + down key press with focus on textbox',
+  exampleFile,
+  'textbox-key-alt-down-arrow',
+  async (t) => {
     // Send ARROW_DOWN to the textbox
     await t.context.session
       .findElement(By.css(ex.textboxSelector))
@@ -254,20 +356,22 @@ ariaTest('Test alt + down key press with focus on textbox',
 
     // Check that the listbox is displayed
     t.true(
-      await t.context.session.findElement(By.css(ex.listboxSelector)).isDisplayed(),
+      await t.context.session
+        .findElement(By.css(ex.listboxSelector))
+        .isDisplayed(),
       'In example the list box should display after ALT + ARROW_DOWN keypress'
     );
 
     // aria-selected should not be on any options
     await assertAttributeDNE(t, ex.optionsSelector, 'aria-selected');
+  }
+);
 
-  });
-
-
-ariaTest('Test down key press with focus on textbox',
-  exampleFile, 'textbox-key-down-arrow', async (t) => {
-
-
+ariaTest(
+  'Test down key press with focus on textbox',
+  exampleFile,
+  'textbox-key-down-arrow',
+  async (t) => {
     // Send ARROW_DOWN to the textbox
     await t.context.session
       .findElement(By.css(ex.textboxSelector))
@@ -275,28 +379,36 @@ ariaTest('Test down key press with focus on textbox',
 
     // Check that the listbox is displayed
     t.true(
-      await t.context.session.findElement(By.css(ex.listboxSelector)).isDisplayed(),
+      await t.context.session
+        .findElement(By.css(ex.listboxSelector))
+        .isDisplayed(),
       'In example ex3 listbox should display after ARROW_DOWN keypress'
     );
 
     await waitForFocusChange(t, ex.textboxSelector, null);
 
     // Check that the active descendent focus is correct
-    await assertAriaSelectedAndActivedescendant(t, ex.textboxSelector, ex.optionsSelector, 0);
+    await assertAriaSelectedAndActivedescendant(
+      t,
+      ex.textboxSelector,
+      ex.optionsSelector,
+      0
+    );
+  }
+);
 
-  });
-
-ariaTest('Test down key press with focus on list',
-  exampleFile, 'listbox-key-down-arrow', async (t) => {
-
-
+ariaTest(
+  'Test down key press with focus on list',
+  exampleFile,
+  'listbox-key-down-arrow',
+  async (t) => {
     // Send 'a' to text box, then send ARROW_DOWN to textbox to set focus on listbox
     await t.context.session
       .findElement(By.css(ex.textboxSelector))
       .sendKeys('a', Key.ARROW_DOWN);
 
     // Test that ARROW_DOWN moves active descendant focus on item in listbox
-    for (let i = 1; i <  ex.numOptions; i++) {
+    for (let i = 1; i < ex.numOptions; i++) {
       let oldfocus = await t.context.session
         .findElement(By.css(ex.textboxSelector))
         .getAttribute('aria-activedescendant');
@@ -308,7 +420,12 @@ ariaTest('Test down key press with focus on list',
       // Account for race condition
       await waitForFocusChange(t, ex.textboxSelector, oldfocus);
 
-      await assertAriaSelectedAndActivedescendant(t, ex.textboxSelector, ex.optionsSelector, i);
+      await assertAriaSelectedAndActivedescendant(
+        t,
+        ex.textboxSelector,
+        ex.optionsSelector,
+        i
+      );
     }
 
     // Sending ARROW_DOWN to the last item should put focus on the first
@@ -323,15 +440,20 @@ ariaTest('Test down key press with focus on list',
     await waitForFocusChange(t, ex.textboxSelector, oldfocus);
 
     // Focus should be on the first item
-    await assertAriaSelectedAndActivedescendant(t, ex.textboxSelector, ex.optionsSelector, 0);
+    await assertAriaSelectedAndActivedescendant(
+      t,
+      ex.textboxSelector,
+      ex.optionsSelector,
+      0
+    );
+  }
+);
 
-  });
-
-
-ariaTest('Test up key press with focus on textbox',
-  exampleFile, 'textbox-key-up-arrow', async (t) => {
-
-
+ariaTest(
+  'Test up key press with focus on textbox',
+  exampleFile,
+  'textbox-key-up-arrow',
+  async (t) => {
     // Send ARROW_UP to the textbox
     await t.context.session
       .findElement(By.css(ex.textboxSelector))
@@ -339,21 +461,31 @@ ariaTest('Test up key press with focus on textbox',
 
     // Check that the listbox is displayed
     t.true(
-      await t.context.session.findElement(By.css(ex.listboxSelector)).isDisplayed(),
+      await t.context.session
+        .findElement(By.css(ex.listboxSelector))
+        .isDisplayed(),
       'In example ex3 listbox should display after ARROW_UP keypress'
     );
 
     await waitForFocusChange(t, ex.textboxSelector, null);
 
     // Check that the active descendent focus is correct
-    let numOptions = (await t.context.queryElements(t, ex.optionsSelector)).length;
-    await assertAriaSelectedAndActivedescendant(t, ex.textboxSelector, ex.optionsSelector, numOptions - 1);
-  });
+    let numOptions = (await t.context.queryElements(t, ex.optionsSelector))
+      .length;
+    await assertAriaSelectedAndActivedescendant(
+      t,
+      ex.textboxSelector,
+      ex.optionsSelector,
+      numOptions - 1
+    );
+  }
+);
 
-ariaTest('Test up key press with focus on listbox',
-  exampleFile, 'listbox-key-up-arrow', async (t) => {
-
-
+ariaTest(
+  'Test up key press with focus on listbox',
+  exampleFile,
+  'listbox-key-up-arrow',
+  async (t) => {
     // Send 'a' to text box, then send ARROW_UP to textbox to textbox to put focus in textbox
     // Up arrow should move selection to the last item in the list
     await t.context.session
@@ -361,7 +493,7 @@ ariaTest('Test up key press with focus on listbox',
       .sendKeys('a', Key.ARROW_UP);
 
     // Test that ARROW_UP moves active descendant focus up one item in the listbox
-    for (let index = ex.numOptions - 2; index > 0 ; index--) {
+    for (let index = ex.numOptions - 2; index > 0; index--) {
       let oldfocus = await t.context.session
         .findElement(By.css(ex.textboxSelector))
         .getAttribute('aria-activedescendant');
@@ -373,14 +505,21 @@ ariaTest('Test up key press with focus on listbox',
 
       await waitForFocusChange(t, ex.textboxSelector, oldfocus);
 
-      await assertAriaSelectedAndActivedescendant(t, ex.textboxSelector, ex.optionsSelector, index);
+      await assertAriaSelectedAndActivedescendant(
+        t,
+        ex.textboxSelector,
+        ex.optionsSelector,
+        index
+      );
     }
-  });
+  }
+);
 
-ariaTest('Test enter key press with focus on textbox',
-  exampleFile, 'textbox-key-enter', async (t) => {
-
-
+ariaTest(
+  'Test enter key press with focus on textbox',
+  exampleFile,
+  'textbox-key-enter',
+  async (t) => {
     // Send key "a" to the textbox, then key ARROW_DOWN to select the first item
 
     await t.context.session
@@ -395,7 +534,12 @@ ariaTest('Test enter key press with focus on textbox',
 
     // Confirm that the listbox is closed
 
-    await assertAttributeValues(t, ex.textboxSelector, 'aria-expanded', 'false');
+    await assertAttributeValues(
+      t,
+      ex.textboxSelector,
+      'aria-expanded',
+      'false'
+    );
 
     // Confirm that the value of the textbox is the same as the characters set to the listbox
 
@@ -406,12 +550,14 @@ ariaTest('Test enter key press with focus on textbox',
       'a',
       'key press "ENTER" should not result in selecting an option'
     );
-  });
+  }
+);
 
-ariaTest('Test enter key press with focus on listbox',
-  exampleFile, 'listbox-key-enter', async (t) => {
-
-
+ariaTest(
+  'Test enter key press with focus on listbox',
+  exampleFile,
+  'listbox-key-enter',
+  async (t) => {
     // Send key "a" to the textbox, then key ARROW_DOWN to select the first item
 
     await t.context.session
@@ -420,7 +566,9 @@ ariaTest('Test enter key press with focus on listbox',
 
     // Get the value of the first option in the listbox
 
-    const firstOption = await t.context.session.findElement(By.css(ex.optionsSelector)).getText();
+    const firstOption = await t.context.session
+      .findElement(By.css(ex.optionsSelector))
+      .getText();
 
     // Send key ENTER
 
@@ -430,7 +578,12 @@ ariaTest('Test enter key press with focus on listbox',
 
     // Confirm that the listbox is note
 
-    await assertAttributeValues(t, ex.textboxSelector, 'aria-expanded', 'false');
+    await assertAttributeValues(
+      t,
+      ex.textboxSelector,
+      'aria-expanded',
+      'false'
+    );
 
     // Confirm that the value of the textbox is now set to the first option
 
@@ -441,12 +594,14 @@ ariaTest('Test enter key press with focus on listbox',
       firstOption,
       'key press "ENTER" should result in first option in textbox'
     );
+  }
+);
 
-  });
-
-ariaTest('Test escape key press with focus on textbox',
-  exampleFile, 'listbox-key-escape', async (t) => {
-
+ariaTest(
+  'Test escape key press with focus on textbox',
+  exampleFile,
+  'listbox-key-escape',
+  async (t) => {
     // Send key "a" then key "ARROW_DOWN to put the focus on the listbox,
     // then key ESCAPE once to the textbox
 
@@ -456,7 +611,12 @@ ariaTest('Test escape key press with focus on textbox',
 
     // Confirm the listbox is closed and the textbox is not cleared
 
-    await assertAttributeValues(t, ex.textboxSelector, 'aria-expanded', 'false');
+    await assertAttributeValues(
+      t,
+      ex.textboxSelector,
+      'aria-expanded',
+      'false'
+    );
     t.is(
       await t.context.session
         .findElement(By.css(ex.textboxSelector))
@@ -464,12 +624,14 @@ ariaTest('Test escape key press with focus on textbox',
       'a',
       'In listbox key press "ESCAPE" should result in first option in textbox'
     );
+  }
+);
 
-  });
-
-ariaTest('Test double escape key press with focus on textbox',
-  exampleFile, 'listbox-key-escape', async (t) => {
-
+ariaTest(
+  'Test double escape key press with focus on textbox',
+  exampleFile,
+  'listbox-key-escape',
+  async (t) => {
     // Send key "a" then key "ARROW_DOWN to put the focus on the listbox,
     // then key ESCAPE twice to the textbox
 
@@ -479,7 +641,12 @@ ariaTest('Test double escape key press with focus on textbox',
 
     // Confirm the listbox is closed and the textbox is cleared
 
-    await assertAttributeValues(t, ex.textboxSelector, 'aria-expanded', 'false');
+    await assertAttributeValues(
+      t,
+      ex.textboxSelector,
+      'aria-expanded',
+      'false'
+    );
     t.is(
       await t.context.session
         .findElement(By.css(ex.textboxSelector))
@@ -487,14 +654,18 @@ ariaTest('Test double escape key press with focus on textbox',
       '',
       'In listbox key press "ESCAPE" should result in first option in textbox'
     );
+  }
+);
 
-  });
-
-ariaTest('left arrow from focus on list puts focus on listbox and moves cursor right',
-  exampleFile, 'listbox-key-left-arrow', async (t) => {
-
+ariaTest(
+  'left arrow from focus on list puts focus on listbox and moves cursor right',
+  exampleFile,
+  'listbox-key-left-arrow',
+  async (t) => {
     // Send key "a" then key "ARROW_DOWN" to put the focus on the listbox
-    const textbox = await t.context.session.findElement(By.css(ex.textboxSelector));
+    const textbox = await t.context.session.findElement(
+      By.css(ex.textboxSelector)
+    );
     await textbox.sendKeys('a', Key.ARROW_DOWN);
 
     // Send key "ARROW_LEFT"
@@ -508,16 +679,20 @@ ariaTest('left arrow from focus on list puts focus on listbox and moves cursor r
     t.is(
       await textbox.getAttribute('aria-activedescendant'),
       '',
-      'Focus should be on the textbox after on ARROW_LEFT key',
+      'Focus should be on the textbox after on ARROW_LEFT key'
     );
-  });
+  }
+);
 
-
-ariaTest('Right arrow from focus on list puts focus on listbox',
-  exampleFile, 'listbox-key-right-arrow', async (t) => {
-
+ariaTest(
+  'Right arrow from focus on list puts focus on listbox',
+  exampleFile,
+  'listbox-key-right-arrow',
+  async (t) => {
     // Send key "a" then key "ARROW_DOWN" to put the focus on the listbox
-    const textbox = await t.context.session.findElement(By.css(ex.textboxSelector));
+    const textbox = await t.context.session.findElement(
+      By.css(ex.textboxSelector)
+    );
     await textbox.sendKeys('a', Key.ARROW_DOWN);
 
     // Send key "RIGHT_ARROW"
@@ -531,15 +706,20 @@ ariaTest('Right arrow from focus on list puts focus on listbox',
     t.is(
       await textbox.getAttribute('aria-activedescendant'),
       '',
-      'Focus should be on the textbox after on ARROW_RIGHT key',
+      'Focus should be on the textbox after on ARROW_RIGHT key'
     );
-  });
+  }
+);
 
-ariaTest('Home from focus on list puts focus on listbox and moves cursor',
-  exampleFile, 'listbox-key-home', async (t) => {
-
+ariaTest(
+  'Home from focus on list puts focus on listbox and moves cursor',
+  exampleFile,
+  'listbox-key-home',
+  async (t) => {
     // Send key "a" then key "ARROW_DOWN" to put the focus on the listbox
-    const textbox = await t.context.session.findElement(By.css(ex.textboxSelector));
+    const textbox = await t.context.session.findElement(
+      By.css(ex.textboxSelector)
+    );
     await textbox.sendKeys('a', Key.ARROW_DOWN);
 
     // Send key "ARROW_HOME"
@@ -553,15 +733,20 @@ ariaTest('Home from focus on list puts focus on listbox and moves cursor',
     t.is(
       await textbox.getAttribute('aria-activedescendant'),
       '',
-      'Focus should be on the textbox after one ARROW_HOME key',
+      'Focus should be on the textbox after one ARROW_HOME key'
     );
-  });
+  }
+);
 
-ariaTest('End from focus on list puts focus on listbox',
-  exampleFile, 'listbox-key-end', async (t) => {
-
+ariaTest(
+  'End from focus on list puts focus on listbox',
+  exampleFile,
+  'listbox-key-end',
+  async (t) => {
     // Send key "a" then key "ARROW_DOWN" to put the focus on the listbox
-    const textbox = await t.context.session.findElement(By.css(ex.textboxSelector));
+    const textbox = await t.context.session.findElement(
+      By.css(ex.textboxSelector)
+    );
     await textbox.sendKeys('a', Key.ARROW_DOWN);
 
     // Send key "END_ARROW"
@@ -575,16 +760,20 @@ ariaTest('End from focus on list puts focus on listbox',
     t.is(
       await textbox.getAttribute('aria-activedescendant'),
       '',
-      'Focus should be on the textbox after on ARROW_END key',
+      'Focus should be on the textbox after on ARROW_END key'
     );
-  });
+  }
+);
 
-
-ariaTest('Sending character keys while focus is on listbox moves focus',
-  exampleFile, 'listbox-key-char', async (t) => {
-
+ariaTest(
+  'Sending character keys while focus is on listbox moves focus',
+  exampleFile,
+  'listbox-key-char',
+  async (t) => {
     // Send key "ARROW_DOWN" to put the focus on the listbox
-    const textbox = await t.context.session.findElement(By.css(ex.textboxSelector));
+    const textbox = await t.context.session.findElement(
+      By.css(ex.textboxSelector)
+    );
     await textbox.sendKeys(Key.ARROW_DOWN);
 
     // Send key "a"
@@ -600,18 +789,23 @@ ariaTest('Sending character keys while focus is on listbox moves focus',
     t.is(
       await textbox.getAttribute('aria-activedescendant'),
       '',
-      'Focus should be on the textbox after sending a character key while the focus is on the listbox',
+      'Focus should be on the textbox after sending a character key while the focus is on the listbox'
     );
+  }
+);
 
-  });
-
-ariaTest('Expected behavior for all other standard single line editing keys',
-  exampleFile, 'standard-single-line-editing-keys', async (t) => {
-
-    let numOptions = (await t.context.queryElements(t, ex.optionsSelector)).length;
+ariaTest(
+  'Expected behavior for all other standard single line editing keys',
+  exampleFile,
+  'standard-single-line-editing-keys',
+  async (t) => {
+    let numOptions = (await t.context.queryElements(t, ex.optionsSelector))
+      .length;
 
     // Send key "w"
-    const textbox = await t.context.session.findElement(By.css(ex.textboxSelector));
+    const textbox = await t.context.session.findElement(
+      By.css(ex.textboxSelector)
+    );
     await textbox.sendKeys('w');
 
     t.is(
@@ -619,4 +813,5 @@ ariaTest('Expected behavior for all other standard single line editing keys',
       numOptions,
       'Sending standard editing keys should NOT filter results'
     );
-  });
+  }
+);

--- a/test/tests/combobox_autocomplete-none.js
+++ b/test/tests/combobox_autocomplete-none.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const { ariaTest } = require('..');
 const { By, Key } = require('selenium-webdriver');
 const assertAttributeValues = require('../util/assertAttributeValues');
@@ -13,7 +15,7 @@ const ex = {
   listboxSelector: '#ex1 [role="listbox"]',
   optionsSelector: '#ex1 [role="option"]',
   buttonSelector: '#ex1 button',
-  numOptions: 11,
+  numOptions: 11
 };
 
 const waitForFocusChange = async (t, textboxSelector, originalFocus) => {
@@ -25,308 +27,226 @@ const waitForFocusChange = async (t, textboxSelector, originalFocus) => {
       return newfocus != originalFocus;
     },
     t.context.waitTime,
-    'Timeout waiting for "aria-activedescendant" value to change from "' +
-      originalFocus +
-      '". '
+    'Timeout waiting for "aria-activedescendant" value to change from "' + originalFocus + '". '
   );
 };
 
 const confirmCursorIndex = async (t, selector, cursorIndex) => {
-  return t.context.session.executeScript(
-    function () {
-      const [selector, cursorIndex] = arguments;
-      let item = document.querySelector(selector);
-      return item.selectionStart === cursorIndex;
-    },
-    selector,
-    cursorIndex
-  );
+  return t.context.session.executeScript(function () {
+    const [selector, cursorIndex] = arguments;
+    let item = document.querySelector(selector);
+    return item.selectionStart === cursorIndex;
+  }, selector, cursorIndex);
 };
 
 // Attributes
-ariaTest(
-  'Test for role="combobox"',
-  exampleFile,
-  'combobox-role',
-  async (t) => {
+ariaTest('Test for role="combobox"', exampleFile, 'combobox-role', async (t) => {
     await assertAriaRoles(t, 'ex1', 'combobox', '1', 'input');
-  }
-);
+});
 
-ariaTest(
-  '"aria-autocomplete" on comboxbox element',
-  exampleFile,
-  'combobox-aria-autocomplete',
-  async (t) => {
-    await assertAttributeValues(
-      t,
-      ex.textboxSelector,
-      'aria-autocomplete',
-      'none'
-    );
-  }
-);
+ariaTest('"aria-autocomplete" on comboxbox element', exampleFile, 'combobox-aria-autocomplete', async (t) => {
+    await assertAttributeValues(t, ex.textboxSelector, 'aria-autocomplete', 'none');
+});
 
-ariaTest(
-  '"aria-controls" attribute on combobox element',
-  exampleFile,
-  'combobox-aria-controls',
-  async (t) => {
-    const popupId = await t.context.session
-      .findElement(By.css(ex.textboxSelector))
-      .getAttribute('aria-controls');
+ariaTest('"aria-controls" attribute on combobox element', exampleFile, 'combobox-aria-controls', async (t) => {
 
-    t.truthy(
-      popupId,
-      '"aria-controls" attribute should exist on: ' + ex.textboxSelector
-    );
+  const popupId = await t.context.session
+    .findElement(By.css(ex.textboxSelector))
+    .getAttribute('aria-controls');
 
-    const popupElements = await t.context.queryElements(t, `#ex1 #${popupId}`);
+  t.truthy(
+    popupId,
+    '"aria-controls" attribute should exist on: ' + ex.textboxSelector
+  );
 
-    t.is(
-      popupElements.length,
-      1,
-      'There should be a element with id "' +
-        popupId +
-        '" as referenced by the aria-controls attribute'
-    );
-  }
-);
+  const popupElements = await t.context.queryElements(t, `#ex1 #${popupId}`);
 
-ariaTest(
-  '"aria-expanded" on combobox element',
-  exampleFile,
-  'combobox-aria-expanded',
-  async (t) => {
-    const combobox = await t.context.session.findElement(
-      By.css(ex.textboxSelector)
-    );
+  t.is(
+    popupElements.length,
+    1,
+    'There should be a element with id "' + popupId + '" as referenced by the aria-controls attribute'
+  );
+});
 
-    // Check that aria-expanded is false and the listbox is not visible before interacting
+ariaTest('"aria-expanded" on combobox element', exampleFile, 'combobox-aria-expanded', async (t) => {
 
-    t.is(
-      await combobox.getAttribute('aria-expanded'),
-      'false',
-      'combobox element should have attribute "aria-expanded" set to false by default.'
-    );
+  const combobox = await t.context.session.findElement(By.css(ex.textboxSelector));
 
-    const popupId = await t.context.session
-      .findElement(By.css(ex.textboxSelector))
-      .getAttribute('aria-controls');
+  // Check that aria-expanded is false and the listbox is not visible before interacting
 
-    const popupElement = await t.context.session
-      .findElement(By.id('ex1'))
-      .findElement(By.id(popupId));
+  t.is(
+    await combobox.getAttribute('aria-expanded'),
+    'false',
+    'combobox element should have attribute "aria-expanded" set to false by default.'
+  );
 
-    t.false(
-      await popupElement.isDisplayed(),
-      "Popup element should not be displayed when 'aria-expanded' is false'"
-    );
+  const popupId = await t.context.session
+    .findElement(By.css(ex.textboxSelector))
+    .getAttribute('aria-controls');
 
-    // Send key "a" to textbox
+  const popupElement = await t.context.session
+    .findElement(By.id('ex1'))
+    .findElement(By.id(popupId));
 
-    await t.context.session
-      .findElement(By.css(ex.textboxSelector))
-      .sendKeys('a');
+  t.false(
+    await popupElement.isDisplayed(),
+    'Popup element should not be displayed when \'aria-expanded\' is false\''
+  );
 
-    // Check that aria-expanded is true and the listbox is visible
+  // Send key "a" to textbox
 
-    t.is(
-      await combobox.getAttribute('aria-expanded'),
-      'true',
-      'combobox element should have attribute "aria-expand" set to true after typing.'
-    );
+  await t.context.session
+    .findElement(By.css(ex.textboxSelector))
+    .sendKeys('a');
 
-    t.true(
-      await popupElement.isDisplayed(),
-      "Popup element should be displayed when 'aria-expanded' is true'"
-    );
-  }
-);
+  // Check that aria-expanded is true and the listbox is visible
 
-ariaTest(
-  '"aria-activedescendant" on combobox element',
-  exampleFile,
-  'combobox-aria-activedescendant',
-  async (t) => {
-    await assertAttributeValues(
-      t,
-      ex.textboxSelector,
-      'aria-activedescendant',
-      null
-    );
-  }
-);
+  t.is(
+    await combobox.getAttribute('aria-expanded'),
+    'true',
+    'combobox element should have attribute "aria-expand" set to true after typing.'
+  );
 
-ariaTest(
-  'role "listbox" on ul element',
-  exampleFile,
-  'listbox-role',
-  async (t) => {
+  t.true(
+    await popupElement.isDisplayed(),
+    'Popup element should be displayed when \'aria-expanded\' is true\''
+  );
+
+});
+
+ariaTest('"aria-activedescendant" on combobox element', exampleFile, 'combobox-aria-activedescendant', async (t) => {
+    await assertAttributeValues(t, ex.textboxSelector, 'aria-activedescendant', null);
+});
+
+ariaTest('role "listbox" on ul element', exampleFile, 'listbox-role', async (t) => {
     await assertAriaRoles(t, 'ex1', 'listbox', '1', 'ul');
-  }
-);
+});
 
-ariaTest(
-  '"aria-label" attribute on listbox element',
-  exampleFile,
-  'listbox-aria-label',
-  async (t) => {
+
+ariaTest('"id" attribute on combobox element', exampleFile, 'combobox-id', async (t) => {
+  const combobox = await t.context.session.findElement(By.css(ex.textboxSelector))
+  const id = await combobox.getAttribute('id');
+
+  console.log(id);
+  t.truthy(
+    id,
+    '"id" attribute should exist on combobox'
+  );
+
+  const label = await t.context.queryElements(t, `[for="${id}"]`);
+  t.is(
+    label.length,
+    1,
+    `There should be one element that labels the combobox with: [for="${id}"]`
+  );
+});
+
+ariaTest('"aria-label" attribute on listbox element', exampleFile, 'listbox-aria-label', async (t) => {
     await assertAriaLabelExists(t, ex.listboxSelector);
-  }
-);
+});
 
-ariaTest(
-  'role "option" on lu elements',
-  exampleFile,
-  'option-role',
-  async (t) => {
-    // Send arrow down to reveal all options
-    await t.context.session
-      .findElement(By.css(ex.textboxSelector))
-      .sendKeys(Key.ARROW_DOWN);
-    await assertAriaRoles(t, 'ex1', 'option', ex.numOptions, 'li');
-  }
-);
+ariaTest('role "option" on lu elements', exampleFile, 'option-role', async (t) => {
 
-ariaTest(
-  '"aria-selected" attribute on options element',
-  exampleFile,
-  'option-aria-selected',
-  async (t) => {
-    // Send key "a"
-    await t.context.session
-      .findElement(By.css(ex.textboxSelector))
-      .sendKeys('a');
-    await assertAttributeDNE(
-      t,
-      ex.optionsSelector + ':nth-of-type(1)',
-      'aria-selected'
-    );
+  // Send arrow down to reveal all options
+  await t.context.session.findElement(By.css(ex.textboxSelector)).sendKeys(Key.ARROW_DOWN);
+  await assertAriaRoles(t, 'ex1', 'option', ex.numOptions, 'li');
+});
 
-    // Send key ARROW_DOWN to selected first option
-    await t.context.session
-      .findElement(By.css(ex.textboxSelector))
-      .sendKeys(Key.ARROW_DOWN);
-    await assertAttributeValues(
-      t,
-      ex.optionsSelector + ':nth-of-type(1)',
-      'aria-selected',
-      'true'
-    );
-  }
-);
+ariaTest('"aria-selected" attribute on options element', exampleFile, 'option-aria-selected', async (t) => {
 
-ariaTest(
-  'Button should have tabindex="-1"',
-  exampleFile,
-  'button-tabindex',
-  async (t) => {
-    const button = await t.context.session.findElement(
-      By.css(ex.buttonSelector)
-    );
+  // Send key "a"
+  await t.context.session.findElement(By.css(ex.textboxSelector)).sendKeys('a');
+  await assertAttributeDNE(t, ex.optionsSelector + ':nth-of-type(1)', 'aria-selected');
 
-    t.is(
-      await button.getAttribute('tabindex'),
-      '-1',
-      'tabindex should be set to "-1" on button'
-    );
-  }
-);
+  // Send key ARROW_DOWN to selected first option
+  await t.context.session.findElement(By.css(ex.textboxSelector)).sendKeys(Key.ARROW_DOWN);
+  await assertAttributeValues(t, ex.optionsSelector + ':nth-of-type(1)', 'aria-selected', 'true');
+});
 
-ariaTest(
-  '"aria-label" attribute on button element',
-  exampleFile,
-  'button-aria-label',
-  async (t) => {
-    await assertAriaLabelExists(t, ex.buttonSelector);
-  }
-);
+ariaTest('Button should have tabindex="-1"', exampleFile, 'button-tabindex', async (t) => {
+  const button = await t.context.session.findElement(By.css(ex.buttonSelector))
 
-ariaTest(
-  '"aria-controls" attribute on button element',
-  exampleFile,
-  'button-aria-controls',
-  async (t) => {
-    const popupId = await t.context.session
-      .findElement(By.css(ex.buttonSelector))
-      .getAttribute('aria-controls');
+  t.is(
+    await button.getAttribute('tabindex'),
+    '-1',
+    'tabindex should be set to "-1" on button'
+  );
+});
 
-    t.truthy(
-      popupId,
-      '"aria-controls" attribute should exist on: ' + ex.buttonSelector
-    );
+ariaTest('"aria-label" attribute on button element', exampleFile, 'button-aria-label', async (t) => {
+  await assertAriaLabelExists(t, ex.buttonSelector);
+});
 
-    const popupElements = await t.context.queryElements(t, `#ex1 #${popupId}`);
+ariaTest('"aria-controls" attribute on button element', exampleFile, 'button-aria-controls', async (t) => {
+  const popupId = await t.context.session
+    .findElement(By.css(ex.buttonSelector))
+    .getAttribute('aria-controls');
 
-    t.is(
-      popupElements.length,
-      1,
-      'There should be a element with id "' +
-        popupId +
-        '" as referenced by the aria-controls attribute'
-    );
-  }
-);
+  t.truthy(
+    popupId,
+    '"aria-controls" attribute should exist on: ' + ex.buttonSelector
+  );
 
-ariaTest(
-  '"aria-expanded" on button element',
-  exampleFile,
-  'button-aria-expanded',
-  async (t) => {
-    const button = await t.context.session.findElement(
-      By.css(ex.buttonSelector)
-    );
+  const popupElements = await t.context.queryElements(t, `#ex1 #${popupId}`);
 
-    // Check that aria-expanded is false and the listbox is not visible before interacting
+  t.is(
+    popupElements.length,
+    1,
+    'There should be a element with id "' + popupId + '" as referenced by the aria-controls attribute'
+  );
+});
 
-    t.is(
-      await button.getAttribute('aria-expanded'),
-      'false',
-      'button element should have attribute "aria-expanded" set to false by default.'
-    );
+ariaTest('"aria-expanded" on button element', exampleFile, 'button-aria-expanded', async (t) => {
+  const button = await t.context.session.findElement(By.css(ex.buttonSelector));
 
-    const popupId = await t.context.session
-      .findElement(By.css(ex.textboxSelector))
-      .getAttribute('aria-controls');
+  // Check that aria-expanded is false and the listbox is not visible before interacting
 
-    const popupElement = await t.context.session
-      .findElement(By.id('ex1'))
-      .findElement(By.id(popupId));
+  t.is(
+    await button.getAttribute('aria-expanded'),
+    'false',
+    'button element should have attribute "aria-expanded" set to false by default.'
+  );
 
-    t.false(
-      await popupElement.isDisplayed(),
-      "Popup element should not be displayed when 'aria-expanded' is 'false'"
-    );
+  const popupId = await t.context.session
+    .findElement(By.css(ex.textboxSelector))
+    .getAttribute('aria-controls');
 
-    // Send key "a" to textbox
+  const popupElement = await t.context.session
+    .findElement(By.id('ex1'))
+    .findElement(By.id(popupId));
 
-    await t.context.session
-      .findElement(By.css(ex.textboxSelector))
-      .sendKeys('a');
+  t.false(
+    await popupElement.isDisplayed(),
+    'Popup element should not be displayed when \'aria-expanded\' is \'false\''
+  );
 
-    // Check that aria-expanded is true and the listbox is visible
+  // Send key "a" to textbox
 
-    t.is(
-      await button.getAttribute('aria-expanded'),
-      'true',
-      'button element should have attribute "aria-expand" set to true after typing.'
-    );
+  await t.context.session
+    .findElement(By.css(ex.textboxSelector))
+    .sendKeys('a');
 
-    t.true(
-      await popupElement.isDisplayed(),
-      "Popup element should be displayed when 'aria-expanded' is 'true'"
-    );
-  }
-);
+  // Check that aria-expanded is true and the listbox is visible
+
+  t.is(
+    await button.getAttribute('aria-expanded'),
+    'true',
+    'button element should have attribute "aria-expand" set to true after typing.'
+  );
+
+  t.true(
+    await popupElement.isDisplayed(),
+    'Popup element should be displayed when \'aria-expanded\' is \'true\''
+  );
+
+});
 
 // Keys
 
-ariaTest(
-  'Test alt + down key press with focus on textbox',
-  exampleFile,
-  'textbox-key-alt-down-arrow',
-  async (t) => {
+ariaTest('Test alt + down key press with focus on textbox',
+  exampleFile, 'textbox-key-alt-down-arrow', async (t) => {
+
+
     // Send ARROW_DOWN to the textbox
     await t.context.session
       .findElement(By.css(ex.textboxSelector))
@@ -334,22 +254,20 @@ ariaTest(
 
     // Check that the listbox is displayed
     t.true(
-      await t.context.session
-        .findElement(By.css(ex.listboxSelector))
-        .isDisplayed(),
+      await t.context.session.findElement(By.css(ex.listboxSelector)).isDisplayed(),
       'In example the list box should display after ALT + ARROW_DOWN keypress'
     );
 
     // aria-selected should not be on any options
     await assertAttributeDNE(t, ex.optionsSelector, 'aria-selected');
-  }
-);
 
-ariaTest(
-  'Test down key press with focus on textbox',
-  exampleFile,
-  'textbox-key-down-arrow',
-  async (t) => {
+  });
+
+
+ariaTest('Test down key press with focus on textbox',
+  exampleFile, 'textbox-key-down-arrow', async (t) => {
+
+
     // Send ARROW_DOWN to the textbox
     await t.context.session
       .findElement(By.css(ex.textboxSelector))
@@ -357,36 +275,28 @@ ariaTest(
 
     // Check that the listbox is displayed
     t.true(
-      await t.context.session
-        .findElement(By.css(ex.listboxSelector))
-        .isDisplayed(),
+      await t.context.session.findElement(By.css(ex.listboxSelector)).isDisplayed(),
       'In example ex3 listbox should display after ARROW_DOWN keypress'
     );
 
     await waitForFocusChange(t, ex.textboxSelector, null);
 
     // Check that the active descendent focus is correct
-    await assertAriaSelectedAndActivedescendant(
-      t,
-      ex.textboxSelector,
-      ex.optionsSelector,
-      0
-    );
-  }
-);
+    await assertAriaSelectedAndActivedescendant(t, ex.textboxSelector, ex.optionsSelector, 0);
 
-ariaTest(
-  'Test down key press with focus on list',
-  exampleFile,
-  'listbox-key-down-arrow',
-  async (t) => {
+  });
+
+ariaTest('Test down key press with focus on list',
+  exampleFile, 'listbox-key-down-arrow', async (t) => {
+
+
     // Send 'a' to text box, then send ARROW_DOWN to textbox to set focus on listbox
     await t.context.session
       .findElement(By.css(ex.textboxSelector))
       .sendKeys('a', Key.ARROW_DOWN);
 
     // Test that ARROW_DOWN moves active descendant focus on item in listbox
-    for (let i = 1; i < ex.numOptions; i++) {
+    for (let i = 1; i <  ex.numOptions; i++) {
       let oldfocus = await t.context.session
         .findElement(By.css(ex.textboxSelector))
         .getAttribute('aria-activedescendant');
@@ -398,12 +308,7 @@ ariaTest(
       // Account for race condition
       await waitForFocusChange(t, ex.textboxSelector, oldfocus);
 
-      await assertAriaSelectedAndActivedescendant(
-        t,
-        ex.textboxSelector,
-        ex.optionsSelector,
-        i
-      );
+      await assertAriaSelectedAndActivedescendant(t, ex.textboxSelector, ex.optionsSelector, i);
     }
 
     // Sending ARROW_DOWN to the last item should put focus on the first
@@ -418,20 +323,15 @@ ariaTest(
     await waitForFocusChange(t, ex.textboxSelector, oldfocus);
 
     // Focus should be on the first item
-    await assertAriaSelectedAndActivedescendant(
-      t,
-      ex.textboxSelector,
-      ex.optionsSelector,
-      0
-    );
-  }
-);
+    await assertAriaSelectedAndActivedescendant(t, ex.textboxSelector, ex.optionsSelector, 0);
 
-ariaTest(
-  'Test up key press with focus on textbox',
-  exampleFile,
-  'textbox-key-up-arrow',
-  async (t) => {
+  });
+
+
+ariaTest('Test up key press with focus on textbox',
+  exampleFile, 'textbox-key-up-arrow', async (t) => {
+
+
     // Send ARROW_UP to the textbox
     await t.context.session
       .findElement(By.css(ex.textboxSelector))
@@ -439,31 +339,21 @@ ariaTest(
 
     // Check that the listbox is displayed
     t.true(
-      await t.context.session
-        .findElement(By.css(ex.listboxSelector))
-        .isDisplayed(),
+      await t.context.session.findElement(By.css(ex.listboxSelector)).isDisplayed(),
       'In example ex3 listbox should display after ARROW_UP keypress'
     );
 
     await waitForFocusChange(t, ex.textboxSelector, null);
 
     // Check that the active descendent focus is correct
-    let numOptions = (await t.context.queryElements(t, ex.optionsSelector))
-      .length;
-    await assertAriaSelectedAndActivedescendant(
-      t,
-      ex.textboxSelector,
-      ex.optionsSelector,
-      numOptions - 1
-    );
-  }
-);
+    let numOptions = (await t.context.queryElements(t, ex.optionsSelector)).length;
+    await assertAriaSelectedAndActivedescendant(t, ex.textboxSelector, ex.optionsSelector, numOptions - 1);
+  });
 
-ariaTest(
-  'Test up key press with focus on listbox',
-  exampleFile,
-  'listbox-key-up-arrow',
-  async (t) => {
+ariaTest('Test up key press with focus on listbox',
+  exampleFile, 'listbox-key-up-arrow', async (t) => {
+
+
     // Send 'a' to text box, then send ARROW_UP to textbox to textbox to put focus in textbox
     // Up arrow should move selection to the last item in the list
     await t.context.session
@@ -471,7 +361,7 @@ ariaTest(
       .sendKeys('a', Key.ARROW_UP);
 
     // Test that ARROW_UP moves active descendant focus up one item in the listbox
-    for (let index = ex.numOptions - 2; index > 0; index--) {
+    for (let index = ex.numOptions - 2; index > 0 ; index--) {
       let oldfocus = await t.context.session
         .findElement(By.css(ex.textboxSelector))
         .getAttribute('aria-activedescendant');
@@ -483,21 +373,14 @@ ariaTest(
 
       await waitForFocusChange(t, ex.textboxSelector, oldfocus);
 
-      await assertAriaSelectedAndActivedescendant(
-        t,
-        ex.textboxSelector,
-        ex.optionsSelector,
-        index
-      );
+      await assertAriaSelectedAndActivedescendant(t, ex.textboxSelector, ex.optionsSelector, index);
     }
-  }
-);
+  });
 
-ariaTest(
-  'Test enter key press with focus on textbox',
-  exampleFile,
-  'textbox-key-enter',
-  async (t) => {
+ariaTest('Test enter key press with focus on textbox',
+  exampleFile, 'textbox-key-enter', async (t) => {
+
+
     // Send key "a" to the textbox, then key ARROW_DOWN to select the first item
 
     await t.context.session
@@ -512,12 +395,7 @@ ariaTest(
 
     // Confirm that the listbox is closed
 
-    await assertAttributeValues(
-      t,
-      ex.textboxSelector,
-      'aria-expanded',
-      'false'
-    );
+    await assertAttributeValues(t, ex.textboxSelector, 'aria-expanded', 'false');
 
     // Confirm that the value of the textbox is the same as the characters set to the listbox
 
@@ -528,14 +406,12 @@ ariaTest(
       'a',
       'key press "ENTER" should not result in selecting an option'
     );
-  }
-);
+  });
 
-ariaTest(
-  'Test enter key press with focus on listbox',
-  exampleFile,
-  'listbox-key-enter',
-  async (t) => {
+ariaTest('Test enter key press with focus on listbox',
+  exampleFile, 'listbox-key-enter', async (t) => {
+
+
     // Send key "a" to the textbox, then key ARROW_DOWN to select the first item
 
     await t.context.session
@@ -544,9 +420,7 @@ ariaTest(
 
     // Get the value of the first option in the listbox
 
-    const firstOption = await t.context.session
-      .findElement(By.css(ex.optionsSelector))
-      .getText();
+    const firstOption = await t.context.session.findElement(By.css(ex.optionsSelector)).getText();
 
     // Send key ENTER
 
@@ -556,12 +430,7 @@ ariaTest(
 
     // Confirm that the listbox is note
 
-    await assertAttributeValues(
-      t,
-      ex.textboxSelector,
-      'aria-expanded',
-      'false'
-    );
+    await assertAttributeValues(t, ex.textboxSelector, 'aria-expanded', 'false');
 
     // Confirm that the value of the textbox is now set to the first option
 
@@ -572,14 +441,12 @@ ariaTest(
       firstOption,
       'key press "ENTER" should result in first option in textbox'
     );
-  }
-);
 
-ariaTest(
-  'Test escape key press with focus on textbox',
-  exampleFile,
-  'listbox-key-escape',
-  async (t) => {
+  });
+
+ariaTest('Test escape key press with focus on textbox',
+  exampleFile, 'listbox-key-escape', async (t) => {
+
     // Send key "a" then key "ARROW_DOWN to put the focus on the listbox,
     // then key ESCAPE once to the textbox
 
@@ -589,12 +456,7 @@ ariaTest(
 
     // Confirm the listbox is closed and the textbox is not cleared
 
-    await assertAttributeValues(
-      t,
-      ex.textboxSelector,
-      'aria-expanded',
-      'false'
-    );
+    await assertAttributeValues(t, ex.textboxSelector, 'aria-expanded', 'false');
     t.is(
       await t.context.session
         .findElement(By.css(ex.textboxSelector))
@@ -602,14 +464,12 @@ ariaTest(
       'a',
       'In listbox key press "ESCAPE" should result in first option in textbox'
     );
-  }
-);
 
-ariaTest(
-  'Test double escape key press with focus on textbox',
-  exampleFile,
-  'listbox-key-escape',
-  async (t) => {
+  });
+
+ariaTest('Test double escape key press with focus on textbox',
+  exampleFile, 'listbox-key-escape', async (t) => {
+
     // Send key "a" then key "ARROW_DOWN to put the focus on the listbox,
     // then key ESCAPE twice to the textbox
 
@@ -619,12 +479,7 @@ ariaTest(
 
     // Confirm the listbox is closed and the textbox is cleared
 
-    await assertAttributeValues(
-      t,
-      ex.textboxSelector,
-      'aria-expanded',
-      'false'
-    );
+    await assertAttributeValues(t, ex.textboxSelector, 'aria-expanded', 'false');
     t.is(
       await t.context.session
         .findElement(By.css(ex.textboxSelector))
@@ -632,18 +487,14 @@ ariaTest(
       '',
       'In listbox key press "ESCAPE" should result in first option in textbox'
     );
-  }
-);
 
-ariaTest(
-  'left arrow from focus on list puts focus on listbox and moves cursor right',
-  exampleFile,
-  'listbox-key-left-arrow',
-  async (t) => {
+  });
+
+ariaTest('left arrow from focus on list puts focus on listbox and moves cursor right',
+  exampleFile, 'listbox-key-left-arrow', async (t) => {
+
     // Send key "a" then key "ARROW_DOWN" to put the focus on the listbox
-    const textbox = await t.context.session.findElement(
-      By.css(ex.textboxSelector)
-    );
+    const textbox = await t.context.session.findElement(By.css(ex.textboxSelector));
     await textbox.sendKeys('a', Key.ARROW_DOWN);
 
     // Send key "ARROW_LEFT"
@@ -657,20 +508,16 @@ ariaTest(
     t.is(
       await textbox.getAttribute('aria-activedescendant'),
       '',
-      'Focus should be on the textbox after on ARROW_LEFT key'
+      'Focus should be on the textbox after on ARROW_LEFT key',
     );
-  }
-);
+  });
 
-ariaTest(
-  'Right arrow from focus on list puts focus on listbox',
-  exampleFile,
-  'listbox-key-right-arrow',
-  async (t) => {
+
+ariaTest('Right arrow from focus on list puts focus on listbox',
+  exampleFile, 'listbox-key-right-arrow', async (t) => {
+
     // Send key "a" then key "ARROW_DOWN" to put the focus on the listbox
-    const textbox = await t.context.session.findElement(
-      By.css(ex.textboxSelector)
-    );
+    const textbox = await t.context.session.findElement(By.css(ex.textboxSelector));
     await textbox.sendKeys('a', Key.ARROW_DOWN);
 
     // Send key "RIGHT_ARROW"
@@ -684,20 +531,15 @@ ariaTest(
     t.is(
       await textbox.getAttribute('aria-activedescendant'),
       '',
-      'Focus should be on the textbox after on ARROW_RIGHT key'
+      'Focus should be on the textbox after on ARROW_RIGHT key',
     );
-  }
-);
+  });
 
-ariaTest(
-  'Home from focus on list puts focus on listbox and moves cursor',
-  exampleFile,
-  'listbox-key-home',
-  async (t) => {
+ariaTest('Home from focus on list puts focus on listbox and moves cursor',
+  exampleFile, 'listbox-key-home', async (t) => {
+
     // Send key "a" then key "ARROW_DOWN" to put the focus on the listbox
-    const textbox = await t.context.session.findElement(
-      By.css(ex.textboxSelector)
-    );
+    const textbox = await t.context.session.findElement(By.css(ex.textboxSelector));
     await textbox.sendKeys('a', Key.ARROW_DOWN);
 
     // Send key "ARROW_HOME"
@@ -711,20 +553,15 @@ ariaTest(
     t.is(
       await textbox.getAttribute('aria-activedescendant'),
       '',
-      'Focus should be on the textbox after one ARROW_HOME key'
+      'Focus should be on the textbox after one ARROW_HOME key',
     );
-  }
-);
+  });
 
-ariaTest(
-  'End from focus on list puts focus on listbox',
-  exampleFile,
-  'listbox-key-end',
-  async (t) => {
+ariaTest('End from focus on list puts focus on listbox',
+  exampleFile, 'listbox-key-end', async (t) => {
+
     // Send key "a" then key "ARROW_DOWN" to put the focus on the listbox
-    const textbox = await t.context.session.findElement(
-      By.css(ex.textboxSelector)
-    );
+    const textbox = await t.context.session.findElement(By.css(ex.textboxSelector));
     await textbox.sendKeys('a', Key.ARROW_DOWN);
 
     // Send key "END_ARROW"
@@ -738,20 +575,16 @@ ariaTest(
     t.is(
       await textbox.getAttribute('aria-activedescendant'),
       '',
-      'Focus should be on the textbox after on ARROW_END key'
+      'Focus should be on the textbox after on ARROW_END key',
     );
-  }
-);
+  });
 
-ariaTest(
-  'Sending character keys while focus is on listbox moves focus',
-  exampleFile,
-  'listbox-key-char',
-  async (t) => {
+
+ariaTest('Sending character keys while focus is on listbox moves focus',
+  exampleFile, 'listbox-key-char', async (t) => {
+
     // Send key "ARROW_DOWN" to put the focus on the listbox
-    const textbox = await t.context.session.findElement(
-      By.css(ex.textboxSelector)
-    );
+    const textbox = await t.context.session.findElement(By.css(ex.textboxSelector));
     await textbox.sendKeys(Key.ARROW_DOWN);
 
     // Send key "a"
@@ -767,23 +600,18 @@ ariaTest(
     t.is(
       await textbox.getAttribute('aria-activedescendant'),
       '',
-      'Focus should be on the textbox after sending a character key while the focus is on the listbox'
+      'Focus should be on the textbox after sending a character key while the focus is on the listbox',
     );
-  }
-);
 
-ariaTest(
-  'Expected behavior for all other standard single line editing keys',
-  exampleFile,
-  'standard-single-line-editing-keys',
-  async (t) => {
-    let numOptions = (await t.context.queryElements(t, ex.optionsSelector))
-      .length;
+  });
+
+ariaTest('Expected behavior for all other standard single line editing keys',
+  exampleFile, 'standard-single-line-editing-keys', async (t) => {
+
+    let numOptions = (await t.context.queryElements(t, ex.optionsSelector)).length;
 
     // Send key "w"
-    const textbox = await t.context.session.findElement(
-      By.css(ex.textboxSelector)
-    );
+    const textbox = await t.context.session.findElement(By.css(ex.textboxSelector));
     await textbox.sendKeys('w');
 
     t.is(
@@ -791,5 +619,4 @@ ariaTest(
       numOptions,
       'Sending standard editing keys should NOT filter results'
     );
-  }
-);
+  });

--- a/test/tests/combobox_grid-combo.js
+++ b/test/tests/combobox_grid-combo.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const { ariaTest } = require('..');
 const { By, Key } = require('selenium-webdriver');
 const assertAriaLabelledby = require('../util/assertAriaLabelledby');
@@ -14,7 +16,7 @@ const ex = {
   rowSelector: '#ex1 [role="row"]',
   gridcellSelector: '#ex1 [role="gridcell"]',
   gridcellFocusedClass: 'focused-cell',
-  numAOptions: 3,
+  numAOptions: 3
 };
 
 const waitForFocusChange = async (t, comboboxSelector, originalFocus) => {
@@ -26,22 +28,16 @@ const waitForFocusChange = async (t, comboboxSelector, originalFocus) => {
       return newfocus != originalFocus;
     },
     t.context.waitTime,
-    'Timeout waiting for "aria-activedescendant" value to change from "' +
-      originalFocus +
-      '". '
+    'Timeout waiting for "aria-activedescendant" value to change from "' + originalFocus + '". '
   );
 };
 
 const confirmCursorIndex = async (t, selector, cursorIndex) => {
-  return t.context.session.executeScript(
-    function () {
-      const [selector, cursorIndex] = arguments;
-      let item = document.querySelector(selector);
-      return item.selectionStart === cursorIndex;
-    },
-    selector,
-    cursorIndex
-  );
+  return t.context.session.executeScript(function () {
+    const [selector, cursorIndex] = arguments;
+    let item = document.querySelector(selector);
+    return item.selectionStart === cursorIndex;
+  }, selector, cursorIndex);
 };
 
 const gridcellId = (row, column) => {
@@ -49,258 +45,163 @@ const gridcellId = (row, column) => {
 };
 
 // Attributes
-ariaTest(
-  'Test for role="combobox"',
-  exampleFile,
-  'combobox-role',
-  async (t) => {
+ariaTest('Test for role="combobox"', exampleFile, 'combobox-role', async (t) => {
     await assertAriaRoles(t, 'ex1', 'combobox', '1', 'input');
-  }
-);
-
-ariaTest(
-  '"aria-haspopup"=grid on combobox element',
-  exampleFile,
-  'combobox-aria-haspopup',
-  async (t) => {
-    await assertAttributeValues(
-      t,
-      ex.comboboxSelector,
-      'aria-haspopup',
-      'grid'
-    );
-  }
-);
-
-ariaTest(
-  '"aria-expanded" on combobox element',
-  exampleFile,
-  'combobox-aria-expanded',
-  async (t) => {
-    const combobox = await t.context.session.findElement(
-      By.css(ex.comboboxSelector)
-    );
-
-    // Check that aria-expanded is false and the grid is not visible before interacting
-
-    t.is(
-      await combobox.getAttribute('aria-expanded'),
-      'false',
-      'combobox element should have attribute "aria-expanded" set to false by default.'
-    );
-
-    const popupId = await t.context.session
-      .findElement(By.css(ex.comboboxSelector))
-      .getAttribute('aria-controls');
-
-    const popupElement = await t.context.session
-      .findElement(By.id('ex1'))
-      .findElement(By.id(popupId));
-
-    t.false(
-      await popupElement.isDisplayed(),
-      "Popup element should not be displayed when 'aria-expanded' is false'"
-    );
-
-    // Send key "a" to combobox
-
-    await t.context.session
-      .findElement(By.css(ex.comboboxSelector))
-      .sendKeys('a');
-
-    // Check that aria-expanded is true and the grid is visible
-
-    t.is(
-      await combobox.getAttribute('aria-expanded'),
-      'true',
-      'combobox element should have attribute "aria-expand" set to true after typing.'
-    );
-
-    t.true(
-      await popupElement.isDisplayed(),
-      "Popup element should be displayed when 'aria-expanded' is true'"
-    );
-  }
-);
-
-ariaTest(
-  '"id" attribute on textbox used to discover accessible name',
-  exampleFile,
-  'combobox-id',
-  async (t) => {
-    const labelForTextboxId = await t.context.session
-      .findElement(By.css(ex.labelSelector))
-      .getAttribute('for');
-
-    t.truthy(
-      labelForTextboxId,
-      '"for" attribute with id value should exist on label: ' + ex.labelSelector
-    );
-
-    const textboxElementId = await t.context.session
-      .findElement(By.css(ex.comboboxSelector))
-      .getAttribute('id');
-
-    t.true(
-      labelForTextboxId === textboxElementId,
-      'Id on textbox element (' +
-        ex.comboboxSelector +
-        ') should match the "for" attribute of the label (' +
-        labelForTextboxId +
-        ')'
-    );
-  }
-);
-
-ariaTest(
-  '"aria-autocomplete" on grid element',
-  exampleFile,
-  'combobox-aria-autocomplete',
-  async (t) => {
-    await assertAttributeValues(
-      t,
-      ex.comboboxSelector,
-      'aria-autocomplete',
-      'list'
-    );
-  }
-);
-
-ariaTest(
-  '"aria-controls" attribute on grid element',
-  exampleFile,
-  'combobox-aria-controls',
-  async (t) => {
-    const popupId = await t.context.session
-      .findElement(By.css(ex.comboboxSelector))
-      .getAttribute('aria-controls');
-
-    t.truthy(
-      popupId,
-      '"aria-controls" attribute should exist on: ' + ex.comboboxSelector
-    );
-
-    const popupElements = await t.context.queryElements(t, `#ex1 #${popupId}`);
-
-    t.is(
-      popupElements.length,
-      1,
-      'There should be a element with id "' +
-        popupId +
-        '" as referenced by the aria-controls attribute'
-    );
-  }
-);
-
-ariaTest(
-  '"aria-activedescendant" on combobox element',
-  exampleFile,
-  'combobox-aria-activedescendant',
-  async (t) => {
-    await assertAttributeValues(
-      t,
-      ex.comboboxSelector,
-      'aria-activedescendant',
-      null
-    );
-  }
-);
-
-ariaTest('role "grid" on div element', exampleFile, 'grid-role', async (t) => {
-  await assertAriaRoles(t, 'ex1', 'grid', '1', 'div');
 });
 
-ariaTest(
-  '"aria-labelledby" attribute on grid element',
-  exampleFile,
-  'grid-aria-labelledby',
-  async (t) => {
+ariaTest('"aria-haspopup"=grid on combobox element', exampleFile, 'combobox-aria-haspopup', async (t) => {
+    await assertAttributeValues(t, ex.comboboxSelector, 'aria-haspopup', 'grid');
+});
+
+ariaTest('"aria-expanded" on combobox element', exampleFile, 'combobox-aria-expanded', async (t) => {
+
+  const combobox = await t.context.session.findElement(By.css(ex.comboboxSelector));
+
+  // Check that aria-expanded is false and the grid is not visible before interacting
+
+  t.is(
+    await combobox.getAttribute('aria-expanded'),
+    'false',
+    'combobox element should have attribute "aria-expanded" set to false by default.'
+  );
+
+  const popupId = await t.context.session
+    .findElement(By.css(ex.comboboxSelector))
+    .getAttribute('aria-controls');
+
+  const popupElement = await t.context.session
+    .findElement(By.id('ex1'))
+    .findElement(By.id(popupId));
+
+  t.false(
+    await popupElement.isDisplayed(),
+    'Popup element should not be displayed when \'aria-expanded\' is false\''
+  );
+
+  // Send key "a" to combobox
+
+  await t.context.session
+    .findElement(By.css(ex.comboboxSelector))
+    .sendKeys('a');
+
+  // Check that aria-expanded is true and the grid is visible
+
+  t.is(
+    await combobox.getAttribute('aria-expanded'),
+    'true',
+    'combobox element should have attribute "aria-expand" set to true after typing.'
+  );
+
+  t.true(
+    await popupElement.isDisplayed(),
+    'Popup element should be displayed when \'aria-expanded\' is true\''
+  );
+});
+
+ariaTest('"id" attribute on textbox used to discover accessible name', exampleFile, 'combobox-id', async (t) => {
+
+  const labelForTextboxId = await t.context.session
+    .findElement(By.css(ex.labelSelector))
+    .getAttribute('for');
+
+  t.truthy(
+    labelForTextboxId,
+    '"for" attribute with id value should exist on label: ' + ex.labelSelector
+  );
+
+  const textboxElementId = await t.context.session
+    .findElement(By.css(ex.comboboxSelector))
+    .getAttribute('id');
+
+  t.true(
+    labelForTextboxId === textboxElementId,
+    'Id on textbox element (' + ex.comboboxSelector + ') should match the "for" attribute of the label (' + labelForTextboxId + ')'
+  );
+});
+
+ariaTest('"aria-autocomplete" on grid element', exampleFile, 'combobox-aria-autocomplete', async (t) => {
+    await assertAttributeValues(t, ex.comboboxSelector, 'aria-autocomplete', 'list');
+});
+
+ariaTest('"aria-controls" attribute on grid element', exampleFile, 'combobox-aria-controls', async (t) => {
+
+  const popupId = await t.context.session
+    .findElement(By.css(ex.comboboxSelector))
+    .getAttribute('aria-controls');
+
+  t.truthy(
+    popupId,
+    '"aria-controls" attribute should exist on: ' + ex.comboboxSelector
+  );
+
+  const popupElements = await t.context.queryElements(t, `#ex1 #${popupId}`);
+
+  t.is(
+    popupElements.length,
+    1,
+    'There should be a element with id "' + popupId + '" as referenced by the aria-controls attribute'
+  );
+});
+
+ariaTest('"aria-activedescendant" on combobox element', exampleFile, 'combobox-aria-activedescendant', async (t) => {
+    await assertAttributeValues(t, ex.comboboxSelector, 'aria-activedescendant', null);
+});
+
+ariaTest('role "grid" on div element', exampleFile, 'grid-role', async (t) => {
+    await assertAriaRoles(t, 'ex1', 'grid', '1', 'div');
+});
+
+ariaTest('"aria-labelledby" attribute on grid element', exampleFile, 'grid-aria-labelledby', async (t) => {
     await assertAriaLabelledby(t, ex.gridSelector);
-  }
-);
+});
 
-ariaTest(
-  'role "row" exists within grid element',
-  exampleFile,
-  'row-role',
-  async (t) => {
-    // Send key "a" then arrow down to reveal all options
-    await t.context.session
-      .findElement(By.css(ex.comboboxSelector))
-      .sendKeys('a', Key.ARROW_DOWN);
+ariaTest('role "row" exists within grid element', exampleFile, 'row-role', async (t) => {
 
-    let gridEl = await t.context.session.findElement(By.css(ex.gridSelector));
-    let rowElements = await t.context.queryElements(t, '[role="row"]', gridEl);
+  // Send key "a" then arrow down to reveal all options
+  await t.context.session.findElement(By.css(ex.comboboxSelector)).sendKeys('a', Key.ARROW_DOWN);
 
-    t.truthy(
-      await rowElements.length,
-      'role="row" elements should be found within a gridcell element after opening popup'
-    );
-  }
-);
+  let gridEl = await t.context.session.findElement(By.css(ex.gridSelector));
+  let rowElements = await t.context.queryElements(t, '[role="row"]', gridEl);
+
+  t.truthy(
+    await rowElements.length,
+    'role="row" elements should be found within a gridcell element after opening popup'
+  );
+});
 
 // This test fails due to bug: https://github.com/w3c/aria-practices/issues/859
-ariaTest.failing(
-  '"aria-selected" attribute on row element',
-  exampleFile,
-  'row-aria-selected',
-  async (t) => {
-    // Send key "a"
-    await t.context.session
-      .findElement(By.css(ex.comboboxSelector))
-      .sendKeys('a');
-    await assertAttributeDNE(
-      t,
-      ex.rowSelector + ':nth-of-type(1)',
-      'aria-selected'
-    );
+ariaTest.failing('"aria-selected" attribute on row element', exampleFile, 'row-aria-selected', async (t) => {
 
-    // Send key ARROW_DOWN to selected first option
-    await t.context.session
-      .findElement(By.css(ex.comboboxSelector))
-      .sendKeys(Key.ARROW_DOWN);
-    await assertAttributeValues(
-      t,
-      ex.rowSelector + ':nth-of-type(1)',
-      'aria-selected',
-      'true'
-    );
-  }
-);
+  // Send key "a"
+  await t.context.session.findElement(By.css(ex.comboboxSelector)).sendKeys('a');
+  await assertAttributeDNE(t, ex.rowSelector + ':nth-of-type(1)', 'aria-selected');
 
-ariaTest(
-  'role "gridcell" exists within row element',
-  exampleFile,
-  'gridcell-role',
-  async (t) => {
-    // Send key "a" then arrow down to reveal all options
-    await t.context.session
-      .findElement(By.css(ex.comboboxSelector))
-      .sendKeys('a', Key.ARROW_DOWN);
+  // Send key ARROW_DOWN to selected first option
+  await t.context.session.findElement(By.css(ex.comboboxSelector)).sendKeys(Key.ARROW_DOWN);
+  await assertAttributeValues(t, ex.rowSelector + ':nth-of-type(1)', 'aria-selected', 'true');
+});
 
-    let rowElement = await t.context.session.findElement(
-      By.css(ex.rowSelector)
-    );
-    let cellElements = await t.context.queryElements(
-      t,
-      '[role="gridcell"]',
-      rowElement
-    );
+ariaTest('role "gridcell" exists within row element', exampleFile, 'gridcell-role', async (t) => {
 
-    t.truthy(
-      await cellElements.length,
-      'role="gridcell" elements should be found within a row element after opening popup'
-    );
-  }
-);
+  // Send key "a" then arrow down to reveal all options
+  await t.context.session.findElement(By.css(ex.comboboxSelector)).sendKeys('a', Key.ARROW_DOWN);
+
+  let rowElement = await t.context.session.findElement(By.css(ex.rowSelector));
+  let cellElements = await t.context.queryElements(t, '[role="gridcell"]', rowElement);
+
+  t.truthy(
+    await cellElements.length,
+    'role="gridcell" elements should be found within a row element after opening popup'
+  );
+});
+
 
 // Keys
 
-ariaTest(
-  'Test down key press with focus on combobox',
-  exampleFile,
-  'popup-key-down-arrow',
-  async (t) => {
+ariaTest('Test down key press with focus on combobox',
+  exampleFile, 'textbox-key-down-arrow', async (t) => {
+
+
     // Send ARROW_DOWN to the combobox
     await t.context.session
       .findElement(By.css(ex.comboboxSelector))
@@ -308,9 +209,7 @@ ariaTest(
 
     // Check that the grid is displayed
     t.false(
-      await t.context.session
-        .findElement(By.css(ex.gridSelector))
-        .isDisplayed(),
+      await t.context.session.findElement(By.css(ex.gridSelector)).isDisplayed(),
       'In example ex3 grid should not be display after ARROW_DOWN keypress while combobox is empty'
     );
 
@@ -324,47 +223,41 @@ ariaTest(
 
     // Check that the grid is displayed
     t.true(
-      await t.context.session
-        .findElement(By.css(ex.gridSelector))
-        .isDisplayed(),
+      await t.context.session.findElement(By.css(ex.gridSelector)).isDisplayed(),
       'In example ex3 grid should display after ARROW_DOWN keypress when combobox has character values'
     );
 
     // Check that the active descendent focus is correct
-    let focusedId = await t.context.session
-      .findElement(By.css(ex.comboboxSelector))
+    let focusedId = await t.context.session.findElement(By.css(ex.comboboxSelector))
       .getAttribute('aria-activedescendant');
 
     t.is(
       focusedId,
-      gridcellId(0, 0),
-      'After down arrow sent to combobox, aria-activedescendant should be set to the first gridcell element: ' +
-        gridcellId(0, 0)
+      gridcellId(0,0),
+      'After down arrow sent to combobox, aria-activedescendant should be set to the first gridcell element: ' + gridcellId(0,0)
     );
 
-    let focusedElementClasses = await t.context.session
-      .findElement(By.id(gridcellId(0, 0)))
+    let focusedElementClasses = await t.context.session.findElement(By.id(gridcellId(0,0)))
       .getAttribute('class');
 
     t.true(
       focusedElementClasses.includes(ex.gridcellFocusedClass),
-      'Gridcell with id "' + gridcellId(0, 0) + '" should have visual focus'
+      'Gridcell with id "' + gridcellId(0,0) + '" should have visual focus'
     );
-  }
-);
 
-ariaTest(
-  'Test down key press with focus on list',
-  exampleFile,
-  'popup-key-down-arrow',
-  async (t) => {
+  });
+
+ariaTest('Test down key press with focus on list',
+  exampleFile, 'popup-key-down-arrow', async (t) => {
+
+
     // Send 'a' to text box, then send ARROW_DOWN to combobox to set focus on grid
     await t.context.session
       .findElement(By.css(ex.comboboxSelector))
       .sendKeys('a', Key.ARROW_DOWN);
 
     // Test that ARROW_DOWN moves active descendant focus on item in grid
-    for (let i = 1; i < ex.numAOptions; i++) {
+    for (let i = 1; i <  ex.numAOptions; i++) {
       let oldfocus = await t.context.session
         .findElement(By.css(ex.comboboxSelector))
         .getAttribute('aria-activedescendant');
@@ -378,22 +271,19 @@ ariaTest(
 
       // Check that the active descendent focus is correct
 
-      let focusedId = await t.context.session
-        .findElement(By.css(ex.comboboxSelector))
+      let focusedId = await t.context.session.findElement(By.css(ex.comboboxSelector))
         .getAttribute('aria-activedescendant');
       t.is(
         focusedId,
-        gridcellId(i, 0),
-        'After down up sent to combobox, aria-activedescendant should be set to this gridcell element: ' +
-          gridcellId(i, 0)
+        gridcellId(i,0),
+        'After down up sent to combobox, aria-activedescendant should be set to this gridcell element: ' + gridcellId(i,0)
       );
 
-      let focusedElementClasses = await t.context.session
-        .findElement(By.id(gridcellId(i, 0)))
+      let focusedElementClasses = await t.context.session.findElement(By.id(gridcellId(i,0)))
         .getAttribute('class');
       t.true(
         focusedElementClasses.includes(ex.gridcellFocusedClass),
-        'Gridcell with id "' + gridcellId(i, 0) + '" should have visual focus'
+        'Gridcell with id "' + gridcellId(i,0) + '" should have visual focus'
       );
     }
 
@@ -410,31 +300,28 @@ ariaTest(
 
     // Focus should be on the first item
 
-    let focusedId = await t.context.session
-      .findElement(By.css(ex.comboboxSelector))
+    let focusedId = await t.context.session.findElement(By.css(ex.comboboxSelector))
       .getAttribute('aria-activedescendant');
     t.is(
       focusedId,
-      gridcellId(0, 0),
-      'After down arrow sent to last grid row, aria-activedescendant should be set to the first gridcell element: ' +
-        gridcellId(0, 0)
+      gridcellId(0,0),
+      'After down arrow sent to last grid row, aria-activedescendant should be set to the first gridcell element: ' + gridcellId(0,0)
     );
 
-    let focusedElementClasses = await t.context.session
-      .findElement(By.id(gridcellId(0, 0)))
+    let focusedElementClasses = await t.context.session.findElement(By.id(gridcellId(0,0)))
       .getAttribute('class');
     t.true(
       focusedElementClasses.includes(ex.gridcellFocusedClass),
-      'Gridcell with id "' + gridcellId(0, 0) + '" should have visual focus'
+      'Gridcell with id "' + gridcellId(0,0) + '" should have visual focus'
     );
-  }
-);
 
-ariaTest(
-  'Test up key press with focus on combobox',
-  exampleFile,
-  'popup-key-up-arrow',
-  async (t) => {
+  });
+
+
+ariaTest('Test up key press with focus on combobox',
+  exampleFile, 'textbox-key-up-arrow', async (t) => {
+
+
     // Send ARROW_UP to the combobox
     await t.context.session
       .findElement(By.css(ex.comboboxSelector))
@@ -442,9 +329,7 @@ ariaTest(
 
     // Check that the grid is displayed
     t.false(
-      await t.context.session
-        .findElement(By.css(ex.gridSelector))
-        .isDisplayed(),
+      await t.context.session.findElement(By.css(ex.gridSelector)).isDisplayed(),
       'In example ex3 grid should not be display after ARROW_UP keypress while combobox is empty'
     );
 
@@ -458,42 +343,34 @@ ariaTest(
 
     // Check that the grid is displayed
     t.true(
-      await t.context.session
-        .findElement(By.css(ex.gridSelector))
-        .isDisplayed(),
+      await t.context.session.findElement(By.css(ex.gridSelector)).isDisplayed(),
       'In example ex3 grid should display after ARROW_UP keypress when combobox has character values'
     );
 
     // Check that the active descendent focus is correct
-    let focusedId = await t.context.session
-      .findElement(By.css(ex.comboboxSelector))
+    let focusedId = await t.context.session.findElement(By.css(ex.comboboxSelector))
       .getAttribute('aria-activedescendant');
 
     t.is(
       focusedId,
-      gridcellId(ex.numAOptions - 1, 0),
-      'After up arrow sent to combobox, aria-activedescendant should be set to the last row first gridcell element: ' +
-        gridcellId(ex.numAOptions - 1, 0)
+      gridcellId(ex.numAOptions - 1,0),
+      'After up arrow sent to combobox, aria-activedescendant should be set to the last row first gridcell element: ' + gridcellId(ex.numAOptions - 1,0)
     );
 
-    let focusedElementClasses = await t.context.session
-      .findElement(By.id(gridcellId(ex.numAOptions - 1, 0)))
+    let focusedElementClasses = await t.context.session.findElement(By.id(gridcellId(ex.numAOptions - 1,0)))
       .getAttribute('class');
 
     t.true(
       focusedElementClasses.includes(ex.gridcellFocusedClass),
-      'Gridcell with id "' +
-        gridcellId(ex.numAOptions - 1, 0) +
-        '" should have visual focus'
+      'Gridcell with id "' + gridcellId(ex.numAOptions - 1,0) + '" should have visual focus'
     );
-  }
-);
 
-ariaTest(
-  'Test up key press with focus on grid',
-  exampleFile,
-  'popup-key-up-arrow',
-  async (t) => {
+  });
+
+ariaTest('Test up key press with focus on grid',
+  exampleFile, 'popup-key-up-arrow', async (t) => {
+
+
     // Send 'a' to text box, then send ARROW_UP to combobox to put focus in combobox
     // Up arrow should move selection to the last item in the list
     await t.context.session
@@ -501,7 +378,7 @@ ariaTest(
       .sendKeys('a', Key.ARROW_UP);
 
     // Test that ARROW_UP moves active descendant focus up one item in the grid
-    for (let index = ex.numAOptions - 2; index >= 0; index--) {
+    for (let index = ex.numAOptions - 2; index >= 0 ; index--) {
       let oldfocus = await t.context.session
         .findElement(By.css(ex.comboboxSelector))
         .getAttribute('aria-activedescendant');
@@ -515,24 +392,19 @@ ariaTest(
 
       // Check that the active descendent focus is correct
 
-      let focusedId = await t.context.session
-        .findElement(By.css(ex.comboboxSelector))
+      let focusedId = await t.context.session.findElement(By.css(ex.comboboxSelector))
         .getAttribute('aria-activedescendant');
       t.is(
         focusedId,
-        gridcellId(index, 0),
-        'After up arrow sent to combobox, aria-activedescendant should be set to gridcell element: ' +
-          gridcellId(index, 0)
+        gridcellId(index,0),
+        'After up arrow sent to combobox, aria-activedescendant should be set to gridcell element: ' + gridcellId(index,0)
       );
 
-      let focusedElementClasses = await t.context.session
-        .findElement(By.id(gridcellId(index, 0)))
+      let focusedElementClasses = await t.context.session.findElement(By.id(gridcellId(index,0)))
         .getAttribute('class');
       t.true(
         focusedElementClasses.includes(ex.gridcellFocusedClass),
-        'Gridcell with id "' +
-          gridcellId(index, 0) +
-          '" should have visual focus'
+        'Gridcell with id "' + gridcellId(index,0) + '" should have visual focus'
       );
     }
 
@@ -550,33 +422,27 @@ ariaTest(
 
     // Check that the active descendent focus is correct
 
-    let focusedId = await t.context.session
-      .findElement(By.css(ex.comboboxSelector))
+    let focusedId = await t.context.session.findElement(By.css(ex.comboboxSelector))
       .getAttribute('aria-activedescendant');
     t.is(
       focusedId,
-      gridcellId(ex.numAOptions - 1, 0),
-      'After up arrow sent to first element in popup, aria-activedescendant should be set to the last row first gridcell element: ' +
-        gridcellId(ex.numAOptions - 1, 0)
+      gridcellId(ex.numAOptions - 1,0),
+      'After up arrow sent to first element in popup, aria-activedescendant should be set to the last row first gridcell element: ' + gridcellId(ex.numAOptions - 1,0)
     );
 
-    let focusedElementClasses = await t.context.session
-      .findElement(By.id(gridcellId(ex.numAOptions - 1, 0)))
+    let focusedElementClasses = await t.context.session.findElement(By.id(gridcellId(ex.numAOptions - 1,0)))
       .getAttribute('class');
     t.true(
       focusedElementClasses.includes(ex.gridcellFocusedClass),
-      'Gridcell with id "' +
-        gridcellId(ex.numAOptions - 1, 0) +
-        '" should have visual focus'
+      'Gridcell with id "' + gridcellId(ex.numAOptions - 1,0) + '" should have visual focus'
     );
-  }
-);
 
-ariaTest(
-  'Test enter key press with focus on grid',
-  exampleFile,
-  'popup-key-enter',
-  async (t) => {
+  });
+
+ariaTest('Test enter key press with focus on grid',
+  exampleFile, 'popup-key-enter', async (t) => {
+
+
     // Send key "a" to the combobox, then key ARROW_DOWN to select the first item
 
     await t.context.session
@@ -585,9 +451,7 @@ ariaTest(
 
     // Get the value of the first option in the grid
 
-    const firstOption = await t.context.session
-      .findElement(By.css(ex.gridcellSelector))
-      .getText();
+    const firstOption = await t.context.session.findElement(By.css(ex.gridcellSelector)).getText();
 
     // Send key ENTER
 
@@ -597,12 +461,7 @@ ariaTest(
 
     // Confirm that the grid is closed
 
-    await assertAttributeValues(
-      t,
-      ex.comboboxSelector,
-      'aria-expanded',
-      'false'
-    );
+    await assertAttributeValues(t, ex.comboboxSelector, 'aria-expanded', 'false');
 
     // Confirm that the value of the combobox is now set to the first option
 
@@ -613,14 +472,11 @@ ariaTest(
       firstOption,
       'key press "ENTER" should result in first option in combobox'
     );
-  }
-);
 
-ariaTest(
-  'Test escape key press with focus on combobox',
-  exampleFile,
-  'textbox-key-escape',
-  async (t) => {
+  });
+
+ariaTest('Test escape key press with focus on combobox',
+  exampleFile, 'textbox-key-escape', async (t) => {
     // Send key "a" then key "ARROW_DOWN to put the focus on the listbox,
     // then key ESCAPE to the textbox
 
@@ -630,12 +486,7 @@ ariaTest(
 
     // Confirm the listbox is closed and the textbox is cleared
 
-    await assertAttributeValues(
-      t,
-      ex.comboboxSelector,
-      'aria-expanded',
-      'false'
-    );
+    await assertAttributeValues(t, ex.comboboxSelector, 'aria-expanded', 'false');
     t.is(
       await t.context.session
         .findElement(By.css(ex.comboboxSelector))
@@ -643,14 +494,12 @@ ariaTest(
       'a',
       'In listbox key press "ESCAPE" should result in "a" in textbox'
     );
-  }
-);
 
-ariaTest(
-  'Test double escape key press with focus on combobox',
-  exampleFile,
-  'textbox-key-escape',
-  async (t) => {
+  });
+
+
+ariaTest('Test double escape key press with focus on combobox',
+  exampleFile, 'textbox-key-escape', async (t) => {
     // Send key "a", then key ESCAPE twice to the textbox
 
     await t.context.session
@@ -659,12 +508,7 @@ ariaTest(
 
     // Confirm the listbox is closed and the textbox is cleared
 
-    await assertAttributeValues(
-      t,
-      ex.comboboxSelector,
-      'aria-expanded',
-      'false'
-    );
+    await assertAttributeValues(t, ex.comboboxSelector, 'aria-expanded', 'false');
     t.is(
       await t.context.session
         .findElement(By.css(ex.comboboxSelector))
@@ -672,14 +516,13 @@ ariaTest(
       '',
       'In key press "ESCAPE" should result in clearing the textbox'
     );
-  }
-);
 
-ariaTest(
-  'Test escape key press with focus on popup',
-  exampleFile,
-  'popup-key-escape',
-  async (t) => {
+  });
+
+
+ariaTest('Test escape key press with focus on popup',
+  exampleFile, 'popup-key-escape', async (t) => {
+
     // Send key "a" then key "ARROW_DOWN to put the focus on the grid,
     // then key ESCAPE to the combobox
 
@@ -696,21 +539,14 @@ ariaTest(
     // Wait for gridbox to close
     await t.context.session.wait(
       async function () {
-        return !(await t.context.session
-          .findElement(By.css(ex.gridSelector))
-          .isDisplayed());
+        return !(await t.context.session.findElement(By.css(ex.gridSelector)).isDisplayed());
       },
       t.context.waitTime,
       'Timeout waiting for gridbox to close afer escape'
     );
 
     // Confirm the grid is closed and the textbox is cleared
-    await assertAttributeValues(
-      t,
-      ex.comboboxSelector,
-      'aria-expanded',
-      'false'
-    );
+    await assertAttributeValues(t, ex.comboboxSelector, 'aria-expanded', 'false');
 
     t.is(
       await t.context.session
@@ -719,14 +555,12 @@ ariaTest(
       'a',
       'In grid key press "ESCAPE" should result the "a" in the combobox'
     );
-  }
-);
 
-ariaTest(
-  'left arrow from focus on list puts focus on grid and moves cursor right',
-  exampleFile,
-  'popup-key-left-arrow',
-  async (t) => {
+  });
+
+ariaTest('left arrow from focus on list puts focus on grid and moves cursor right',
+  exampleFile, 'popup-key-left-arrow', async (t) => {
+
     // Send key "a" then key "ARROW_DOWN" to put the focus on the grid
     const combobox = t.context.session.findElement(By.css(ex.comboboxSelector));
     await combobox.sendKeys('a', Key.ARROW_DOWN);
@@ -737,57 +571,46 @@ ariaTest(
     // Check that the active descendent focus is correct
     let lastrow = ex.numAOptions - 1;
 
-    var focusedId = await t.context.session
-      .findElement(By.css(ex.comboboxSelector))
+    var focusedId = await t.context.session.findElement(By.css(ex.comboboxSelector))
       .getAttribute('aria-activedescendant');
     t.is(
       focusedId,
-      gridcellId(lastrow, 1),
-      'After left arrow sent to popup, aria-activedescendant should be set to the last row, last gricell: ' +
-        gridcellId(lastrow, 1)
+      gridcellId(lastrow,1),
+      'After left arrow sent to popup, aria-activedescendant should be set to the last row, last gricell: ' + gridcellId(lastrow, 1)
     );
 
-    var focusedElementClasses = await t.context.session
-      .findElement(By.id(gridcellId(lastrow, 1)))
+    var focusedElementClasses = await t.context.session.findElement(By.id(gridcellId(lastrow,1)))
       .getAttribute('class');
     t.true(
       focusedElementClasses.includes(ex.gridcellFocusedClass),
-      'Gridcell with id "' +
-        gridcellId(lastrow, 1) +
-        '" should have visual focus'
+      'Gridcell with id "' + gridcellId(lastrow,1) + '" should have visual focus'
     );
 
     // Send key "ARROW_LEFT" a second time
     await combobox.sendKeys(Key.ARROW_LEFT);
 
     // Check that the active descendent focus is correct
-    focusedId = await t.context.session
-      .findElement(By.css(ex.comboboxSelector))
+    focusedId = await t.context.session.findElement(By.css(ex.comboboxSelector))
       .getAttribute('aria-activedescendant');
     t.is(
       focusedId,
-      gridcellId(lastrow, 0),
-      'After left arrow sent twice to popup, aria-activedescendant should be set to the last row first gridcell: ' +
-        gridcellId(lastrow, 0)
+      gridcellId(lastrow,0),
+      'After left arrow sent twice to popup, aria-activedescendant should be set to the last row first gridcell: ' + gridcellId(lastrow, 0)
     );
 
-    focusedElementClasses = await t.context.session
-      .findElement(By.id(gridcellId(lastrow, 0)))
+    focusedElementClasses = await t.context.session.findElement(By.id(gridcellId(lastrow,0)))
       .getAttribute('class');
     t.true(
       focusedElementClasses.includes(ex.gridcellFocusedClass),
-      'Gridcell with id "' +
-        gridcellId(lastrow, 0) +
-        '" should have visual focus'
+      'Gridcell with id "' + gridcellId(lastrow,0) + '" should have visual focus'
     );
-  }
-);
 
-ariaTest(
-  'Right arrow from focus on list puts focus on grid',
-  exampleFile,
-  'popup-key-right-arrow',
-  async (t) => {
+  });
+
+
+ariaTest('Right arrow from focus on list puts focus on grid',
+  exampleFile, 'popup-key-right-arrow', async (t) => {
+
     // Send key "a" then key "ARROW_DOWN" to put the focus on the grid
     const combobox = t.context.session.findElement(By.css(ex.comboboxSelector));
     await combobox.sendKeys('a', Key.ARROW_DOWN);
@@ -796,80 +619,64 @@ ariaTest(
     await combobox.sendKeys(Key.ARROW_RIGHT);
 
     // Check that the active descendent focus is correct
-    var focusedId = await t.context.session
-      .findElement(By.css(ex.comboboxSelector))
+    var focusedId = await t.context.session.findElement(By.css(ex.comboboxSelector))
       .getAttribute('aria-activedescendant');
     t.is(
       focusedId,
-      gridcellId(0, 1),
-      'After right arrow sent to popup, aria-activedescendant should be set to the first row second gridcell element: ' +
-        gridcellId(0, 1)
+      gridcellId(0,1),
+      'After right arrow sent to popup, aria-activedescendant should be set to the first row second gridcell element: ' + gridcellId(0, 1)
     );
 
-    var focusedElementClasses = await t.context.session
-      .findElement(By.id(gridcellId(0, 1)))
+    var focusedElementClasses = await t.context.session.findElement(By.id(gridcellId(0,1)))
       .getAttribute('class');
     t.true(
       focusedElementClasses.includes(ex.gridcellFocusedClass),
-      'Gridcell with id "' + gridcellId(0, 1) + '" should have visual focus'
+      'Gridcell with id "' + gridcellId(0,1) + '" should have visual focus'
     );
 
     // Send key "ARROW_RIGHT" a second time
     await combobox.sendKeys(Key.ARROW_RIGHT);
 
     // Check that the active descendent focus is correct
-    focusedId = await t.context.session
-      .findElement(By.css(ex.comboboxSelector))
+    focusedId = await t.context.session.findElement(By.css(ex.comboboxSelector))
       .getAttribute('aria-activedescendant');
     t.is(
       focusedId,
-      gridcellId(1, 0),
-      'After right arrow send twice to popup, aria-activedescendant should be set to the second row first gridcell element: ' +
-        gridcellId(1, 0)
+      gridcellId(1,0),
+      'After right arrow send twice to popup, aria-activedescendant should be set to the second row first gridcell element: ' + gridcellId(1, 0)
     );
 
-    focusedElementClasses = await t.context.session
-      .findElement(By.id(gridcellId(1, 0)))
+    focusedElementClasses = await t.context.session.findElement(By.id(gridcellId(1,0)))
       .getAttribute('class');
     t.true(
       focusedElementClasses.includes(ex.gridcellFocusedClass),
-      'Gridcell with id "' + gridcellId(1, 0) + '" should have visual focus'
+      'Gridcell with id "' + gridcellId(1,0) + '" should have visual focus'
     );
 
     // Send key "ARROW_RIGHT" four more times
-    await combobox.sendKeys(
-      Key.ARROW_RIGHT,
-      Key.ARROW_RIGHT,
-      Key.ARROW_RIGHT,
-      Key.ARROW_RIGHT
-    );
+    await combobox.sendKeys(Key.ARROW_RIGHT, Key.ARROW_RIGHT, Key.ARROW_RIGHT, Key.ARROW_RIGHT);
 
     // Check that the active descendent focus is correct
-    focusedId = await t.context.session
-      .findElement(By.css(ex.comboboxSelector))
+    focusedId = await t.context.session.findElement(By.css(ex.comboboxSelector))
       .getAttribute('aria-activedescendant');
     t.is(
       focusedId,
-      gridcellId(0, 0),
-      'After right arrow to the popup 6 times in total, aria-activedescendant should be back on the first row, first gridcell: ' +
-        gridcellId(0, 0)
+      gridcellId(0,0),
+      'After right arrow to the popup 6 times in total, aria-activedescendant should be back on the first row, first gridcell: ' + gridcellId(0, 0)
     );
 
-    focusedElementClasses = await t.context.session
-      .findElement(By.id(gridcellId(0, 0)))
+    focusedElementClasses = await t.context.session.findElement(By.id(gridcellId(0,0)))
       .getAttribute('class');
     t.true(
       focusedElementClasses.includes(ex.gridcellFocusedClass),
-      'Gridcell with id "' + gridcellId(0, 0) + '" should have visual focus'
+      'Gridcell with id "' + gridcellId(0,0) + '" should have visual focus'
     );
-  }
-);
 
-ariaTest(
-  'Home from focus on list puts focus on grid and moves cursor',
-  exampleFile,
-  'popup-key-home',
-  async (t) => {
+  });
+
+ariaTest('Home from focus on list puts focus on grid and moves cursor',
+  exampleFile, 'popup-key-home', async (t) => {
+
     // Send key "a" then key "ARROW_DOWN" to put the focus on the grid
     const combobox = t.context.session.findElement(By.css(ex.comboboxSelector));
     await combobox.sendKeys('a', Key.ARROW_DOWN);
@@ -885,16 +692,13 @@ ariaTest(
     t.is(
       await combobox.getAttribute('aria-activedescendant'),
       '',
-      'Focus should be on the combobox after one ARROW_HOME key'
+      'Focus should be on the combobox after one ARROW_HOME key',
     );
-  }
-);
+  });
 
-ariaTest(
-  'End from focus on list puts focus on grid',
-  exampleFile,
-  'popup-key-end',
-  async (t) => {
+ariaTest('End from focus on list puts focus on grid',
+  exampleFile, 'popup-key-end', async (t) => {
+
     // Send key "a" then key "ARROW_DOWN" to put the focus on the grid
     const combobox = t.context.session.findElement(By.css(ex.comboboxSelector));
     await combobox.sendKeys('a', Key.ARROW_DOWN);
@@ -910,16 +714,13 @@ ariaTest(
     t.is(
       await combobox.getAttribute('aria-activedescendant'),
       '',
-      'Focus should be on the combobox after on ARROW_END key'
+      'Focus should be on the combobox after on ARROW_END key',
     );
-  }
-);
+  });
 
-ariaTest(
-  'Sending character keys while focus is on grid moves focus',
-  exampleFile,
-  'popup-key-char',
-  async (t) => {
+ariaTest('Sending character keys while focus is on grid moves focus',
+  exampleFile, 'popup-key-char', async (t) => {
+
     // Send key "ARROW_DOWN" to put the focus on the grid
     const combobox = t.context.session.findElement(By.css(ex.comboboxSelector));
     await combobox.sendKeys(Key.ARROW_DOWN);
@@ -937,16 +738,13 @@ ariaTest(
     t.is(
       await combobox.getAttribute('aria-activedescendant'),
       '',
-      'Focus should be on the combobox after sending a character key while the focus is on the grid'
+      'Focus should be on the combobox after sending a character key while the focus is on the grid',
     );
-  }
-);
 
-ariaTest.failing(
-  'Expected behavior for all other standard single line editing keys',
-  exampleFile,
-  'standard-single-line-editing-keys',
-  async (t) => {
-    t.fail();
-  }
-);
+  });
+
+ariaTest.failing('Expected behavior for all other standard single line editing keys',
+  exampleFile, 'standard-single-line-editing-keys', async (t) => {
+        t.fail();
+  });
+

--- a/test/tests/combobox_grid-combo.js
+++ b/test/tests/combobox_grid-combo.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { ariaTest } = require('..');
 const { By, Key } = require('selenium-webdriver');
 const assertAriaLabelledby = require('../util/assertAriaLabelledby');
@@ -16,7 +14,7 @@ const ex = {
   rowSelector: '#ex1 [role="row"]',
   gridcellSelector: '#ex1 [role="gridcell"]',
   gridcellFocusedClass: 'focused-cell',
-  numAOptions: 3
+  numAOptions: 3,
 };
 
 const waitForFocusChange = async (t, comboboxSelector, originalFocus) => {
@@ -28,16 +26,22 @@ const waitForFocusChange = async (t, comboboxSelector, originalFocus) => {
       return newfocus != originalFocus;
     },
     t.context.waitTime,
-    'Timeout waiting for "aria-activedescendant" value to change from "' + originalFocus + '". '
+    'Timeout waiting for "aria-activedescendant" value to change from "' +
+      originalFocus +
+      '". '
   );
 };
 
 const confirmCursorIndex = async (t, selector, cursorIndex) => {
-  return t.context.session.executeScript(function () {
-    const [selector, cursorIndex] = arguments;
-    let item = document.querySelector(selector);
-    return item.selectionStart === cursorIndex;
-  }, selector, cursorIndex);
+  return t.context.session.executeScript(
+    function () {
+      const [selector, cursorIndex] = arguments;
+      let item = document.querySelector(selector);
+      return item.selectionStart === cursorIndex;
+    },
+    selector,
+    cursorIndex
+  );
 };
 
 const gridcellId = (row, column) => {
@@ -45,163 +49,258 @@ const gridcellId = (row, column) => {
 };
 
 // Attributes
-ariaTest('Test for role="combobox"', exampleFile, 'combobox-role', async (t) => {
+ariaTest(
+  'Test for role="combobox"',
+  exampleFile,
+  'combobox-role',
+  async (t) => {
     await assertAriaRoles(t, 'ex1', 'combobox', '1', 'input');
-});
+  }
+);
 
-ariaTest('"aria-haspopup"=grid on combobox element', exampleFile, 'combobox-aria-haspopup', async (t) => {
-    await assertAttributeValues(t, ex.comboboxSelector, 'aria-haspopup', 'grid');
-});
+ariaTest(
+  '"aria-haspopup"=grid on combobox element',
+  exampleFile,
+  'combobox-aria-haspopup',
+  async (t) => {
+    await assertAttributeValues(
+      t,
+      ex.comboboxSelector,
+      'aria-haspopup',
+      'grid'
+    );
+  }
+);
 
-ariaTest('"aria-expanded" on combobox element', exampleFile, 'combobox-aria-expanded', async (t) => {
+ariaTest(
+  '"aria-expanded" on combobox element',
+  exampleFile,
+  'combobox-aria-expanded',
+  async (t) => {
+    const combobox = await t.context.session.findElement(
+      By.css(ex.comboboxSelector)
+    );
 
-  const combobox = await t.context.session.findElement(By.css(ex.comboboxSelector));
+    // Check that aria-expanded is false and the grid is not visible before interacting
 
-  // Check that aria-expanded is false and the grid is not visible before interacting
+    t.is(
+      await combobox.getAttribute('aria-expanded'),
+      'false',
+      'combobox element should have attribute "aria-expanded" set to false by default.'
+    );
 
-  t.is(
-    await combobox.getAttribute('aria-expanded'),
-    'false',
-    'combobox element should have attribute "aria-expanded" set to false by default.'
-  );
+    const popupId = await t.context.session
+      .findElement(By.css(ex.comboboxSelector))
+      .getAttribute('aria-controls');
 
-  const popupId = await t.context.session
-    .findElement(By.css(ex.comboboxSelector))
-    .getAttribute('aria-controls');
+    const popupElement = await t.context.session
+      .findElement(By.id('ex1'))
+      .findElement(By.id(popupId));
 
-  const popupElement = await t.context.session
-    .findElement(By.id('ex1'))
-    .findElement(By.id(popupId));
+    t.false(
+      await popupElement.isDisplayed(),
+      "Popup element should not be displayed when 'aria-expanded' is false'"
+    );
 
-  t.false(
-    await popupElement.isDisplayed(),
-    'Popup element should not be displayed when \'aria-expanded\' is false\''
-  );
+    // Send key "a" to combobox
 
-  // Send key "a" to combobox
+    await t.context.session
+      .findElement(By.css(ex.comboboxSelector))
+      .sendKeys('a');
 
-  await t.context.session
-    .findElement(By.css(ex.comboboxSelector))
-    .sendKeys('a');
+    // Check that aria-expanded is true and the grid is visible
 
-  // Check that aria-expanded is true and the grid is visible
+    t.is(
+      await combobox.getAttribute('aria-expanded'),
+      'true',
+      'combobox element should have attribute "aria-expand" set to true after typing.'
+    );
 
-  t.is(
-    await combobox.getAttribute('aria-expanded'),
-    'true',
-    'combobox element should have attribute "aria-expand" set to true after typing.'
-  );
+    t.true(
+      await popupElement.isDisplayed(),
+      "Popup element should be displayed when 'aria-expanded' is true'"
+    );
+  }
+);
 
-  t.true(
-    await popupElement.isDisplayed(),
-    'Popup element should be displayed when \'aria-expanded\' is true\''
-  );
-});
+ariaTest(
+  '"id" attribute on textbox used to discover accessible name',
+  exampleFile,
+  'combobox-id',
+  async (t) => {
+    const labelForTextboxId = await t.context.session
+      .findElement(By.css(ex.labelSelector))
+      .getAttribute('for');
 
-ariaTest('"id" attribute on textbox used to discover accessible name', exampleFile, 'combobox-id', async (t) => {
+    t.truthy(
+      labelForTextboxId,
+      '"for" attribute with id value should exist on label: ' + ex.labelSelector
+    );
 
-  const labelForTextboxId = await t.context.session
-    .findElement(By.css(ex.labelSelector))
-    .getAttribute('for');
+    const textboxElementId = await t.context.session
+      .findElement(By.css(ex.comboboxSelector))
+      .getAttribute('id');
 
-  t.truthy(
-    labelForTextboxId,
-    '"for" attribute with id value should exist on label: ' + ex.labelSelector
-  );
+    t.true(
+      labelForTextboxId === textboxElementId,
+      'Id on textbox element (' +
+        ex.comboboxSelector +
+        ') should match the "for" attribute of the label (' +
+        labelForTextboxId +
+        ')'
+    );
+  }
+);
 
-  const textboxElementId = await t.context.session
-    .findElement(By.css(ex.comboboxSelector))
-    .getAttribute('id');
+ariaTest(
+  '"aria-autocomplete" on grid element',
+  exampleFile,
+  'combobox-aria-autocomplete',
+  async (t) => {
+    await assertAttributeValues(
+      t,
+      ex.comboboxSelector,
+      'aria-autocomplete',
+      'list'
+    );
+  }
+);
 
-  t.true(
-    labelForTextboxId === textboxElementId,
-    'Id on textbox element (' + ex.comboboxSelector + ') should match the "for" attribute of the label (' + labelForTextboxId + ')'
-  );
-});
+ariaTest(
+  '"aria-controls" attribute on grid element',
+  exampleFile,
+  'combobox-aria-controls',
+  async (t) => {
+    const popupId = await t.context.session
+      .findElement(By.css(ex.comboboxSelector))
+      .getAttribute('aria-controls');
 
-ariaTest('"aria-autocomplete" on grid element', exampleFile, 'combobox-aria-autocomplete', async (t) => {
-    await assertAttributeValues(t, ex.comboboxSelector, 'aria-autocomplete', 'list');
-});
+    t.truthy(
+      popupId,
+      '"aria-controls" attribute should exist on: ' + ex.comboboxSelector
+    );
 
-ariaTest('"aria-controls" attribute on grid element', exampleFile, 'combobox-aria-controls', async (t) => {
+    const popupElements = await t.context.queryElements(t, `#ex1 #${popupId}`);
 
-  const popupId = await t.context.session
-    .findElement(By.css(ex.comboboxSelector))
-    .getAttribute('aria-controls');
+    t.is(
+      popupElements.length,
+      1,
+      'There should be a element with id "' +
+        popupId +
+        '" as referenced by the aria-controls attribute'
+    );
+  }
+);
 
-  t.truthy(
-    popupId,
-    '"aria-controls" attribute should exist on: ' + ex.comboboxSelector
-  );
-
-  const popupElements = await t.context.queryElements(t, `#ex1 #${popupId}`);
-
-  t.is(
-    popupElements.length,
-    1,
-    'There should be a element with id "' + popupId + '" as referenced by the aria-controls attribute'
-  );
-});
-
-ariaTest('"aria-activedescendant" on combobox element', exampleFile, 'combobox-aria-activedescendant', async (t) => {
-    await assertAttributeValues(t, ex.comboboxSelector, 'aria-activedescendant', null);
-});
+ariaTest(
+  '"aria-activedescendant" on combobox element',
+  exampleFile,
+  'combobox-aria-activedescendant',
+  async (t) => {
+    await assertAttributeValues(
+      t,
+      ex.comboboxSelector,
+      'aria-activedescendant',
+      null
+    );
+  }
+);
 
 ariaTest('role "grid" on div element', exampleFile, 'grid-role', async (t) => {
-    await assertAriaRoles(t, 'ex1', 'grid', '1', 'div');
+  await assertAriaRoles(t, 'ex1', 'grid', '1', 'div');
 });
 
-ariaTest('"aria-labelledby" attribute on grid element', exampleFile, 'grid-aria-labelledby', async (t) => {
+ariaTest(
+  '"aria-labelledby" attribute on grid element',
+  exampleFile,
+  'grid-aria-labelledby',
+  async (t) => {
     await assertAriaLabelledby(t, ex.gridSelector);
-});
+  }
+);
 
-ariaTest('role "row" exists within grid element', exampleFile, 'row-role', async (t) => {
+ariaTest(
+  'role "row" exists within grid element',
+  exampleFile,
+  'row-role',
+  async (t) => {
+    // Send key "a" then arrow down to reveal all options
+    await t.context.session
+      .findElement(By.css(ex.comboboxSelector))
+      .sendKeys('a', Key.ARROW_DOWN);
 
-  // Send key "a" then arrow down to reveal all options
-  await t.context.session.findElement(By.css(ex.comboboxSelector)).sendKeys('a', Key.ARROW_DOWN);
+    let gridEl = await t.context.session.findElement(By.css(ex.gridSelector));
+    let rowElements = await t.context.queryElements(t, '[role="row"]', gridEl);
 
-  let gridEl = await t.context.session.findElement(By.css(ex.gridSelector));
-  let rowElements = await t.context.queryElements(t, '[role="row"]', gridEl);
-
-  t.truthy(
-    await rowElements.length,
-    'role="row" elements should be found within a gridcell element after opening popup'
-  );
-});
+    t.truthy(
+      await rowElements.length,
+      'role="row" elements should be found within a gridcell element after opening popup'
+    );
+  }
+);
 
 // This test fails due to bug: https://github.com/w3c/aria-practices/issues/859
-ariaTest.failing('"aria-selected" attribute on row element', exampleFile, 'row-aria-selected', async (t) => {
+ariaTest.failing(
+  '"aria-selected" attribute on row element',
+  exampleFile,
+  'row-aria-selected',
+  async (t) => {
+    // Send key "a"
+    await t.context.session
+      .findElement(By.css(ex.comboboxSelector))
+      .sendKeys('a');
+    await assertAttributeDNE(
+      t,
+      ex.rowSelector + ':nth-of-type(1)',
+      'aria-selected'
+    );
 
-  // Send key "a"
-  await t.context.session.findElement(By.css(ex.comboboxSelector)).sendKeys('a');
-  await assertAttributeDNE(t, ex.rowSelector + ':nth-of-type(1)', 'aria-selected');
+    // Send key ARROW_DOWN to selected first option
+    await t.context.session
+      .findElement(By.css(ex.comboboxSelector))
+      .sendKeys(Key.ARROW_DOWN);
+    await assertAttributeValues(
+      t,
+      ex.rowSelector + ':nth-of-type(1)',
+      'aria-selected',
+      'true'
+    );
+  }
+);
 
-  // Send key ARROW_DOWN to selected first option
-  await t.context.session.findElement(By.css(ex.comboboxSelector)).sendKeys(Key.ARROW_DOWN);
-  await assertAttributeValues(t, ex.rowSelector + ':nth-of-type(1)', 'aria-selected', 'true');
-});
+ariaTest(
+  'role "gridcell" exists within row element',
+  exampleFile,
+  'gridcell-role',
+  async (t) => {
+    // Send key "a" then arrow down to reveal all options
+    await t.context.session
+      .findElement(By.css(ex.comboboxSelector))
+      .sendKeys('a', Key.ARROW_DOWN);
 
-ariaTest('role "gridcell" exists within row element', exampleFile, 'gridcell-role', async (t) => {
+    let rowElement = await t.context.session.findElement(
+      By.css(ex.rowSelector)
+    );
+    let cellElements = await t.context.queryElements(
+      t,
+      '[role="gridcell"]',
+      rowElement
+    );
 
-  // Send key "a" then arrow down to reveal all options
-  await t.context.session.findElement(By.css(ex.comboboxSelector)).sendKeys('a', Key.ARROW_DOWN);
-
-  let rowElement = await t.context.session.findElement(By.css(ex.rowSelector));
-  let cellElements = await t.context.queryElements(t, '[role="gridcell"]', rowElement);
-
-  t.truthy(
-    await cellElements.length,
-    'role="gridcell" elements should be found within a row element after opening popup'
-  );
-});
-
+    t.truthy(
+      await cellElements.length,
+      'role="gridcell" elements should be found within a row element after opening popup'
+    );
+  }
+);
 
 // Keys
 
-ariaTest('Test down key press with focus on combobox',
-  exampleFile, 'textbox-key-down-arrow', async (t) => {
-
-
+ariaTest(
+  'Test down key press with focus on combobox',
+  exampleFile,
+  'textbox-key-down-arrow',
+  async (t) => {
     // Send ARROW_DOWN to the combobox
     await t.context.session
       .findElement(By.css(ex.comboboxSelector))
@@ -209,7 +308,9 @@ ariaTest('Test down key press with focus on combobox',
 
     // Check that the grid is displayed
     t.false(
-      await t.context.session.findElement(By.css(ex.gridSelector)).isDisplayed(),
+      await t.context.session
+        .findElement(By.css(ex.gridSelector))
+        .isDisplayed(),
       'In example ex3 grid should not be display after ARROW_DOWN keypress while combobox is empty'
     );
 
@@ -223,41 +324,47 @@ ariaTest('Test down key press with focus on combobox',
 
     // Check that the grid is displayed
     t.true(
-      await t.context.session.findElement(By.css(ex.gridSelector)).isDisplayed(),
+      await t.context.session
+        .findElement(By.css(ex.gridSelector))
+        .isDisplayed(),
       'In example ex3 grid should display after ARROW_DOWN keypress when combobox has character values'
     );
 
     // Check that the active descendent focus is correct
-    let focusedId = await t.context.session.findElement(By.css(ex.comboboxSelector))
+    let focusedId = await t.context.session
+      .findElement(By.css(ex.comboboxSelector))
       .getAttribute('aria-activedescendant');
 
     t.is(
       focusedId,
-      gridcellId(0,0),
-      'After down arrow sent to combobox, aria-activedescendant should be set to the first gridcell element: ' + gridcellId(0,0)
+      gridcellId(0, 0),
+      'After down arrow sent to combobox, aria-activedescendant should be set to the first gridcell element: ' +
+        gridcellId(0, 0)
     );
 
-    let focusedElementClasses = await t.context.session.findElement(By.id(gridcellId(0,0)))
+    let focusedElementClasses = await t.context.session
+      .findElement(By.id(gridcellId(0, 0)))
       .getAttribute('class');
 
     t.true(
       focusedElementClasses.includes(ex.gridcellFocusedClass),
-      'Gridcell with id "' + gridcellId(0,0) + '" should have visual focus'
+      'Gridcell with id "' + gridcellId(0, 0) + '" should have visual focus'
     );
+  }
+);
 
-  });
-
-ariaTest('Test down key press with focus on list',
-  exampleFile, 'popup-key-down-arrow', async (t) => {
-
-
+ariaTest(
+  'Test down key press with focus on list',
+  exampleFile,
+  'popup-key-down-arrow',
+  async (t) => {
     // Send 'a' to text box, then send ARROW_DOWN to combobox to set focus on grid
     await t.context.session
       .findElement(By.css(ex.comboboxSelector))
       .sendKeys('a', Key.ARROW_DOWN);
 
     // Test that ARROW_DOWN moves active descendant focus on item in grid
-    for (let i = 1; i <  ex.numAOptions; i++) {
+    for (let i = 1; i < ex.numAOptions; i++) {
       let oldfocus = await t.context.session
         .findElement(By.css(ex.comboboxSelector))
         .getAttribute('aria-activedescendant');
@@ -271,19 +378,22 @@ ariaTest('Test down key press with focus on list',
 
       // Check that the active descendent focus is correct
 
-      let focusedId = await t.context.session.findElement(By.css(ex.comboboxSelector))
+      let focusedId = await t.context.session
+        .findElement(By.css(ex.comboboxSelector))
         .getAttribute('aria-activedescendant');
       t.is(
         focusedId,
-        gridcellId(i,0),
-        'After down up sent to combobox, aria-activedescendant should be set to this gridcell element: ' + gridcellId(i,0)
+        gridcellId(i, 0),
+        'After down up sent to combobox, aria-activedescendant should be set to this gridcell element: ' +
+          gridcellId(i, 0)
       );
 
-      let focusedElementClasses = await t.context.session.findElement(By.id(gridcellId(i,0)))
+      let focusedElementClasses = await t.context.session
+        .findElement(By.id(gridcellId(i, 0)))
         .getAttribute('class');
       t.true(
         focusedElementClasses.includes(ex.gridcellFocusedClass),
-        'Gridcell with id "' + gridcellId(i,0) + '" should have visual focus'
+        'Gridcell with id "' + gridcellId(i, 0) + '" should have visual focus'
       );
     }
 
@@ -300,28 +410,31 @@ ariaTest('Test down key press with focus on list',
 
     // Focus should be on the first item
 
-    let focusedId = await t.context.session.findElement(By.css(ex.comboboxSelector))
+    let focusedId = await t.context.session
+      .findElement(By.css(ex.comboboxSelector))
       .getAttribute('aria-activedescendant');
     t.is(
       focusedId,
-      gridcellId(0,0),
-      'After down arrow sent to last grid row, aria-activedescendant should be set to the first gridcell element: ' + gridcellId(0,0)
+      gridcellId(0, 0),
+      'After down arrow sent to last grid row, aria-activedescendant should be set to the first gridcell element: ' +
+        gridcellId(0, 0)
     );
 
-    let focusedElementClasses = await t.context.session.findElement(By.id(gridcellId(0,0)))
+    let focusedElementClasses = await t.context.session
+      .findElement(By.id(gridcellId(0, 0)))
       .getAttribute('class');
     t.true(
       focusedElementClasses.includes(ex.gridcellFocusedClass),
-      'Gridcell with id "' + gridcellId(0,0) + '" should have visual focus'
+      'Gridcell with id "' + gridcellId(0, 0) + '" should have visual focus'
     );
+  }
+);
 
-  });
-
-
-ariaTest('Test up key press with focus on combobox',
-  exampleFile, 'textbox-key-up-arrow', async (t) => {
-
-
+ariaTest(
+  'Test up key press with focus on combobox',
+  exampleFile,
+  'textbox-key-up-arrow',
+  async (t) => {
     // Send ARROW_UP to the combobox
     await t.context.session
       .findElement(By.css(ex.comboboxSelector))
@@ -329,7 +442,9 @@ ariaTest('Test up key press with focus on combobox',
 
     // Check that the grid is displayed
     t.false(
-      await t.context.session.findElement(By.css(ex.gridSelector)).isDisplayed(),
+      await t.context.session
+        .findElement(By.css(ex.gridSelector))
+        .isDisplayed(),
       'In example ex3 grid should not be display after ARROW_UP keypress while combobox is empty'
     );
 
@@ -343,34 +458,42 @@ ariaTest('Test up key press with focus on combobox',
 
     // Check that the grid is displayed
     t.true(
-      await t.context.session.findElement(By.css(ex.gridSelector)).isDisplayed(),
+      await t.context.session
+        .findElement(By.css(ex.gridSelector))
+        .isDisplayed(),
       'In example ex3 grid should display after ARROW_UP keypress when combobox has character values'
     );
 
     // Check that the active descendent focus is correct
-    let focusedId = await t.context.session.findElement(By.css(ex.comboboxSelector))
+    let focusedId = await t.context.session
+      .findElement(By.css(ex.comboboxSelector))
       .getAttribute('aria-activedescendant');
 
     t.is(
       focusedId,
-      gridcellId(ex.numAOptions - 1,0),
-      'After up arrow sent to combobox, aria-activedescendant should be set to the last row first gridcell element: ' + gridcellId(ex.numAOptions - 1,0)
+      gridcellId(ex.numAOptions - 1, 0),
+      'After up arrow sent to combobox, aria-activedescendant should be set to the last row first gridcell element: ' +
+        gridcellId(ex.numAOptions - 1, 0)
     );
 
-    let focusedElementClasses = await t.context.session.findElement(By.id(gridcellId(ex.numAOptions - 1,0)))
+    let focusedElementClasses = await t.context.session
+      .findElement(By.id(gridcellId(ex.numAOptions - 1, 0)))
       .getAttribute('class');
 
     t.true(
       focusedElementClasses.includes(ex.gridcellFocusedClass),
-      'Gridcell with id "' + gridcellId(ex.numAOptions - 1,0) + '" should have visual focus'
+      'Gridcell with id "' +
+        gridcellId(ex.numAOptions - 1, 0) +
+        '" should have visual focus'
     );
+  }
+);
 
-  });
-
-ariaTest('Test up key press with focus on grid',
-  exampleFile, 'popup-key-up-arrow', async (t) => {
-
-
+ariaTest(
+  'Test up key press with focus on grid',
+  exampleFile,
+  'popup-key-up-arrow',
+  async (t) => {
     // Send 'a' to text box, then send ARROW_UP to combobox to put focus in combobox
     // Up arrow should move selection to the last item in the list
     await t.context.session
@@ -378,7 +501,7 @@ ariaTest('Test up key press with focus on grid',
       .sendKeys('a', Key.ARROW_UP);
 
     // Test that ARROW_UP moves active descendant focus up one item in the grid
-    for (let index = ex.numAOptions - 2; index >= 0 ; index--) {
+    for (let index = ex.numAOptions - 2; index >= 0; index--) {
       let oldfocus = await t.context.session
         .findElement(By.css(ex.comboboxSelector))
         .getAttribute('aria-activedescendant');
@@ -392,19 +515,24 @@ ariaTest('Test up key press with focus on grid',
 
       // Check that the active descendent focus is correct
 
-      let focusedId = await t.context.session.findElement(By.css(ex.comboboxSelector))
+      let focusedId = await t.context.session
+        .findElement(By.css(ex.comboboxSelector))
         .getAttribute('aria-activedescendant');
       t.is(
         focusedId,
-        gridcellId(index,0),
-        'After up arrow sent to combobox, aria-activedescendant should be set to gridcell element: ' + gridcellId(index,0)
+        gridcellId(index, 0),
+        'After up arrow sent to combobox, aria-activedescendant should be set to gridcell element: ' +
+          gridcellId(index, 0)
       );
 
-      let focusedElementClasses = await t.context.session.findElement(By.id(gridcellId(index,0)))
+      let focusedElementClasses = await t.context.session
+        .findElement(By.id(gridcellId(index, 0)))
         .getAttribute('class');
       t.true(
         focusedElementClasses.includes(ex.gridcellFocusedClass),
-        'Gridcell with id "' + gridcellId(index,0) + '" should have visual focus'
+        'Gridcell with id "' +
+          gridcellId(index, 0) +
+          '" should have visual focus'
       );
     }
 
@@ -422,27 +550,33 @@ ariaTest('Test up key press with focus on grid',
 
     // Check that the active descendent focus is correct
 
-    let focusedId = await t.context.session.findElement(By.css(ex.comboboxSelector))
+    let focusedId = await t.context.session
+      .findElement(By.css(ex.comboboxSelector))
       .getAttribute('aria-activedescendant');
     t.is(
       focusedId,
-      gridcellId(ex.numAOptions - 1,0),
-      'After up arrow sent to first element in popup, aria-activedescendant should be set to the last row first gridcell element: ' + gridcellId(ex.numAOptions - 1,0)
+      gridcellId(ex.numAOptions - 1, 0),
+      'After up arrow sent to first element in popup, aria-activedescendant should be set to the last row first gridcell element: ' +
+        gridcellId(ex.numAOptions - 1, 0)
     );
 
-    let focusedElementClasses = await t.context.session.findElement(By.id(gridcellId(ex.numAOptions - 1,0)))
+    let focusedElementClasses = await t.context.session
+      .findElement(By.id(gridcellId(ex.numAOptions - 1, 0)))
       .getAttribute('class');
     t.true(
       focusedElementClasses.includes(ex.gridcellFocusedClass),
-      'Gridcell with id "' + gridcellId(ex.numAOptions - 1,0) + '" should have visual focus'
+      'Gridcell with id "' +
+        gridcellId(ex.numAOptions - 1, 0) +
+        '" should have visual focus'
     );
+  }
+);
 
-  });
-
-ariaTest('Test enter key press with focus on grid',
-  exampleFile, 'popup-key-enter', async (t) => {
-
-
+ariaTest(
+  'Test enter key press with focus on grid',
+  exampleFile,
+  'popup-key-enter',
+  async (t) => {
     // Send key "a" to the combobox, then key ARROW_DOWN to select the first item
 
     await t.context.session
@@ -451,7 +585,9 @@ ariaTest('Test enter key press with focus on grid',
 
     // Get the value of the first option in the grid
 
-    const firstOption = await t.context.session.findElement(By.css(ex.gridcellSelector)).getText();
+    const firstOption = await t.context.session
+      .findElement(By.css(ex.gridcellSelector))
+      .getText();
 
     // Send key ENTER
 
@@ -461,7 +597,12 @@ ariaTest('Test enter key press with focus on grid',
 
     // Confirm that the grid is closed
 
-    await assertAttributeValues(t, ex.comboboxSelector, 'aria-expanded', 'false');
+    await assertAttributeValues(
+      t,
+      ex.comboboxSelector,
+      'aria-expanded',
+      'false'
+    );
 
     // Confirm that the value of the combobox is now set to the first option
 
@@ -472,11 +613,14 @@ ariaTest('Test enter key press with focus on grid',
       firstOption,
       'key press "ENTER" should result in first option in combobox'
     );
+  }
+);
 
-  });
-
-ariaTest('Test escape key press with focus on combobox',
-  exampleFile, 'textbox-key-escape', async (t) => {
+ariaTest(
+  'Test escape key press with focus on combobox',
+  exampleFile,
+  'textbox-key-escape',
+  async (t) => {
     // Send key "a" then key "ARROW_DOWN to put the focus on the listbox,
     // then key ESCAPE to the textbox
 
@@ -486,7 +630,12 @@ ariaTest('Test escape key press with focus on combobox',
 
     // Confirm the listbox is closed and the textbox is cleared
 
-    await assertAttributeValues(t, ex.comboboxSelector, 'aria-expanded', 'false');
+    await assertAttributeValues(
+      t,
+      ex.comboboxSelector,
+      'aria-expanded',
+      'false'
+    );
     t.is(
       await t.context.session
         .findElement(By.css(ex.comboboxSelector))
@@ -494,12 +643,14 @@ ariaTest('Test escape key press with focus on combobox',
       'a',
       'In listbox key press "ESCAPE" should result in "a" in textbox'
     );
+  }
+);
 
-  });
-
-
-ariaTest('Test double escape key press with focus on combobox',
-  exampleFile, 'textbox-key-escape', async (t) => {
+ariaTest(
+  'Test double escape key press with focus on combobox',
+  exampleFile,
+  'textbox-key-escape',
+  async (t) => {
     // Send key "a", then key ESCAPE twice to the textbox
 
     await t.context.session
@@ -508,7 +659,12 @@ ariaTest('Test double escape key press with focus on combobox',
 
     // Confirm the listbox is closed and the textbox is cleared
 
-    await assertAttributeValues(t, ex.comboboxSelector, 'aria-expanded', 'false');
+    await assertAttributeValues(
+      t,
+      ex.comboboxSelector,
+      'aria-expanded',
+      'false'
+    );
     t.is(
       await t.context.session
         .findElement(By.css(ex.comboboxSelector))
@@ -516,13 +672,14 @@ ariaTest('Test double escape key press with focus on combobox',
       '',
       'In key press "ESCAPE" should result in clearing the textbox'
     );
+  }
+);
 
-  });
-
-
-ariaTest('Test escape key press with focus on popup',
-  exampleFile, 'popup-key-escape', async (t) => {
-
+ariaTest(
+  'Test escape key press with focus on popup',
+  exampleFile,
+  'popup-key-escape',
+  async (t) => {
     // Send key "a" then key "ARROW_DOWN to put the focus on the grid,
     // then key ESCAPE to the combobox
 
@@ -539,14 +696,21 @@ ariaTest('Test escape key press with focus on popup',
     // Wait for gridbox to close
     await t.context.session.wait(
       async function () {
-        return !(await t.context.session.findElement(By.css(ex.gridSelector)).isDisplayed());
+        return !(await t.context.session
+          .findElement(By.css(ex.gridSelector))
+          .isDisplayed());
       },
       t.context.waitTime,
       'Timeout waiting for gridbox to close afer escape'
     );
 
     // Confirm the grid is closed and the textbox is cleared
-    await assertAttributeValues(t, ex.comboboxSelector, 'aria-expanded', 'false');
+    await assertAttributeValues(
+      t,
+      ex.comboboxSelector,
+      'aria-expanded',
+      'false'
+    );
 
     t.is(
       await t.context.session
@@ -555,12 +719,14 @@ ariaTest('Test escape key press with focus on popup',
       'a',
       'In grid key press "ESCAPE" should result the "a" in the combobox'
     );
+  }
+);
 
-  });
-
-ariaTest('left arrow from focus on list puts focus on grid and moves cursor right',
-  exampleFile, 'popup-key-left-arrow', async (t) => {
-
+ariaTest(
+  'left arrow from focus on list puts focus on grid and moves cursor right',
+  exampleFile,
+  'popup-key-left-arrow',
+  async (t) => {
     // Send key "a" then key "ARROW_DOWN" to put the focus on the grid
     const combobox = t.context.session.findElement(By.css(ex.comboboxSelector));
     await combobox.sendKeys('a', Key.ARROW_DOWN);
@@ -571,46 +737,57 @@ ariaTest('left arrow from focus on list puts focus on grid and moves cursor righ
     // Check that the active descendent focus is correct
     let lastrow = ex.numAOptions - 1;
 
-    var focusedId = await t.context.session.findElement(By.css(ex.comboboxSelector))
+    var focusedId = await t.context.session
+      .findElement(By.css(ex.comboboxSelector))
       .getAttribute('aria-activedescendant');
     t.is(
       focusedId,
-      gridcellId(lastrow,1),
-      'After left arrow sent to popup, aria-activedescendant should be set to the last row, last gricell: ' + gridcellId(lastrow, 1)
+      gridcellId(lastrow, 1),
+      'After left arrow sent to popup, aria-activedescendant should be set to the last row, last gricell: ' +
+        gridcellId(lastrow, 1)
     );
 
-    var focusedElementClasses = await t.context.session.findElement(By.id(gridcellId(lastrow,1)))
+    var focusedElementClasses = await t.context.session
+      .findElement(By.id(gridcellId(lastrow, 1)))
       .getAttribute('class');
     t.true(
       focusedElementClasses.includes(ex.gridcellFocusedClass),
-      'Gridcell with id "' + gridcellId(lastrow,1) + '" should have visual focus'
+      'Gridcell with id "' +
+        gridcellId(lastrow, 1) +
+        '" should have visual focus'
     );
 
     // Send key "ARROW_LEFT" a second time
     await combobox.sendKeys(Key.ARROW_LEFT);
 
     // Check that the active descendent focus is correct
-    focusedId = await t.context.session.findElement(By.css(ex.comboboxSelector))
+    focusedId = await t.context.session
+      .findElement(By.css(ex.comboboxSelector))
       .getAttribute('aria-activedescendant');
     t.is(
       focusedId,
-      gridcellId(lastrow,0),
-      'After left arrow sent twice to popup, aria-activedescendant should be set to the last row first gridcell: ' + gridcellId(lastrow, 0)
+      gridcellId(lastrow, 0),
+      'After left arrow sent twice to popup, aria-activedescendant should be set to the last row first gridcell: ' +
+        gridcellId(lastrow, 0)
     );
 
-    focusedElementClasses = await t.context.session.findElement(By.id(gridcellId(lastrow,0)))
+    focusedElementClasses = await t.context.session
+      .findElement(By.id(gridcellId(lastrow, 0)))
       .getAttribute('class');
     t.true(
       focusedElementClasses.includes(ex.gridcellFocusedClass),
-      'Gridcell with id "' + gridcellId(lastrow,0) + '" should have visual focus'
+      'Gridcell with id "' +
+        gridcellId(lastrow, 0) +
+        '" should have visual focus'
     );
+  }
+);
 
-  });
-
-
-ariaTest('Right arrow from focus on list puts focus on grid',
-  exampleFile, 'popup-key-right-arrow', async (t) => {
-
+ariaTest(
+  'Right arrow from focus on list puts focus on grid',
+  exampleFile,
+  'popup-key-right-arrow',
+  async (t) => {
     // Send key "a" then key "ARROW_DOWN" to put the focus on the grid
     const combobox = t.context.session.findElement(By.css(ex.comboboxSelector));
     await combobox.sendKeys('a', Key.ARROW_DOWN);
@@ -619,64 +796,80 @@ ariaTest('Right arrow from focus on list puts focus on grid',
     await combobox.sendKeys(Key.ARROW_RIGHT);
 
     // Check that the active descendent focus is correct
-    var focusedId = await t.context.session.findElement(By.css(ex.comboboxSelector))
+    var focusedId = await t.context.session
+      .findElement(By.css(ex.comboboxSelector))
       .getAttribute('aria-activedescendant');
     t.is(
       focusedId,
-      gridcellId(0,1),
-      'After right arrow sent to popup, aria-activedescendant should be set to the first row second gridcell element: ' + gridcellId(0, 1)
+      gridcellId(0, 1),
+      'After right arrow sent to popup, aria-activedescendant should be set to the first row second gridcell element: ' +
+        gridcellId(0, 1)
     );
 
-    var focusedElementClasses = await t.context.session.findElement(By.id(gridcellId(0,1)))
+    var focusedElementClasses = await t.context.session
+      .findElement(By.id(gridcellId(0, 1)))
       .getAttribute('class');
     t.true(
       focusedElementClasses.includes(ex.gridcellFocusedClass),
-      'Gridcell with id "' + gridcellId(0,1) + '" should have visual focus'
+      'Gridcell with id "' + gridcellId(0, 1) + '" should have visual focus'
     );
 
     // Send key "ARROW_RIGHT" a second time
     await combobox.sendKeys(Key.ARROW_RIGHT);
 
     // Check that the active descendent focus is correct
-    focusedId = await t.context.session.findElement(By.css(ex.comboboxSelector))
+    focusedId = await t.context.session
+      .findElement(By.css(ex.comboboxSelector))
       .getAttribute('aria-activedescendant');
     t.is(
       focusedId,
-      gridcellId(1,0),
-      'After right arrow send twice to popup, aria-activedescendant should be set to the second row first gridcell element: ' + gridcellId(1, 0)
+      gridcellId(1, 0),
+      'After right arrow send twice to popup, aria-activedescendant should be set to the second row first gridcell element: ' +
+        gridcellId(1, 0)
     );
 
-    focusedElementClasses = await t.context.session.findElement(By.id(gridcellId(1,0)))
+    focusedElementClasses = await t.context.session
+      .findElement(By.id(gridcellId(1, 0)))
       .getAttribute('class');
     t.true(
       focusedElementClasses.includes(ex.gridcellFocusedClass),
-      'Gridcell with id "' + gridcellId(1,0) + '" should have visual focus'
+      'Gridcell with id "' + gridcellId(1, 0) + '" should have visual focus'
     );
 
     // Send key "ARROW_RIGHT" four more times
-    await combobox.sendKeys(Key.ARROW_RIGHT, Key.ARROW_RIGHT, Key.ARROW_RIGHT, Key.ARROW_RIGHT);
+    await combobox.sendKeys(
+      Key.ARROW_RIGHT,
+      Key.ARROW_RIGHT,
+      Key.ARROW_RIGHT,
+      Key.ARROW_RIGHT
+    );
 
     // Check that the active descendent focus is correct
-    focusedId = await t.context.session.findElement(By.css(ex.comboboxSelector))
+    focusedId = await t.context.session
+      .findElement(By.css(ex.comboboxSelector))
       .getAttribute('aria-activedescendant');
     t.is(
       focusedId,
-      gridcellId(0,0),
-      'After right arrow to the popup 6 times in total, aria-activedescendant should be back on the first row, first gridcell: ' + gridcellId(0, 0)
+      gridcellId(0, 0),
+      'After right arrow to the popup 6 times in total, aria-activedescendant should be back on the first row, first gridcell: ' +
+        gridcellId(0, 0)
     );
 
-    focusedElementClasses = await t.context.session.findElement(By.id(gridcellId(0,0)))
+    focusedElementClasses = await t.context.session
+      .findElement(By.id(gridcellId(0, 0)))
       .getAttribute('class');
     t.true(
       focusedElementClasses.includes(ex.gridcellFocusedClass),
-      'Gridcell with id "' + gridcellId(0,0) + '" should have visual focus'
+      'Gridcell with id "' + gridcellId(0, 0) + '" should have visual focus'
     );
+  }
+);
 
-  });
-
-ariaTest('Home from focus on list puts focus on grid and moves cursor',
-  exampleFile, 'popup-key-home', async (t) => {
-
+ariaTest(
+  'Home from focus on list puts focus on grid and moves cursor',
+  exampleFile,
+  'popup-key-home',
+  async (t) => {
     // Send key "a" then key "ARROW_DOWN" to put the focus on the grid
     const combobox = t.context.session.findElement(By.css(ex.comboboxSelector));
     await combobox.sendKeys('a', Key.ARROW_DOWN);
@@ -692,13 +885,16 @@ ariaTest('Home from focus on list puts focus on grid and moves cursor',
     t.is(
       await combobox.getAttribute('aria-activedescendant'),
       '',
-      'Focus should be on the combobox after one ARROW_HOME key',
+      'Focus should be on the combobox after one ARROW_HOME key'
     );
-  });
+  }
+);
 
-ariaTest('End from focus on list puts focus on grid',
-  exampleFile, 'popup-key-end', async (t) => {
-
+ariaTest(
+  'End from focus on list puts focus on grid',
+  exampleFile,
+  'popup-key-end',
+  async (t) => {
     // Send key "a" then key "ARROW_DOWN" to put the focus on the grid
     const combobox = t.context.session.findElement(By.css(ex.comboboxSelector));
     await combobox.sendKeys('a', Key.ARROW_DOWN);
@@ -714,13 +910,16 @@ ariaTest('End from focus on list puts focus on grid',
     t.is(
       await combobox.getAttribute('aria-activedescendant'),
       '',
-      'Focus should be on the combobox after on ARROW_END key',
+      'Focus should be on the combobox after on ARROW_END key'
     );
-  });
+  }
+);
 
-ariaTest('Sending character keys while focus is on grid moves focus',
-  exampleFile, 'popup-key-char', async (t) => {
-
+ariaTest(
+  'Sending character keys while focus is on grid moves focus',
+  exampleFile,
+  'popup-key-char',
+  async (t) => {
     // Send key "ARROW_DOWN" to put the focus on the grid
     const combobox = t.context.session.findElement(By.css(ex.comboboxSelector));
     await combobox.sendKeys(Key.ARROW_DOWN);
@@ -738,13 +937,16 @@ ariaTest('Sending character keys while focus is on grid moves focus',
     t.is(
       await combobox.getAttribute('aria-activedescendant'),
       '',
-      'Focus should be on the combobox after sending a character key while the focus is on the grid',
+      'Focus should be on the combobox after sending a character key while the focus is on the grid'
     );
+  }
+);
 
-  });
-
-ariaTest.failing('Expected behavior for all other standard single line editing keys',
-  exampleFile, 'standard-single-line-editing-keys', async (t) => {
-        t.fail();
-  });
-
+ariaTest.failing(
+  'Expected behavior for all other standard single line editing keys',
+  exampleFile,
+  'standard-single-line-editing-keys',
+  async (t) => {
+    t.fail();
+  }
+);

--- a/test/tests/spinbutton_datepicker.js
+++ b/test/tests/spinbutton_datepicker.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { ariaTest } = require('..');
 const { By, Key } = require('selenium-webdriver');
 const assertAttributeValues = require('../util/assertAttributeValues');
@@ -8,8 +6,54 @@ const assertAriaRoles = require('../util/assertAriaRoles');
 
 const exampleFile = 'spinbutton/datepicker-spinbuttons.html';
 
-const valuesDay = ['', 'first', 'second', 'third', 'fourth', 'fifth', 'sixth', 'seventh', 'eighth', 'ninth', 'tenth', 'eleventh', 'twelfth', 'thirteenth', 'fourteen', 'fifteenth', 'sixteenth', 'seveneenth', 'eighteenth', 'nineteenth', 'twentieth', 'twenty first', 'twenty second', 'twenty third', 'twenty fourth', 'twenty fifth', 'twenty sixth', 'twenty seventh', 'twenty eighth', 'twenty ninth', 'thirtieth', 'thirty first'];
-const valuesMonth = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'];
+const valuesDay = [
+  '',
+  'first',
+  'second',
+  'third',
+  'fourth',
+  'fifth',
+  'sixth',
+  'seventh',
+  'eighth',
+  'ninth',
+  'tenth',
+  'eleventh',
+  'twelfth',
+  'thirteenth',
+  'fourteen',
+  'fifteenth',
+  'sixteenth',
+  'seveneenth',
+  'eighteenth',
+  'nineteenth',
+  'twentieth',
+  'twenty first',
+  'twenty second',
+  'twenty third',
+  'twenty fourth',
+  'twenty fifth',
+  'twenty sixth',
+  'twenty seventh',
+  'twenty eighth',
+  'twenty ninth',
+  'thirtieth',
+  'thirty first',
+];
+const valuesMonth = [
+  'January',
+  'February',
+  'March',
+  'April',
+  'May',
+  'June',
+  'July',
+  'August',
+  'September',
+  'October',
+  'November',
+  'December',
+];
 
 var getDaysInMonth = function (year, month) {
   return new Date(year, month + 1, 0).getDate();
@@ -52,90 +96,241 @@ const ex = {
   dayIncreaseSelector: '#example .spinbutton.day .increase',
   dayDecreaseSelector: '#example .spinbutton.day .decrease',
   dayHiddenPreviousSelector: '#example .spinbutton.day .previous',
-  dayHiddenNextSelector: '#example .spinbutton.day .next'
+  dayHiddenNextSelector: '#example .spinbutton.day .next',
 };
 
 // Attributes
 
-ariaTest('role="group" on div element', exampleFile, 'group-role', async (t) => {
-  await assertAriaRoles(t, 'example', 'group', '1', 'div');
-});
+ariaTest(
+  'role="group" on div element',
+  exampleFile,
+  'group-role',
+  async (t) => {
+    await assertAriaRoles(t, 'example', 'group', '1', 'div');
+  }
+);
 
-ariaTest('"aria-labelledby" attribute on group', exampleFile, 'group-aria-labelledby', async (t) => {
-  await assertAriaLabelledby(t,  ex.groupSelector);
-});
+ariaTest(
+  '"aria-labelledby" attribute on group',
+  exampleFile,
+  'group-aria-labelledby',
+  async (t) => {
+    await assertAriaLabelledby(t, ex.groupSelector);
+  }
+);
 
-ariaTest('role="spinbutton" on div element', exampleFile, 'spinbutton-role', async (t) => {
-  await assertAriaRoles(t, 'example', 'spinbutton', '3', 'div');
-});
+ariaTest(
+  'role="spinbutton" on div element',
+  exampleFile,
+  'spinbutton-role',
+  async (t) => {
+    await assertAriaRoles(t, 'example', 'spinbutton', '3', 'div');
+  }
+);
 
-ariaTest('"aria-valuemax" represents the minimum value on spinbuttons', exampleFile, 'spinbutton-aria-valuemax', async (t) => {
-  await assertAttributeValues(t, ex.daySelector, 'aria-valuemax', ex.dayMax);
-  await assertAttributeValues(t, ex.monthSelector, 'aria-valuemax', ex.monthMax);
-  await assertAttributeValues(t, ex.yearSelector, 'aria-valuemax', ex.yearMax);
-});
+ariaTest(
+  '"aria-valuemax" represents the minimum value on spinbuttons',
+  exampleFile,
+  'spinbutton-aria-valuemax',
+  async (t) => {
+    await assertAttributeValues(t, ex.daySelector, 'aria-valuemax', ex.dayMax);
+    await assertAttributeValues(
+      t,
+      ex.monthSelector,
+      'aria-valuemax',
+      ex.monthMax
+    );
+    await assertAttributeValues(
+      t,
+      ex.yearSelector,
+      'aria-valuemax',
+      ex.yearMax
+    );
+  }
+);
 
-ariaTest('"aria-valuemin" represents the maximum value on spinbuttons', exampleFile, 'spinbutton-aria-valuemin', async (t) => {
-  await assertAttributeValues(t, ex.daySelector, 'aria-valuemin', ex.dayMin);
-  await assertAttributeValues(t, ex.monthSelector, 'aria-valuemin', ex.monthMin);
-  await assertAttributeValues(t, ex.yearSelector, 'aria-valuemin', ex.yearMin);
-});
+ariaTest(
+  '"aria-valuemin" represents the maximum value on spinbuttons',
+  exampleFile,
+  'spinbutton-aria-valuemin',
+  async (t) => {
+    await assertAttributeValues(t, ex.daySelector, 'aria-valuemin', ex.dayMin);
+    await assertAttributeValues(
+      t,
+      ex.monthSelector,
+      'aria-valuemin',
+      ex.monthMin
+    );
+    await assertAttributeValues(
+      t,
+      ex.yearSelector,
+      'aria-valuemin',
+      ex.yearMin
+    );
+  }
+);
 
-ariaTest('"aria-valuenow" reflects spinbutton value as a number', exampleFile, 'spinbutton-aria-valuenow', async (t) => {
-  await assertAttributeValues(t, ex.daySelector, 'aria-valuenow', ex.dayNow);
-  await assertAttributeValues(t, ex.monthSelector, 'aria-valuenow', ex.monthNow);
-  await assertAttributeValues(t, ex.yearSelector, 'aria-valuenow', ex.yearNow);
-});
+ariaTest(
+  '"aria-valuenow" reflects spinbutton value as a number',
+  exampleFile,
+  'spinbutton-aria-valuenow',
+  async (t) => {
+    await assertAttributeValues(t, ex.daySelector, 'aria-valuenow', ex.dayNow);
+    await assertAttributeValues(
+      t,
+      ex.monthSelector,
+      'aria-valuenow',
+      ex.monthNow
+    );
+    await assertAttributeValues(
+      t,
+      ex.yearSelector,
+      'aria-valuenow',
+      ex.yearNow
+    );
+  }
+);
 
+ariaTest(
+  '"aria-valuetext" reflects spin button value as a text string',
+  exampleFile,
+  'spinbutton-aria-valuetext',
+  async (t) => {
+    await assertAttributeValues(
+      t,
+      ex.daySelector,
+      'aria-valuetext',
+      ex.dayText
+    );
+    await assertAttributeValues(
+      t,
+      ex.monthSelector,
+      'aria-valuetext',
+      ex.monthText
+    );
+  }
+);
 
-ariaTest('"aria-valuetext" reflects spin button value as a text string', exampleFile, 'spinbutton-aria-valuetext', async (t) => {
-  await assertAttributeValues(t, ex.daySelector, 'aria-valuetext', ex.dayText);
-  await assertAttributeValues(t, ex.monthSelector, 'aria-valuetext', ex.monthText);
-});
+ariaTest(
+  '"aria-label" provides accessible name for the spin buttons to screen reader users',
+  exampleFile,
+  'spinbutton-aria-label',
+  async (t) => {
+    await assertAttributeValues(t, ex.daySelector, 'aria-label', 'Day');
+    await assertAttributeValues(t, ex.monthSelector, 'aria-label', 'Month');
+    await assertAttributeValues(t, ex.yearSelector, 'aria-label', 'Year');
+  }
+);
 
-ariaTest('"aria-label" provides accessible name for the spin buttons to screen reader users', exampleFile, 'spinbutton-aria-label', async (t) => {
+ariaTest(
+  '"tabindex=-1" removes previous and next from the tab order of the page',
+  exampleFile,
+  'button-tabindex',
+  async (t) => {
+    await assertAttributeValues(t, ex.dayIncreaseSelector, 'tabindex', '-1');
+    await assertAttributeValues(t, ex.dayDecreaseSelector, 'tabindex', '-1');
 
-  await assertAttributeValues(t, ex.daySelector, 'aria-label', 'Day');
-  await assertAttributeValues(t, ex.monthSelector, 'aria-label', 'Month');
-  await assertAttributeValues(t, ex.yearSelector, 'aria-label', 'Year');
+    await assertAttributeValues(t, ex.monthIncreaseSelector, 'tabindex', '-1');
+    await assertAttributeValues(t, ex.monthDecreaseSelector, 'tabindex', '-1');
 
-});
+    await assertAttributeValues(t, ex.yearIncreaseSelector, 'tabindex', '-1');
+    await assertAttributeValues(t, ex.yearDecreaseSelector, 'tabindex', '-1');
+  }
+);
 
-ariaTest('"tabindex=-1" removes previous and next from the tab order of the page', exampleFile, 'button-tabindex', async (t) => {
-  await assertAttributeValues(t, ex.dayIncreaseSelector, 'tabindex', '-1');
-  await assertAttributeValues(t, ex.dayDecreaseSelector, 'tabindex', '-1');
+ariaTest(
+  '"aria-label" provides accessible name for the previous and next buttons to screen reader users',
+  exampleFile,
+  'button-aria-label',
+  async (t) => {
+    await assertAttributeValues(
+      t,
+      ex.dayIncreaseSelector,
+      'aria-label',
+      'next day'
+    );
+    await assertAttributeValues(
+      t,
+      ex.dayDecreaseSelector,
+      'aria-label',
+      'previous day'
+    );
 
-  await assertAttributeValues(t, ex.monthIncreaseSelector, 'tabindex', '-1');
-  await assertAttributeValues(t, ex.monthDecreaseSelector, 'tabindex', '-1');
+    await assertAttributeValues(
+      t,
+      ex.monthIncreaseSelector,
+      'aria-label',
+      'next month'
+    );
+    await assertAttributeValues(
+      t,
+      ex.monthDecreaseSelector,
+      'aria-label',
+      'previous month'
+    );
 
-  await assertAttributeValues(t, ex.yearIncreaseSelector, 'tabindex', '-1');
-  await assertAttributeValues(t, ex.yearDecreaseSelector, 'tabindex', '-1');
-});
+    await assertAttributeValues(
+      t,
+      ex.yearIncreaseSelector,
+      'aria-label',
+      'next year'
+    );
+    await assertAttributeValues(
+      t,
+      ex.yearDecreaseSelector,
+      'aria-label',
+      'previous year'
+    );
+  }
+);
 
-ariaTest('"aria-label" provides accessible name for the previous and next buttons to screen reader users', exampleFile, 'button-aria-label', async (t) => {
-  await assertAttributeValues(t, ex.dayIncreaseSelector, 'aria-label', 'next day');
-  await assertAttributeValues(t, ex.dayDecreaseSelector, 'aria-label', 'previous day');
+ariaTest(
+  '"aria-hidden" hides decorative and redundant content form screen reader users',
+  exampleFile,
+  'spinbutton-aria-hidden',
+  async (t) => {
+    await assertAttributeValues(
+      t,
+      ex.dayHiddenPreviousSelector,
+      'aria-hidden',
+      'true'
+    );
+    await assertAttributeValues(
+      t,
+      ex.dayHiddenNextSelector,
+      'aria-hidden',
+      'true'
+    );
 
-  await assertAttributeValues(t, ex.monthIncreaseSelector, 'aria-label', 'next month');
-  await assertAttributeValues(t, ex.monthDecreaseSelector, 'aria-label', 'previous month');
+    await assertAttributeValues(
+      t,
+      ex.monthHiddenPreviousSelector,
+      'aria-hidden',
+      'true'
+    );
+    await assertAttributeValues(
+      t,
+      ex.monthHiddenNextSelector,
+      'aria-hidden',
+      'true'
+    );
 
-  await assertAttributeValues(t, ex.yearIncreaseSelector, 'aria-label', 'next year');
-  await assertAttributeValues(t, ex.yearDecreaseSelector, 'aria-label', 'previous year');
-});
+    await assertAttributeValues(
+      t,
+      ex.yearHiddenPreviousSelector,
+      'aria-hidden',
+      'true'
+    );
+    await assertAttributeValues(
+      t,
+      ex.yearHiddenNextSelector,
+      'aria-hidden',
+      'true'
+    );
+  }
+);
 
-ariaTest('"aria-hidden" hides decorative and redundant content form screen reader users', exampleFile, 'spinbutton-aria-hidden', async (t) => {
-  await assertAttributeValues(t, ex.dayHiddenPreviousSelector, 'aria-hidden', 'true');
-  await assertAttributeValues(t, ex.dayHiddenNextSelector, 'aria-hidden', 'true');
-
-  await assertAttributeValues(t, ex.monthHiddenPreviousSelector, 'aria-hidden', 'true');
-  await assertAttributeValues(t, ex.monthHiddenNextSelector, 'aria-hidden', 'true');
-
-  await assertAttributeValues(t, ex.yearHiddenPreviousSelector, 'aria-hidden', 'true');
-  await assertAttributeValues(t, ex.yearHiddenNextSelector, 'aria-hidden', 'true');
-});
-
-
-// keys 
+// keys
 
 ariaTest('up arrow on day', exampleFile, 'spinbutton-up-arrow', async (t) => {
   let control = parseInt(ex.dayNow);
@@ -151,9 +346,8 @@ ariaTest('up arrow on day', exampleFile, 'spinbutton-up-arrow', async (t) => {
   t.is(
     parseInt(await daySpinner.getText()),
     control,
-    "After sending 1 up arrow to the day spinner, the day should be: " + control
+    'After sending 1 up arrow to the day spinner, the day should be: ' + control
   );
-
 
   // Send up arrow 30 more times to date spinner
   for (let i = 1; i <= 30; i++) {
@@ -166,48 +360,59 @@ ariaTest('up arrow on day', exampleFile, 'spinbutton-up-arrow', async (t) => {
   t.is(
     parseInt(await daySpinner.getText()),
     control,
-    "After sending 31 up arrows to the day spinner, the day should be: " + control
+    'After sending 31 up arrows to the day spinner, the day should be: ' +
+      control
   );
 });
 
-ariaTest('down arrow on day', exampleFile, 'spinbutton-down-arrow', async (t) => {
-  let control = parseInt(ex.dayNow);
-  let daysInMonth = parseInt(ex.dayMax);
+ariaTest(
+  'down arrow on day',
+  exampleFile,
+  'spinbutton-down-arrow',
+  async (t) => {
+    let control = parseInt(ex.dayNow);
+    let daysInMonth = parseInt(ex.dayMax);
 
-  // Send down arrow to day date spinner
-  let daySpinner = await t.context.session.findElement(By.css(ex.daySelector));
-  await daySpinner.sendKeys(Key.ARROW_DOWN);
-
-  // Subract a day to the control
-  control = (control - 1) % daysInMonth;
-
-  t.is(
-    parseInt(await daySpinner.getText()),
-    control,
-    "After sending 1 down arrow to the day spinner, the day should be: " + control
-  );
-
-  // Send down arrow 30 more times to date spinner
-  for (let i = 1; i <= 30; i++) {
+    // Send down arrow to day date spinner
+    let daySpinner = await t.context.session.findElement(
+      By.css(ex.daySelector)
+    );
     await daySpinner.sendKeys(Key.ARROW_DOWN);
+
+    // Subract a day to the control
+    control = (control - 1) % daysInMonth;
+
+    t.is(
+      parseInt(await daySpinner.getText()),
+      control,
+      'After sending 1 down arrow to the day spinner, the day should be: ' +
+        control
+    );
+
+    // Send down arrow 30 more times to date spinner
+    for (let i = 1; i <= 30; i++) {
+      await daySpinner.sendKeys(Key.ARROW_DOWN);
+    }
+
+    // Subtract 30 days to the control
+    control = daysInMonth + ((control - 30) % daysInMonth);
+
+    t.is(
+      parseInt(await daySpinner.getText()),
+      control,
+      'After sending 31 down arrows to the day spinner, the day should be: ' +
+        control
+    );
   }
-
-  // Subtract 30 days to the control
-  control = daysInMonth + ((control - 30) % daysInMonth);
-
-  t.is(
-    parseInt(await daySpinner.getText()),
-    control,
-    "After sending 31 down arrows to the day spinner, the day should be: " + control
-  );
-});
-
+);
 
 ariaTest('up arrow on month', exampleFile, 'spinbutton-up-arrow', async (t) => {
   let control = parseInt(ex.monthNow) + 1;
 
   // Send up arrow to day date spinner
-  let monthSpinner = await t.context.session.findElement(By.css(ex.monthSelector));
+  let monthSpinner = await t.context.session.findElement(
+    By.css(ex.monthSelector)
+  );
   await monthSpinner.sendKeys(Key.ARROW_UP);
 
   // Add a month to the control
@@ -216,9 +421,9 @@ ariaTest('up arrow on month', exampleFile, 'spinbutton-up-arrow', async (t) => {
   t.is(
     await monthSpinner.getText(),
     valuesMonth[control - 1],
-    "After sending 1 up arrow to the month spinner, the month should be: " + valuesMonth[control - 1]
+    'After sending 1 up arrow to the month spinner, the month should be: ' +
+      valuesMonth[control - 1]
   );
-
 
   // Send up arrow 30 more times to date spinner
   for (let i = 1; i <= 30; i++) {
@@ -231,45 +436,56 @@ ariaTest('up arrow on month', exampleFile, 'spinbutton-up-arrow', async (t) => {
   t.is(
     await monthSpinner.getText(),
     valuesMonth[control - 1],
-    "After sending 31 up arrows to the month spinner, the month should be: " + valuesMonth[control - 1]
+    'After sending 31 up arrows to the month spinner, the month should be: ' +
+      valuesMonth[control - 1]
   );
 });
 
-ariaTest('down arrow on month', exampleFile, 'spinbutton-down-arrow', async (t) => {
-  let control = parseInt(ex.monthNow) + 1;
+ariaTest(
+  'down arrow on month',
+  exampleFile,
+  'spinbutton-down-arrow',
+  async (t) => {
+    let control = parseInt(ex.monthNow) + 1;
 
-  // Send down arrow to month date spinner
-  let monthSpinner = await t.context.session.findElement(By.css(ex.monthSelector));
-  await monthSpinner.sendKeys(Key.ARROW_DOWN);
-
-  // Subract a month to the control
-  control = (control - 1) % 12;
-
-  t.is(
-    await monthSpinner.getText(),
-    valuesMonth[control - 1],
-    "After sending 1 down arrow to the month spinner, the month should be: " + valuesMonth[control - 1]
-  );
-
-  // Send down arrow 30 more times to date spinner
-  for (let i = 1; i <= 30; i++) {
+    // Send down arrow to month date spinner
+    let monthSpinner = await t.context.session.findElement(
+      By.css(ex.monthSelector)
+    );
     await monthSpinner.sendKeys(Key.ARROW_DOWN);
+
+    // Subract a month to the control
+    control = (control - 1) % 12;
+
+    t.is(
+      await monthSpinner.getText(),
+      valuesMonth[control - 1],
+      'After sending 1 down arrow to the month spinner, the month should be: ' +
+        valuesMonth[control - 1]
+    );
+
+    // Send down arrow 30 more times to date spinner
+    for (let i = 1; i <= 30; i++) {
+      await monthSpinner.sendKeys(Key.ARROW_DOWN);
+    }
+
+    // Subtract 30 months to the control
+    control = 12 + ((control - 30) % 12);
+
+    t.is(
+      await monthSpinner.getText(),
+      valuesMonth[control - 1],
+      'After sending 31 down arrows to the month spinner, the month should be: ' +
+        valuesMonth[control - 1]
+    );
   }
-
-  // Subtract 30 months to the control
-  control = 12 + ((control - 30) % 12);
-
-  t.is(
-    await monthSpinner.getText(),
-    valuesMonth[control - 1],
-    "After sending 31 down arrows to the month spinner, the month should be: " + valuesMonth[control - 1]
-  );
-});
+);
 
 ariaTest('up arrow on year', exampleFile, 'spinbutton-up-arrow', async (t) => {
-
   // Send up arrow to day date spinner
-  let yearSpinner = await t.context.session.findElement(By.css(ex.yearSelector));
+  let yearSpinner = await t.context.session.findElement(
+    By.css(ex.yearSelector)
+  );
   await yearSpinner.sendKeys(Key.ARROW_UP);
 
   let nextYear = (parseInt(ex.yearNow) + 1).toString();
@@ -277,7 +493,8 @@ ariaTest('up arrow on year', exampleFile, 'spinbutton-up-arrow', async (t) => {
   t.is(
     await yearSpinner.getText(),
     nextYear,
-    "After sending 1 up arrow to the year spinner, the year should be: " + nextYear
+    'After sending 1 up arrow to the year spinner, the year should be: ' +
+      nextYear
   );
 
   let manyYears = parseInt(ex.yearMax) - parseInt(ex.yearNow);
@@ -288,174 +505,221 @@ ariaTest('up arrow on year', exampleFile, 'spinbutton-up-arrow', async (t) => {
   t.is(
     await yearSpinner.getText(),
     ex.yearMax,
-    "After sending " + (manyYears + 1) + " up arrows to the year spinner, the year should be: " + ex.yearMax
+    'After sending ' +
+      (manyYears + 1) +
+      ' up arrows to the year spinner, the year should be: ' +
+      ex.yearMax
   );
 });
 
-ariaTest('down arrow on year', exampleFile, 'spinbutton-down-arrow', async (t) => {
-
-  // Send down arrow to year date spinner
-  let yearSpinner = await t.context.session.findElement(By.css(ex.yearSelector));
-  await yearSpinner.sendKeys(Key.ARROW_DOWN);
-
-  // Subract a year to the control
-  let lastYear = (parseInt(ex.yearNow) - 1).toString();
-
-  t.is(
-    await yearSpinner.getText(),
-    lastYear,
-    "After sending 1 down arrow to the year spinner, the year should be: " + lastYear
-  );
-
-  let manyYears = parseInt(ex.yearNow) - parseInt(ex.yearMin);
-  for (let i = 1; i <= manyYears; i++) {
+ariaTest(
+  'down arrow on year',
+  exampleFile,
+  'spinbutton-down-arrow',
+  async (t) => {
+    // Send down arrow to year date spinner
+    let yearSpinner = await t.context.session.findElement(
+      By.css(ex.yearSelector)
+    );
     await yearSpinner.sendKeys(Key.ARROW_DOWN);
-  }
 
-  t.is(
-    await yearSpinner.getText(),
-    ex.yearMin,
-    "After sending " + manyYears + " down arrows to the year spinner, the year should be: " + ex.yearMin
-  );
-});
+    // Subract a year to the control
+    let lastYear = (parseInt(ex.yearNow) - 1).toString();
+
+    t.is(
+      await yearSpinner.getText(),
+      lastYear,
+      'After sending 1 down arrow to the year spinner, the year should be: ' +
+        lastYear
+    );
+
+    let manyYears = parseInt(ex.yearNow) - parseInt(ex.yearMin);
+    for (let i = 1; i <= manyYears; i++) {
+      await yearSpinner.sendKeys(Key.ARROW_DOWN);
+    }
+
+    t.is(
+      await yearSpinner.getText(),
+      ex.yearMin,
+      'After sending ' +
+        manyYears +
+        ' down arrows to the year spinner, the year should be: ' +
+        ex.yearMin
+    );
+  }
+);
 
 // The bug causing this test to fail is tracked in https://github.com/w3c/aria-practices/issues/1426
-ariaTest.failing('page up on day', exampleFile, 'spinbutton-page-up', async (t) => {
-  let control = parseInt(ex.dayNow);
-  let daysInMonth = parseInt(ex.dayMax);
+ariaTest.failing(
+  'page up on day',
+  exampleFile,
+  'spinbutton-page-up',
+  async (t) => {
+    let control = parseInt(ex.dayNow);
+    let daysInMonth = parseInt(ex.dayMax);
 
-  // Send page up to day date spinner
-  let daySpinner = await t.context.session.findElement(By.css(ex.daySelector));
-  await daySpinner.sendKeys(Key.PAGE_UP);
-
-  // Add a day to the control
-  control = (control + 5) % daysInMonth;
-
-  t.is(
-    parseInt(await daySpinner.getText()),
-    control,
-    "After sending 1 page up to the day spinner, the day should be: " + control
-  );
-
-
-  // Send page up 5 more times to date spinner
-  for (let i = 1; i <= 5; i++) {
+    // Send page up to day date spinner
+    let daySpinner = await t.context.session.findElement(
+      By.css(ex.daySelector)
+    );
     await daySpinner.sendKeys(Key.PAGE_UP);
+
+    // Add a day to the control
+    control = (control + 5) % daysInMonth;
+
+    t.is(
+      parseInt(await daySpinner.getText()),
+      control,
+      'After sending 1 page up to the day spinner, the day should be: ' +
+        control
+    );
+
+    // Send page up 5 more times to date spinner
+    for (let i = 1; i <= 5; i++) {
+      await daySpinner.sendKeys(Key.PAGE_UP);
+    }
+
+    // Add 25 days to the control
+    control = (control + 25) % daysInMonth;
+
+    t.is(
+      parseInt(await daySpinner.getText()),
+      control,
+      'After sending 6 page ups to the day spinner, the day should be: ' +
+        control
+    );
   }
-
-  // Add 25 days to the control
-  control = (control + 25) % daysInMonth;
-
-  t.is(
-    parseInt(await daySpinner.getText()),
-    control,
-    "After sending 6 page ups to the day spinner, the day should be: " + control
-  );
-});
+);
 
 // The bug causing this test to fail is tracked in https://github.com/w3c/aria-practices/issues/1426
-ariaTest.failing('page down on day', exampleFile, 'spinbutton-page-down', async (t) => {
-  let control = parseInt(ex.dayNow);
-  let daysInMonth = parseInt(ex.dayMax);
+ariaTest.failing(
+  'page down on day',
+  exampleFile,
+  'spinbutton-page-down',
+  async (t) => {
+    let control = parseInt(ex.dayNow);
+    let daysInMonth = parseInt(ex.dayMax);
 
-  // Send page down to day date spinner
-  let daySpinner = await t.context.session.findElement(By.css(ex.daySelector));
-  await daySpinner.sendKeys(Key.PAGE_DOWN);
-
-  // Subract 5 days to the control
-  control = (control - 5) % daysInMonth;
-
-  t.is(
-    parseInt(await daySpinner.getText()),
-    control,
-    "After sending 1 page down to the day spinner, the day should be: " + control
-  );
-
-  // Send page down 5 more times to date spinner
-  for (let i = 1; i <= 5; i++) {
+    // Send page down to day date spinner
+    let daySpinner = await t.context.session.findElement(
+      By.css(ex.daySelector)
+    );
     await daySpinner.sendKeys(Key.PAGE_DOWN);
+
+    // Subract 5 days to the control
+    control = (control - 5) % daysInMonth;
+
+    t.is(
+      parseInt(await daySpinner.getText()),
+      control,
+      'After sending 1 page down to the day spinner, the day should be: ' +
+        control
+    );
+
+    // Send page down 5 more times to date spinner
+    for (let i = 1; i <= 5; i++) {
+      await daySpinner.sendKeys(Key.PAGE_DOWN);
+    }
+
+    // Subtract 25 days to the control
+    control = daysInMonth + ((control - 25) % daysInMonth);
+
+    t.is(
+      parseInt(await daySpinner.getText()),
+      control,
+      'After sending 6 page downs to the day spinner, the day should be: ' +
+        control
+    );
   }
-
-  // Subtract 25 days to the control
-  control = daysInMonth + ((control - 25) % daysInMonth);
-
-  t.is(
-    parseInt(await daySpinner.getText()),
-    control,
-    "After sending 6 page downs to the day spinner, the day should be: " + control
-  );
-});
+);
 
 // The bug causing this test to fail is tracked in https://github.com/w3c/aria-practices/issues/1426
-ariaTest.failing('page up on month', exampleFile, 'spinbutton-page-up', async (t) => {
-  let control = parseInt(ex.monthNow) + 1;
+ariaTest.failing(
+  'page up on month',
+  exampleFile,
+  'spinbutton-page-up',
+  async (t) => {
+    let control = parseInt(ex.monthNow) + 1;
 
-  // Send page up to day date spinner
-  let monthSpinner = await t.context.session.findElement(By.css(ex.monthSelector));
-  await monthSpinner.sendKeys(Key.PAGE_UP);
-
-  // Add 5 month to the control
-  control = (control + 5) % 12;
-
-  t.is(
-    await monthSpinner.getText(),
-    valuesMonth[control - 1],
-    "After sending 1 page up to the month spinner, the month should be: " + valuesMonth[control - 1]
-  );
-
-
-  // Send page up 2 more times to date spinner
-  for (let i = 1; i <= 2; i++) {
+    // Send page up to day date spinner
+    let monthSpinner = await t.context.session.findElement(
+      By.css(ex.monthSelector)
+    );
     await monthSpinner.sendKeys(Key.PAGE_UP);
+
+    // Add 5 month to the control
+    control = (control + 5) % 12;
+
+    t.is(
+      await monthSpinner.getText(),
+      valuesMonth[control - 1],
+      'After sending 1 page up to the month spinner, the month should be: ' +
+        valuesMonth[control - 1]
+    );
+
+    // Send page up 2 more times to date spinner
+    for (let i = 1; i <= 2; i++) {
+      await monthSpinner.sendKeys(Key.PAGE_UP);
+    }
+
+    // Add 10 months to the control
+    control = (control + 10) % 12;
+
+    t.is(
+      await monthSpinner.getText(),
+      valuesMonth[control - 1],
+      'After sending 3 page ups to the month spinner, the month should be: ' +
+        valuesMonth[control - 1]
+    );
   }
-
-  // Add 10 months to the control
-  control = (control + 10) % 12;
-
-  t.is(
-    await monthSpinner.getText(),
-    valuesMonth[control - 1],
-    "After sending 3 page ups to the month spinner, the month should be: " + valuesMonth[control - 1]
-  );
-});
+);
 
 // The bug causing this test to fail is tracked in https://github.com/w3c/aria-practices/issues/1426
-ariaTest.failing('page down on month', exampleFile, 'spinbutton-page-down', async (t) => {
-  let control = parseInt(ex.monthNow) + 1;
+ariaTest.failing(
+  'page down on month',
+  exampleFile,
+  'spinbutton-page-down',
+  async (t) => {
+    let control = parseInt(ex.monthNow) + 1;
 
-  // Send page down to month date spinner
-  let monthSpinner = await t.context.session.findElement(By.css(ex.monthSelector));
-  await monthSpinner.sendKeys(Key.PAGE_DOWN);
-
-  // Subract 5 month to the control
-  control = (control - 5) % 12;
-
-  t.is(
-    await monthSpinner.getText(),
-    valuesMonth[control - 1],
-    "After sending 1 page down to the month spinner, the month should be: " + valuesMonth[control - 1]
-  );
-
-  // Send page down 2 more times to date spinner
-  for (let i = 1; i <= 2; i++) {
+    // Send page down to month date spinner
+    let monthSpinner = await t.context.session.findElement(
+      By.css(ex.monthSelector)
+    );
     await monthSpinner.sendKeys(Key.PAGE_DOWN);
+
+    // Subract 5 month to the control
+    control = (control - 5) % 12;
+
+    t.is(
+      await monthSpinner.getText(),
+      valuesMonth[control - 1],
+      'After sending 1 page down to the month spinner, the month should be: ' +
+        valuesMonth[control - 1]
+    );
+
+    // Send page down 2 more times to date spinner
+    for (let i = 1; i <= 2; i++) {
+      await monthSpinner.sendKeys(Key.PAGE_DOWN);
+    }
+
+    // Subtract 30 months to the control
+    control = 12 + ((control - 10) % 12);
+
+    t.is(
+      await monthSpinner.getText(),
+      valuesMonth[control - 1],
+      'After sending 3 page downs to the month spinner, the month should be: ' +
+        valuesMonth[control - 1]
+    );
   }
-
-  // Subtract 30 months to the control
-  control = 12 + ((control - 10) % 12);
-
-  t.is(
-    await monthSpinner.getText(),
-    valuesMonth[control - 1],
-    "After sending 3 page downs to the month spinner, the month should be: " + valuesMonth[control - 1]
-  );
-});
-
+);
 
 ariaTest('page up on year', exampleFile, 'spinbutton-page-up', async (t) => {
-
   // Send page up to day date spinner
-  let yearSpinner = await t.context.session.findElement(By.css(ex.yearSelector));
+  let yearSpinner = await t.context.session.findElement(
+    By.css(ex.yearSelector)
+  );
   await yearSpinner.sendKeys(Key.PAGE_UP);
 
   let nextYear = (parseInt(ex.yearNow) + 5).toString();
@@ -463,7 +727,8 @@ ariaTest('page up on year', exampleFile, 'spinbutton-page-up', async (t) => {
   t.is(
     await yearSpinner.getText(),
     nextYear,
-    "After sending 1 page up to the year spinner, the year should be: " + nextYear
+    'After sending 1 page up to the year spinner, the year should be: ' +
+      nextYear
   );
 
   let manyYears = Math.ceil((parseInt(ex.yearMax) - parseInt(ex.yearNow)) / 5);
@@ -474,34 +739,49 @@ ariaTest('page up on year', exampleFile, 'spinbutton-page-up', async (t) => {
   t.is(
     await yearSpinner.getText(),
     ex.yearMax,
-    "After sending " + (manyYears + 1) + " page ups to the year spinner, the year should be: " + ex.yearMax
+    'After sending ' +
+      (manyYears + 1) +
+      ' page ups to the year spinner, the year should be: ' +
+      ex.yearMax
   );
 });
 
-ariaTest('down arrow on year', exampleFile, 'spinbutton-page-down', async (t) => {
-
-  // Send down arrow to year date spinner
-  let yearSpinner = await t.context.session.findElement(By.css(ex.yearSelector));
-  await yearSpinner.sendKeys(Key.PAGE_UP);
-  await yearSpinner.sendKeys(Key.PAGE_DOWN);
-
-  t.is(
-    await yearSpinner.getText(),
-    ex.yearNow,
-    "After sending 1 up arrow, then 1 down arrow to the year spinner, the year should be: " + ex.yearNow
-  );
-
-  let manyYears = Math.ceil((parseInt(ex.yearNow) - parseInt(ex.yearMin)) / 5);
-  for (let i = 1; i <= manyYears; i++) {
+ariaTest(
+  'down arrow on year',
+  exampleFile,
+  'spinbutton-page-down',
+  async (t) => {
+    // Send down arrow to year date spinner
+    let yearSpinner = await t.context.session.findElement(
+      By.css(ex.yearSelector)
+    );
+    await yearSpinner.sendKeys(Key.PAGE_UP);
     await yearSpinner.sendKeys(Key.PAGE_DOWN);
-  }
 
-  t.is(
-    await yearSpinner.getText(),
-    ex.yearMin,
-    "After sending " + manyYears + " down arrows to the year spinner, the year should be: " + ex.yearMin
-  );
-});
+    t.is(
+      await yearSpinner.getText(),
+      ex.yearNow,
+      'After sending 1 up arrow, then 1 down arrow to the year spinner, the year should be: ' +
+        ex.yearNow
+    );
+
+    let manyYears = Math.ceil(
+      (parseInt(ex.yearNow) - parseInt(ex.yearMin)) / 5
+    );
+    for (let i = 1; i <= manyYears; i++) {
+      await yearSpinner.sendKeys(Key.PAGE_DOWN);
+    }
+
+    t.is(
+      await yearSpinner.getText(),
+      ex.yearMin,
+      'After sending ' +
+        manyYears +
+        ' down arrows to the year spinner, the year should be: ' +
+        ex.yearMin
+    );
+  }
+);
 
 ariaTest('home on day', exampleFile, 'spinbutton-home', async (t) => {
   // Send home to day date spinner
@@ -510,10 +790,9 @@ ariaTest('home on day', exampleFile, 'spinbutton-home', async (t) => {
 
   t.is(
     await daySpinner.getText(),
-    "1",
-    "After sending home to the day spinner, the day should be: 1"
+    '1',
+    'After sending home to the day spinner, the day should be: 1'
   );
-
 });
 
 ariaTest('end on day', exampleFile, 'spinbutton-end', async (t) => {
@@ -524,56 +803,62 @@ ariaTest('end on day', exampleFile, 'spinbutton-end', async (t) => {
   t.is(
     await daySpinner.getText(),
     ex.dayMax,
-    "After sending end to the day spinner, the day should be: " + ex.dayMax
+    'After sending end to the day spinner, the day should be: ' + ex.dayMax
   );
 });
 
 ariaTest('home on month', exampleFile, 'spinbutton-home', async (t) => {
   // Send home to month date spinner
-  let monthSpinner = await t.context.session.findElement(By.css(ex.monthSelector));
+  let monthSpinner = await t.context.session.findElement(
+    By.css(ex.monthSelector)
+  );
   await monthSpinner.sendKeys(Key.HOME);
 
   t.is(
     await monthSpinner.getText(),
-    "January",
-    "After sending home to the month spinner, the month should be: January"
+    'January',
+    'After sending home to the month spinner, the month should be: January'
   );
-
 });
 
 ariaTest('end on month', exampleFile, 'spinbutton-end', async (t) => {
   // Send home to month date spinner
-  let monthSpinner = await t.context.session.findElement(By.css(ex.monthSelector));
+  let monthSpinner = await t.context.session.findElement(
+    By.css(ex.monthSelector)
+  );
   await monthSpinner.sendKeys(Key.END);
 
   t.is(
     await monthSpinner.getText(),
-    "December",
-    "After sending end to the month spinner, the month should be: December"
+    'December',
+    'After sending end to the month spinner, the month should be: December'
   );
 });
 
 ariaTest('home on year', exampleFile, 'spinbutton-home', async (t) => {
   // Send home to year date spinner
-  let yearSpinner = await t.context.session.findElement(By.css(ex.yearSelector));
+  let yearSpinner = await t.context.session.findElement(
+    By.css(ex.yearSelector)
+  );
   await yearSpinner.sendKeys(Key.HOME);
 
   t.is(
     await yearSpinner.getText(),
     ex.yearMin,
-    "After sending home to the year spinner, the year should be: " +  ex.yearMin
+    'After sending home to the year spinner, the year should be: ' + ex.yearMin
   );
-
 });
 
 ariaTest('end on year', exampleFile, 'spinbutton-end', async (t) => {
   // Send home to year date spinner
-  let yearSpinner = await t.context.session.findElement(By.css(ex.yearSelector));
+  let yearSpinner = await t.context.session.findElement(
+    By.css(ex.yearSelector)
+  );
   await yearSpinner.sendKeys(Key.END);
 
   t.is(
     await yearSpinner.getText(),
     ex.yearMax,
-    "After sending end to the year spinner, the year should be: " + ex.yearMax
+    'After sending end to the year spinner, the year should be: ' + ex.yearMax
   );
 });

--- a/test/tests/spinbutton_datepicker.js
+++ b/test/tests/spinbutton_datepicker.js
@@ -407,38 +407,23 @@ ariaTest(
 );
 
 ariaTest('up arrow on month', exampleFile, 'spinbutton-up-arrow', async (t) => {
-  let control = parseInt(ex.monthNow) + 1;
+  let date = new Date();
 
-  // Send up arrow to day date spinner
   let monthSpinner = await t.context.session.findElement(
     By.css(ex.monthSelector)
   );
-  await monthSpinner.sendKeys(Key.ARROW_UP);
 
-  // Add a month to the control
-  control = (control + 1) % 12;
-
-  t.is(
-    await monthSpinner.getText(),
-    valuesMonth[control - 1],
-    'After sending 1 up arrow to the month spinner, the month should be: ' +
-      valuesMonth[control - 1]
-  );
-
-  // Send up arrow 30 more times to date spinner
-  for (let i = 1; i <= 30; i++) {
+  // Send up arrow 12 times to date spinner
+  for (let i = 1; i <= 12; i++) {
     await monthSpinner.sendKeys(Key.ARROW_UP);
+    const index = new Date(date.setMonth(date.getMonth() + 1)).getMonth();
+    console.log(index);
+    t.is(
+      await monthSpinner.getText(),
+      valuesMonth[index],
+      `After sending ${i} up arrows to the month spinner, the month should be: ${valuesMonth[index]}`
+    );
   }
-
-  // Add 30 months to the control
-  control = (control + 30) % 12;
-
-  t.is(
-    await monthSpinner.getText(),
-    valuesMonth[control - 1],
-    'After sending 31 up arrows to the month spinner, the month should be: ' +
-      valuesMonth[control - 1]
-  );
 });
 
 ariaTest(

--- a/test/tests/spinbutton_datepicker.js
+++ b/test/tests/spinbutton_datepicker.js
@@ -353,7 +353,8 @@ ariaTest.failing('page up on day', exampleFile, 'spinbutton-page-up', async (t) 
   );
 });
 
-ariaTest('page down on day', exampleFile, 'spinbutton-page-down', async (t) => {
+// The bug causing this test to fail is tracked in https://github.com/w3c/aria-practices/issues/1426
+ariaTest.failing('page down on day', exampleFile, 'spinbutton-page-down', async (t) => {
   let control = parseInt(ex.dayNow);
   let daysInMonth = parseInt(ex.dayMax);
 
@@ -361,7 +362,7 @@ ariaTest('page down on day', exampleFile, 'spinbutton-page-down', async (t) => {
   let daySpinner = await t.context.session.findElement(By.css(ex.daySelector));
   await daySpinner.sendKeys(Key.PAGE_DOWN);
 
-  // Subract a day to the control
+  // Subract 5 days to the control
   control = (control - 5) % daysInMonth;
 
   t.is(
@@ -375,7 +376,7 @@ ariaTest('page down on day', exampleFile, 'spinbutton-page-down', async (t) => {
     await daySpinner.sendKeys(Key.PAGE_DOWN);
   }
 
-  // Subtract 15 days to the control
+  // Subtract 25 days to the control
   control = daysInMonth + ((control - 25) % daysInMonth);
 
   t.is(

--- a/test/tests/spinbutton_datepicker.js
+++ b/test/tests/spinbutton_datepicker.js
@@ -319,6 +319,7 @@ ariaTest('down arrow on year', exampleFile, 'spinbutton-down-arrow', async (t) =
   );
 });
 
+// The bug causing this test to fail is tracked in https://github.com/w3c/aria-practices/issues/1426
 ariaTest.failing('page up on day', exampleFile, 'spinbutton-page-up', async (t) => {
   let control = parseInt(ex.dayNow);
   let daysInMonth = parseInt(ex.dayMax);
@@ -384,6 +385,7 @@ ariaTest('page down on day', exampleFile, 'spinbutton-page-down', async (t) => {
   );
 });
 
+// The bug causing this test to fail is tracked in https://github.com/w3c/aria-practices/issues/1426
 ariaTest.failing('page up on month', exampleFile, 'spinbutton-page-up', async (t) => {
   let control = parseInt(ex.monthNow) + 1;
 
@@ -416,6 +418,7 @@ ariaTest.failing('page up on month', exampleFile, 'spinbutton-page-up', async (t
   );
 });
 
+// The bug causing this test to fail is tracked in https://github.com/w3c/aria-practices/issues/1426
 ariaTest.failing('page down on month', exampleFile, 'spinbutton-page-down', async (t) => {
   let control = parseInt(ex.monthNow) + 1;
 

--- a/test/tests/spinbutton_datepicker.js
+++ b/test/tests/spinbutton_datepicker.js
@@ -1,58 +1,15 @@
+'use strict';
+
 const { ariaTest } = require('..');
+const { By, Key } = require('selenium-webdriver');
 const assertAttributeValues = require('../util/assertAttributeValues');
 const assertAriaLabelledby = require('../util/assertAriaLabelledby');
 const assertAriaRoles = require('../util/assertAriaRoles');
 
 const exampleFile = 'spinbutton/datepicker-spinbuttons.html';
 
-const valuesDay = [
-  '',
-  'first',
-  'second',
-  'third',
-  'fourth',
-  'fifth',
-  'sixth',
-  'seventh',
-  'eighth',
-  'ninth',
-  'tenth',
-  'eleventh',
-  'twelfth',
-  'thirteenth',
-  'fourteen',
-  'fifteenth',
-  'sixteenth',
-  'seveneenth',
-  'eighteenth',
-  'nineteenth',
-  'twentieth',
-  'twenty first',
-  'twenty second',
-  'twenty third',
-  'twenty fourth',
-  'twenty fifth',
-  'twenty sixth',
-  'twenty seventh',
-  'twenty eighth',
-  'twenty ninth',
-  'thirtieth',
-  'thirty first',
-];
-const valuesMonth = [
-  'January',
-  'February',
-  'March',
-  'April',
-  'May',
-  'June',
-  'July',
-  'August',
-  'September',
-  'October',
-  'November',
-  'December',
-];
+const valuesDay = ['', 'first', 'second', 'third', 'fourth', 'fifth', 'sixth', 'seventh', 'eighth', 'ninth', 'tenth', 'eleventh', 'twelfth', 'thirteenth', 'fourteen', 'fifteenth', 'sixteenth', 'seveneenth', 'eighteenth', 'nineteenth', 'twentieth', 'twenty first', 'twenty second', 'twenty third', 'twenty fourth', 'twenty fifth', 'twenty sixth', 'twenty seventh', 'twenty eighth', 'twenty ninth', 'thirtieth', 'thirty first'];
+const valuesMonth = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'];
 
 var getDaysInMonth = function (year, month) {
   return new Date(year, month + 1, 0).getDate();
@@ -95,236 +52,524 @@ const ex = {
   dayIncreaseSelector: '#example .spinbutton.day .increase',
   dayDecreaseSelector: '#example .spinbutton.day .decrease',
   dayHiddenPreviousSelector: '#example .spinbutton.day .previous',
-  dayHiddenNextSelector: '#example .spinbutton.day .next',
+  dayHiddenNextSelector: '#example .spinbutton.day .next'
 };
 
 // Attributes
 
-ariaTest(
-  'role="group" on div element',
-  exampleFile,
-  'group-role',
-  async (t) => {
-    await assertAriaRoles(t, 'example', 'group', '1', 'div');
+ariaTest('role="group" on div element', exampleFile, 'group-role', async (t) => {
+  await assertAriaRoles(t, 'example', 'group', '1', 'div');
+});
+
+ariaTest('"aria-labelledby" attribute on group', exampleFile, 'group-aria-labelledby', async (t) => {
+  await assertAriaLabelledby(t,  ex.groupSelector);
+});
+
+ariaTest('role="spinbutton" on div element', exampleFile, 'spinbutton-role', async (t) => {
+  await assertAriaRoles(t, 'example', 'spinbutton', '3', 'div');
+});
+
+ariaTest('"aria-valuemax" represents the minimum value on spinbuttons', exampleFile, 'spinbutton-aria-valuemax', async (t) => {
+  await assertAttributeValues(t, ex.daySelector, 'aria-valuemax', ex.dayMax);
+  await assertAttributeValues(t, ex.monthSelector, 'aria-valuemax', ex.monthMax);
+  await assertAttributeValues(t, ex.yearSelector, 'aria-valuemax', ex.yearMax);
+});
+
+ariaTest('"aria-valuemin" represents the maximum value on spinbuttons', exampleFile, 'spinbutton-aria-valuemin', async (t) => {
+  await assertAttributeValues(t, ex.daySelector, 'aria-valuemin', ex.dayMin);
+  await assertAttributeValues(t, ex.monthSelector, 'aria-valuemin', ex.monthMin);
+  await assertAttributeValues(t, ex.yearSelector, 'aria-valuemin', ex.yearMin);
+});
+
+ariaTest('"aria-valuenow" reflects spinbutton value as a number', exampleFile, 'spinbutton-aria-valuenow', async (t) => {
+  await assertAttributeValues(t, ex.daySelector, 'aria-valuenow', ex.dayNow);
+  await assertAttributeValues(t, ex.monthSelector, 'aria-valuenow', ex.monthNow);
+  await assertAttributeValues(t, ex.yearSelector, 'aria-valuenow', ex.yearNow);
+});
+
+
+ariaTest('"aria-valuetext" reflects spin button value as a text string', exampleFile, 'spinbutton-aria-valuetext', async (t) => {
+  await assertAttributeValues(t, ex.daySelector, 'aria-valuetext', ex.dayText);
+  await assertAttributeValues(t, ex.monthSelector, 'aria-valuetext', ex.monthText);
+});
+
+ariaTest('"aria-label" provides accessible name for the spin buttons to screen reader users', exampleFile, 'spinbutton-aria-label', async (t) => {
+
+  await assertAttributeValues(t, ex.daySelector, 'aria-label', 'Day');
+  await assertAttributeValues(t, ex.monthSelector, 'aria-label', 'Month');
+  await assertAttributeValues(t, ex.yearSelector, 'aria-label', 'Year');
+
+});
+
+ariaTest('"tabindex=-1" removes previous and next from the tab order of the page', exampleFile, 'button-tabindex', async (t) => {
+  await assertAttributeValues(t, ex.dayIncreaseSelector, 'tabindex', '-1');
+  await assertAttributeValues(t, ex.dayDecreaseSelector, 'tabindex', '-1');
+
+  await assertAttributeValues(t, ex.monthIncreaseSelector, 'tabindex', '-1');
+  await assertAttributeValues(t, ex.monthDecreaseSelector, 'tabindex', '-1');
+
+  await assertAttributeValues(t, ex.yearIncreaseSelector, 'tabindex', '-1');
+  await assertAttributeValues(t, ex.yearDecreaseSelector, 'tabindex', '-1');
+});
+
+ariaTest('"aria-label" provides accessible name for the previous and next buttons to screen reader users', exampleFile, 'button-aria-label', async (t) => {
+  await assertAttributeValues(t, ex.dayIncreaseSelector, 'aria-label', 'next day');
+  await assertAttributeValues(t, ex.dayDecreaseSelector, 'aria-label', 'previous day');
+
+  await assertAttributeValues(t, ex.monthIncreaseSelector, 'aria-label', 'next month');
+  await assertAttributeValues(t, ex.monthDecreaseSelector, 'aria-label', 'previous month');
+
+  await assertAttributeValues(t, ex.yearIncreaseSelector, 'aria-label', 'next year');
+  await assertAttributeValues(t, ex.yearDecreaseSelector, 'aria-label', 'previous year');
+});
+
+ariaTest('"aria-hidden" hides decorative and redundant content form screen reader users', exampleFile, 'spinbutton-aria-hidden', async (t) => {
+  await assertAttributeValues(t, ex.dayHiddenPreviousSelector, 'aria-hidden', 'true');
+  await assertAttributeValues(t, ex.dayHiddenNextSelector, 'aria-hidden', 'true');
+
+  await assertAttributeValues(t, ex.monthHiddenPreviousSelector, 'aria-hidden', 'true');
+  await assertAttributeValues(t, ex.monthHiddenNextSelector, 'aria-hidden', 'true');
+
+  await assertAttributeValues(t, ex.yearHiddenPreviousSelector, 'aria-hidden', 'true');
+  await assertAttributeValues(t, ex.yearHiddenNextSelector, 'aria-hidden', 'true');
+});
+
+
+// keys 
+
+ariaTest('up arrow on day', exampleFile, 'spinbutton-up-arrow', async (t) => {
+  let control = parseInt(ex.dayNow);
+  let daysInMonth = parseInt(ex.dayMax);
+
+  // Send up arrow to day date spinner
+  let daySpinner = await t.context.session.findElement(By.css(ex.daySelector));
+  await daySpinner.sendKeys(Key.ARROW_UP);
+
+  // Add a day to the control
+  control = (control + 1) % daysInMonth;
+
+  t.is(
+    parseInt(await daySpinner.getText()),
+    control,
+    "After sending 1 up arrow to the day spinner, the day should be: " + control
+  );
+
+
+  // Send up arrow 30 more times to date spinner
+  for (let i = 1; i <= 30; i++) {
+    await daySpinner.sendKeys(Key.ARROW_UP);
   }
-);
 
-ariaTest(
-  '"aria-labelledby" attribute on group',
-  exampleFile,
-  'group-aria-labelledby',
-  async (t) => {
-    await assertAriaLabelledby(t, ex.groupSelector);
+  // Add 30 days to the control
+  control = (control + 30) % daysInMonth;
+
+  t.is(
+    parseInt(await daySpinner.getText()),
+    control,
+    "After sending 31 up arrows to the day spinner, the day should be: " + control
+  );
+});
+
+ariaTest('down arrow on day', exampleFile, 'spinbutton-down-arrow', async (t) => {
+  let control = parseInt(ex.dayNow);
+  let daysInMonth = parseInt(ex.dayMax);
+
+  // Send down arrow to day date spinner
+  let daySpinner = await t.context.session.findElement(By.css(ex.daySelector));
+  await daySpinner.sendKeys(Key.ARROW_DOWN);
+
+  // Subract a day to the control
+  control = (control - 1) % daysInMonth;
+
+  t.is(
+    parseInt(await daySpinner.getText()),
+    control,
+    "After sending 1 down arrow to the day spinner, the day should be: " + control
+  );
+
+  // Send down arrow 30 more times to date spinner
+  for (let i = 1; i <= 30; i++) {
+    await daySpinner.sendKeys(Key.ARROW_DOWN);
   }
-);
 
-ariaTest(
-  'role="spinbutton" on div element',
-  exampleFile,
-  'spinbutton-role',
-  async (t) => {
-    await assertAriaRoles(t, 'example', 'spinbutton', '3', 'div');
+  // Subtract 30 days to the control
+  control = daysInMonth + ((control - 30) % daysInMonth);
+
+  t.is(
+    parseInt(await daySpinner.getText()),
+    control,
+    "After sending 31 down arrows to the day spinner, the day should be: " + control
+  );
+});
+
+
+ariaTest('up arrow on month', exampleFile, 'spinbutton-up-arrow', async (t) => {
+  let control = parseInt(ex.monthNow) + 1;
+
+  // Send up arrow to day date spinner
+  let monthSpinner = await t.context.session.findElement(By.css(ex.monthSelector));
+  await monthSpinner.sendKeys(Key.ARROW_UP);
+
+  // Add a month to the control
+  control = (control + 1) % 12;
+
+  t.is(
+    await monthSpinner.getText(),
+    valuesMonth[control - 1],
+    "After sending 1 up arrow to the month spinner, the month should be: " + valuesMonth[control - 1]
+  );
+
+
+  // Send up arrow 30 more times to date spinner
+  for (let i = 1; i <= 30; i++) {
+    await monthSpinner.sendKeys(Key.ARROW_UP);
   }
-);
 
-ariaTest(
-  '"aria-valuemax" represents the minimum value on spinbuttons',
-  exampleFile,
-  'spinbutton-aria-valuemax',
-  async (t) => {
-    await assertAttributeValues(t, ex.daySelector, 'aria-valuemax', ex.dayMax);
-    await assertAttributeValues(
-      t,
-      ex.monthSelector,
-      'aria-valuemax',
-      ex.monthMax
-    );
-    await assertAttributeValues(
-      t,
-      ex.yearSelector,
-      'aria-valuemax',
-      ex.yearMax
-    );
+  // Add 30 months to the control
+  control = (control + 30) % 12;
+
+  t.is(
+    await monthSpinner.getText(),
+    valuesMonth[control - 1],
+    "After sending 31 up arrows to the month spinner, the month should be: " + valuesMonth[control - 1]
+  );
+});
+
+ariaTest('down arrow on month', exampleFile, 'spinbutton-down-arrow', async (t) => {
+  let control = parseInt(ex.monthNow) + 1;
+
+  // Send down arrow to month date spinner
+  let monthSpinner = await t.context.session.findElement(By.css(ex.monthSelector));
+  await monthSpinner.sendKeys(Key.ARROW_DOWN);
+
+  // Subract a month to the control
+  control = (control - 1) % 12;
+
+  t.is(
+    await monthSpinner.getText(),
+    valuesMonth[control - 1],
+    "After sending 1 down arrow to the month spinner, the month should be: " + valuesMonth[control - 1]
+  );
+
+  // Send down arrow 30 more times to date spinner
+  for (let i = 1; i <= 30; i++) {
+    await monthSpinner.sendKeys(Key.ARROW_DOWN);
   }
-);
 
-ariaTest(
-  '"aria-valuemin" represents the maximum value on spinbuttons',
-  exampleFile,
-  'spinbutton-aria-valuemin',
-  async (t) => {
-    await assertAttributeValues(t, ex.daySelector, 'aria-valuemin', ex.dayMin);
-    await assertAttributeValues(
-      t,
-      ex.monthSelector,
-      'aria-valuemin',
-      ex.monthMin
-    );
-    await assertAttributeValues(
-      t,
-      ex.yearSelector,
-      'aria-valuemin',
-      ex.yearMin
-    );
+  // Subtract 30 months to the control
+  control = 12 + ((control - 30) % 12);
+
+  t.is(
+    await monthSpinner.getText(),
+    valuesMonth[control - 1],
+    "After sending 31 down arrows to the month spinner, the month should be: " + valuesMonth[control - 1]
+  );
+});
+
+ariaTest('up arrow on year', exampleFile, 'spinbutton-up-arrow', async (t) => {
+
+  // Send up arrow to day date spinner
+  let yearSpinner = await t.context.session.findElement(By.css(ex.yearSelector));
+  await yearSpinner.sendKeys(Key.ARROW_UP);
+
+  let nextYear = (parseInt(ex.yearNow) + 1).toString();
+
+  t.is(
+    await yearSpinner.getText(),
+    nextYear,
+    "After sending 1 up arrow to the year spinner, the year should be: " + nextYear
+  );
+
+  let manyYears = parseInt(ex.yearMax) - parseInt(ex.yearNow);
+  for (let i = 1; i <= manyYears; i++) {
+    await yearSpinner.sendKeys(Key.ARROW_UP);
   }
-);
 
-ariaTest(
-  '"aria-valuenow" reflects spinbutton value as a number',
-  exampleFile,
-  'spinbutton-aria-valuenow',
-  async (t) => {
-    await assertAttributeValues(t, ex.daySelector, 'aria-valuenow', ex.dayNow);
-    await assertAttributeValues(
-      t,
-      ex.monthSelector,
-      'aria-valuenow',
-      ex.monthNow
-    );
-    await assertAttributeValues(
-      t,
-      ex.yearSelector,
-      'aria-valuenow',
-      ex.yearNow
-    );
+  t.is(
+    await yearSpinner.getText(),
+    ex.yearMax,
+    "After sending " + (manyYears + 1) + " up arrows to the year spinner, the year should be: " + ex.yearMax
+  );
+});
+
+ariaTest('down arrow on year', exampleFile, 'spinbutton-down-arrow', async (t) => {
+
+  // Send down arrow to year date spinner
+  let yearSpinner = await t.context.session.findElement(By.css(ex.yearSelector));
+  await yearSpinner.sendKeys(Key.ARROW_DOWN);
+
+  // Subract a year to the control
+  let lastYear = (parseInt(ex.yearNow) - 1).toString();
+
+  t.is(
+    await yearSpinner.getText(),
+    lastYear,
+    "After sending 1 down arrow to the year spinner, the year should be: " + lastYear
+  );
+
+  let manyYears = parseInt(ex.yearNow) - parseInt(ex.yearMin);
+  for (let i = 1; i <= manyYears; i++) {
+    await yearSpinner.sendKeys(Key.ARROW_DOWN);
   }
-);
 
-ariaTest(
-  '"aria-valuetext" reflects spin button value as a text string',
-  exampleFile,
-  'spinbutton-aria-valuetext',
-  async (t) => {
-    await assertAttributeValues(
-      t,
-      ex.daySelector,
-      'aria-valuetext',
-      ex.dayText
-    );
-    await assertAttributeValues(
-      t,
-      ex.monthSelector,
-      'aria-valuetext',
-      ex.monthText
-    );
+  t.is(
+    await yearSpinner.getText(),
+    ex.yearMin,
+    "After sending " + manyYears + " down arrows to the year spinner, the year should be: " + ex.yearMin
+  );
+});
+
+ariaTest.failing('page up on day', exampleFile, 'spinbutton-page-up', async (t) => {
+  let control = parseInt(ex.dayNow);
+  let daysInMonth = parseInt(ex.dayMax);
+
+  // Send page up to day date spinner
+  let daySpinner = await t.context.session.findElement(By.css(ex.daySelector));
+  await daySpinner.sendKeys(Key.PAGE_UP);
+
+  // Add a day to the control
+  control = (control + 5) % daysInMonth;
+
+  t.is(
+    parseInt(await daySpinner.getText()),
+    control,
+    "After sending 1 page up to the day spinner, the day should be: " + control
+  );
+
+
+  // Send page up 5 more times to date spinner
+  for (let i = 1; i <= 5; i++) {
+    await daySpinner.sendKeys(Key.PAGE_UP);
   }
-);
 
-ariaTest(
-  '"aria-label" provides accessible name for the spin buttons to screen reader users',
-  exampleFile,
-  'spinbutton-aria-label',
-  async (t) => {
-    await assertAttributeValues(t, ex.daySelector, 'aria-label', 'Day');
-    await assertAttributeValues(t, ex.monthSelector, 'aria-label', 'Month');
-    await assertAttributeValues(t, ex.yearSelector, 'aria-label', 'Year');
+  // Add 25 days to the control
+  control = (control + 25) % daysInMonth;
+
+  t.is(
+    parseInt(await daySpinner.getText()),
+    control,
+    "After sending 6 page ups to the day spinner, the day should be: " + control
+  );
+});
+
+ariaTest('page down on day', exampleFile, 'spinbutton-page-down', async (t) => {
+  let control = parseInt(ex.dayNow);
+  let daysInMonth = parseInt(ex.dayMax);
+
+  // Send page down to day date spinner
+  let daySpinner = await t.context.session.findElement(By.css(ex.daySelector));
+  await daySpinner.sendKeys(Key.PAGE_DOWN);
+
+  // Subract a day to the control
+  control = (control - 5) % daysInMonth;
+
+  t.is(
+    parseInt(await daySpinner.getText()),
+    control,
+    "After sending 1 page down to the day spinner, the day should be: " + control
+  );
+
+  // Send page down 5 more times to date spinner
+  for (let i = 1; i <= 5; i++) {
+    await daySpinner.sendKeys(Key.PAGE_DOWN);
   }
-);
 
-ariaTest(
-  '"tabindex=-1" removes previous and next from the tab order of the page',
-  exampleFile,
-  'button-tabindex',
-  async (t) => {
-    await assertAttributeValues(t, ex.dayIncreaseSelector, 'tabindex', '-1');
-    await assertAttributeValues(t, ex.dayDecreaseSelector, 'tabindex', '-1');
+  // Subtract 15 days to the control
+  control = daysInMonth + ((control - 25) % daysInMonth);
 
-    await assertAttributeValues(t, ex.monthIncreaseSelector, 'tabindex', '-1');
-    await assertAttributeValues(t, ex.monthDecreaseSelector, 'tabindex', '-1');
+  t.is(
+    parseInt(await daySpinner.getText()),
+    control,
+    "After sending 6 page downs to the day spinner, the day should be: " + control
+  );
+});
 
-    await assertAttributeValues(t, ex.yearIncreaseSelector, 'tabindex', '-1');
-    await assertAttributeValues(t, ex.yearDecreaseSelector, 'tabindex', '-1');
+ariaTest.failing('page up on month', exampleFile, 'spinbutton-page-up', async (t) => {
+  let control = parseInt(ex.monthNow) + 1;
+
+  // Send page up to day date spinner
+  let monthSpinner = await t.context.session.findElement(By.css(ex.monthSelector));
+  await monthSpinner.sendKeys(Key.PAGE_UP);
+
+  // Add 5 month to the control
+  control = (control + 5) % 12;
+
+  t.is(
+    await monthSpinner.getText(),
+    valuesMonth[control - 1],
+    "After sending 1 page up to the month spinner, the month should be: " + valuesMonth[control - 1]
+  );
+
+
+  // Send page up 2 more times to date spinner
+  for (let i = 1; i <= 2; i++) {
+    await monthSpinner.sendKeys(Key.PAGE_UP);
   }
-);
 
-ariaTest(
-  '"aria-label" provides accessible name for the previous and next buttons to screen reader users',
-  exampleFile,
-  'button-aria-label',
-  async (t) => {
-    await assertAttributeValues(
-      t,
-      ex.dayIncreaseSelector,
-      'aria-label',
-      'next day'
-    );
-    await assertAttributeValues(
-      t,
-      ex.dayDecreaseSelector,
-      'aria-label',
-      'previous day'
-    );
+  // Add 10 months to the control
+  control = (control + 10) % 12;
 
-    await assertAttributeValues(
-      t,
-      ex.monthIncreaseSelector,
-      'aria-label',
-      'next month'
-    );
-    await assertAttributeValues(
-      t,
-      ex.monthDecreaseSelector,
-      'aria-label',
-      'previous month'
-    );
+  t.is(
+    await monthSpinner.getText(),
+    valuesMonth[control - 1],
+    "After sending 3 page ups to the month spinner, the month should be: " + valuesMonth[control - 1]
+  );
+});
 
-    await assertAttributeValues(
-      t,
-      ex.yearIncreaseSelector,
-      'aria-label',
-      'next year'
-    );
-    await assertAttributeValues(
-      t,
-      ex.yearDecreaseSelector,
-      'aria-label',
-      'previous year'
-    );
+ariaTest.failing('page down on month', exampleFile, 'spinbutton-page-down', async (t) => {
+  let control = parseInt(ex.monthNow) + 1;
+
+  // Send page down to month date spinner
+  let monthSpinner = await t.context.session.findElement(By.css(ex.monthSelector));
+  await monthSpinner.sendKeys(Key.PAGE_DOWN);
+
+  // Subract 5 month to the control
+  control = (control - 5) % 12;
+
+  t.is(
+    await monthSpinner.getText(),
+    valuesMonth[control - 1],
+    "After sending 1 page down to the month spinner, the month should be: " + valuesMonth[control - 1]
+  );
+
+  // Send page down 2 more times to date spinner
+  for (let i = 1; i <= 2; i++) {
+    await monthSpinner.sendKeys(Key.PAGE_DOWN);
   }
-);
 
-ariaTest(
-  '"aria-hidden" hides decorative and redundant content form screen reader users',
-  exampleFile,
-  'spinbutton-aria-hidden',
-  async (t) => {
-    await assertAttributeValues(
-      t,
-      ex.dayHiddenPreviousSelector,
-      'aria-hidden',
-      'true'
-    );
-    await assertAttributeValues(
-      t,
-      ex.dayHiddenNextSelector,
-      'aria-hidden',
-      'true'
-    );
+  // Subtract 30 months to the control
+  control = 12 + ((control - 10) % 12);
 
-    await assertAttributeValues(
-      t,
-      ex.monthHiddenPreviousSelector,
-      'aria-hidden',
-      'true'
-    );
-    await assertAttributeValues(
-      t,
-      ex.monthHiddenNextSelector,
-      'aria-hidden',
-      'true'
-    );
+  t.is(
+    await monthSpinner.getText(),
+    valuesMonth[control - 1],
+    "After sending 3 page downs to the month spinner, the month should be: " + valuesMonth[control - 1]
+  );
+});
 
-    await assertAttributeValues(
-      t,
-      ex.yearHiddenPreviousSelector,
-      'aria-hidden',
-      'true'
-    );
-    await assertAttributeValues(
-      t,
-      ex.yearHiddenNextSelector,
-      'aria-hidden',
-      'true'
-    );
+
+ariaTest('page up on year', exampleFile, 'spinbutton-page-up', async (t) => {
+
+  // Send page up to day date spinner
+  let yearSpinner = await t.context.session.findElement(By.css(ex.yearSelector));
+  await yearSpinner.sendKeys(Key.PAGE_UP);
+
+  let nextYear = (parseInt(ex.yearNow) + 5).toString();
+
+  t.is(
+    await yearSpinner.getText(),
+    nextYear,
+    "After sending 1 page up to the year spinner, the year should be: " + nextYear
+  );
+
+  let manyYears = Math.ceil((parseInt(ex.yearMax) - parseInt(ex.yearNow)) / 5);
+  for (let i = 1; i <= manyYears; i++) {
+    await yearSpinner.sendKeys(Key.PAGE_UP);
   }
-);
+
+  t.is(
+    await yearSpinner.getText(),
+    ex.yearMax,
+    "After sending " + (manyYears + 1) + " page ups to the year spinner, the year should be: " + ex.yearMax
+  );
+});
+
+ariaTest('down arrow on year', exampleFile, 'spinbutton-page-down', async (t) => {
+
+  // Send down arrow to year date spinner
+  let yearSpinner = await t.context.session.findElement(By.css(ex.yearSelector));
+  await yearSpinner.sendKeys(Key.PAGE_UP);
+  await yearSpinner.sendKeys(Key.PAGE_DOWN);
+
+  t.is(
+    await yearSpinner.getText(),
+    ex.yearNow,
+    "After sending 1 up arrow, then 1 down arrow to the year spinner, the year should be: " + ex.yearNow
+  );
+
+  let manyYears = Math.ceil((parseInt(ex.yearNow) - parseInt(ex.yearMin)) / 5);
+  for (let i = 1; i <= manyYears; i++) {
+    await yearSpinner.sendKeys(Key.PAGE_DOWN);
+  }
+
+  t.is(
+    await yearSpinner.getText(),
+    ex.yearMin,
+    "After sending " + manyYears + " down arrows to the year spinner, the year should be: " + ex.yearMin
+  );
+});
+
+ariaTest('home on day', exampleFile, 'spinbutton-home', async (t) => {
+  // Send home to day date spinner
+  let daySpinner = await t.context.session.findElement(By.css(ex.daySelector));
+  await daySpinner.sendKeys(Key.HOME);
+
+  t.is(
+    await daySpinner.getText(),
+    "1",
+    "After sending home to the day spinner, the day should be: 1"
+  );
+
+});
+
+ariaTest('end on day', exampleFile, 'spinbutton-end', async (t) => {
+  // Send home to day date spinner
+  let daySpinner = await t.context.session.findElement(By.css(ex.daySelector));
+  await daySpinner.sendKeys(Key.END);
+
+  t.is(
+    await daySpinner.getText(),
+    ex.dayMax,
+    "After sending end to the day spinner, the day should be: " + ex.dayMax
+  );
+});
+
+ariaTest('home on month', exampleFile, 'spinbutton-home', async (t) => {
+  // Send home to month date spinner
+  let monthSpinner = await t.context.session.findElement(By.css(ex.monthSelector));
+  await monthSpinner.sendKeys(Key.HOME);
+
+  t.is(
+    await monthSpinner.getText(),
+    "January",
+    "After sending home to the month spinner, the month should be: January"
+  );
+
+});
+
+ariaTest('end on month', exampleFile, 'spinbutton-end', async (t) => {
+  // Send home to month date spinner
+  let monthSpinner = await t.context.session.findElement(By.css(ex.monthSelector));
+  await monthSpinner.sendKeys(Key.END);
+
+  t.is(
+    await monthSpinner.getText(),
+    "December",
+    "After sending end to the month spinner, the month should be: December"
+  );
+});
+
+ariaTest('home on year', exampleFile, 'spinbutton-home', async (t) => {
+  // Send home to year date spinner
+  let yearSpinner = await t.context.session.findElement(By.css(ex.yearSelector));
+  await yearSpinner.sendKeys(Key.HOME);
+
+  t.is(
+    await yearSpinner.getText(),
+    ex.yearMin,
+    "After sending home to the year spinner, the year should be: " +  ex.yearMin
+  );
+
+});
+
+ariaTest('end on year', exampleFile, 'spinbutton-end', async (t) => {
+  // Send home to year date spinner
+  let yearSpinner = await t.context.session.findElement(By.css(ex.yearSelector));
+  await yearSpinner.sendKeys(Key.END);
+
+  t.is(
+    await yearSpinner.getText(),
+    ex.yearMax,
+    "After sending end to the year spinner, the year should be: " + ex.yearMax
+  );
+});

--- a/test/util/assertDotValue.js
+++ b/test/util/assertDotValue.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const { By } = require('selenium-webdriver');
+const assert = require('assert');
+
+/**
+ * Confirm the dot value value of an element in javascript (testing the IDL Interface)
+ *
+ * @param {obj} t                  - ava execution object
+ * @param {String} elementSelector - a selector that returns one element
+ * @param {String} attr            - the attribute to access by javascript dot notation
+ * @param {String} value           - the value of the attribute
+ */
+
+module.exports = async function assertDotValue (t, elementSelector, attr, value) {
+
+    let valueOfAttr = await t.context.session.executeScript(async function () {
+      const [selector, attr, value] = arguments;
+      let el = document.querySelector(selector);
+      return el[attr];
+    }, elementSelector, attr, value);
+
+    assert.equal(
+      valueOfAttr,
+      value,
+      'attribute `' + attr + '` with value `' + value + '` should be found on javascript node returned by: ' + elementSelector
+    );
+
+    t.pass();
+};

--- a/test/util/assertDotValue.js
+++ b/test/util/assertDotValue.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { By } = require('selenium-webdriver');
 const assert = require('assert');
 
@@ -12,19 +10,33 @@ const assert = require('assert');
  * @param {String} value           - the value of the attribute
  */
 
-module.exports = async function assertDotValue (t, elementSelector, attr, value) {
-
-    let valueOfAttr = await t.context.session.executeScript(async function () {
+module.exports = async function assertDotValue(
+  t,
+  elementSelector,
+  attr,
+  value
+) {
+  let valueOfAttr = await t.context.session.executeScript(
+    async function () {
       const [selector, attr, value] = arguments;
       let el = document.querySelector(selector);
       return el[attr];
-    }, elementSelector, attr, value);
+    },
+    elementSelector,
+    attr,
+    value
+  );
 
-    assert.equal(
-      valueOfAttr,
-      value,
-      'attribute `' + attr + '` with value `' + value + '` should be found on javascript node returned by: ' + elementSelector
-    );
+  assert.equal(
+    valueOfAttr,
+    value,
+    'attribute `' +
+      attr +
+      '` with value `' +
+      value +
+      '` should be found on javascript node returned by: ' +
+      elementSelector
+  );
 
-    t.pass();
+  t.pass();
 };


### PR DESCRIPTION
https://github.com/w3c/aria-practices/issues/1378

This PR adds tests for: 
- [the button idl example](https://w3c.github.io/aria-practices/examples/button/button_idl.html)
- Fixes some references in the combobox grid text file
- Adds some missing tests for the rest of the combobox tests
- Adds the missing keyboard interaction tests to the spin button date picker