### PR TITLE
chore: Trigger regression for lock file changes

### DIFF
--- a/scripts/regression-tests.sh
+++ b/scripts/regression-tests.sh
@@ -27,7 +27,7 @@ TEST_INFRA=$(git diff --name-only $COMMIT_RANGE | grep -oP 'test/(util|index)')
 EXAMPLE_DIRS=$(git diff --name-only $COMMIT_RANGE | grep -oP 'examples/\K[\w-]+(?=/)' | uniq)
 EXAMPLE_INFRA=$(echo "$EXAMPLE_DIRS" | grep -P '^(js|css)$')
 
-PACKAGE_UPDATE=$(git diff --name-only $COMMIT_RANGE | grep -P '(package\.json)')
+PACKAGE_UPDATE=$(git diff --name-only $COMMIT_RANGE | grep -P 'package(-lock)?\.json')
 
 if [[ $TEST_INFRA || $EXAMPLE_INFRA || $PACKAGE_UPDATE ]]
 then


### PR DESCRIPTION
I thing usually when dependencies are updated it includes both package and the lock file, but I've seen some security Dependabot updates that only update the lockfile to fix security issues. This will then trigger the regression tests to make sure lockfile only changes don't regress anything.