### PR TITLE
Editable Combobox With List Autocomplete: Remove "onBlur" events.

### DIFF
--- a/examples/combobox/js/combobox-autocomplete.js
+++ b/examples/combobox/js/combobox-autocomplete.js
@@ -515,7 +515,8 @@ class ComboboxAutocomplete {
   onBackgroundMouseUp(event) {
     if (
       !this.comboboxNode.contains(event.target) &&
-      !this.listboxNode.contains(event.target)
+      !this.listboxNode.contains(event.target) &&
+      !this.buttonNode.contains(event.target)
     ) {
       this.comboboxHasVisualFocus = false;
       this.setCurrentOptionStyle(null);

--- a/examples/combobox/js/combobox-autocomplete.js
+++ b/examples/combobox/js/combobox-autocomplete.js
@@ -57,7 +57,12 @@ class ComboboxAutocomplete {
       'focus',
       this.onComboboxFocus.bind(this)
     );
-    this.comboboxNode.addEventListener('blur', this.onComboboxBlur.bind(this));
+
+    document.body.addEventListener(
+      'mouseup',
+      this.onBackgroundMouseUp.bind(this),
+      true
+    );
 
     // initialize pop up menu
 
@@ -507,11 +512,16 @@ class ComboboxAutocomplete {
     this.setCurrentOptionStyle(null);
   }
 
-  onComboboxBlur() {
-    this.comboboxHasVisualFocus = false;
-    this.setCurrentOptionStyle(null);
-    this.removeVisualFocusAll();
-    setTimeout(this.close.bind(this, false), 300);
+  onBackgroundMouseUp(event) {
+    if (
+      !this.comboboxNode.contains(event.target) &&
+      !this.listboxNode.contains(event.target)
+    ) {
+      this.comboboxHasVisualFocus = false;
+      this.setCurrentOptionStyle(null);
+      this.removeVisualFocusAll();
+      setTimeout(this.close.bind(this, true), 300);
+    }
   }
 
   onButtonClick() {
@@ -564,6 +574,5 @@ window.addEventListener('load', function () {
     var buttonNode = combobox.querySelector('button');
     var listboxNode = combobox.querySelector('[role="listbox"]');
     var cba = new ComboboxAutocomplete(comboboxNode, buttonNode, listboxNode);
-    cba.init();
   }
 });

--- a/examples/combobox/js/combobox-autocomplete.js
+++ b/examples/combobox/js/combobox-autocomplete.js
@@ -573,6 +573,6 @@ window.addEventListener('load', function () {
     var comboboxNode = combobox.querySelector('input');
     var buttonNode = combobox.querySelector('button');
     var listboxNode = combobox.querySelector('[role="listbox"]');
-    var cba = new ComboboxAutocomplete(comboboxNode, buttonNode, listboxNode);
+    new ComboboxAutocomplete(comboboxNode, buttonNode, listboxNode);
   }
 });

--- a/test/tests/combobox_autocomplete-list.js
+++ b/test/tests/combobox_autocomplete-list.js
@@ -833,7 +833,7 @@ ariaTest(
       .findElement(By.css(ex.textboxSelector))
       .sendKeys('a', Key.ARROW_DOWN, Key.ESCAPE);
 
-    // Confirm the listbox is closed and the textboxed is cleared
+    // Confirm the listbox is closed and the textbox is cleared
 
     await assertAttributeValues(
       t,
@@ -877,7 +877,7 @@ ariaTest(
       'Error waiting for listbox to close after outside click'
     );
 
-    // Confirm the listbox is closed and the textboxed is cleared
+    // Confirm the listbox is closed and the textbox is cleared
     await assertAttributeValues(
       t,
       ex.textboxSelector,
@@ -920,7 +920,7 @@ ariaTest(
       'Error waiting for listbox to close after outside click'
     );
 
-    // Confirm the listbox is closed and the textboxed is cleared
+    // Confirm the listbox is closed and the textbox is cleared
     await assertAttributeValues(
       t,
       ex.textboxSelector,

--- a/test/tests/combobox_autocomplete-list.js
+++ b/test/tests/combobox_autocomplete-list.js
@@ -889,7 +889,7 @@ ariaTest(
         .findElement(By.css(ex.textboxSelector))
         .getAttribute('value'),
       'a',
-      'Click outside of a textbox will close the testbox without selecting the highlighted value'
+      'Click outside of a textbox will close the textbox without selecting the highlighted value'
     );
   }
 );
@@ -932,7 +932,7 @@ ariaTest(
         .findElement(By.css(ex.textboxSelector))
         .getAttribute('value'),
       'a',
-      'Click outside of a textbox will close the testbox without selecting the highlighted value'
+      'Click outside of a textbox will close the textbox without selecting the highlighted value'
     );
   }
 );

--- a/test/tests/combobox_autocomplete-list.js
+++ b/test/tests/combobox_autocomplete-list.js
@@ -14,6 +14,7 @@ const ex = {
   optionsSelector: '#ex1 [role="option"]',
   buttonSelector: '#ex1 button',
   numAOptions: 5,
+  exampleHeadingSelector: '.example-header',
 };
 
 const waitForFocusChange = async (t, textboxSelector, originalFocus) => {
@@ -846,6 +847,92 @@ ariaTest(
         .getAttribute('value'),
       'a',
       'In listbox key press "ESCAPE" should result in first option in textbox'
+    );
+  }
+);
+
+ariaTest(
+  'Clicking outside of textbox and listbox when focus is on listbox closes listbox',
+  exampleFile,
+  'test-additional-behavior',
+  async (t) => {
+    // Send key "a" to open listbox then key "ARROW_DOWN" to put the focus on the listbox
+    await t.context.session
+      .findElement(By.css(ex.textboxSelector))
+      .sendKeys('a', Key.ARROW_DOWN);
+
+    // click outside the listbox
+    await t.context.session
+      .findElement(By.css(ex.exampleHeadingSelector))
+      .click();
+
+    await t.context.session.wait(
+      async function () {
+        let listbox = await t.context.session.findElement(
+          By.css(ex.listboxSelector)
+        );
+        return !(await listbox.isDisplayed());
+      },
+      t.context.waitTime,
+      'Error waiting for listbox to close after outside click'
+    );
+
+    // Confirm the listbox is closed and the textboxed is cleared
+    await assertAttributeValues(
+      t,
+      ex.textboxSelector,
+      'aria-expanded',
+      'false'
+    );
+    t.is(
+      await t.context.session
+        .findElement(By.css(ex.textboxSelector))
+        .getAttribute('value'),
+      'a',
+      'Click outside of a textbox will close the testbox without selecting the highlighted value'
+    );
+  }
+);
+
+ariaTest(
+  'Clicking outside of textbox and listbox when focus is on textbox closes listbox',
+  exampleFile,
+  'test-additional-behavior',
+  async (t) => {
+    // Send key "a" to open listbox to put focus on textbox
+    await t.context.session
+      .findElement(By.css(ex.textboxSelector))
+      .sendKeys('a');
+
+    // click outside the listbox
+    await t.context.session
+      .findElement(By.css(ex.exampleHeadingSelector))
+      .click();
+
+    await t.context.session.wait(
+      async function () {
+        let listbox = await t.context.session.findElement(
+          By.css(ex.listboxSelector)
+        );
+        return !(await listbox.isDisplayed());
+      },
+      t.context.waitTime,
+      'Error waiting for listbox to close after outside click'
+    );
+
+    // Confirm the listbox is closed and the textboxed is cleared
+    await assertAttributeValues(
+      t,
+      ex.textboxSelector,
+      'aria-expanded',
+      'false'
+    );
+    t.is(
+      await t.context.session
+        .findElement(By.css(ex.textboxSelector))
+        .getAttribute('value'),
+      'a',
+      'Click outside of a textbox will close the testbox without selecting the highlighted value'
     );
   }
 );


### PR DESCRIPTION
Adding the change request in this comment: https://github.com/w3c/aria-practices/issues/1619#issuecomment-748882630

In summary:
- Removed the "on blur" event which causes the listbox to close every time the textbox loses focus
- Close the listbox every time there is a click outside of the listbox or text box
- There was a request to close the listbox on `tab`, this is already supported 

[Preview](https://raw.githack.com/w3c/aria-practices/combobox-VOMac-fix/examples/combobox/combobox-autocomplete-list.html)