### PR TITLE
chore: Separate kbd cords for multiple key strokes

### DIFF
--- a/aria-practices-DeletedSectionsArchive.html
+++ b/aria-practices-DeletedSectionsArchive.html
@@ -184,7 +184,7 @@
                 <h4>Keyboard Interaction</h4>
                 <ul>
                     <li>With focus in an empty text box, press <kbd>Down Arrow</kbd>, <kbd>Up
-                            Arrow</kbd>, <kbd>Alt + Down Arrow</kbd>, or <kbd>Alt + Up Arrow</kbd> to
+                        Arrow</kbd>, <kbd>Alt</kbd> + <kbd>Arrow</kbd>, or <kbd>Alt</kbd> + <kbd>Up Arrow</kbd> to
                         display the entire list of choices. Focus remains in the text box and no
                         choice is highlighted.
                         <ul>
@@ -278,7 +278,7 @@
                                 <kbd>Escape</kbd> closes the drop down and leaves the typed text
                                 displayed in the text box. Need to consider if pressing <kbd>Escape</kbd>
                                 again should clear the typed text. The user must press the <kbd>Down</kbd>
-                                arrow or <kbd>Alt + Down</kbd> arrow or click the associated icon to
+                                arrow or <kbd>Alt</kbd> + <kbd>Down</kbd> arrow or click the associated icon to
                                 invoke the drop-down list of choices again.
                             </li>
                         </ul>
@@ -341,11 +341,11 @@
                 <ul>
                     <li><kbd>Left Arrow</kbd> or <kbd>Right Arrow</kbd> move the caret within
                         the edit field.</li>
-                    <li><kbd>Alt + Up/Down Arrow</kbd> opens and closes the list.</li>
+                    <li><kbd>Alt</kbd> + <kbd>Up</kbd>/<kbd>Down Arrow</kbd> opens and closes the list.</li>
                     <li><kbd>Up Arrow</kbd> and <kbd>Down Arrow</kbd> moves focus up and down
                         the list. As focus moves inside the dropdown list, the edit field is
                         updated.</li>
-                    <li><kbd>Page Up / Page Down</kbd> selects the next/previous pages item
+                    <li><kbd>Page Up</kbd> / <kbd>Page Down</kbd> selects the next/previous pages item
                         depending on the lists size.</li>
                     <li><kbd>Escape</kbd> closes the dropdown list, returns focus to the edit
                         field, and does not change the current selection.</li>
@@ -536,7 +536,7 @@
                 Focus initially is placed on today's date.
               </li>
               <li>
-                <kbd>Shift + Tab</kbd> - reverses the direction of the tab order.
+                <kbd>Shift</kbd> + <kbd>Tab</kbd> - reverses the direction of the tab order.
                 Once in the widget, a Shift+Tab will take the user to the previous focusable element in the tab order.
               </li>
               <li>
@@ -547,8 +547,8 @@
                 <kbd>Left Arrow</kbd> and <kbd>Right Arrow</kbd> - advances one day to the next, also in a continuum.
                 Visually focus is moved from day to day and wraps from row to row in a grid of days and weeks.
               </li>
-              <li><kbd>Control + Page Up</kbd> - Moves to the same date in the previous year.</li>
-              <li><kbd>Control + Page Down</kbd> - Moves to the same date in the next year.</li>
+              <li><kbd>Control</kbd> + <kbd>Page Up</kbd> - Moves to the same date in the previous year.</li>
+              <li><kbd>Control</kbd> + <kbd>Page Down</kbd> - Moves to the same date in the next year.</li>
               <li>
                 <kbd>Space</kbd> -
                 <ul>
@@ -556,7 +556,7 @@
                   <li>
                     Contiguous Mode: Similar to selecting a range of text.
                     <kbd>Space</kbd> selects the first date.
-                    <kbd>Shift + Arrow</kbd>s add to the selection.
+                    <kbd>Shift</kbd> + <kbd>Arrow</kbd>s add to the selection.
                     Pressing <kbd>Space</kbd> again deselects the previous selections and selects the current focused date.
                   </li>
                 </ul>
@@ -678,9 +678,9 @@
         <ul>
           <li><kbd>Escape</kbd> The tooltip dialog is closed by pressing the escape key when focus is within the dialog, mouse clicking on a close icon, or mouse clicking outside of the dialog onto the application.</li>
           <li><kbd>Tab</kbd> Focus must be held within the dialog until it is cancelled or submitted. As the user presses tab to move within items in the dialog, pressing tab with focus on the last focusable item in the dialog will move focus back to the first focusable item in the dialog.</li>
-          <li><kbd>Shift + Tab</kbd> Likewise, if the user is shift-tabbing through elements in the dialog, pressing shift-tab with focus on the first focusable item in the dialog will move focus to the last item in the dialog.</li>
+          <li><kbd>Shift</kbd> + <kbd>Tab</kbd> Likewise, if the user is shift-tabbing through elements in the dialog, pressing shift-tab with focus on the first focusable item in the dialog will move focus to the last item in the dialog.</li>
         </ul>
-        <p class="note">It is modal because focus is trapped within the dialog as the user navigates via the <kbd>Tab</kbd> and <kbd>Shift + Tab</kbd> key.</p>
+        <p class="note">It is modal because focus is trapped within the dialog as the user navigates via the <kbd>Tab</kbd> and <kbd>Shift</kbd> + <kbd>Tab</kbd> key.</p>
         <p class="note">Unlike a true modal dialog, the user can click outside of the dialog, however in that case the tooltip dialog is immediately closed.</p>
         <p class="note">A tooltip dialog can not be moved/dragged.</p>
         <p class="note">Other than the close and move behavior, all other behaviors of a modal dialog are implemented by the tooltip dialog.</p>
@@ -735,7 +735,7 @@
       <section class="notoc">
         <h4>Keyboard Interaction</h4>
         <ul>
-          <li><kbd>Control + F1</kbd>
+          <li><kbd>Control</kbd> + <kbd>F1</kbd>
             <ul>
               <li>Posts the Popup Help widget. </li>
               <li>Input focus is placed on the first interactive element in the Popup Help. </li>
@@ -782,9 +782,9 @@
               </li>
             </ul>
           </li>
-          <li><kbd>Shift + Tab</kbd>
+          <li><kbd>Shift</kbd> + <kbd>Tab</kbd>
             <ul>
-              <li>As with other keyboard conventions described here, the <kbd>Shift + Tab</kbd> has the effect of moving the focus up rather than down and follows the same conventions as described for the modal and non-modal <kbd>Tab</kbd> key above. </li>
+              <li>As with other keyboard conventions described here, the <kbd>Shift</kbd> + <kbd>Tab</kbd> has the effect of moving the focus up rather than down and follows the same conventions as described for the modal and non-modal <kbd>Tab</kbd> key above. </li>
             </ul>
           </li>
           <li><kbd>Enter</kbd>
@@ -832,12 +832,12 @@
           <li>The edit control is provided by the browser; it provides the keyboard support for navigating, adding, removing and   selecting text, so that behavior is not defined by the rich internet application. </li>
           <li>The browser should also provide a keyboard mechanism   for navigating into and out of the edit control. Within most browsers the edit   control is put into the tab order of the page and can be navigated into, out of,   and through using the tab and shift-tab keys like any standard form control. </li>
           <li>A rich text editor widget needs to provide a user   interface for interacting with the browser provided edit control. Interaction   between the user interface and editor is defined here assuming that a toolbar is   used. </li>
-          <li><kbd>Tab</kbd> and <kbd>Shift + Tab</kbd> - If not provided by the browser, the rich   text editor widget provides a keyboard mechanism to move into and out of the   edit control. Tab and shift-tab are the recommended keystrokes. The toolbar or   other user interface component associated with the editor is placed in the tab   order immediately before the editor. To set an attribute on text within the edit   control the user sets focus into the edit control, moves the insertion point,   selects text and presses shift-tab to move focus from the editor back to the   toolbar. The user navigates through the toolbar (see toolbar behavior) to a   desired attribute and invokes that attribute. When an attribute is invoked, that   attribute is applied to the selected text in the editor and focus moves back   into the editor at the previous insertion point with the selection intact. </li>
+          <li><kbd>Tab</kbd> and <kbd>Shift</kbd> + <kbd>Tab</kbd> - If not provided by the browser, the rich   text editor widget provides a keyboard mechanism to move into and out of the   edit control. Tab and shift-tab are the recommended keystrokes. The toolbar or   other user interface component associated with the editor is placed in the tab   order immediately before the editor. To set an attribute on text within the edit   control the user sets focus into the edit control, moves the insertion point,   selects text and presses shift-tab to move focus from the editor back to the   toolbar. The user navigates through the toolbar (see toolbar behavior) to a   desired attribute and invokes that attribute. When an attribute is invoked, that   attribute is applied to the selected text in the editor and focus moves back   into the editor at the previous insertion point with the selection intact. </li>
           <li><strong>Options:</strong>
             <ul>
-              <li>Rather than using <kbd>Shift + Tab</kbd> to move focus from within the editor to the   toolbar, another key combination could be used (<kbd>Alt + Up Arrow</kbd>, <kbd>Control + Shift + Letter</kbd>,   etc.). This would eliminate the need to put the user interface control (in this   example a toolbar) into the tab order immediately before the editor component.   However, there are drawbacks to using a different keystroke to navigate to the   user interface:
+              <li>Rather than using <kbd>Shift</kbd> + <kbd>Tab</kbd> to move focus from within the editor to the   toolbar, another key combination could be used (<kbd>Alt</kbd> + <kbd>Up Arrow</kbd>, <kbd>Control</kbd> + <kbd>Shift</kbd> + <kbd>Letter</kbd>,   etc.). This would eliminate the need to put the user interface control (in this   example a toolbar) into the tab order immediately before the editor component.   However, there are drawbacks to using a different keystroke to navigate to the   user interface:
                 <ol>
