### PR TITLE
Infrastructure: Disable push builds for Dependabot

### DIFF
--- a/.github/workflows/lint-js.yml
+++ b/.github/workflows/lint-js.yml
@@ -1,6 +1,8 @@
 name: JavaScript Linting
 on:
   push:
+    branches-ignore:
+      - "dependabot/**"
     paths:
       - "package*.json"
       - ".eslint*"

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -2,6 +2,8 @@ name: Spellcheck
 
 on:
   push:
+    branches-ignore:
+      - "dependabot/**"
     paths:
       - "package*.json"
       - "cspell.json"


### PR DESCRIPTION

They get run as part of the PRs submited and avoids a double build