### PR TITLE
fix: Spin Button Date tests and sync spec to current behaviour

### DIFF
--- a/examples/spinbutton/datepicker-spinbuttons.html
+++ b/examples/spinbutton/datepicker-spinbuttons.html
@@ -198,6 +198,7 @@
             <td>
               <ul>
                 <li>Increases the value 5 steps.</li>
+                <li>When focus is on the <q>Day</q> spin button and the value is the last day of the month, changes value to the first day of the month.</li>
                 <li>When focus is on the <q>Month</q> spin button and the value is <q>December</q>, changes value to <q>January</q>.</li>
               </ul>
             </td>

--- a/examples/spinbutton/datepicker-spinbuttons.html
+++ b/examples/spinbutton/datepicker-spinbuttons.html
@@ -199,7 +199,7 @@
               <ul>
                 <li>Increases the value 5 steps.</li>
                 <li>When focus is on the <q>Day</q> spin button and the value is the last day of the month, changes value to the first day of the month.</li>
-                <li>When focus is on the <q>Month</q> spin button and the value is <q>December</q>, changes value to <q>January</q>.</li>
+                <li>When focus is on the <q>Month</q> spin button and the value is <q>December</q>, <q>November</q>, <q>October</q>, <q>September</q>, or <q>August</q>, changes value to <q>January</q>.</li>
               </ul>
             </td>
           </tr>

--- a/examples/spinbutton/datepicker-spinbuttons.html
+++ b/examples/spinbutton/datepicker-spinbuttons.html
@@ -189,7 +189,7 @@
               <ul>
                 <li>Decreases the value 5 steps.</li>
                 <li>When focus is on the <q>Day</q> spin button and the value is the first day of the month, changes value to the last day of the month.</li>
-                <li>When focus is on the <q>Month</q> spin button and the value is <q>January</q>, changes value to <q>December</q>.</li>
+                <li>When focus is on the <q>Month</q> spin button and the value is <q>January</q>, <q>February</q>, <q>March</q>, <q>April</q>, or <q>May</q>, changes value to <q>December</q>.</li>
               </ul>
             </td>
           </tr>

--- a/examples/spinbutton/datepicker-spinbuttons.html
+++ b/examples/spinbutton/datepicker-spinbuttons.html
@@ -189,6 +189,7 @@
               <ul>
                 <li>Decreases the value 5 steps.</li>
                 <li>When focus is on the <q>Day</q> spin button and the value is the first day of the month, changes value to the last day of the month.</li>
+                <li>When focus is on the <q>Month</q> spin button and the value is <q>January</q>, changes value to <q>December</q>.</li>
               </ul>
             </td>
           </tr>

--- a/examples/spinbutton/datepicker-spinbuttons.html
+++ b/examples/spinbutton/datepicker-spinbuttons.html
@@ -194,7 +194,12 @@
           </tr>
           <tr data-test-id="spinbutton-page-up">
             <th><kbd>Page Up</kbd></th>
-            <td>Increases the value 5 steps.</td>
+            <td>
+              <ul>
+                <li>Increases the value 5 steps.</li>
+                <li>When focus is on the <q>Month</q> spin button and the value is <q>December</q>, changes value to <q>January</q>.</li>
+              </ul>
+            </td>
           </tr>
           <tr data-test-id="spinbutton-home">
             <th><kbd>Home</kbd></th>

--- a/examples/spinbutton/datepicker-spinbuttons.html
+++ b/examples/spinbutton/datepicker-spinbuttons.html
@@ -185,7 +185,12 @@
           </tr>
           <tr data-test-id="spinbutton-page-down">
             <th><kbd>Page Down</kbd></th>
-            <td>Decreases the value 5 steps.</td>
+            <td>
+              <ul>
+                <li>Decreases the value 5 steps.</li>
+                <li>When focus is on the <q>Day</q> spin button and the value is the first day of the month, changes value to the last day of the month.</li>
+              </ul>
+            </td>
           </tr>
           <tr data-test-id="spinbutton-page-up">
             <th><kbd>Page Up</kbd></th>

--- a/examples/spinbutton/datepicker-spinbuttons.html
+++ b/examples/spinbutton/datepicker-spinbuttons.html
@@ -198,7 +198,7 @@
             <td>
               <ul>
                 <li>Increases the value 5 steps.</li>