-                    <li>It is not as &quot;discoverable&quot; as relying on the standard <kbd>Tab/Shift + Tab</kbd>   behavior; </li>
+                  <li>It is not as &quot;discoverable&quot; as relying on the standard <kbd>Tab/Shift</kbd> + <kbd>Tab</kbd> behavior; </li>
                   <li>It is difficult to find key combinations which are not already captured by   the browser or assistive technology. </li>
                   <li>Focus could stay within the toolbar after the user invokes an attribute. The   user would then have to press an additional key to move focus back into the   editor. This would allow multiple attributes to be set on the current selection   without having to return back to the user interface but it would add an extra   key sequence after setting just a single attribute. Requiring a keystroke to   move focus back into the editor would also require modifying the toolbar   behavior to intercept this keystroke and to know how to set focus back to the   component (the editor) that the toolbar is associated with. </li>
                 </ol>
@@ -848,8 +848,8 @@
 
         <p>Optionally, if the developer wishes to provide the   ability to insert a tab into the document, it is recommended one of the   following methods be used.            </p>
         <ul>
-          <li>Provide indent and outdent buttons in the menu. Keyboard shortcuts to the   buttons should be <kbd>Control + M</kbd> for indent and <kbd>Control + Shift + M</kbd> for outdent. </li>
-          <li>Provide a button in the menu to toggle the use of <kbd>Tab</kbd> between the two modes.   If this button is used, then <kbd>Control + M</kbd> is recommended as a   keyboard shortcut to toggle the button. </li>
+          <li>Provide indent and outdent buttons in the menu. Keyboard shortcuts to the   buttons should be <kbd>Control</kbd> + <kbd>M</kbd> for indent and <kbd>Control</kbd> + <kbd>Shift</kbd> + <kbd>M</kbd> for outdent. </li>
+          <li>Provide a button in the menu to toggle the use of <kbd>Tab</kbd> between the two modes.   If this button is used, then <kbd>Control</kbd> + <kbd>M</kbd> is recommended as a   keyboard shortcut to toggle the button. </li>
         </ul>
       </section>
 
@@ -1075,20 +1075,20 @@
                 <ul>
                   <li>The initial tab enters the grid with focus on the first cell of the first row, often a header. </li>
                   <li>Once in the grid a second tab moves out of the grid to the next tab stop. </li>
-                  <li>Once focus is established in the grid, a <kbd>Tab</kbd> into or a <kbd>Shift + Tab</kbd> into the   grid will return to the cell which last had focus. </li>
+                  <li>Once focus is established in the grid, a <kbd>Tab</kbd> into or a <kbd>Shift</kbd> + <kbd>Tab</kbd> into the   grid will return to the cell which last had focus. </li>
                 </ul>
               </li>
               <li><kbd>Left Arrow</kbd> and <kbd>Right Arrow</kbd> keys  navigate between columns. If the   next cell in the row is empty, focus should not move. </li>
               <li><kbd>Up Arrow</kbd> and <kbd>Down Arrow</kbd> The down arrow moves focus to the first column of a child row, if expanded. Otherwise focus is moved to the same column in the next row. Up arrow performs the same navigation but in reverse. </li>
-              <li><kbd>Control + Left</kbd> and <kbd>Control + Right Arrows</kbd> expand or collapse rows. </li>
+              <li><kbd>Control</kbd> + <kbd>Left</kbd> and <kbd>Control</kbd> + <kbd>Right Arrows</kbd> expand or collapse rows. </li>
               <li>If the cell contains an editable field, the <kbd>Enter</kbd> key starts edit mode and the <kbd>Escape</kbd> key exits edit mode. </li>
               <li>Selecting Cells
                 <ul>
-                  <li><kbd>Control + Space</kbd> selects the current column. </li>
-                  <li><kbd>Shift + Space</kbd> selects the current row. </li>
-                  <li><kbd>Control + A</kbd> selects the entire grid. </li>
-                  <li><kbd>Shift + Arrow</kbd> selects contiguous cells. </li>
-                  <li><kbd>Shift + F8</kbd> Allows additional cells to be added to a   previous selection to accomplish non-contiguous selection. </li>
+                  <li><kbd>Control</kbd> + <kbd>Space</kbd> selects the current column. </li>
+                  <li><kbd>Shift</kbd> + <kbd>Space</kbd> selects the current row. </li>
+                  <li><kbd>Control</kbd> + <kbd>A</kbd> selects the entire grid. </li>
+                  <li><kbd>Shift</kbd> + <kbd>Arrow</kbd> selects contiguous cells. </li>
+                  <li><kbd>Shift</kbd> + <kbd>F8</kbd> Allows additional cells to be added to a   previous selection to accomplish non-contiguous selection. </li>
                 </ul>
                   <p class="note">See <a href="#aria_ex_widget">Global Recommendations</a> for information on cut, copy and paste. </p>
               </li>
@@ -1107,7 +1107,7 @@
               <li><kbd>Enter</kbd> pressed while focus is on an actionable item will   enter Actionable Mode. Focus will remain on the actionable item that has focus. </li>
               <li>Optionally, alphanumeric keys pressed while focus is on an actionable item will enter Actionable Mode. Focus will remain on the actionable item that has focus. </li>
               <li><kbd>Tab</kbd> will move to the next actionable (tabbable) item in the   grid and stay within the grid wrapping at the bottom. In this mode each tabbable   object in each cell of the grid can be reached with the tab key. If multiple   tabbable items are located inside a single grid cell, the tab will stop at each   one. When the last tabbable item in a cell is reached the next tab will move to   the next tabbable item in the grid, wrapping at the last tabbable item in the   grid. </li>
-              <li><kbd>Shift + Tab</kbd> moves to the previous actionable (tabbable) item   in the grid and stays within the grid, wrapping at the top. </li>
+              <li><kbd>Shift</kbd> + <kbd>Tab</kbd> moves to the previous actionable (tabbable) item   in the grid and stays within the grid, wrapping at the top. </li>
               <li><kbd>Escape</kbd> exits Actionable mode (by which the user may enter text or perform an action to complete a operation) and returns to Navigation Mode (where the user is allowed to move focus among elements). If a widget is in the current grid cell that also uses the <kbd>Escape</kbd> key, then it should cancel the event propagation. A subsequent press of the <kbd>Escape</kbd> key will return focus to the parent widget.</li>
             </ul>
           </li>
@@ -1154,11 +1154,11 @@
           </li>
           <li>Method 3: Hot Keys
             <ul>
-              <li><kbd>Control + Alt + N</kbd> next, finish </li>
-              <li><kbd>Control + Alt + P</kbd> previous </li>
+              <li><kbd>Control</kbd> + <kbd>Alt</kbd> + <kbd>N</kbd> next, finish </li>
+              <li><kbd>Control</kbd> + <kbd>Alt</kbd> + <kbd>P</kbd> previous </li>
               <li><kbd>Escape</kbd> cancel, exit without saving </li>
-              <li><kbd>Control + Alt + R</kbd> reset current page to default settings </li>
-              <li><kbd>Control + Alt + S</kbd> save and exit </li>
+              <li><kbd>Control</kbd> + <kbd>Alt</kbd> + <kbd>R</kbd> reset current page to default settings </li>
+              <li><kbd>Control</kbd> + <kbd>Alt</kbd> + <kbd>S</kbd> save and exit </li>
               </ul>
           </li>
           <li>Method 4: Like a <a href="#dialog_nonmodal">Dialog</a> </li>
@@ -1887,7 +1887,7 @@ excommunication&lt;/dd&gt;
 
       <ul>
         <li>
-          If the keypress is a <kbd>Shift + Tab</kbd> key and the target == the first tab navigable object, then set focus to the last tab-navigable object and stop the key press event. If there is only a single tab focusable item, then focus does not have to be set, but the key press event must be stopped.
+          If the keypress is a <kbd>Shift</kbd> + <kbd>Tab</kbd> key and the target == the first tab navigable object, then set focus to the last tab-navigable object and stop the key press event. If there is only a single tab focusable item, then focus does not have to be set, but the key press event must be stopped.
         </li>
         <li>
           If the keypress is a <kbd>Tab</kbd> key and the target == the last tab navigable object, then set focus to the first tab-navigable object and stop the keypress event. If there is only a single tab-focusable item, then focus does not have to be set but the keypress event must be stopped.

--- a/aria-practices.html
+++ b/aria-practices.html
@@ -203,7 +203,7 @@ Some JavaScript and CSS may not function correctly in Internet Explorer.
             </ul>
           </li>
           <li><kbd>Tab</kbd>: Moves focus to the next focusable element; all focusable elements in the accordion are included in the page <kbd>Tab</kbd> sequence.</li>
-          <li><kbd>Shift + Tab</kbd>: Moves focus to the previous focusable element; all focusable elements in the accordion are included in the page <kbd>Tab</kbd> sequence.</li>
+          <li><kbd>Shift</kbd> + <kbd>Tab</kbd>: Moves focus to the previous focusable element; all focusable elements in the accordion are included in the page <kbd>Tab</kbd> sequence.</li>
           <li>
             <kbd>Down Arrow</kbd> (Optional): If focus is on an accordion header, moves focus to the next accordion header.
             If focus is on the last accordion header, either does nothing or moves focus to the first accordion header.
@@ -454,7 +454,7 @@ Some JavaScript and CSS may not function correctly in Internet Explorer.
                 If the button is activated with a shortcut key, the focus usually remains in
                 the context from which the shortcut key was activated. For example, if <kbd>Alt
                   + U</kbd> were assigned to an &quot;Up&quot; button that moves the currently focused
-                item in a list one position higher in the list, pressing <kbd>Alt + U</kbd> when the
+                item in a list one position higher in the list, pressing <kbd>Alt</kbd> + <kbd>U</kbd> when the
                 focus is in the list would not move the focus from the list.
               </li>
             </ul>
@@ -539,7 +539,7 @@ Some JavaScript and CSS may not function correctly in Internet Explorer.
             If the carousel has an auto-rotate feature, automatic slide rotation stops when any element in the carousel receives keyboard focus.
             It does not resume unless the user activates the rotation control.
           </li>
