### PR TITLE
Listbox Example with Grouped Options: Apply aria-hidden to option group label

### DIFF
--- a/examples/listbox/listbox-grouped.html
+++ b/examples/listbox/listbox-grouped.html
@@ -46,7 +46,7 @@
           <span id="ss_elem" class="listbox-label">Choose your animal sidekick</span>
           <div id="ss_elem_list" tabindex="0" role="listbox" aria-labelledby="ss_elem">
             <ul role="group" aria-labelledby="cat1">
-              <li role="presentation" id="cat1">Land</li>
+              <li aria-hidden="true" id="cat1">Land</li>
               <li id="ss_elem_1" role="option">Cat</li>
               <li id="ss_elem_2" role="option">Dog</li>
               <li id="ss_elem_3" role="option">Tiger</li>
@@ -54,13 +54,13 @@
               <li id="ss_elem_5" role="option">Raccoon</li>
             </ul>
             <ul role="group" aria-labelledby="cat2">
-              <li role="presentation" id="cat2">Water</li>
+              <li aria-hidden="true" id="cat2">Water</li>
               <li id="ss_elem_6" role="option">Dolphin</li>
               <li id="ss_elem_7" role="option">Flounder</li>
               <li id="ss_elem_8" role="option">Eel</li>
             </ul>
             <ul role="group" aria-labelledby="cat3">
-              <li role="presentation" id="cat3">Air</li>
+              <li aria-hidden="true" id="cat3">Air</li>
               <li id="ss_elem_9" role="option">Falcon</li>
               <li id="ss_elem_10" role="option">Winged Horse</li>
               <li id="ss_elem_11" role="option">Owl</li>


### PR DESCRIPTION
This ensures that the label of a group in a listbox is not counted / identified by AT as also being a member of the group. Putting role="presentation" on the li just means the li will be ignored by AT, but not its children. The text node instead ends up as a member of the group.

#### Preview link

[View proposed changes using RawGitHack](https://raw.githack.com/WilcoFiers/aria-practices/patch-1/examples/listbox/listbox-grouped.html)