### PR TITLE
utils.js: Recognize file inputs as focusable elements

### DIFF
--- a/examples/js/utils.js
+++ b/examples/js/utils.js
@@ -76,7 +76,7 @@ aria.Utils.isFocusable = function (element) {
     case 'A':
       return !!element.href && element.rel != 'ignore';
     case 'INPUT':
-      return element.type != 'hidden' && element.type != 'file';
+      return element.type != 'hidden';
     case 'BUTTON':
     case 'SELECT':
     case 'TEXTAREA':


### PR DESCRIPTION
Made from #1418  by @MartijnCuppens 

Could not merge #1418 directly because it is from a patch. Replacing with this PR.