-          <li><kbd>Tab</kbd> and <kbd>Shift + Tab</kbd>: Move focus through the interactive elements of the carousel as specified by the page tab sequence -- scripting for <kbd>Tab</kbd> is not necessary.</li>
+          <li><kbd>Tab</kbd> and <kbd>Shift</kbd> + <kbd>Tab</kbd>: Move focus through the interactive elements of the carousel as specified by the page tab sequence -- scripting for <kbd>Tab</kbd> is not necessary.</li>
           <li>
             Button elements implement the keyboard interaction defined in the <a href="#button">button pattern</a>.
             Note: Activating the rotation control, next slide, and previous slide do not move focus, so users may easily repetitively activate them as many times as desired.
@@ -828,8 +828,8 @@ Some JavaScript and CSS may not function correctly in Internet Explorer.
             </ul>
           </li>
           <li>If the combobox is editable, it supports standard single line text editing keys appropriate for the device platform (see note below).</li>
-          <li><kbd>Alt + Down Arrow</kbd> (Optional): If the popup is available but not displayed, displays the popup without moving focus.</li>
-          <li><kbd>Alt + Up Arrow</kbd> (Optional): If the popup is displayed:
+          <li><kbd>Alt</kbd> + <kbd>Down Arrow</kbd> (Optional): If the popup is available but not displayed, displays the popup without moving focus.</li>
+          <li><kbd>Alt</kbd> + <kbd>Up Arrow</kbd> (Optional): If the popup is displayed:
             <ul>
               <li>If the popup contains focus, returns focus to the combobox.</li>
               <li>Closes the popup.</li>
@@ -921,8 +921,8 @@ Some JavaScript and CSS may not function correctly in Internet Explorer.
               <li>If the combobox is editable, returns focus to the combobox and places the cursor after the last character.</li>
             </ul>
           </li>
-          <li><kbd>Control + Home</kbd> (optional): moves focus to the first row.</li>
-          <li><kbd>Control + End</kbd> (Optional): moves focus to the last row.</li>
+          <li><kbd>Control</kbd> + <kbd>Home</kbd> (optional): moves focus to the first row.</li>
+          <li><kbd>Control</kbd> + <kbd>End</kbd> (Optional): moves focus to the last row.</li>
           <li>Any printable character: If the combobox is editable, returns the focus to the combobox without closing the popup and types the character.</li>
           <li><kbd>Backspace</kbd> (Optional): If the combobox is editable, returns focus to the combobox and deletes the character prior to the cursor.</li>
           <li><kbd>Delete</kbd> (Optional): If the combobox is editable, returns focus to the combobox, removes the selected state if a suggestion was selected, and removes the inline autocomplete string if present.</li>
@@ -1091,7 +1091,7 @@ Some JavaScript and CSS may not function correctly in Internet Explorer.
       </p>
       <p>
         Like non-modal dialogs, modal dialogs contain their tab sequence.
-        That is, <kbd>Tab</kbd> and <kbd>Shift + Tab</kbd> do not move focus outside the dialog.
+        That is, <kbd>Tab</kbd> and <kbd>Shift</kbd> + <kbd>Tab</kbd> do not move focus outside the dialog.
         However, unlike most non-modal dialogs, modal dialogs do not provide means for moving keyboard focus outside the dialog window without closing the dialog.
       </p>
       <p>
@@ -1119,7 +1119,7 @@ Some JavaScript and CSS may not function correctly in Internet Explorer.
               <li>If focus is on the last tabbable element inside the dialog, moves focus to the first tabbable element inside the dialog. </li>
             </ul>
           </li>
-          <li><kbd>Shift + Tab</kbd>:
+          <li><kbd>Shift</kbd> + <kbd>Tab</kbd>:
             <ul>
               <li>Moves focus to the previous tabbable element inside the dialog.</li>
               <li>If focus is on the first tabbable element inside the dialog, moves focus to the last tabbable element inside the dialog.</li>
@@ -1323,8 +1323,8 @@ Some JavaScript and CSS may not function correctly in Internet Explorer.
         <ul>
           <li><kbd>Page Down</kbd>: Move focus to next article.</li>
           <li><kbd>Page Up</kbd>: Move focus to previous article.</li>
-          <li><kbd>Control + End</kbd>: Move focus to the first focusable element after the feed.</li>
-          <li><kbd>Control + Home</kbd>: Move focus to the first focusable element before the feed.</li>
+          <li><kbd>Control</kbd> + <kbd>End</kbd>: Move focus to the first focusable element after the feed.</li>
+          <li><kbd>Control</kbd> + <kbd>Home</kbd>: Move focus to the first focusable element before the feed.</li>
         </ul>
         <ol class="note">
           <li>Due to the lack of convention, providing easily discoverable keyboard interface documentation is especially important.</li>
@@ -1338,8 +1338,8 @@ Some JavaScript and CSS may not function correctly in Internet Explorer.
                 Users move focus into the nested feed from the content of the containing article with <kbd>Tab</kbd>.
                 This may be slow if the article contains a significant number of links, buttons, or other widgets.
                </li>
-              <li>Provide a key for moving focus from the elements in the containing article to the first item in the nested feed, e.g., <kbd>Alt + Page Down</kbd>.</li>
-              <li>To continue reading the outer feed, <kbd>Control + End</kbd> moves focus to the next article in the outer feed.</li>
+              <li>Provide a key for moving focus from the elements in the containing article to the first item in the nested feed, e.g., <kbd>Alt</kbd> + <kbd>Page Down</kbd>.</li>
+              <li>To continue reading the outer feed, <kbd>Control</kbd> + <kbd>End</kbd> moves focus to the next article in the outer feed.</li>
             </ul>
           </li>
           <li>In the rare circumstance that a feed article contains a widget that uses the above suggested keys, the feed navigation key will operate the contained widget, and the user needs to move focus to an element that does not utilize the feed navigation keys in order to navigate the feed.</li>
@@ -1466,8 +1466,8 @@ Some JavaScript and CSS may not function correctly in Internet Explorer.
             <li><kbd>Page Up</kbd>: Moves focus up an author-determined number of rows, typically scrolling so the top row in the currently visible set of rows becomes one of the last visible rows. If focus is in the first row of the grid, focus does not move.</li>
             <li><kbd>Home</kbd>: moves focus to the first cell in the row that contains focus.</li>
             <li><kbd>End</kbd>: moves focus to the last cell in the row that contains focus.</li>
-            <li><kbd>Control + Home</kbd>: moves focus to the first cell in the first row.</li>
-            <li><kbd>Control + End</kbd>: moves focus to the last cell in the last row.</li>
+            <li><kbd>Control</kbd> + <kbd>Home</kbd>: moves focus to the first cell in the first row.</li>
+            <li><kbd>Control</kbd> + <kbd>End</kbd>: moves focus to the last cell in the last row.</li>
           </ul>
           <ul class="note">
             <li>
@@ -1478,17 +1478,17 @@ Some JavaScript and CSS may not function correctly in Internet Explorer.
               While navigation keys, such as arrow keys, are moving focus from cell to cell, they are not available to do something like operate a combobox or move an editing caret inside of a cell.
               If this functionality is needed, see <a href="#gridNav_inside">Editing and Navigating Inside a Cell</a>.
             </li>
-            <li>If navigation functions can dynamically add more rows or columns to the DOM, key events that move focus to the beginning or end of the grid, such as <kbd>control + End</kbd>, may move focus to the last row in the DOM rather than the last available row in the back-end data.</li>
+            <li>If navigation functions can dynamically add more rows or columns to the DOM, key events that move focus to the beginning or end of the grid, such as <kbd>Control</kbd> + <kbd>End</kbd>, may move focus to the last row in the DOM rather than the last available row in the back-end data.</li>
           </ul>
           <p>If a grid supports selection of cells, rows, or columns, the following keys are commonly used for these functions.</p>
           <ul>
-            <li><kbd>Control + Space</kbd>: selects the column that contains the focus.</li>
-            <li><kbd>Shift + Space</kbd>: Selects the row that contains the focus. If the grid includes a column with checkboxes for selecting rows, this key can serve as a shortcut for checking the box when focus is not on the checkbox.</li>
-            <li><kbd>Control + A</kbd>: Selects all cells.</li>
-            <li><kbd>Shift + Right Arrow</kbd>: Extends selection one cell to the right.</li>
-            <li><kbd>Shift + Left Arrow</kbd>: Extends selection one cell to the left.</li>
-            <li><kbd>Shift + Down Arrow</kbd>: Extends selection one cell down.</li>
-            <li><kbd>Shift + Up Arrow</kbd>: Extends selection one cell Up.</li>
+            <li><kbd>Control</kbd> + <kbd>Space</kbd>: selects the column that contains the focus.</li>
+            <li><kbd>Shift</kbd> + <kbd>Space</kbd>: Selects the row that contains the focus. If the grid includes a column with checkboxes for selecting rows, this key can serve as a shortcut for checking the box when focus is not on the checkbox.</li>
+            <li><kbd>Control</kbd> + <kbd>A</kbd>: Selects all cells.</li>
+            <li><kbd>Shift</kbd> + <kbd>Right Arrow</kbd>: Extends selection one cell to the right.</li>
+            <li><kbd>Shift</kbd> + <kbd>Left Arrow</kbd>: Extends selection one cell to the left.</li>
+            <li><kbd>Shift</kbd> + <kbd>Down Arrow</kbd>: Extends selection one cell down.</li>
+            <li><kbd>Shift</kbd> + <kbd>Up Arrow</kbd>: Extends selection one cell Up.</li>
           </ul>
           <p class="note">See <a href="#kbd_common_conventions"></a> for cut, copy, and paste key assignments.</p>
         </section>
