### PR TITLE
disclosure navigation Example: Add "Open in CodePen" button

### DIFF
--- a/examples/disclosure/disclosure-navigation.html
+++ b/examples/disclosure/disclosure-navigation.html
@@ -57,7 +57,9 @@
   </label>
 
   <section>
-    <h2 id="ex_label">Example</h2>
+    <div class="example-header">
+      <h2 id="ex_label">Example</h2>
+    </div>
     <div role="separator" id="ex_start_sep" aria-labelledby="ex_start_sep ex_label" aria-label="Start of" ></div>
     <div id="ex1">
       <nav aria-label="Mythical University">
@@ -349,7 +351,7 @@
   <section>
     <h2>Javascript and CSS Source Code</h2>
     <!--  After the js and css files are named with the name of this example, change the href and text of the following 2 links to refer to the appropriate js and css files.  -->
-    <ul>
+    <ul id="css_js_files">
       <li>
         CSS:
         <a href="css/disclosure-navigation.css" type="tex/css">disclosure-navigation.css</a>
@@ -367,7 +369,7 @@
     <pre><code id="sc1"></code></pre>
     <div role="separator" id="sc1_end_sep" aria-labelledby="sc1_end_sep sc1_label" aria-label="End of" ></div>
     <script>
-      sourceCode.add('sc1', 'ex1');
+      sourceCode.add('sc1', 'ex1', 'ex_label', 'css_js_files');
       sourceCode.make();
     </script>
   </section>


### PR DESCRIPTION
Hi everyone! This "Open to codepen" is in it's own PR because I'm not totally sure how to move forward with it.

Here is example: [Preview Disclosure Navigation Example](https://raw.githack.com/w3c/aria-practices/codepen-disclosure-navigation/examples/disclosure/disclosure-navigation.html)

The problem is that when we open these examples in codepen, the links send you back to the APG page instead of just updating the main content within the copepen HTML rendering. The reason why is that we send a `base` url to Codepen so that all images and links in the HTML lead back to the APG website.

The codepen example works up until you click a link, so it is probably useful to most programmers. My suggestion is that we leave it in this state for now, and see if there is an elegant solution to keep the example links working in codepen when the example is updated to our APG coding guidelines (this example hasn't been updated yet).