-                <li>When focus is on the <q>Day</q> spin button and the value is the last day of the month, changes value to the first day of the month.</li>
+                <li>When focus is on the <q>Day</q> spin button and the value is the last day of the month or any of the last four days, changes value to the first day of the month.</li>
                 <li>When focus is on the <q>Month</q> spin button and the value is <q>December</q>, <q>November</q>, <q>October</q>, <q>September</q>, or <q>August</q>, changes value to <q>January</q>.</li>
               </ul>
             </td>

--- a/examples/spinbutton/datepicker-spinbuttons.html
+++ b/examples/spinbutton/datepicker-spinbuttons.html
@@ -188,7 +188,7 @@
             <td>
               <ul>
                 <li>Decreases the value 5 steps.</li>
-                <li>When focus is on the <q>Day</q> spin button and the value is the first day of the month, changes value to the last day of the month.</li>
+                <li>When focus is on the <q>Day</q> spin button and the value is the first day of the month or up to the fifth, changes value to the last day of the month.</li>
                 <li>When focus is on the <q>Month</q> spin button and the value is <q>January</q>, <q>February</q>, <q>March</q>, <q>April</q>, or <q>May</q>, changes value to <q>December</q>.</li>
               </ul>
             </td>

--- a/examples/spinbutton/datepicker-spinbuttons.html
+++ b/examples/spinbutton/datepicker-spinbuttons.html
@@ -188,8 +188,8 @@
             <td>
               <ul>
                 <li>Decreases the value 5 steps.</li>
-                <li>When focus is on the <q>Day</q> spin button and the value is the first day of the month or up to the fifth, changes value to the last day of the month.</li>
-                <li>When focus is on the <q>Month</q> spin button and the value is <q>January</q>, <q>February</q>, <q>March</q>, <q>April</q>, or <q>May</q>, changes value to <q>December</q>.</li>
+                <li>When focus is on the <q>Day</q> spin button and the value is the fifth day of the month or less, changes value to the last day of the month.</li>
+                <li>When focus is on the <q>Month</q> spin button and the value is the fifth month of the year or less, changes value to <q>December</q>.</li>
               </ul>
             </td>
           </tr>
@@ -198,8 +198,8 @@
             <td>
               <ul>
                 <li>Increases the value 5 steps.</li>
-                <li>When focus is on the <q>Day</q> spin button and the value is the last day of the month or any of the last four days, changes value to the first day of the month.</li>
-                <li>When focus is on the <q>Month</q> spin button and the value is <q>December</q>, <q>November</q>, <q>October</q>, <q>September</q>, or <q>August</q>, changes value to <q>January</q>.</li>
+                <li>When focus is on the <q>Day</q> spin button and the value is any of the last five days of the month, changes value to the first day of the month.</li>
+                <li>When focus is on the <q>Month</q> spin button and the value is any of the last five months of the year, changes value to <q>January</q>.</li>
               </ul>
             </td>
           </tr>

--- a/test/tests/spinbutton_datepicker.js
+++ b/test/tests/spinbutton_datepicker.js
@@ -541,46 +541,46 @@ ariaTest(
 );
 
 // The bug causing this test to fail is tracked in https://github.com/w3c/aria-practices/issues/1426
