### PR TITLE
chore: Remove run-node dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5882,12 +5882,6 @@
         "glob": "^7.1.3"
       }
     },
-    "run-node": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/run-node/-/run-node-2.0.0.tgz",
-      "integrity": "sha512-M024oSKOfXRbBZ4dzWeS4mZfLlkVrLbR+02lSno344whh60hFN7qjWnf3QXm/JePD9CR7W4gRe9tt4H/2PGkcw==",
-      "dev": true
-    },
     "run-parallel": {
       "version": "1.1.9",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "lint-staged": "^10.5.3",
     "npm-merge-driver": "^2.3.6",
     "prettier": "^2.2.1",
-    "run-node": "^2.0.0",
     "selenium-webdriver": "^4.0.0-alpha.8",
     "stylelint": "^13.8.0",
     "stylelint-config-prettier": "^8.0.2",


### PR DESCRIPTION
Doesn't seem like the dependency is used anymore