### PR TITLE
Fix broken links in menubar examples

### DIFF
--- a/examples/menubar/menubar-editor.html
+++ b/examples/menubar/menubar-editor.html
@@ -29,17 +29,17 @@
 <body>
   <nav aria-label="Related Links" class="feedback">
     <ul>
-      <li><a href="../../../#browser_and_AT_support">Browser and Assistive Technology Support</a></li>
+      <li><a href="../../#browser_and_AT_support">Browser and Assistive Technology Support</a></li>
       <li><a href="https://github.com/w3c/aria-practices/issues/new">Report Issue</a></li>
       <li><a href="https://github.com/w3c/aria-practices/projects/5">Related Issues</a></li>
-      <li><a href="../../../#menu">Design Pattern</a></li>
+      <li><a href="../../#menu">Design Pattern</a></li>
     </ul>
   </nav>
   <main>
   <h1>Editor Menubar Example</h1>
   <p>
     The following example demonstrates using the
-    <a href="../../../#menu">menubar design pattern</a>
+    <a href="../../#menu">menubar design pattern</a>
     to provide access to sets of actions.
     Each item in the below menubar identifies a category of text formatting actions that can be executed from its submenu.
     The submenus also demonstrate <code>menuitemradio</code> and <code>menuitemcheckbox</code> elements.
@@ -371,7 +371,7 @@
             <td>
               <ul>
                 <li>Identifies the element as a <code>menubar</code> container for a set of <code>menuitem</code> elements.</li>
-                <li>Is not focusable because focus is managed using <a href="../../../#kbd_roving_tabindex">roving tabindex.</a></li>
+                <li>Is not focusable because focus is managed using <a href="../../#kbd_roving_tabindex">roving tabindex.</a></li>
               </ul>
             </td>
           </tr>
@@ -443,7 +443,7 @@
                   When the page loads, the first item in the menubar has <code>tabindex=&quot;0&quot;</code>.
                 </li>
                 <li>
-                  Focus is managed using <a href="../../../#kbd_roving_tabindex">roving tabindex</a>.
+                  Focus is managed using <a href="../../#kbd_roving_tabindex">roving tabindex</a>.
                 </li>
               </ul>
             </td>
@@ -504,7 +504,7 @@
           <td>
             <ul>
               <li>Identifies the element as a menu container for a set of menu items.</li>
-              <li>Is not focusable because focus is managed using <a href="../../../#kbd_roving_tabindex">roving tabindex.</a></li>
+              <li>Is not focusable because focus is managed using <a href="../../#kbd_roving_tabindex">roving tabindex.</a></li>
             </ul>
           </td>
         </tr>
@@ -815,7 +815,7 @@ sourceCode.make();
   </section>
   </main>
   <nav>
-    <a href="../../../#menu">Menu or Menubar Design Pattern in WAI-ARIA Authoring Practices 1.2</a>
+    <a href="../../#menu">Menu or Menubar Design Pattern in WAI-ARIA Authoring Practices 1.2</a>
   </nav>
 
 </body>

--- a/examples/menubar/menubar-navigation.html
+++ b/examples/menubar/menubar-navigation.html
@@ -424,7 +424,7 @@
           <td>
             <ul>
               <li>Identifies the element as a <code>menubar</code> container for a set of <code>menuitem</code> elements.</li>
-              <li>Is not focusable because focus is managed using <a href="../../../#kbd_roving_tabindex">roving tabindex.</a></li>
+              <li>Is not focusable because focus is managed using <a href="../../#kbd_roving_tabindex">roving tabindex.</a></li>
             </ul>
           </td>
         </tr>
@@ -487,7 +487,7 @@
               <li>Includes the element in the <kbd>Tab</kbd> sequence.</li>
               <li>Only one menubar item has <code>tabindex=&quot;0&quot;</code>.</li>
               <li>On page load, the first menubar item has <code>tabindex=&quot;0&quot;</code>.</li>
-              <li>Focus is managed using <a href="../../../#kbd_roving_tabindex">roving tabindex</a>.</li>
+              <li>Focus is managed using <a href="../../#kbd_roving_tabindex">roving tabindex</a>.</li>
             </ul>
           </td>
         </tr>


### PR DESCRIPTION
- removes ../ that is no longer needed after refactoring
- fixes 7 broken links in application menubar example
- fixes 2 broken links in navigation menubar example

(Note that this is a stand-alone PR - there is no linked issue)