### PR TITLE
Accessible Name Guidance by Role Section: Change marquee name from required to discretionary

### DIFF
--- a/aria-practices.html
+++ b/aria-practices.html
@@ -4586,7 +4586,7 @@ So, As advised by <a href="#naming_rule_avoid_fallback">Rule 4: Avoid Browser Fa
             </tr>
             <tr>
               <td><a href="#marquee" class="role-reference"><code>marquee</code></a></td>
-              <td>Required</td>
+              <td>Discretionary</td>
               <td>Use <code>aria-labelledby</code> if a visible label is present, otherwise use <code>aria-label</code>.</td>
             </tr>
             <tr>


### PR DESCRIPTION
Related to https://github.com/w3c/aria/issues/1339 and https://github.com/w3c/aria/pull/1342 on the ARIA repo.

I chose "discretionary" to match the guidance for log.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria-practices/pull/1572.html" title="Last updated on Oct 23, 2020, 4:35 AM UTC (ee56d0f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria-practices/1572/c2ee25e...ee56d0f.html" title="Last updated on Oct 23, 2020, 4:35 AM UTC (ee56d0f)">Diff</a>