### PR TITLE
Infrastructure: Move Regression coverage to PR comment

### DIFF
--- a/.github/workflows/coverage-report.yml
+++ b/.github/workflows/coverage-report.yml
@@ -1,0 +1,60 @@
+name: Regression Tests Coverage Report
+
+on:
+  pull_request_target:
+    paths:
+    - "examples/**"
+    - "test/**"
+    - "!examples/landmarks/**"
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/head
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run coverage report
+        run: |
+          node test/util/report.js >> coverage.log || true
+
+      - name: Comment on PR
+        uses: actions/github-script@0.9.0
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            const fs = require('fs');
+            const commentBody = '```' + fs.readFileSync('coverage.log', 'utf8') + '```';
+
+            if (commentBody.length === 0) {
+              return
+            }
+            // Get the existing comments.
+            const {data: comments} = await github.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.number,
+            })
+            // Find any comment already made by the bot.
+            const botComment = comments.find(comment => comment.user.id === 41898282)
+
+            if (botComment) {
+              await github.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id,
+                body: commentBody
+              })
+            } else {
+              await github.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.number,
+                body: commentBody
+              })
+            }

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,3 @@ jobs:
       name: Spellcheck
       script: npm run lint:spelling
       env: ALLOW_FAILURE=true
-    - stage: Lint
-      name: Regression Tests Coverage Report
-      script: node test/util/report.js
-      env: ALLOW_FAILURE=true


### PR DESCRIPTION
Currently this is a job that is allowed to fail on Travis CI. This moves it to an action that will leave a comment on the PR if any of the regression related files are changed. Additional pushes will update the same comment instead of continuing to create new ones on the PR.
~~I'm set it so it also runs when the CI config file is touched so you'll see it on this PR~~, but wouldn't on a PR that doesn't touch anything in the `examples` or `test` folder.