### PR TITLE
fix: Broken CSS links and anchor tags

### DIFF
--- a/aria-practices.html
+++ b/aria-practices.html
@@ -995,7 +995,7 @@ Some JavaScript and CSS may not function correctly in Internet Explorer.
               <li>In either case, focus is visually distinct from selection so users can readily see if a value is selected or not.</li>
             </ul>
         </li>
-          <li>If nodes in the tree are arranged horizontally (<a href="aria-orientation" class="property-reference">aria-orientation</a> is set to <code>horizontal</code>):
+          <li>If nodes in the tree are arranged horizontally (<a href="#aria-orientation" class="property-reference">aria-orientation</a> is set to <code>horizontal</code>):
             <ol>
               <li><kbd>Down Arrow</kbd> performs as <kbd>Right Arrow</kbd> is described above, and vice versa.</li>
               <li><kbd>Up Arrow</kbd> performs as <kbd>Left Arrow</kbd> is described above, and vice versa.</li>
@@ -4809,7 +4809,7 @@ So, As advised by <a href="#naming_rule_avoid_fallback">Rule 4: Avoid Browser Fa
                 <ul>
                   <li>Helps screen reader users understand the context and purpose of the search landmark.</li>
                   <li>Named using <code>aria-labelledby</code> if a visible label is present, otherwise with <code>aria-label</code>.</li>
-                  <li>See the <a href="aria_lh_search">Search Landmark</a> section.</li>
+                  <li>See the <a href="#aria_lh_search">Search Landmark</a> section.</li>
                 </ul>
               </td>
             </tr>

--- a/examples/combobox/grid-combo.html
+++ b/examples/combobox/grid-combo.html
@@ -380,7 +380,7 @@
     <section>
       <h2>Javascript and CSS Source Code</h2>
       <ul>
-        <li> CSS: <a href="css/combobox.css" type="tex/css">combobox.css</a></li>
+        <li> CSS: <a href="css/grid-combo.css" type="tex/css">grid-combo.css</a></li>
         <li>Javascript: <a href="js/grid-combo.js">grid-combo.js</a>, <a href="js/grid-combo-example.js">grid-combo-example.js</a>, <a href="../js/utils.js">utils.js</a></li>
       </ul>
     </section>

--- a/examples/menubar/mb-about.html
+++ b/examples/menubar/mb-about.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <title>Menubar Example Landing Page: About</title>
-    <link href="../../css/core.css" rel="stylesheet">
+    <link href="../css/core.css" rel="stylesheet">
 
 </head>
 

--- a/examples/menubar/mb-academics.html
+++ b/examples/menubar/mb-academics.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <title>Menubar Example Landing Page: Academics</title>
-    <link href="../../css/core.css" rel="stylesheet">
+    <link href="../css/core.css" rel="stylesheet">
 
 </head>
 

--- a/examples/menubar/mb-admissions.html
+++ b/examples/menubar/mb-admissions.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <title>Menubar Example Landing Page: Admissions</title>
-    <link href="../../css/core.css" rel="stylesheet">
+    <link href="../css/core.css" rel="stylesheet">
 
 </head>
 

--- a/examples/radio/radio-activedescendant.html
+++ b/examples/radio/radio-activedescendant.html
@@ -261,7 +261,7 @@
       <section>
         <h2>Javascript and CSS Source Code</h2>
         <ul>
-            <li>CSS: <a href="../css/radio.css" type="tex/css">radio.css</a></li>
+            <li>CSS: <a href="css/radio.css" type="tex/css">radio.css</a></li>
             <li>Javascript: <a href="js/radio-activedescendant.js" type="text/javascript">radio-activedescendant.js</a></li>
         </ul>
       </section>


### PR DESCRIPTION
Was tring to figure out a link checker solution. Didn't find anything yet, but one did flag thesee (along with the ones @spectranaut is fixing in #1530)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/nschonni/aria-practices/pull/1535.html" title="Last updated on Sep 29, 2020, 3:19 PM UTC (556247b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria-practices/1535/2233e5c...nschonni:556247b.html" title="Last updated on Sep 29, 2020, 3:19 PM UTC (556247b)">Diff</a>