### PR TITLE
chore: Allow spellchecking to fail the build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,6 @@ jobs:
     - stage: Lint
       name: Spellcheck
       script: npm run lint:spelling
-      env: ALLOW_FAILURE=true
     - stage: Lint
       name: Regression Tests Coverage Report
       script: node test/util/report.js


### PR DESCRIPTION
This landed awhile ago with it being allowed to fail. I think it's been around awhile and the instances where is started to fail PRs were valid rather than false positives, so I think it's OK to enable this now to fail PRs