### PR TITLE
Fix links to Carousel Example with Buttons for Slide Control

### DIFF
--- a/aria-practices.html
+++ b/aria-practices.html
@@ -510,7 +510,7 @@ Some JavaScript and CSS may not function correctly in Internet Explorer.
       <section class="notoc">
         <h4>Examples</h4>
         <ul>
-          <li><a href="examples/carousel/carousel-1.html">Auto-Rotating Image Carousel with Buttons for Slide Control:</a> A basic image carousel that demonstrates the accessibility features necessary for carousels that rotate automatically on page load and also enables users to choose which slide is displayed with buttons for previous and next slide.</li>
+          <li><a href="examples/carousel/carousel-1-prev-next.html">Auto-Rotating Image Carousel with Buttons for Slide Control:</a> A basic image carousel that demonstrates the accessibility features necessary for carousels that rotate automatically on page load and also enables users to choose which slide is displayed with buttons for previous and next slide.</li>
           <li><a href="examples/carousel/carousel-2-tablist.html">Auto-Rotating Image Carousel with Tabs for Slide Control:</a> An image carousel that demonstrates accessibility features necessary for carousels that rotate automatically on page load and also enables users to choose which slide is displayed with a set of tabs.</li>
         </ul>
       </section>

--- a/examples/carousel/carousel-2-tablist.html
+++ b/examples/carousel/carousel-2-tablist.html
@@ -39,7 +39,7 @@
       </p>
       <p>Similar examples include:</p>
       <ul>
-        <li><a href="carousel-1.html">Auto-Rotating Image Carousel with Buttons for Slide Control:</a> A basic image carousel that demonstrates the accessibility features necessary for carousels that rotate automatically on page load and also enables users to choose which slide is displayed with buttons for previous and next slide.</li>
+        <li><a href="carousel-1-prev-next.html">Auto-Rotating Image Carousel with Buttons for Slide Control:</a> A basic image carousel that demonstrates the accessibility features necessary for carousels that rotate automatically on page load and also enables users to choose which slide is displayed with buttons for previous and next slide.</li>
       </ul>
 
       <section>


### PR DESCRIPTION
I  just notice the link to [the first carousel example](https://w3c.github.io/aria-practices/#carousel) is broken in master:


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria-practices/pull/1530.html" title="Last updated on Sep 30, 2020, 5:36 PM UTC (671f5dd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria-practices/1530/9d19d94...671f5dd.html" title="Last updated on Sep 30, 2020, 5:36 PM UTC (671f5dd)">Diff</a>