### PR TITLE
Create Dependabot config file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+- package-ecosystem: npm
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "10:00"
+  open-pull-requests-limit: 10
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "10:00"
+  open-pull-requests-limit: 10

--- a/.github/workflows/lint-css.yml
+++ b/.github/workflows/lint-css.yml
@@ -1,6 +1,8 @@
 name: CSS Linting
 on:
   push:
+    branches-ignore:
+      - "dependabot/**"
     paths:
       - "package*.json"
       - ".stylelint*"

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -11,6 +11,7 @@ on:
   push:
     branches-ignore:
       - master
+      - "dependabot/**"
     paths:
       - ".github/workflows/regression.yml"
       - "package*.json"


### PR DESCRIPTION
Since greenkeeper is shutdown, this will enable the native dependabot PRs to this repo for new version releases of the dependencies.

Closes #1368
Closes #1402
Closes #1382
Closes #1351