### PR TITLE
Carousel Pattern: Add link to tabbed carousel example page

### DIFF
--- a/aria-practices.html
+++ b/aria-practices.html
@@ -510,7 +510,8 @@ Some JavaScript and CSS may not function correctly in Internet Explorer.
       <section class="notoc">
         <h4>Example</h4>
         <ul>
-          <li><a href="examples/carousel/carousel-1.html">Auto-Rotating Image Carousel Example:</a> A basic image carousel that demonstrates the accessibility features necessary for carousels that rotate automatically on page load.</li>
+          <li><a href="examples/carousel/carousel-1.html">Auto-Rotating Image Carousel with Buttons for Slide Control:</a> A basic image carousel that demonstrates the accessibility features necessary for carousels that rotate automatically on page load and also enables users to choose which slide is displayed with buttons for previous and next slide.</li>
+          <li><a href="examples/carousel/carousel-2-tablist.html">Auto-Rotating Image Carousel with Tabs for Slide Control:</a> An image carousel that demonstrates accessibility features necessary for carousels that rotate automatically on page load and also enables users to choose which slide is displayed with a set of tabs.</li>
         </ul>
       </section>
 

--- a/aria-practices.html
+++ b/aria-practices.html
@@ -509,9 +509,9 @@ Some JavaScript and CSS may not function correctly in Internet Explorer.
 
       <section class="notoc">
         <h4>Example</h4>
-        <p>
-          <a href="examples/carousel/carousel-1.html">Auto-Rotating Image Carousel Example:</a> A basic image carousel that demonstrates the accessibility features necessary for carousels that rotate automatically on page load.
-        </p>
+        <ul>
+          <li><a href="examples/carousel/carousel-1.html">Auto-Rotating Image Carousel Example:</a> A basic image carousel that demonstrates the accessibility features necessary for carousels that rotate automatically on page load.</li>
+        </ul>
       </section>
 
       <section class="notoc">

--- a/aria-practices.html
+++ b/aria-practices.html
@@ -508,7 +508,7 @@ Some JavaScript and CSS may not function correctly in Internet Explorer.
       </ul>
 
       <section class="notoc">
-        <h4>Example</h4>
+        <h4>Examples</h4>
         <ul>
           <li><a href="examples/carousel/carousel-1.html">Auto-Rotating Image Carousel with Buttons for Slide Control:</a> A basic image carousel that demonstrates the accessibility features necessary for carousels that rotate automatically on page load and also enables users to choose which slide is displayed with buttons for previous and next slide.</li>
           <li><a href="examples/carousel/carousel-2-tablist.html">Auto-Rotating Image Carousel with Tabs for Slide Control:</a> An image carousel that demonstrates accessibility features necessary for carousels that rotate automatically on page load and also enables users to choose which slide is displayed with a set of tabs.</li>

--- a/examples/carousel/carousel-2-tablist.html
+++ b/examples/carousel/carousel-2-tablist.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <title>Auto-Rotating Image Carousel with a Tablist Example | WAI-ARIA Authoring Practices 1.2</title>
+    <title>Auto-Rotating Image Carousel with Tabs for Slide Controls Example | WAI-ARIA Authoring Practices 1.2</title>
 
     <!--  Core js and css shared by all examples; do not modify when using this template. -->
     <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/base.css">
@@ -25,7 +25,7 @@
       </ul>
     </nav>
     <main>
-      <h1>Auto-Rotating Image Carousel with a Tablist Example</h1>
+      <h1>Auto-Rotating Image Carousel with Tabs for Slide Controls Example</h1>
       <p>
         The following example implementation of the
         <a href="../../#carousel">carousel design pattern</a>

--- a/examples/carousel/carousel-2-tablist.html
+++ b/examples/carousel/carousel-2-tablist.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <title>Auto-Rotating Image Carousel with Tabs for Slide Controls Example | WAI-ARIA Authoring Practices 1.2</title>
+    <title>Auto-Rotating Image Carousel with Tabs for Slide Control Example | WAI-ARIA Authoring Practices 1.2</title>
 
     <!--  Core js and css shared by all examples; do not modify when using this template. -->
     <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/base.css">
@@ -25,7 +25,7 @@
       </ul>
     </nav>
     <main>
-      <h1>Auto-Rotating Image Carousel with Tabs for Slide Controls Example</h1>
+      <h1>Auto-Rotating Image Carousel with Tabs for Slide Control Example</h1>
       <p>
         The following example implementation of the
         <a href="../../#carousel">carousel design pattern</a>
@@ -39,8 +39,7 @@
       </p>
       <p>Similar examples include:</p>
       <ul>
-        <li><a href="carousel-1-prev-next.html">Auto-Rotating Image Carousel with Previous and Next Buttons
-        Example:</a> A basic image carousel that demonstrates the accessibility features necessary for carousels that rotate automatically on page load.</li>
+        <li><a href="carousel-1.html">Auto-Rotating Image Carousel with Buttons for Slide Control:</a> A basic image carousel that demonstrates the accessibility features necessary for carousels that rotate automatically on page load and also enables users to choose which slide is displayed with buttons for previous and next slide.</li>
       </ul>
 
       <section>


### PR DESCRIPTION
In the examples subsection of the carousel pattern, adds a link to the carousel example that uses a tab set for slide control.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria-practices/pull/1489.html" title="Last updated on Aug 9, 2020, 10:25 PM UTC (68b054b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria-practices/1489/b1e4f2c...68b054b.html" title="Last updated on Aug 9, 2020, 10:25 PM UTC (68b054b)">Diff</a>