### PR TITLE
Fix 2 spelling errors caught by CSpell during travis build

### DIFF
--- a/examples/combobox/combobox-datepicker.html
+++ b/examples/combobox/combobox-datepicker.html
@@ -497,7 +497,7 @@
             <th scope="row"><code>aria-controls="IDREF"</code></th>
             <td><code>input</code></td>
             <td>
-              Identifies the element controled by the combobox.
+              Identifies the element controlled by the combobox.
             </td>
           </tr>
           <tr data-test-id="textbox-aria-describedby">
@@ -505,7 +505,7 @@
             <th scope="row"><code>aria-describedby="IDREF"</code></th>
             <td><code>input</code></td>
             <td>
-              Identifies the element that provides an accessible description for the combobox, enableing assistive technologies to associate the date format description with the input.
+              Identifies the element that provides an accessible description for the combobox, enabling assistive technologies to associate the date format description with the input.
             </td>
           </tr>
         </tbody>


### PR DESCRIPTION
- controled -> controlled
- enableing -> enabling

This little PR was created without a fork. Just making sure everything works ok. :)

This fixes the [failing build](https://travis-ci.com/github/carmacleod/aria-practices/jobs/361077898) for [PR #1432 Select-only Combobox Example: Add Accessibility Features section](https://github.com/w3c/aria-practices/pull/1432).

Not sure why CSpell didn't catch these before [PR #1413](https://github.com/w3c/aria-practices/pull/1413) was merged? Almost looks like Travis didn't run CSpell that day?