### PR TITLE
chore: Switch regression test to GitHub Actions

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -1,0 +1,56 @@
+name: Run regression tests
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/regression.yml"
+      - "package*.json"
+      - "test/**"
+      - "examples/**"
+      - "!examples/landmarks/**"
+  push:
+    branches-ignore:
+      - master
+    paths:
+      - ".github/workflows/regression.yml"
+      - "package*.json"
+      - "test/**"
+      - "examples/**"
+      - "!examples/landmarks/**"
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        CI_NODE_INDEX: [0, 1, 2, 3, 4]
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v1
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Run Ava on changed files in PR
+        run: ./scripts/regression-tests.sh
+        if: github.event_name == 'pull_request'
+        env:
+          COMMIT_RANGE: "origin/${{ github.base_ref }}...${{ github.sha }}"
+          CI_NODE_TOTAL: 5
+          CI_NODE_INDEX: ${{ matrix.CI_NODE_INDEX }}
+          TEST_WAIT_TIME: 10000
+
+      - name: Run Ava for changed files from origin branch
+        run: ./scripts/regression-tests.sh
+        if: github.event_name == 'push'
+        env:
+          COMMIT_RANGE: "origin/master...${{ github.ref }}"
+          CI_NODE_TOTAL: 5
+          CI_NODE_INDEX: ${{ matrix.CI_NODE_INDEX }}
+          TEST_WAIT_TIME: 10000

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ git:
 
 stages:
 - Lint
-- Test
 
 jobs:
   fast_finish: true
@@ -30,31 +29,3 @@ jobs:
       name: Regression Tests Coverage Report
       script: node test/util/report.js
       env: ALLOW_FAILURE=true
-
-    - stage: Test
-      name: AVA Regression Tests
-      addons:
-        firefox: latest
-      script: scripts/regression-tests.sh
-      env:
-        - TEST_WAIT_TIME=1000
-        - CI_NODE_TOTAL=3
-        - CI_NODE_INDEX=0
-    - stage: Test
-      name: AVA Regression Tests
-      addons:
-        firefox: latest
-      script: scripts/regression-tests.sh
-      env:
-        - TEST_WAIT_TIME=1000
-        - CI_NODE_TOTAL=3
-        - CI_NODE_INDEX=1
-    - stage: Test
-      name: AVA Regression Tests
-      addons:
-        firefox: latest
-      script: scripts/regression-tests.sh
-      env:
-        - TEST_WAIT_TIME=1000
-        - CI_NODE_TOTAL=3
-        - CI_NODE_INDEX=2

--- a/scripts/regression-tests.sh
+++ b/scripts/regression-tests.sh
@@ -4,18 +4,6 @@ if [[ "$CI" != "true" ]]
 then
   # When running this script locally, compare the current branch to master
   COMMIT_RANGE="..master"
-
-elif [[ "$TRAVIS_PULL_REQUEST" != "false" ]]
-then
-  # If we are on a PR build, we can use TRAVIS_COMMIT_RANGE
-  COMMIT_RANGE=$TRAVIS_COMMIT_RANGE
-
-else
-  # If we are on a branch build, and it has been force pushed, then TRAVIS_PULL_REQUEST will
-  # not contain useful information for the branch build.
-  COMMIT_RANGE="origin/master...$TRAVIS_BRANCH"
-  git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
-  git fetch origin master
 fi
 
 AVACMD="npm run regression -- -t"


### PR DESCRIPTION
I played around with keeping the parallel job splitting by using letter ranges in a separate branch, but found that this was the most straightforward.
This uses @spectranaut script for limiting the runs to changed files, and adds the GitHub Action path filtering so the job is also only triggered if those files are touched.

@spectranaut should the full suite run on merges to the main branch?