@@ -1559,8 +1559,8 @@ Some JavaScript and CSS may not function correctly in Internet Explorer.
               <kbd>End</kbd>: moves focus to the last cell in the row that contains focus.
               Optionally, if the grid has a single column or fewer than three cells per row, focus may instead move to the last cell in the grid.
             </li>
-            <li><kbd>Control + Home</kbd> (optional): moves focus to the first cell in the first row.</li>
-            <li><kbd>Control + End</kbd> (Optional): moves focus to the last cell in the last row.</li>
+            <li><kbd>Control</kbd> + <kbd>Home</kbd> (optional): moves focus to the first cell in the first row.</li>
+            <li><kbd>Control</kbd> + <kbd>End</kbd> (Optional): moves focus to the last cell in the last row.</li>
           </ul>
           <ul class="note">
             <li>
@@ -1571,22 +1571,22 @@ Some JavaScript and CSS may not function correctly in Internet Explorer.
               While navigation keys, such as arrow keys, are moving focus from cell to cell, they are not available to do something like operate a combobox or move an editing caret inside of a cell.
               If this functionality is needed, see <a href="#gridNav_inside">Editing and Navigating Inside a Cell</a>.
             </li>
-            <li>If navigation functions can dynamically add more rows or columns to the DOM, key events that move focus to the beginning or end of the grid, such as <kbd>control + End</kbd>, may move focus to the last row in the DOM rather than the last available row in the back-end data.</li>
+            <li>If navigation functions can dynamically add more rows or columns to the DOM, key events that move focus to the beginning or end of the grid, such as <kbd>Control</kbd> + <kbd>End</kbd>, may move focus to the last row in the DOM rather than the last available row in the back-end data.</li>
           </ul>
 
           <p>It would be unusual for a layout grid to provide functions that require cell selection. If it did, though, the following keys are commonly used for these functions.</p>
 
           <ul>
-            <li><kbd>Control + Space</kbd>: selects the column that contains the focus.</li>
+            <li><kbd>Control</kbd> + <kbd>Space</kbd>: selects the column that contains the focus.</li>
             <li>
-              <kbd>Shift + Space</kbd>: Selects the row that contains the focus.
+              <kbd>Shift</kbd> + <kbd>Space</kbd>: Selects the row that contains the focus.
               If the grid includes a column with checkboxes for selecting rows, this key can serve as a shortcut for checking the box when focus is not on the checkbox.
             </li>
-            <li><kbd>Control + A</kbd>: Selects all cells.</li>
-            <li><kbd>Shift + Right Arrow</kbd>: Extends selection one cell to the right.</li>
-            <li><kbd>Shift + Left Arrow</kbd>: Extends selection one cell to the left.</li>
-            <li><kbd>Shift + Down Arrow</kbd>: Extends selection one cell down.</li>
-            <li><kbd>Shift + Up Arrow</kbd>: Extends selection one cell Up.</li>
+            <li><kbd>Control</kbd> + <kbd>A</kbd>: Selects all cells.</li>
+            <li><kbd>Shift</kbd> + <kbd>Right Arrow</kbd>: Extends selection one cell to the right.</li>
+            <li><kbd>Shift</kbd> + <kbd>Left Arrow</kbd>: Extends selection one cell to the left.</li>
+            <li><kbd>Shift</kbd> + <kbd>Down Arrow</kbd>: Extends selection one cell down.</li>
+            <li><kbd>Shift</kbd> + <kbd>Up Arrow</kbd>: Extends selection one cell Up.</li>
           </ul>
           <p class="note">See <a href="#kbd_common_conventions"></a> for cut, copy, and paste key assignments.</p>
         </section>
@@ -1679,7 +1679,7 @@ Some JavaScript and CSS may not function correctly in Internet Explorer.
               Optionally, the focus movement may wrap inside a single cell or within the grid itself.
             </li>
             <li>
-              <kbd>Shift + Tab</kbd>: moves focus to the previous widget in the grid.
+              <kbd>Shift</kbd> + <kbd>Tab</kbd>: moves focus to the previous widget in the grid.
               Optionally, the focus movement may wrap inside a single cell or within the grid itself.
             </li>
           </ul>
@@ -1761,7 +1761,7 @@ Some JavaScript and CSS may not function correctly in Internet Explorer.
         <h4>Keyboard Interaction</h4>
         <ul>
           <li><kbd>Enter</kbd>: Executes the link and moves focus to the link target.</li>
-          <li><kbd>Shift + F10</kbd> (Optional): Opens a context menu for the link.</li>
+          <li><kbd>Shift</kbd> + <kbd>F10</kbd> (Optional): Opens a context menu for the link.</li>
         </ul>
       </section>
 
@@ -1846,25 +1846,25 @@ Some JavaScript and CSS may not function correctly in Internet Explorer.
               <li>Recommended selection model -- holding modifier keys is not necessary:
                 <ul>
                   <li><kbd>Space</kbd>: changes the selection state of the focused option.</li>
-                  <li><kbd>Shift + Down Arrow</kbd> (Optional): Moves focus to and toggles the selected state of the next option.</li>
-                  <li><kbd>Shift + Up Arrow</kbd> (Optional): Moves focus to and toggles the selected state of the previous option.</li>
-                  <li><kbd>Shift + Space</kbd> (Optional): Selects contiguous items from the most recently selected item to the focused item.</li>
-                  <li><kbd>Control + Shift + Home</kbd> (Optional): Selects the focused option and all options up to the first option. Optionally, moves focus to the first option.</li>
-                  <li><kbd>Control + Shift + End</kbd> (Optional): Selects the focused option and all options down to the last option. Optionally, moves focus to the last option.</li>
-                  <li><kbd>Control + A</kbd> (Optional): Selects all options in the list. Optionally, if all options are selected, it may also unselect all options.</li>
+                  <li><kbd>Shift</kbd> + <kbd>Down Arrow</kbd> (Optional): Moves focus to and toggles the selected state of the next option.</li>
+                  <li><kbd>Shift</kbd> + <kbd>Up Arrow</kbd> (Optional): Moves focus to and toggles the selected state of the previous option.</li>
+                  <li><kbd>Shift</kbd> + <kbd>Space</kbd> (Optional): Selects contiguous items from the most recently selected item to the focused item.</li>
+                  <li><kbd>Control</kbd> + <kbd>Shift</kbd> + <kbd>Home</kbd> (Optional): Selects the focused option and all options up to the first option. Optionally, moves focus to the first option.</li>
+                  <li><kbd>Control</kbd> + <kbd>Shift</kbd> + <kbd>End</kbd> (Optional): Selects the focused option and all options down to the last option. Optionally, moves focus to the last option.</li>
+                  <li><kbd>Control</kbd> + <kbd>A</kbd> (Optional): Selects all options in the list. Optionally, if all options are selected, it may also unselect all options.</li>
                 </ul>
               </li>
               <li>Alternative selection model -- moving focus without holding a <kbd>Shift</kbd> or <kbd>Control</kbd> modifier unselects all selected nodes except the focused node:
               <ul>
-                  <li><kbd>Shift + Down Arrow</kbd>: Moves focus to and toggles the selection state of the next option.</li>
-                  <li><kbd>Shift + Up Arrow</kbd>: Moves focus to and toggles the selection state of the previous option.</li>
-                  <li><kbd>Control + Down Arrow</kbd>: Moves focus to the next option without changing its selection state.</li>
-                  <li><kbd>Control + Up Arrow</kbd>: Moves focus to the previous option without changing its selection state.</li>
-                  <li><kbd>Control + Space</kbd> Changes the selection state of the focused option. </li>
-                  <li><kbd>Shift + Space</kbd> (Optional): Selects contiguous items from the most recently selected item to the focused item.</li>
-                  <li><kbd>Control + Shift + Home</kbd> (Optional): Selects the focused option and all options up to the first option. Optionally, moves focus to the first option.</li>
-                  <li><kbd>Control + Shift + End</kbd> (Optional): Selects the focused option and all options down to the last option. Optionally, moves focus to the last option.</li>
-                  <li><kbd>Control + A</kbd> (Optional): Selects all options in the list. Optionally, if all options are selected, it may also unselect all options.</li>
+                  <li><kbd>Shift</kbd> + <kbd>Down Arrow</kbd>: Moves focus to and toggles the selection state of the next option.</li>
+                  <li><kbd>Shift</kbd> + <kbd>Up Arrow</kbd>: Moves focus to and toggles the selection state of the previous option.</li>
+                  <li><kbd>Control</kbd> + <kbd>Down Arrow</kbd>: Moves focus to the next option without changing its selection state.</li>
+                  <li><kbd>Control</kbd> + <kbd>Up Arrow</kbd>: Moves focus to the previous option without changing its selection state.</li>
+                  <li><kbd>Control</kbd> + <kbd>Space</kbd> Changes the selection state of the focused option. </li>
+                  <li><kbd>Shift</kbd> + <kbd>Space</kbd> (Optional): Selects contiguous items from the most recently selected item to the focused item.</li>
+                  <li><kbd>Control</kbd> + <kbd>Shift</kbd> + <kbd>Home</kbd> (Optional): Selects the focused option and all options up to the first option. Optionally, moves focus to the first option.</li>
+                  <li><kbd>Control</kbd> + <kbd>Shift</kbd> + <kbd>End</kbd> (Optional): Selects the focused option and all options down to the last option. Optionally, moves focus to the last option.</li>
+                  <li><kbd>Control</kbd> + <kbd>A</kbd> (Optional): Selects all options in the list. Optionally, if all options are selected, it may also unselect all options.</li>
                 </ul>
               </li>
             </ul>
@@ -1922,7 +1922,7 @@ Some JavaScript and CSS may not function correctly in Internet Explorer.
       <p>
         A <a href="#menu" class="role-reference">menu</a> is a widget that offers a list of choices to the user, such as a set of actions or functions.
         Menu widgets behave like native operating system menus, such as the menus that pull down from the menubars commonly found at the top of many desktop application windows.
