### PR TITLE
Infrastructure: Convert spellcheck to GitHub Action

### DIFF
--- a/.github/workflows/cspell-problem-matcher.json
+++ b/.github/workflows/cspell-problem-matcher.json
@@ -1,0 +1,16 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "cspell",
+      "pattern": [
+        {
+          "regexp": "^(.*):(\\d+):(\\d+)\\s+\\-\\s+(.*)$",
+          "file": 1,
+          "line": 2,
+          "column": 3,
+          "message": 4
+        }
+      ]
+    }
+  ]
+}

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -1,0 +1,39 @@
+name: Spellcheck
+
+on:
+  push:
+    paths:
+      - "package*.json"
+      - "cspell.json"
+      - "aria-practices.html"
+      - "examples/**/*.html"
+      - ".github/workflows/cspell-problem-matcher.json"
+      - ".github/workflows/spelling.yml"
+
+  pull_request:
+    paths:
+      - "package*.json"
+      - "cspell.json"
+      - "aria-practices.html"
+      - "examples/**/*.html"
+      - ".github/workflows/cspell-problem-matcher.json"
+      - ".github/workflows/spelling.yml"
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v2.1.1
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: cSpell
+        run: |
+          echo "::add-matcher::.github/workflows/cspell-problem-matcher.json"
+          npm run lint:spelling

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,15 +10,8 @@ stages:
 - Lint
 
 jobs:
-  fast_finish: true
-  allow_failures:
-    - env: ALLOW_FAILURE=true
 
   include:
     - stage: Lint
       name: HTML Linting
       script: npm run vnu-jar
-    - stage: Lint
-      name: Spellcheck
-      script: npm run lint:spelling
-      env: ALLOW_FAILURE=true


### PR DESCRIPTION
Runs the spellchecking only if the `aria-practices.html` or HTML files in the `example` directory. Add a problem matcher so that comments are left on the lines with spelling issues in PRs and pushes.
The main change that this swap brings, is that GitHub Actions don't have the concept of "allowed failures", so these will be blocking failures.

Closes #1497