### PR TITLE
Changes tests to not follow external links

### DIFF
--- a/test/tests/link_link.js
+++ b/test/tests/link_link.js
@@ -103,18 +103,24 @@ ariaTest(
       let linkLocator = By.css(ex.linkSelector);
       let linkElement = await t.context.session.findElement(linkLocator);
 
-      await linkElement.sendKeys(Key.ENTER);
-      await t.context.session
-        .wait(() => {
-          return t.context.session.getCurrentUrl().then((url) => {
-            return url != t.context.url;
-          });
-        }, t.context.waitTime)
-        .catch(() => {});
+      // Update url to remove external reference for dependable testing
+      const newUrl = t.context.url + '#test-url-change';
+      await t.context.session.executeScript(
+        function () {
+          let [selector, newUrl] = arguments;
+          document.querySelector(selector).onkeydown = function () {
+            goToLink(event, newUrl);
+          };
+        },
+        ex.linkSelector,
+        newUrl
+      );
 
-      t.not(
+      await linkElement.sendKeys(Key.ENTER);
+
+      t.is(
         await t.context.session.getCurrentUrl(),
-        t.context.url,
+        newUrl,
         'ENTER key on element with selector "' +
           ex.linkSelector +
           '" should activate link.'

--- a/test/tests/link_link.js
+++ b/test/tests/link_link.js
@@ -108,7 +108,7 @@ ariaTest(
       await t.context.session.executeScript(
         function () {
           let [selector, newUrl] = arguments;
-          document.querySelector(selector).onkeydown = function () {
+          document.querySelector(selector).onkeydown = function (event) {
             goToLink(event, newUrl);
           };
         },

--- a/test/tests/menu-button_links.js
+++ b/test/tests/menu-button_links.js
@@ -4,6 +4,7 @@ const assertAttributeValues = require('../util/assertAttributeValues');
 const assertAriaLabelledby = require('../util/assertAriaLabelledby');
 const assertAriaControls = require('../util/assertAriaControls');
 const assertAriaRoles = require('../util/assertAriaRoles');
+const replaceExternalLink = require('../util/replaceExternalLink');
 
 const exampleFile = 'menu-button/menu-button-links.html';
 
@@ -260,15 +261,7 @@ ariaTest('"enter" on role="menuitem"', exampleFile, 'menu-enter', async (t) => {
 
     // Update url to remove external reference for dependable testing
     const newUrl = t.context.url + '#test-url-change';
-    await t.context.session.executeScript(
-      function () {
-        let [selector, index, newUrl] = arguments;
-        document.querySelectorAll(selector)[index].href = newUrl;
-      },
-      ex.menuitemSelector,
-      index,
-      newUrl
-    );
+    await replaceExternalLink(t, newUrl, ex.menuitemSelector, index);
 
     await openMenu(t);
     await item.sendKeys(Key.ENTER);

--- a/test/tests/treeview_treeview-2a.js
+++ b/test/tests/treeview_treeview-2a.js
@@ -272,21 +272,24 @@ ariaTest(
     // Assert that the attribute value "aria-expanded" on all folders is "true"
     await assertAttributeValues(t, ex.folderSelector, 'aria-expanded', 'true');
 
+    // Update url to remove external reference for dependable testing
+    const newUrl = t.context.url + '#test-url-change';
+    await t.context.session.executeScript(
+      function () {
+        let [selector, newUrl] = arguments;
+        document.querySelectorAll(selector)[0].href = newUrl;
+      },
+      ex.linkSelector,
+      newUrl
+    );
+
     // Test a leaf node
     let leafnodes = await t.context.queryElements(t, ex.linkSelector);
     await leafnodes[0].sendKeys(Key.ENTER);
 
-    await t.context.session
-      .wait(() => {
-        return t.context.session.getCurrentUrl().then((url) => {
-          return url != t.context.url;
-        });
-      }, t.context.waitTime)
-      .catch(() => {});
-
-    t.not(
+    t.is(
       await t.context.session.getCurrentUrl(),
-      t.context.url,
+      newUrl,
       'ENTER key on first element found by selector "' +
         ex.linkSelector +
         '" should activate link.'
@@ -311,21 +314,24 @@ ariaTest.failing(
     // Assert that the attribute value "aria-expanded" on all folders is "true"
     await assertAttributeValues(t, ex.folderSelector, 'aria-expanded', 'true');
 
+    // Update url to remove external reference for dependable testing
+    const newUrl = t.context.url + '#test-url-change';
+    await t.context.session.executeScript(
+      function () {
+        let [selector, newUrl] = arguments;
+        document.querySelectorAll(selector)[0].href = newUrl;
+      },
+      ex.linkSelector,
+      newUrl
+    );
+
     // Test a leaf node
     let leafnodes = await t.context.queryElements(t, ex.linkSelector);
     await leafnodes[0].sendKeys(Key.SPACE);
 
-    await t.context.session
-      .wait(() => {
-        return t.context.session.getCurrentUrl().then((url) => {
-          return url != t.context.url;
-        });
-      }, t.context.waitTime)
-      .catch(() => {});
-
-    t.not(
+    t.is(
       await t.context.session.getCurrentUrl(),
-      t.context.url,
+      newUrl,
       'SPACE key on first element found by selector "' +
         ex.linkSelector +
         '" should activate link.'

--- a/test/tests/treeview_treeview-2a.js
+++ b/test/tests/treeview_treeview-2a.js
@@ -3,6 +3,7 @@ const { Key } = require('selenium-webdriver');
 const assertAttributeValues = require('../util/assertAttributeValues');
 const assertAriaLabelledby = require('../util/assertAriaLabelledby');
 const assertRovingTabindex = require('../util/assertRovingTabindex');
+const replaceExternalLink = require('../util/replaceExternalLink');
 
 const exampleFile = 'treeview/treeview-2/treeview-2a.html';
 
@@ -274,14 +275,7 @@ ariaTest(
 
     // Update url to remove external reference for dependable testing
     const newUrl = t.context.url + '#test-url-change';
-    await t.context.session.executeScript(
-      function () {
-        let [selector, newUrl] = arguments;
-        document.querySelectorAll(selector)[0].href = newUrl;
-      },
-      ex.linkSelector,
-      newUrl
-    );
+    await replaceExternalLink(t, newUrl, ex.linkSelector, 0);
 
     // Test a leaf node
     let leafnodes = await t.context.queryElements(t, ex.linkSelector);
@@ -316,14 +310,7 @@ ariaTest.failing(
 
     // Update url to remove external reference for dependable testing
     const newUrl = t.context.url + '#test-url-change';
-    await t.context.session.executeScript(
-      function () {
-        let [selector, newUrl] = arguments;
-        document.querySelectorAll(selector)[0].href = newUrl;
-      },
-      ex.linkSelector,
-      newUrl
-    );
+    await replaceExternalLink(t, newUrl, ex.linkSelector, 0);
 
     // Test a leaf node
     let leafnodes = await t.context.queryElements(t, ex.linkSelector);

--- a/test/tests/treeview_treeview-2b.js
+++ b/test/tests/treeview_treeview-2b.js
@@ -439,21 +439,24 @@ ariaTest(
     // Assert that the attribute value "aria-expanded" on all folders is "true"
     await assertAttributeValues(t, ex.folderSelector, 'aria-expanded', 'true');
 
+    // Update url to remove external reference for dependable testing
+    const newUrl = t.context.url + '#test-url-change';
+    await t.context.session.executeScript(
+      function () {
+        let [selector, newUrl] = arguments;
+        document.querySelectorAll(selector)[0].href = newUrl;
+      },
+      ex.linkSelector,
+      newUrl
+    );
+
     // Test a leaf node
     let leafnodes = await t.context.queryElements(t, ex.linkSelector);
     await leafnodes[0].sendKeys(Key.ENTER);
 
-    await t.context.session
-      .wait(() => {
-        return t.context.session.getCurrentUrl().then((url) => {
-          return url != t.context.url;
-        });
-      }, t.context.waitTime)
-      .catch(() => {});
-
-    t.not(
+    t.is(
       await t.context.session.getCurrentUrl(),
-      t.context.url,
+      newUrl,
       'ENTER key on first element found by selector "' +
         ex.linkSelector +
         '" should activate link.'
@@ -470,7 +473,7 @@ ariaTest.failing(
     let folders = await t.context.queryElements(t, ex.folderSelector);
 
     // Going through all closed folder elements in dom order will open parent
-    // folders first, therefore all child folders will be visible before sending "enter"
+    // folders first, therefore all child folders will be visible before sending "space"
     for (let folder of folders) {
       await folder.sendKeys(Key.SPACE);
     }
@@ -478,21 +481,24 @@ ariaTest.failing(
     // Assert that the attribute value "aria-expanded" on all folders is "true"
     await assertAttributeValues(t, ex.folderSelector, 'aria-expanded', 'true');
 
+    // Update url to remove external reference for dependable testing
+    const newUrl = t.context.url + '#test-url-change';
+    await t.context.session.executeScript(
+      function () {
+        let [selector, newUrl] = arguments;
+        document.querySelectorAll(selector)[0].href = newUrl;
+      },
+      ex.linkSelector,
+      newUrl
+    );
+
     // Test a leaf node
     let leafnodes = await t.context.queryElements(t, ex.linkSelector);
     await leafnodes[0].sendKeys(Key.SPACE);
 
-    await t.context.session
-      .wait(() => {
-        return t.context.session.getCurrentUrl().then((url) => {
-          return url != t.context.url;
-        });
-      }, t.context.waitTime)
-      .catch(() => {});
-
-    t.not(
+    t.is(
       await t.context.session.getCurrentUrl(),
-      t.context.url,
+      newUrl,
       'SPACE key on first element found by selector "' +
         ex.linkSelector +
         '" should activate link.'

--- a/test/tests/treeview_treeview-2b.js
+++ b/test/tests/treeview_treeview-2b.js
@@ -3,6 +3,7 @@ const { By, Key } = require('selenium-webdriver');
 const assertAttributeValues = require('../util/assertAttributeValues');
 const assertAriaLabelledby = require('../util/assertAriaLabelledby');
 const assertRovingTabindex = require('../util/assertRovingTabindex');
+const replaceExternalLink = require('../util/replaceExternalLink');
 
 const exampleFile = 'treeview/treeview-2/treeview-2b.html';
 
@@ -441,14 +442,7 @@ ariaTest(
 
     // Update url to remove external reference for dependable testing
     const newUrl = t.context.url + '#test-url-change';
-    await t.context.session.executeScript(
-      function () {
-        let [selector, newUrl] = arguments;
-        document.querySelectorAll(selector)[0].href = newUrl;
-      },
-      ex.linkSelector,
-      newUrl
-    );
+    await replaceExternalLink(t, newUrl, ex.linkSelector, 0);
 
     // Test a leaf node
     let leafnodes = await t.context.queryElements(t, ex.linkSelector);
@@ -483,14 +477,7 @@ ariaTest.failing(
 
     // Update url to remove external reference for dependable testing
     const newUrl = t.context.url + '#test-url-change';
-    await t.context.session.executeScript(
-      function () {
-        let [selector, newUrl] = arguments;
-        document.querySelectorAll(selector)[0].href = newUrl;
-      },
-      ex.linkSelector,
-      newUrl
-    );
+    await replaceExternalLink(t, newUrl, ex.linkSelector, 0);
 
     // Test a leaf node
     let leafnodes = await t.context.queryElements(t, ex.linkSelector);

--- a/test/util/replaceExternalLink.js
+++ b/test/util/replaceExternalLink.js
@@ -1,0 +1,26 @@
+/**
+ * Replace and href with an link -- typically use url fragement -- to test behavior related to link following
+ *
+ * @param {ExecutionContext} t - Test execution context
+ * @param {String} newUrl - the url to replace the external url
+ * @param {String} linkSelector - CSS selector string
+ * @param {Number} index - if the link selector returns a list, the index of the item to test
+ *
+ * @returns {Promise} Resolves to array of elements
+ */
+module.exports = async function replaceExternalLinks(
+  t,
+  newUrl,
+  linkSelector,
+  index
+) {
+  await t.context.session.executeScript(
+    function () {
+      let [selector, index, newUrl] = arguments;
+      document.querySelectorAll(selector)[index].href = newUrl;
+    },
+    linkSelector,
+    index || 0,
+    newUrl
+  );
+};


### PR DESCRIPTION
Fixes issue #1594

Following external links in tests to test key board interactions with links cause many time out related failures in github checks. I replace the four tests to replace the `href` on the dom element with a url fragment to test the keyboard behavior.