-        A menu is usually opened, or made visible, by activating a <a href="#menubutton">menu button</a>, choosing an item in a menu that opens a sub menu, or by invoking a command, such as <kbd>Shift + F10</kbd> in Windows, that opens a context specific menu.
+        A menu is usually opened, or made visible, by activating a <a href="#menubutton">menu button</a>, choosing an item in a menu that opens a sub menu, or by invoking a command, such as <kbd>Shift</kbd> + <kbd>F10</kbd> in Windows, that opens a context specific menu.
         When a user activates a choice in a menu, the menu usually closes unless the choice opened a submenu.
       </p>
 
@@ -2027,14 +2027,14 @@ Some JavaScript and CSS may not function correctly in Internet Explorer.
           <li>Any key that corresponds to a printable character (Optional): Move focus to the next item in the current menu whose label begins with that printable character.</li>
           <li><kbd>Escape</kbd>: Close the menu that contains focus and return focus to the element or context, e.g., menu button or parent <code>menuitem</code>, from which the menu was opened.</li>
           <li><kbd>Tab</kbd>: Moves focus to the next element in the tab sequence, and if the item that had focus is not in a <code>menubar</code>, closes its <code>menu</code> and all open parent <code>menu</code> containers.</li>
-          <li><kbd>Shift + Tab</kbd>: Moves focus to the previous element in the tab sequence, and if the item that had focus is not in a <code>menubar</code>, closes its <code>menu</code> and all open parent <code>menu</code> containers.</li>
+          <li><kbd>Shift</kbd> + <kbd>Tab</kbd>: Moves focus to the previous element in the tab sequence, and if the item that had focus is not in a <code>menubar</code>, closes its <code>menu</code> and all open parent <code>menu</code> containers.</li>
         </ul>
         <ol class="note">
           <li>Disabled menu items are focusable but cannot be activated. </li>
           <li>A <a href="#separator" class="role-reference">separator</a> in a menu is not focusable or interactive.</li>
           <li>
             If a menu is opened or a menubar receives focus as a result of a context action, <kbd>Escape</kbd> or <kbd>Enter</kbd> may return focus to the invoking context.
-            For example, a rich text editor may have a menubar that receives focus when a shortcut key, e.g., <kbd>alt + F10</kbd>, is pressed while editing.
+            For example, a rich text editor may have a menubar that receives focus when a shortcut key, e.g., <kbd>Alt</kbd> + <kbd>F10</kbd>, is pressed while editing.
             In this case, pressing <kbd>Escape</kbd> or activating a command from the menu may return focus to the editor.
           </li>
           <li>
@@ -2231,7 +2231,7 @@ Some JavaScript and CSS may not function correctly in Internet Explorer.
           </p>
           <ul>
             <li>
-              <kbd>Tab</kbd> and <kbd>Shift + Tab</kbd>:
+              <kbd>Tab</kbd> and <kbd>Shift</kbd> + <kbd>Tab</kbd>:
               Move focus into and out of the radio group.
               When focus moves into a radio group :
               <ul>
@@ -2668,7 +2668,7 @@ Some JavaScript and CSS may not function correctly in Internet Explorer.
               <li><kbd>Space or Enter</kbd>: Activates the tab if it was not activated automatically on focus.</li>
               <li><kbd>Home</kbd> (Optional): Moves focus to the first tab. Optionally, activates the newly focused tab (See note below).</li>
               <li><kbd>End</kbd> (Optional): Moves focus to the last tab. Optionally, activates the newly focused tab (See note below).</li>
-              <li><kbd>Shift + F10</kbd>: If the tab has an associated popup menu, opens the menu. </li>
+              <li><kbd>Shift</kbd> + <kbd>F10</kbd>: If the tab has an associated popup menu, opens the menu. </li>
               <li>
                 <kbd>Delete</kbd> (Optional): If deletion is allowed, deletes (closes) the current tab element and its associated tab panel,
                 sets focus on the tab following the tab that was closed, and optionally activates the newly focused tab. If there is not a tab that followed the tab that was deleted,
@@ -2750,7 +2750,7 @@ Some JavaScript and CSS may not function correctly in Internet Explorer.
       <section class="notoc">
         <h4>Keyboard Interaction</h4>
         <ul>
-          <li><kbd>Tab</kbd> and <kbd>Shift + Tab</kbd>: Move focus into and out of the toolbar. When focus moves into a toolbar:
+          <li><kbd>Tab</kbd> and <kbd>Shift</kbd> + <kbd>Tab</kbd>: Move focus into and out of the toolbar. When focus moves into a toolbar:
             <ul>
               <li>If focus is moving into the toolbar for the first time, focus is set on the first control that is not disabled.</li>
               <li>If the toolbar has previously contained focus, focus is optionally set on the control that last had focus. Otherwise, it is set on the first control that is not disabled.</li>
@@ -2944,25 +2944,25 @@ Some JavaScript and CSS may not function correctly in Internet Explorer.
               <li>Recommended selection model -- holding a modifier key while moving focus is not necessary:
                 <ul>
                   <li><kbd>Space</kbd>: Toggles the selection state of the focused node.</li>
-                  <li><kbd>Shift + Down Arrow</kbd> (Optional): Moves focus to and toggles the selection state of the next node.</li>
-                  <li><kbd>Shift + Up Arrow</kbd> (Optional): Moves focus to and toggles the selection state of the previous node.</li>
-                  <li><kbd>Shift + Space</kbd> (Optional): Selects contiguous nodes from the most recently selected node to the current node.</li>
-                  <li><kbd>Control + Shift + Home</kbd> (Optional): Selects the node with focus and all nodes up to the first node. Optionally, moves focus to the first node.</li>
-                  <li><kbd>Control + Shift + End</kbd> (Optional): Selects the node with focus and all nodes down to the last node. Optionally, moves focus to the last node.</li>
-                  <li><kbd>Control + A</kbd> (Optional): Selects all nodes in the tree. Optionally, if all nodes are selected, it can also unselect all nodes.</li>
+                  <li><kbd>Shift</kbd> + <kbd>Down Arrow</kbd> (Optional): Moves focus to and toggles the selection state of the next node.</li>
+                  <li><kbd>Shift</kbd> + <kbd>Up Arrow</kbd> (Optional): Moves focus to and toggles the selection state of the previous node.</li>
+                  <li><kbd>Shift</kbd> + <kbd>Space</kbd> (Optional): Selects contiguous nodes from the most recently selected node to the current node.</li>
+                  <li><kbd>Control</kbd> + <kbd>Shift</kbd> + <kbd>Home</kbd> (Optional): Selects the node with focus and all nodes up to the first node. Optionally, moves focus to the first node.</li>
+                  <li><kbd>Control</kbd> + <kbd>Shift</kbd> + <kbd>End</kbd> (Optional): Selects the node with focus and all nodes down to the last node. Optionally, moves focus to the last node.</li>
+                  <li><kbd>Control</kbd> + <kbd>A</kbd> (Optional): Selects all nodes in the tree. Optionally, if all nodes are selected, it can also unselect all nodes.</li>
                 </ul>
               </li>
               <li>Alternative selection model -- Moving focus without holding the <kbd>Shift</kbd> or <kbd>Control</kbd> modifier unselects all selected nodes except for the focused node:
                 <ul>
-                  <li><kbd>Shift + Down Arrow</kbd>: Moves focus to and toggles the selection state of the next node.</li>
-                  <li><kbd>Shift + Up Arrow</kbd>: Moves focus to and toggles the selection state of the previous node.</li>
-                  <li><kbd>Control + Down Arrow</kbd>: Without changing the selection state, moves focus to the next node.</li>
-                  <li><kbd>Control + Up Arrow</kbd>: Without changing the selection state, moves focus to the previous node.</li>
-                  <li><kbd>Control + Space</kbd>: Toggles the selection state of the focused node.</li>
-                  <li><kbd>Shift + Space</kbd> (Optional): Selects contiguous nodes from the most recently selected node to the current node.</li>
-                  <li><kbd>Control + Shift + Home</kbd> (Optional): Selects the node with focus and all nodes up to the first node. Optionally, moves focus to the first node.</li>
-                  <li><kbd>Control + Shift + End</kbd> (Optional): Selects the node with focus and all nodes down to the last node. Optionally, moves focus to the last node.</li>
-                  <li><kbd>Control + A</kbd> (Optional): Selects all nodes in the tree. Optionally, if all nodes are selected, it can also unselect all nodes.</li>
+                  <li><kbd>Shift</kbd> + <kbd>Down Arrow</kbd>: Moves focus to and toggles the selection state of the next node.</li>
+                  <li><kbd>Shift</kbd> + <kbd>Up Arrow</kbd>: Moves focus to and toggles the selection state of the previous node.</li>
+                  <li><kbd>Control</kbd> + <kbd>Down Arrow</kbd>: Without changing the selection state, moves focus to the next node.</li>
+                  <li><kbd>Control</kbd> + <kbd>Up Arrow</kbd>: Without changing the selection state, moves focus to the previous node.</li>
+                  <li><kbd>Control</kbd> + <kbd>Space</kbd>: Toggles the selection state of the focused node.</li>
+                  <li><kbd>Shift</kbd> + <kbd>Space</kbd> (Optional): Selects contiguous nodes from the most recently selected node to the current node.</li>
+                  <li><kbd>Control</kbd> + <kbd>Shift</kbd> + <kbd>Home</kbd> (Optional): Selects the node with focus and all nodes up to the first node. Optionally, moves focus to the first node.</li>
+                  <li><kbd>Control</kbd> + <kbd>Shift</kbd> + <kbd>End</kbd> (Optional): Selects the node with focus and all nodes down to the last node. Optionally, moves focus to the last node.</li>
+                  <li><kbd>Control</kbd> + <kbd>A</kbd> (Optional): Selects all nodes in the tree. Optionally, if all nodes are selected, it can also unselect all nodes.</li>
                 </ul>
               </li>
             </ul>
@@ -3134,14 +3134,14 @@ Some JavaScript and CSS may not function correctly in Internet Explorer.
               </ul>
           </li>
           <li>
