### PR TITLE
Infrastructure: chore: Ignore coding-template from report CI

### DIFF
--- a/.github/workflows/coverage-report.yml
+++ b/.github/workflows/coverage-report.yml
@@ -3,9 +3,11 @@ name: Regression Tests Coverage Report
 on:
   pull_request_target:
     paths:
-    - "examples/**"
-    - "test/**"
-    - "!examples/landmarks/**"
+      - "package*.json"
+      - "test/**"
+      - "examples/**"
+      - "!examples/landmarks/**"
+      - "!examples/coding-template/**"
 
 jobs:
   report:


### PR DESCRIPTION
These are ignored the same way in the regression job, and likely don't get touched often. This syncs the `paths` values from that other job.
This will start to trigger on some of Dependabot PRs, but will then be able to see if those bumps cause any issues in the job. Alternately a branch filter could be added to prevent that