### PR TITLE
Add orange box style for the cautionary note

### DIFF
--- a/examples/css/core.css
+++ b/examples/css/core.css
@@ -123,6 +123,3 @@ table.data.attributes tbody td {
   box-shadow: inset 0 3px 5px 1px hsl(216, 82%, 30%);
 }
 
-.advisement {
-    border-style: none none none solid;
-}

--- a/examples/css/core.css
+++ b/examples/css/core.css
@@ -122,4 +122,3 @@ table.data.attributes tbody td {
   );
   box-shadow: inset 0 3px 5px 1px hsl(216, 82%, 30%);
 }
-

--- a/examples/css/core.css
+++ b/examples/css/core.css
@@ -122,3 +122,7 @@ table.data.attributes tbody td {
   );
   box-shadow: inset 0 3px 5px 1px hsl(216, 82%, 30%);
 }
+
+.advisement {
+    border-style: none none none solid;
+}

--- a/examples/treeview/treeview-navigation.html
+++ b/examples/treeview/treeview-navigation.html
@@ -26,11 +26,13 @@
     </nav>
     <main>
       <h1>Navigation Treeview Example</h1>
-      <p><strong>CAUTION!</strong> Before considering use of the <a href="../../#TreeView">ARIA tree pattern</a> for site navigation, it is important to understand:</p>
-      <ul>
-        <li>Correct implementation of the <code>tree</code> role requires implementation of complex functionality that is not needed for typical site navigation that is styled to look like a tree with expandable sections.</li>
-        <li>A pattern more suited for typical site navigation with expandable groups of links is the <a href="../../#disclosure">disclosure pattern.</a></li>
-      </ul>
+      <div class="advisement">
+        <p><strong>CAUTION!</strong> Before considering use of the <a href="../../#TreeView">ARIA tree pattern</a> for site navigation, it is important to understand:</p>
+        <ul>
+          <li>Correct implementation of the <code>tree</code> role requires implementation of complex functionality that is not needed for typical site navigation that is styled to look like a tree with expandable sections.</li>
+          <li>A pattern more suited for typical site navigation with expandable groups of links is the <a href="../../#disclosure">disclosure pattern.</a></li>
+        </ul>
+      </div>
       <p>
         The below example demonstrates how the
         <a href="../../#TreeView">Treeview Design Pattern</a>


### PR DESCRIPTION
Wrap caution paragraph/list in a div with w3c "advisement" class, which gives the div a light orange background with a darker orange border on the left.