-            <kbd>Control + Home</kbd>:
+            <kbd>Control</kbd> + <kbd>Home</kbd>:
              <ul>
                 <li>If focus is on a row, moves focus to the first row.  If focus is in the first row, focus does not move.</li>
                 <li>If focus is on a cell, moves focus to the first cell in the column. If focus is in the first row, focus does not move.</li>
               </ul>
           </li>
           <li>
-            <kbd>Control + End</kbd>:
+            <kbd>Control</kbd> + <kbd>End</kbd>:
              <ul>
                 <li>If focus is on a row, moves focus to the last row.  If focus is in the last row, focus does not move.</li>
                 <li>If focus is on a cell, moves focus to the last cell in the column. If focus is in the last row, focus does not move.</li>
@@ -3157,48 +3157,48 @@ Some JavaScript and CSS may not function correctly in Internet Explorer.
             While navigation keys, such as arrow keys, are moving focus from cell to cell, they are not available to do something like operate a combobox or move an editing caret inside of a cell.
             If this functionality is needed, see <a href="#gridNav_inside">Editing and Navigating Inside a Cell</a>.
           </li>
-          <li>If navigation functions can dynamically add more rows or columns to the DOM, key events that move focus to the beginning or end of the grid, such as <kbd>control + End</kbd>, may move focus to the last row in the DOM rather than the last available row in the back-end data.</li>
+          <li>If navigation functions can dynamically add more rows or columns to the DOM, key events that move focus to the beginning or end of the grid, such as <kbd>Control</kbd> + <kbd>End</kbd>, may move focus to the last row in the DOM rather than the last available row in the back-end data.</li>
         </ul>
         <p>If a treegrid supports selection of cells, rows, or columns, the following keys are commonly used for these functions.</p>
         <ul>
           <li>
-            <kbd>Control + Space</kbd>:
+            <kbd>Control</kbd> + <kbd>Space</kbd>:
             <ul>
               <li>If focus is on a row, selects all cells.</li>
               <li>If focus is on a cell, selects the column that contains the focus.</li>
             </ul>
           </li>
           <li>
-            <kbd>Shift + Space</kbd>:
+            <kbd>Shift</kbd> + <kbd>Space</kbd>:
             <ul>
               <li>If focus is on a row, selects the row.</li>
               <li>If focus is on a cell, selects the row that contains the focus. If the treegrid includes a column with checkboxes for selecting rows, this key can serve as a shortcut for checking the box when focus is not on the checkbox.</li>
             </ul>
           </li>
-          <li><kbd>Control + A</kbd>: Selects all cells.</li>
+          <li><kbd>Control</kbd> + <kbd>A</kbd>: Selects all cells.</li>
           <li>
-            <kbd>Shift + Right Arrow</kbd>:
+            <kbd>Shift</kbd> + <kbd>Right Arrow</kbd>:
             <ul>
               <li>If focus is on a row, does not change selection.</li>
               <li>if focus is on a cell, extends selection one cell to the right.</li>
             </ul>
           </li>
           <li>
-            <kbd>Shift + Left Arrow</kbd>:
+            <kbd>Shift</kbd> + <kbd>Left Arrow</kbd>:
             <ul>
               <li>If focus is on a row, does not change selection.</li>
               <li>if focus is on a cell, extends selection one cell to the left.</li>
             </ul>
           </li>
           <li>
-            <kbd>Shift + Down Arrow</kbd>:
+            <kbd>Shift</kbd> + <kbd>Down Arrow</kbd>:
             <ul>
               <li>If focus is on a row, extends selection to all the cells in the next row.</li>
               <li>If focus is on a cell, extends selection one cell down.</li>
             </ul>
           </li>
           <li>
-            <kbd>Shift + Up Arrow</kbd>:
+            <kbd>Shift</kbd> + <kbd>Up Arrow</kbd>:
             <ul>
               <li>If focus is on a row, extends selection to all the cells in the previous row.</li>
               <li>If focus is on a cell, extends selection one cell up.</li>
@@ -5535,7 +5535,7 @@ So, As advised by <a href="#naming_rule_avoid_fallback">Rule 4: Avoid Browser Fa
 
       <p>
         As described in section <a href="#kbd_generalnav"></a>, the tab sequence should include only one focusable element of a composite UI component.
-        Once a composite contains focus, keys other than <kbd>Tab</kbd> and <kbd>Shift + Tab</kbd> enable the user to move focus among its focusable elements.
+        Once a composite contains focus, keys other than <kbd>Tab</kbd> and <kbd>Shift</kbd> + <kbd>Tab</kbd> enable the user to move focus among its focusable elements.
         Authors are free to choose which keys move focus inside of a composite, but they are strongly advised to use the same key bindings as similar components in common GUI operating systems as demonstrated in <a href="#aria_ex"></a>.
       </p>
 
@@ -5719,32 +5719,32 @@ So, As advised by <a href="#naming_rule_avoid_fallback">Rule 4: Avoid Browser Fa
         <tbody>
           <tr>
             <th scope="row">open context menu</th>
-            <td><kbd>Shift + F10</kbd></td>
+            <td><kbd>Shift</kbd> + <kbd>F10</kbd></td>
             <td></td>
           </tr>
           <tr>
             <th scope="row">Copy to clipboard</th>
-            <td><kbd>Control + C</kbd></td>
-            <td><kbd>Command + C</kbd></td>
+            <td><kbd>Control</kbd> + <kbd>C</kbd></td>
+            <td><kbd>Command</kbd> + <kbd>C</kbd></td>
           </tr>
           <tr>
             <th scope="row">Paste from clipboard</th>
-            <td><kbd>Control + V</kbd></td>
-            <td><kbd>Command + V</kbd></td>
+            <td><kbd>Control</kbd> + <kbd>V</kbd></td>
+            <td><kbd>Command</kbd> + <kbd>V</kbd></td>
           </tr>
           <tr>
             <th scope="row">Cut to clipboard</th>
-            <td><kbd>Control + X</kbd></td>
-            <td><kbd>Command + X</kbd></td>
+            <td><kbd>Control</kbd> + <kbd>X</kbd></td>
+            <td><kbd>Command</kbd> + <kbd>X</kbd></td>
           </tr>
           <tr>
             <th scope="row">undo last action</th>
-            <td><kbd>Control + Z</kbd></td>
-            <td><kbd>Command + Z</kbd></td>
+            <td><kbd>Control</kbd> + <kbd>Z</kbd></td>
+            <td><kbd>Command</kbd> + <kbd>Z</kbd></td>
           </tr>
           <tr>
             <th scope="row">Redo action</th>
-            <td><kbd>Control + Y</kbd></td>
+            <td><kbd>Control</kbd> + <kbd>Y</kbd></td>
             <td>Command + Shift + Z</td>
           </tr>
         </tbody>
@@ -5844,7 +5844,7 @@ So, As advised by <a href="#naming_rule_avoid_fallback">Rule 4: Avoid Browser Fa
         <h4>Assigning Keyboard Shortcuts</h4>
         <p>When choosing the keys to assign to a shortcut, there are many factors to consider.</p>
         <ul>
-          <li>Making the shortcut easy to learn and remember by using a mnemonic (e.g., <kbd>Control + S</kbd> for "Save") or following a logical or spacial pattern.</li>
+          <li>Making the shortcut easy to learn and remember by using a mnemonic (e.g., <kbd>Control</kbd> + <kbd>S</kbd> for "Save") or following a logical or spacial pattern.</li>
           <li> Localizing the interface, including for differences in which keys are available and how they behave and for language considerations that could impact mnemonics. </li>
           <li>Avoiding and managing conflicts with key assignments used by an assistive technology, the browser, or the operating system.</li>
         </ul>

--- a/examples/accordion/accordion.html
+++ b/examples/accordion/accordion.html
@@ -213,7 +213,7 @@
           </td>
         </tr>
         <tr data-test-id="key-shift-tab">
-          <th><kbd>Shift + Tab</kbd></th>
+          <th><kbd>Shift</kbd> + <kbd>Tab</kbd></th>
           <td>
             <ul>
               <li>Moves focus to the previous focusable element.</li>
@@ -273,7 +273,7 @@
             <ul>
               <li>Element that serves as an accordion header.</li>
               <li>Each accordion header element contains a button that controls the visibility of its content panel.</li>
-              <li>The example uses heading level 3 so it fits correctly within the outline of the page; the example is contained in a section titled with a level 2 heading.</li> 
+              <li>The example uses heading level 3 so it fits correctly within the outline of the page; the example is contained in a section titled with a level 2 heading.</li>
             </ul>
           </td>
         </tr>

--- a/examples/coding-template/Example-Template.html
+++ b/examples/coding-template/Example-Template.html
@@ -112,7 +112,7 @@
       Use kbd tags,e.g. <kbd>KeyName</kbd>.
       Key names use first-letter caps, e.g., <kbd>Enter</kbd>.
       Single space between multiple Words, e.g., <kbd>Up Arrow</kbd>.
-      Use + to separate modifiers, e.g., <kbd>Control + Right Arrow</kbd>.
+      Use + to separate modifiers, e.g., <kbd>Control</kbd> + <kbd>Right Arrow</kbd>.
       One key per row, e.g., do not combine <kbd>Up Arrow</kbd> and <kbd>Down Arrow</kbd> into a single row.
       Do not use the word "key", e.g., do not write <kbd>Enter Key</kbd> or <kbd>Enter</kbd> key.
      -->

--- a/examples/combobox/combobox-autocomplete-both.html
+++ b/examples/combobox/combobox-autocomplete-both.html
@@ -155,7 +155,7 @@
             </td>
           </tr>
           <tr data-test-id="textbox-key-alt-down-arrow">
-            <th><kbd>Alt + Down Arrow</kbd></th>
+            <th><kbd>Alt</kbd> + <kbd>Down Arrow</kbd></th>
             <td>
                 Opens the listbox without moving focus or changing selection.
             </td>