-ariaTest.failing(
-  'page up on day',
-  exampleFile,
-  'spinbutton-page-up',
-  async (t) => {
-    let control = parseInt(ex.dayNow);
-    let daysInMonth = parseInt(ex.dayMax);
+ariaTest('page up on day', exampleFile, 'spinbutton-page-up', async (t) => {
+  let control = parseInt(ex.dayNow);
 
-    // Send page up to day date spinner
-    let daySpinner = await t.context.session.findElement(
-      By.css(ex.daySelector)
-    );
+  // Set to December for a 31 day month
+  let monthSpinner = await t.context.session.findElement(
+    By.css(ex.monthSelector)
+  );
+  await monthSpinner.sendKeys(Key.END);
+
+  // Send page up to day date spinner
+  let daySpinner = await t.context.session.findElement(By.css(ex.daySelector));
+
+  // Set to first of month
+  await daySpinner.sendKeys(Key.HOME);
+
+  await daySpinner.sendKeys(Key.PAGE_UP);
+
+  // Add a day to the control
+  control = 6;
+
+  t.is(
+    parseInt(await daySpinner.getText()),
+    control,
+    'After sending 1 page up to the day spinner, the day should be: ' + control
+  );
+
+  // Send page up 5 more times to date spinner
+  for (let i = 1; i <= 5; i++) {
     await daySpinner.sendKeys(Key.PAGE_UP);
-
-    // Add a day to the control
-    control = (control + 5) % daysInMonth;
-
-    t.is(
-      parseInt(await daySpinner.getText()),
-      control,
-      'After sending 1 page up to the day spinner, the day should be: ' +
-        control
-    );
-
-    // Send page up 5 more times to date spinner
-    for (let i = 1; i <= 5; i++) {
-      await daySpinner.sendKeys(Key.PAGE_UP);
-    }
-
-    // Add 25 days to the control
-    control = (control + 25) % daysInMonth;
-
-    t.is(
-      parseInt(await daySpinner.getText()),
-      control,
-      'After sending 6 page ups to the day spinner, the day should be: ' +
-        control
-    );
   }
-);
+
+  // Add 25 days to the control
+  control = 31;
+
+  t.is(
+    parseInt(await daySpinner.getText()),
+    control,
+    'After sending 6 page ups to the day spinner, the day should be: ' + control
+  );
+});
 
 // The bug causing this test to fail is tracked in https://github.com/w3c/aria-practices/issues/1426
 ariaTest.failing(

--- a/test/tests/spinbutton_datepicker.js
+++ b/test/tests/spinbutton_datepicker.js
@@ -701,6 +701,23 @@ ariaTest('page up on month', exampleFile, 'spinbutton-page-up', async (t) => {
     'After sending page ups to the month spinner in December, the month should be: ' +
       valuesMonth[control - 1]
   );
+
+  // Set to December
+  await monthSpinner.sendKeys(Key.END);
+
+  // Set to August
+  for (let i = 1; i <= 4; i++) {
+    await monthSpinner.sendKeys(Key.DOWN);
+  }
+
+  await monthSpinner.sendKeys(Key.PAGE_UP);
+
+  t.is(
+    await monthSpinner.getText(),
+    valuesMonth[control - 1],
+    'After sending page up to the month spinner on August, the month should be: ' +
+      valuesMonth[control - 1]
+  );
 });
 
 ariaTest(

--- a/test/tests/spinbutton_datepicker.js
+++ b/test/tests/spinbutton_datepicker.js
@@ -757,6 +757,23 @@ ariaTest(
       'After sending page down to the month spinner on January, the month should be: ' +
         valuesMonth[control - 1]
     );
+
+    // Set to January
+    await monthSpinner.sendKeys(Key.HOME);
+
+    // Set to May
+    for (let i = 1; i <= 4; i++) {
+      await monthSpinner.sendKeys(Key.ARROW_UP);
+    }
+
+    await monthSpinner.sendKeys(Key.PAGE_DOWN);
+
+    t.is(
+      await monthSpinner.getText(),
+      valuesMonth[control - 1],
+      'After sending page down to the month spinner on May, the month should be: ' +
+        valuesMonth[control - 1]
+    );
   }
 );
 

--- a/test/tests/spinbutton_datepicker.js
+++ b/test/tests/spinbutton_datepicker.js
@@ -689,22 +689,25 @@ ariaTest('page up on month', exampleFile, 'spinbutton-page-up', async (t) => {
   );
 });
 
