### PR TITLE
make filename in link text match href

### DIFF
--- a/examples/menu-button/menu-button-actions-active-descendant.html
+++ b/examples/menu-button/menu-button-actions-active-descendant.html
@@ -325,7 +325,7 @@
 
         <ul id="css_js_files">
           <li>CSS: <a href="css/menuButtonAction.css" type="text/css">MenubuttonAction.css</a></li>
-          <li>Javascript: <a href="js/Menubutton.js" type="text/javascript">Menubutton2.js</a></li>
+          <li>Javascript: <a href="js/Menubutton.js" type="text/javascript">Menubutton.js</a></li>
           <li>Javascript: <a href="js/MenuItemActionActivedescendant.js" type="text/javascript">MenuItemActionActivedescendant.js</a></li>
           <li>Javascript: <a href="js/PopupMenuActionActivedescendant.js" type="text/javascript">PopupMenuActionActivedescendant.js</a></li>
         </ul>


### PR DESCRIPTION
Code was changed to use `js/Menubutton.js` but link text in the "Javascript and CSS Source Code" section still said `Menubutton2.js`.
This PR just deletes the `2` in the link text's filename.