@@ -192,7 +192,7 @@
             <th>Standard single line text editing keys</th>
             <td>
               <ul>
-                <li>Keys used for cursor movement and text manipulation, such as <kbd>Delete</kbd> and <kbd>Shift + Right Arrow</kbd>.</li>
+                <li>Keys used for cursor movement and text manipulation, such as <kbd>Delete</kbd> and <kbd>Shift</kbd> + <kbd>Right Arrow</kbd>.</li>
                 <li>An HTML <code>input</code> with <code>type="text"</code> is used for the textbox so the browser will provide platform-specific editing keys.</li>
               </ul>
             </td>

--- a/examples/combobox/combobox-autocomplete-list.html
+++ b/examples/combobox/combobox-autocomplete-list.html
@@ -156,7 +156,7 @@
             </td>
           </tr>
           <tr data-test-id="textbox-key-alt-down-arrow">
-            <th><kbd>Alt + Down Arrow</kbd></th>
+            <th><kbd>Alt</kbd> + <kbd>Down Arrow</kbd></th>
             <td>
                 Opens the listbox without moving focus or changing selection.
             </td>
@@ -188,7 +188,7 @@
             <th>Standard single line text editing keys</th>
             <td>
               <ul>
-                <li>Keys used for cursor movement and text manipulation, such as <kbd>Delete</kbd> and <kbd>Shift + Right Arrow</kbd>.</li>
+                <li>Keys used for cursor movement and text manipulation, such as <kbd>Delete</kbd> and <kbd>Shift</kbd> + <kbd>Right Arrow</kbd>.</li>
                 <li>An HTML <code>input</code> with <code>type="text"</code> is used for the textbox so the browser will provide platform-specific editing keys.</li>
               </ul>
             </td>

--- a/examples/combobox/combobox-autocomplete-none.html
+++ b/examples/combobox/combobox-autocomplete-none.html
@@ -110,7 +110,7 @@
             </td>
           </tr>
           <tr data-test-id="textbox-key-alt-down-arrow">
-            <th><kbd>Alt + Down Arrow</kbd></th>
+            <th><kbd>Alt</kbd> + <kbd>Down Arrow</kbd></th>
             <td>
                 Opens the listbox without moving focus or changing selection.
             </td>
@@ -137,7 +137,7 @@
             <th>Standard single line text editing keys</th>
             <td>
               <ul>
-                <li>Keys used for cursor movement and text manipulation, such as <kbd>Delete</kbd> and <kbd>Shift + Right Arrow</kbd>.</li>
+                <li>Keys used for cursor movement and text manipulation, such as <kbd>Delete</kbd> and <kbd>Shift</kbd> + <kbd>Right Arrow</kbd>.</li>
                 <li>An HTML <code>input</code> with <code>type="text"</code> is used for the textbox so the browser will provide platform-specific editing keys.</li>
               </ul>
             </td>

--- a/examples/combobox/combobox-datepicker.html
+++ b/examples/combobox/combobox-datepicker.html
@@ -29,7 +29,7 @@
     <h1>Date Picker Combobox Example</h1>
     <p>
       The below date picker demonstrates an implementation of the <a href="../../#combobox">combobox design pattern</a> that opens a dialog.
-      The date picker dialog is opened by activating the choose date button or by moving keyboard focus to the combobox and pressing <kbd>Down Arrow</kbd> or <kbd>Alt + Down Arrow</kbd>.
+      The date picker dialog is opened by activating the choose date button or by moving keyboard focus to the combobox and pressing <kbd>Down Arrow</kbd> or <kbd>Alt</kbd> + <kbd>Down Arrow</kbd>.
       The  dialog contains an implementation of the <a href="../../#grid">grid pattern</a> for displaying a calendar and enabling selection of a date.
       Additional buttons in the dialog are available for changing the month and year shown in the grid.
     </p>
@@ -42,7 +42,7 @@
       <li><a href="combobox-autocomplete-none.html">Editable Combobox Without Autocomplete</a>: An editable combobox that demonstrates the behavior associated with <code>aria-autocomplete=none</code>.</li>
       <li><a href="grid-combo.html">Editable Combobox with Grid Popup</a>: An editable combobox that presents suggestions in a grid, enabling users to navigate descriptive information about each suggestion.</li>
     </ul>
-    
+
   <section>
     <div class="example-header">
       <h2 id="ex_label">Example</h2>
@@ -214,7 +214,7 @@
     <ul>
      <li>The description of the date format is associated with the combobox via <code>aria-describedby</code>, making it available to assistive technologies as an accessible description.</li>
       <li>
-        While the down arrow icon is excluded from the <kbd>Tab</kbd> sequence as specified in the <code>combobox</code> design pattern, it is made accessible to assistive technologies as the Choose Date button. 
+        While the down arrow icon is excluded from the <kbd>Tab</kbd> sequence as specified in the <code>combobox</code> design pattern, it is made accessible to assistive technologies as the Choose Date button.
         This enables assistive technology users who might not have a keyboard, e.g., someone using a touch-based screen reader, to open the date picker dialog.
       </li>
       <li>In the dialog, shortcut keys are assigned to the additional buttons for changing the month and year displayed in the calendar.</li>
@@ -249,7 +249,7 @@
         </thead>
         <tbody>
             <tr data-test-id="combobox-down-arrow">
-                <th><kbd>Down Arrow</kbd>,<br><kbd>ALT + Down Arrow</kbd></th>
+                <th><kbd>Down Arrow</kbd>,<br><kbd>ALT</kbd> + <kbd>Down Arrow</kbd></th>
                 <td>
                   <ul>
                   <li>Open the date picker dialog.</li>
@@ -289,7 +289,7 @@
               </td>
             </tr>
             <tr data-test-id="dialog-shift-tab">
-              <th><kbd>Shift + TAB</kbd></th>
+              <th><kbd>Shift</kbd> + <kbd>TAB</kbd></th>
               <td>
                 <ul>
                   <li>Moves focus to previous element in the dialog <kbd>Tab</kbd> sequence.</li>
@@ -483,7 +483,7 @@
             <th scope="row"><code>aria-expanded="true"</code></th>
             <td><code>input</code></td>
             <td>
-              Indicates that the combobox is expanded, i.e., the &quot;Choose Date&quot; dialog is open. 
+              Indicates that the combobox is expanded, i.e., the &quot;Choose Date&quot; dialog is open.
             </td>
           </tr>
           <tr data-test-id="textbox-aria-autocomplete">

--- a/examples/combobox/combobox-select-only.html
+++ b/examples/combobox/combobox-select-only.html
@@ -112,7 +112,7 @@
             </td>
           </tr>
           <tr data-test-id="combobox-key-alt-down-arrow">
-            <th><kbd>Alt + Down Arrow</kbd></th>
+            <th><kbd>Alt</kbd> + <kbd>Down Arrow</kbd></th>
             <td>
                 Opens the listbox without moving focus or changing selection.
             </td>
@@ -237,7 +237,7 @@
             </td>
           </tr>
           <tr data-test-id="listbox-key-alt-up-arrow">
-            <th><kbd>Alt + Up Arrow</kbd></th>
+            <th><kbd>Alt</kbd> + <kbd>Up Arrow</kbd></th>
             <td>
               <ul>
                 <li>Sets the value to the content of the focused option in the listbox.</li>

--- a/examples/combobox/grid-combo.html
+++ b/examples/combobox/grid-combo.html
@@ -118,7 +118,7 @@
             <th>Standard single line text editing keys</th>
             <td>
               <ul>
-                <li>Keys used for cursor movement and text manipulation, such as <kbd>Delete</kbd> and <kbd>Shift + Right Arrow</kbd>.</li>
+                <li>Keys used for cursor movement and text manipulation, such as <kbd>Delete</kbd> and <kbd>Shift</kbd> + <kbd>Right Arrow</kbd>.</li>
                 <li>An HTML <code>input</code> with <code>type=<q>text</q></code> is used for the textbox so the browser will provide platform-specific editing keys.</li>
               </ul>
             </td>

--- a/examples/dialog-modal/alertdialog.html
+++ b/examples/dialog-modal/alertdialog.html
@@ -117,7 +117,7 @@
               </td>
             </tr>
             <tr>
-              <th><kbd>Shift + Tab</kbd></th>
+              <th><kbd>Shift</kbd> + <kbd>Tab</kbd></th>
               <td>
                 <ul>
                   <li>Moves focus to previous focusable element inside the dialog.</li>
@@ -130,11 +130,11 @@
               <td>Closes the dialog.</td>
             </tr>
             <tr>
-              <th><kbd>Command + S</kbd></th>
+              <th><kbd>Command</kbd> + <kbd>S</kbd></th>
               <td>(Mac only) Save the contents of the notes <code>textarea</code> when focused.</td>
             </tr>
             <tr>
-              <th><kbd>Control + S</kbd></th>
+              <th><kbd>Control</kbd> + <kbd>S</kbd></th>
               <td>(Windows only) Save the contents of the notes <code>textarea</code> when focused.</td>
             </tr>
           </tbody>

--- a/examples/dialog-modal/datepicker-dialog.html
+++ b/examples/dialog-modal/datepicker-dialog.html
@@ -273,7 +273,7 @@
             </td>
           </tr>
           <tr data-test-id="dialog-shift-tab">
-            <th><kbd>Shift + Tab</kbd></th>
+            <th><kbd>Shift</kbd> + <kbd>Tab</kbd></th>
             <td>
               <ul>
                 <li>Moves focus to previous element in the dialog <kbd>Tab</kbd> sequence.</li>
@@ -360,7 +360,7 @@
             </td>
           </tr>
           <tr data-test-id="grid-shift-pageup">
-            <th><kbd>Shift + Page Up</kbd></th>
+            <th><kbd>Shift</kbd> + <kbd>Page Up</kbd></th>
             <td>
               <ul>
                 <li>Changes the grid of dates to the previous Year.</li>
@@ -378,7 +378,7 @@
             </td>
           </tr>
           <tr data-test-id="grid-shift-pagedown">