-// The bug causing this test to fail is tracked in https://github.com/w3c/aria-practices/issues/1426
-ariaTest.failing(
+ariaTest(
   'page down on month',
   exampleFile,
   'spinbutton-page-down',
   async (t) => {
-    let control = parseInt(ex.monthNow) + 1;
+    let control = 12;
 
     // Send page down to month date spinner
     let monthSpinner = await t.context.session.findElement(
       By.css(ex.monthSelector)
     );
+
+    // Set spinner to December
+    await monthSpinner.sendKeys(Key.END);
+
     await monthSpinner.sendKeys(Key.PAGE_DOWN);
 
     // Subtract 5 month to the control
-    control = (control - 5) % 12;
+    control -= 5;
 
     t.is(
       await monthSpinner.getText(),
@@ -718,13 +721,26 @@ ariaTest.failing(
       await monthSpinner.sendKeys(Key.PAGE_DOWN);
     }
 
-    // Subtract 30 months to the control
-    control = 12 + ((control - 10) % 12);
+    // Roll around to December
+    control = 12;
 
     t.is(
       await monthSpinner.getText(),
       valuesMonth[control - 1],
       'After sending 3 page downs to the month spinner, the month should be: ' +
+        valuesMonth[control - 1]
+    );
+
+    // Set to January
+    await monthSpinner.sendKeys(Key.HOME);
+
+    // Roll around to December
+    await monthSpinner.sendKeys(Key.PAGE_DOWN);
+
+    t.is(
+      await monthSpinner.getText(),
+      valuesMonth[control - 1],
+      'After sending page down to the month spinner on January, the month should be: ' +
         valuesMonth[control - 1]
     );
   }

--- a/test/tests/spinbutton_datepicker.js
+++ b/test/tests/spinbutton_datepicker.js
@@ -583,46 +583,48 @@ ariaTest('page up on day', exampleFile, 'spinbutton-page-up', async (t) => {
 });
 
 // The bug causing this test to fail is tracked in https://github.com/w3c/aria-practices/issues/1426
-ariaTest.failing(
-  'page down on day',
-  exampleFile,
-  'spinbutton-page-down',
-  async (t) => {
-    let control = parseInt(ex.dayNow);
-    let daysInMonth = parseInt(ex.dayMax);
+ariaTest('page down on day', exampleFile, 'spinbutton-page-down', async (t) => {
+  let control = parseInt(ex.dayNow);
 
-    // Send page down to day date spinner
-    let daySpinner = await t.context.session.findElement(
-      By.css(ex.daySelector)
-    );
+  // Set to December for a 31 day month
+  let monthSpinner = await t.context.session.findElement(
+    By.css(ex.monthSelector)
+  );
+  await monthSpinner.sendKeys(Key.END);
+
+  // Send page down to day date spinner
+  let daySpinner = await t.context.session.findElement(By.css(ex.daySelector));
+
+  // Set to 31st
+  await daySpinner.sendKeys(Key.END);
+
+  await daySpinner.sendKeys(Key.PAGE_DOWN);
+
+  // Subtract 5 days to the control
+  control = 26;
+
+  t.is(
+    parseInt(await daySpinner.getText()),
+    control,
+    'After sending 1 page down to the day spinner, the day should be: ' +
+      control
+  );
+
+  // Send page down 5 more times to date spinner
+  for (let i = 1; i <= 5; i++) {
     await daySpinner.sendKeys(Key.PAGE_DOWN);
-
-    // Subtract 5 days to the control
-    control = (control - 5) % daysInMonth;
-
-    t.is(
-      parseInt(await daySpinner.getText()),
-      control,
-      'After sending 1 page down to the day spinner, the day should be: ' +
-        control
-    );
-
-    // Send page down 5 more times to date spinner
-    for (let i = 1; i <= 5; i++) {
-      await daySpinner.sendKeys(Key.PAGE_DOWN);
-    }
-
-    // Subtract 25 days to the control
-    control = daysInMonth + ((control - 25) % daysInMonth);
-
-    t.is(
-      parseInt(await daySpinner.getText()),
-      control,
-      'After sending 6 page downs to the day spinner, the day should be: ' +
-        control
-    );
   }
-);
+
+  // Subtract 25 days to the control
+  control -= 25;
+
+  t.is(
+    parseInt(await daySpinner.getText()),
+    control,
+    'After sending 6 page downs to the day spinner, the day should be: ' +
+      control
+  );
+});
 
 // The bug causing this test to fail is tracked in https://github.com/w3c/aria-practices/issues/1426
 ariaTest.failing(

--- a/test/tests/spinbutton_datepicker.js
+++ b/test/tests/spinbutton_datepicker.js
@@ -637,46 +637,57 @@ ariaTest('page down on day', exampleFile, 'spinbutton-page-down', async (t) => {
   );
 });
 
-// The bug causing this test to fail is tracked in https://github.com/w3c/aria-practices/issues/1426
-ariaTest.failing(
-  'page up on month',
-  exampleFile,
-  'spinbutton-page-up',
-  async (t) => {
-    let control = parseInt(ex.monthNow) + 1;
+ariaTest('page up on month', exampleFile, 'spinbutton-page-up', async (t) => {
+  let control = 1;
 
-    // Send page up to day date spinner
-    let monthSpinner = await t.context.session.findElement(
-      By.css(ex.monthSelector)
-    );
+  // Send page up to day date spinner
+  let monthSpinner = await t.context.session.findElement(
+    By.css(ex.monthSelector)
+  );
+
+  // Set to January
+  await monthSpinner.sendKeys(Key.HOME);
+
+  await monthSpinner.sendKeys(Key.PAGE_UP);
+
+  // Add 5 month to the control
+  control += 5;
+
+  t.is(
+    await monthSpinner.getText(),
+    valuesMonth[control - 1],
+    'After sending 1 page up to the month spinner, the month should be: ' +
+      valuesMonth[control - 1]
+  );
+
+  // Send page up 2 more times to date spinner
+  for (let i = 1; i <= 2; i++) {
     await monthSpinner.sendKeys(Key.PAGE_UP);
-
-    // Add 5 month to the control
-    control = (control + 5) % 12;
-
-    t.is(
-      await monthSpinner.getText(),
-      valuesMonth[control - 1],
-      'After sending 1 page up to the month spinner, the month should be: ' +
-        valuesMonth[control - 1]
-    );
-
-    // Send page up 2 more times to date spinner
-    for (let i = 1; i <= 2; i++) {
-      await monthSpinner.sendKeys(Key.PAGE_UP);
-    }
-
-    // Add 10 months to the control
-    control = (control + 10) % 12;
-
-    t.is(
-      await monthSpinner.getText(),
-      valuesMonth[control - 1],
-      'After sending 3 page ups to the month spinner, the month should be: ' +
-        valuesMonth[control - 1]
-    );
   }
-);
+
+  // Should roll around to January
+  control = 1;
+
+  t.is(
+    await monthSpinner.getText(),
+    valuesMonth[control - 1],
+    'After sending 3 page ups to the month spinner, the month should be: ' +
+      valuesMonth[control - 1]
+  );
+
+  // Set to December
+  await monthSpinner.sendKeys(Key.END);
+
+  // Should roll around to January
+  await monthSpinner.sendKeys(Key.PAGE_UP);
+
+  t.is(
+    await monthSpinner.getText(),
+    valuesMonth[control - 1],
+    'After sending page ups to the month spinner in December, the month should be: ' +
+      valuesMonth[control - 1]
+  );
+});
 
 // The bug causing this test to fail is tracked in https://github.com/w3c/aria-practices/issues/1426
 ariaTest.failing(

--- a/test/tests/spinbutton_datepicker.js
+++ b/test/tests/spinbutton_datepicker.js
@@ -540,7 +540,6 @@ ariaTest(
   }
 );
 
-// The bug causing this test to fail is tracked in https://github.com/w3c/aria-practices/issues/1426
 ariaTest('page up on day', exampleFile, 'spinbutton-page-up', async (t) => {
   let control = parseInt(ex.dayNow);
 
@@ -579,6 +578,21 @@ ariaTest('page up on day', exampleFile, 'spinbutton-page-up', async (t) => {
     parseInt(await daySpinner.getText()),
     control,
     'After sending 6 page ups to the day spinner, the day should be: ' + control
+  );
+
+  // Set to end of month
+  await daySpinner.sendKeys(Key.END);
+
+  // Rolls around to start of month
+  control = 1;
+
+  await daySpinner.sendKeys(Key.PAGE_UP);
+
+  t.is(
+    parseInt(await daySpinner.getText()),
+    control,
+    'After sending page up to the day spinner on the last day of the month, the day should be: ' +
+      control
   );
 });
 

--- a/test/tests/spinbutton_datepicker.js
+++ b/test/tests/spinbutton_datepicker.js
@@ -666,6 +666,23 @@ ariaTest('page down on day', exampleFile, 'spinbutton-page-down', async (t) => {
     'After sending page downs to the day spinner when set to 1, the day should be: ' +
       control
   );
+
+  // Set to first of month
+  await daySpinner.sendKeys(Key.HOME);
+
+  // Set to five
+  for (let i = 1; i <= 4; i++) {
+    await daySpinner.sendKeys(Key.UP);
+  }
+
+  await daySpinner.sendKeys(Key.PAGE_DOWN);
+
+  t.is(
+    parseInt(await daySpinner.getText()),
+    control,
+    'After sending page down to the day spinner when set to 5, the day should be: ' +
+      control
+  );
 });
 
 ariaTest('page up on month', exampleFile, 'spinbutton-page-up', async (t) => {

--- a/test/tests/spinbutton_datepicker.js
+++ b/test/tests/spinbutton_datepicker.js
@@ -582,7 +582,6 @@ ariaTest('page up on day', exampleFile, 'spinbutton-page-up', async (t) => {
   );
 });
 
-// The bug causing this test to fail is tracked in https://github.com/w3c/aria-practices/issues/1426
 ariaTest('page down on day', exampleFile, 'spinbutton-page-down', async (t) => {
   let control = parseInt(ex.dayNow);
 
@@ -622,6 +621,18 @@ ariaTest('page down on day', exampleFile, 'spinbutton-page-down', async (t) => {
     parseInt(await daySpinner.getText()),
     control,
     'After sending 6 page downs to the day spinner, the day should be: ' +
+      control
+  );
+
+  await daySpinner.sendKeys(Key.PAGE_DOWN);
+
+  // End of month if hit when at first of month.
+  control = 31;
+
+  t.is(
+    parseInt(await daySpinner.getText()),
+    control,
+    'After sending page downs to the day spinner when set to 1, the day should be: ' +
       control
   );
 });

--- a/test/tests/spinbutton_datepicker.js
+++ b/test/tests/spinbutton_datepicker.js
@@ -594,6 +594,23 @@ ariaTest('page up on day', exampleFile, 'spinbutton-page-up', async (t) => {
     'After sending page up to the day spinner on the last day of the month, the day should be: ' +
       control
   );
+
+  // Set to end of month
+  await daySpinner.sendKeys(Key.END);
+
+  // Set to four days before
+  for (let i = 1; i <= 4; i++) {
+    await daySpinner.sendKeys(Key.DOWN);
+  }
+
+  await daySpinner.sendKeys(Key.PAGE_UP);
+
+  t.is(
+    parseInt(await daySpinner.getText()),
+    control,
+    'After sending page up to the day spinner on 4 days before the end of the month, the day should be: ' +
+      control
+  );
 });
 
 ariaTest('page down on day', exampleFile, 'spinbutton-page-down', async (t) => {

--- a/test/tests/spinbutton_datepicker.js
+++ b/test/tests/spinbutton_datepicker.js
@@ -437,22 +437,25 @@ ariaTest(
   exampleFile,
   'spinbutton-down-arrow',
   async (t) => {
-    let control = parseInt(ex.monthNow) + 1;
+    let control = 0;
 
     // Send down arrow to month date spinner
     let monthSpinner = await t.context.session.findElement(
       By.css(ex.monthSelector)
     );
+    // Set to January
+    await monthSpinner.sendKeys(Key.HOME);
+
     await monthSpinner.sendKeys(Key.ARROW_DOWN);
 
     // Subtract a month to the control
-    control = (control - 1) % 12;
+    control = 11;
 
     t.is(
       await monthSpinner.getText(),
-      valuesMonth[control - 1],
+      valuesMonth[control],
       'After sending 1 down arrow to the month spinner, the month should be: ' +
-        valuesMonth[control - 1]
+        valuesMonth[control]
     );
 
     // Send down arrow 30 more times to date spinner
@@ -465,9 +468,9 @@ ariaTest(
 
     t.is(
       await monthSpinner.getText(),
-      valuesMonth[control - 1],
+      valuesMonth[control],
       'After sending 31 down arrows to the month spinner, the month should be: ' +
-        valuesMonth[control - 1]
+        valuesMonth[control]
     );
   }
 );


### PR DESCRIPTION
https://github.com/w3c/aria-practices/issues/1426 suggests that the behaviour should be updated in the future.
This enables the tests reliably and adds the current undocumented behaviour in the example around some keystrokes.