### PR TITLE
Allow comma or semicolon at end of cspell ignore regex for css background image urls

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -208,7 +208,7 @@
         "aria-owns=\"(?:[^\\\"]+|\\.)*\"",
         "href=\"(?:[^\\\"]+|\\.)*\"",
         "for=\"(?:[^\\\"]+|\\.)*\"",
-        "url\\(\"data\\:image/svg\\+xml.*\"\\);"
+        "url\\(\"data\\:image/svg\\+xml.*\"\\)[,;]"
     ],
     "allowCompoundWords": true,
     "ignorePaths": [


### PR DESCRIPTION
Don't spell-check any css background-image urls (including comma-separated urls).
Hopefully, merging this will stop the automated spell-check from failing in PR #1694.