-            <th><kbd>Shift + Page Down</kbd></th>
+            <th><kbd>Shift</kbd> + <kbd>Page Down</kbd></th>
             <td>
               <ul>
                 <li>Changes the grid of dates to the next Year.</li>

--- a/examples/dialog-modal/dialog.html
+++ b/examples/dialog-modal/dialog.html
@@ -257,7 +257,7 @@
             </td>
           </tr>
           <tr data-test-id="key-shift-tab">
-            <th><kbd>Shift + Tab</kbd></th>
+            <th><kbd>Shift</kbd> + <kbd>Tab</kbd></th>
             <td>
               <ul>
                 <li>Moves focus to previous focusable element inside the dialog.</li>

--- a/examples/disclosure/disclosure-navigation.html
+++ b/examples/disclosure/disclosure-navigation.html
@@ -179,7 +179,7 @@
         <tr data-test-id="key-tab">
           <th>
             <kbd>Tab</kbd><br>
-            <kbd>Shift + Tab</kbd>
+            <kbd>Shift</kbd> + <kbd>Tab</kbd>
           </th>
           <td>Move keyboard focus among top-level buttons, and if a dropdown is open, into and through links in the dropdown.</td>
         </tr>

--- a/examples/feed/feed.html
+++ b/examples/feed/feed.html
@@ -70,11 +70,11 @@
           <td>Move focus to previous article.</td>
         </tr>
         <tr data-test-id="key-control-end">
-          <th><kbd>Control + End</kbd></th>
+          <th><kbd>Control</kbd> + <kbd>End</kbd></th>
           <td>Move focus to the first focusable element after the feed.</td>
         </tr>
         <tr data-test-id="key-control-home">
-          <th><kbd>Control + Home</kbd></th>
+          <th><kbd>Control</kbd> + <kbd>Home</kbd></th>
           <td>Move focus to the first focusable element before the feed.</td>
         </tr>
       </tbody>

--- a/examples/grid/LayoutGrids.html
+++ b/examples/grid/LayoutGrids.html
@@ -554,13 +554,13 @@
         </tr>
         <tr data-test-id="key-control-home">
           <th>
-            <kbd>Control + Home</kbd>
+            <kbd>Control</kbd> + <kbd>Home</kbd>
           </th>
           <td>Moves focus to the first cell in the first row.</td>
         </tr>
         <tr data-test-id="key-control-end">
           <th>
-            <kbd>Control + End</kbd>
+            <kbd>Control</kbd> + <kbd>End</kbd>
           </th>
           <td>Moves focus to the last cell in the last row.</td>
         </tr>

--- a/examples/grid/dataGrids.html
+++ b/examples/grid/dataGrids.html
@@ -120,7 +120,7 @@
       <ol>
         <li>
           Data cells can be focused using standard navigation keys, including directional arrows, <kbd>Home</kbd>,
-          <kbd>End</kbd>, <kbd>Control + Home</kbd>, and <kbd>Control + End</kbd>.
+          <kbd>End</kbd>, <kbd>Control</kbd> + <kbd>Home</kbd>, and <kbd>Control</kbd> + <kbd>End</kbd>.
         </li>
         <li>
           The <kbd>Page Down</kbd> and <kbd>Page Up</kbd> keys are not supported since such
@@ -613,13 +613,13 @@
       </tr>
       <tr data-test-id="key-control-home">
         <th scope="row">
-          <kbd>Control + Home</kbd>
+          <kbd>Control</kbd> + <kbd>Home</kbd>
         </th>
         <td>moves focus to the first cell in the first row.</td>
       </tr>
       <tr data-test-id="key-control-end">
         <th scope="row">
-          <kbd>Control + End</kbd>
+          <kbd>Control</kbd> + <kbd>End</kbd>
         </th>
         <td>moves focus to the last cell in the last row.</td>
       </tr>

--- a/examples/listbox/listbox-rearrangeable.html
+++ b/examples/listbox/listbox-rearrangeable.html
@@ -181,8 +181,8 @@ while in the second example, they may select multiple options before activating 
         <ol>
           <li>Action buttons have the following shortcuts:
             <ul>
-              <li>&quot;Up&quot;: <kbd>Alt + Up Arrow</kbd></li>
-              <li>&quot;Down&quot;: <kbd>Alt + Down Arrow</kbd></li>
+              <li>&quot;Up&quot;: <kbd>Alt</kbd> + <kbd>Up Arrow</kbd></li>
+              <li>&quot;Down&quot;: <kbd>Alt</kbd> + <kbd>Down Arrow</kbd></li>
               <li>&quot;Add&quot;: <kbd>Enter</kbd></li>
               <li>&quot;Not Important&quot;, &quot;Important&quot;, and &quot;Remove&quot;: <kbd>Delete</kbd></li>
             </ul>
@@ -194,7 +194,7 @@ while in the second example, they may select multiple options before activating 
           </li>
           <li>
             Using a shortcut key intentionally places focus to optimize both screen reader and keyboard usability.
-            For example, pressing <kbd>Alt + Up Arrow</kbd> in the &quot;Important Features&quot; list keeps focus on the option that is moved up,
+            For example, pressing <kbd>Alt</kbd> + <kbd>Up Arrow</kbd> in the &quot;Important Features&quot; list keeps focus on the option that is moved up,
             enabling all keyboard users to easily perform consecutive move operations for an option
             and screen reader users to hear the position of an option after it is moved.
             Similarly, pressing <kbd>Enter</kbd> in the available options list leaves focus in the available options list.
@@ -274,25 +274,25 @@ while in the second example, they may select multiple options before activating 
           <td>changes the selection state of the focused option .</td>
         </tr>
         <tr data-test-id="key-shift-down-arrow">
-          <th><kbd>Shift + Down Arrow</kbd></th>
+          <th><kbd>Shift</kbd> + <kbd>Down Arrow</kbd></th>
           <td>Moves focus to and selects the next option.</td>
         </tr>
         <tr data-test-id="key-shift-up-arrow">
-          <th><kbd>Shift + Up Arrow</kbd></th>
+          <th><kbd>Shift</kbd> + <kbd>Up Arrow</kbd></th>
           <td>Moves focus to and selects the previous option.</td>
         </tr>
         <tr data-test-id="key-control-shift-home">
-          <th><kbd>Control + Shift + Home</kbd></th>
+          <th><kbd>Control</kbd> + <kbd>Shift</kbd> + <kbd>Home</kbd></th>
           <td>Selects from the focused option to the beginning of the list.</td>
         </tr>
         <tr data-test-id="key-control-shift-end">
-          <th><kbd>Control + Shift + End</kbd></th>
+          <th><kbd>Control</kbd> + <kbd>Shift</kbd> + <kbd>End</kbd></th>
           <td>Selects from the focused option to the end of the list.</td>
         </tr>
         <tr data-test-id="key-control-a">
           <th>
-            <kbd>Control + A</kbd> (All Platforms)<br>
-            <kbd>Command-A</kbd> (macOS)
+            <kbd>Control</kbd> + <kbd>A</kbd> (All Platforms)<br>
+            <kbd>Command</kbd> + <kbd>A</kbd> (macOS)
           </th>
           <td>selects all options in the list. If all options are selected, unselects all options.</td>
         </tr>

--- a/examples/treegrid/treegrid-1.html
+++ b/examples/treegrid/treegrid-1.html
@@ -78,7 +78,7 @@ document.addEventListener('DOMContentLoaded', function () {
   <h1>Treegrid Email Inbox Example</h1>
   <p>
     <strong>NOTE:</strong> This example is new in APG 1.1 release 2.
-    Please provide feedback in 
+    Please provide feedback in
     <a href="https://github.com/w3c/aria-practices/issues/790">issue 790.</a>
   </p>
   <p>
@@ -203,7 +203,7 @@ document.addEventListener('DOMContentLoaded', function () {
     <p>
       <strong>NOTE:</strong> The following table includes descriptions of how keyboard commands move focus among cells and rows in the treegrid implementation on this page.
       In the example on this page, some cells contain a single focusable widget, and if a cell contains a widget, the cell is not focusable; the widget receives focus instead of the cell.
-      So, when a keyboard command description says a command moves focus to a cell, the command may either focus the cell or a widget inside the cell.     
+      So, when a keyboard command description says a command moves focus to a cell, the command may either focus the cell or a widget inside the cell.
     </p>
      <table aria-labelledby="kbd_label" class="def">
       <thead>
@@ -274,7 +274,7 @@ document.addEventListener('DOMContentLoaded', function () {
       </tr>
       <tr data-test-id="key-shift-tab">
         <th scope="row">
-          <kbd>Shift + Tab</kbd>
+          <kbd>Shift</kbd> + <kbd>Tab</kbd>
         </th>
         <td>
           <ul>
@@ -307,7 +307,7 @@ document.addEventListener('DOMContentLoaded', function () {
       </tr>
       <tr data-test-id="key-control-home">
         <th scope="row">
-          <kbd>Control + Home</kbd>
+          <kbd>Control</kbd> + <kbd>Home</kbd>
         </th>
         <td>
           <ul>
@@ -318,7 +318,7 @@ document.addEventListener('DOMContentLoaded', function () {
       </tr>
       <tr data-test-id="key-control-end">
         <th scope="row">
-          <kbd>Control + End</kbd>
+          <kbd>Control</kbd> + <kbd>End</kbd>
         </th>
         <td>
           <ul>


### PR DESCRIPTION
Related to this, it would be nice to have a little styling on the `kbd` element, but I'm not sure if that's something that is supposed to come from the common CSS rather than specific to this repo. Some examples of the styling over here https://auth0.github.io/kbd/


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/nschonni/aria-practices/pull/1611.html" title="Last updated on Mar 3, 2021, 6:13 PM UTC (7bd118b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria-practices/1611/b034ccd...nschonni:7bd118b.html" title="Last updated on Mar 3, 2021, 6:13 PM UTC (7bd118b)">Diff</a>