### PR TITLE
Modal Dialog Pattern: Clarify initial focus and aria-describedby guidance

### DIFF
--- a/aria-practices.html
+++ b/aria-practices.html
@@ -1130,7 +1130,11 @@ Some JavaScript and CSS may not function correctly in Internet Explorer.
         <ol class="note">
           <li>When a dialog opens, focus moves to an element contained in the dialog. Generally, focus is initially set on the first focusable element. However, the most appropriate focus placement will depend on the nature and size of the content. Examples include:
             <ul>
-              <li>If a dialog primarily serves to present structured content (including multiple paragraphs, lists, tables, etc.) which would not make sense when announced as a single unbroken string of content by assistive technologies, then it is advisable to omit <code>aria-describedby</code> on the dialog itself, add <code>tabindex="-1"</code> to a static element at the start of the content, and initially focus that element.</li>
+              <li>
+                If the dialog content includes semantic structures, such as lists, tables, or multiple paragraphs, that need to be perceived in order to easily understand the content, i.e., if the content would be difficult to understand when announced as a single unbroken string, then it is advisable to add <code>tabindex="-1"</code> to a static element at the start of the content and initially focus that element.
+                This makes it easier for assistive technology users to read the content by navigating the semantic structures.
+                Additionally, it is advisable to omit applying <code>aria-describedby</code> to the dialog container in this scenario.
+              </li>
               <li>If content is large enough that focusing the first interactive element could cause the beginning of content to scroll out of view,
                 it is advisable to add <code>tabindex="-1"</code> to a static element at the top of the dialog, such as the dialog title or first paragraph, and initially focus that element.
               </li>

--- a/aria-practices.html
+++ b/aria-practices.html
@@ -1128,12 +1128,10 @@ Some JavaScript and CSS may not function correctly in Internet Explorer.
         <li><kbd>Escape</kbd>: Closes the dialog.</li>
         </ul>
         <ol class="note">
-          <li> When a dialog opens, focus placement depends on the nature and size of the content.
+          <li>When a dialog opens, focus moves to an element contained in the dialog. Generally, focus is initially set on the first focusable element. However, the most appropriate focus placement will depend on the nature and size of the content. Examples include:
             <ul>
-              <li>In all circumstances, focus moves to an element contained in the dialog.</li>
-              <li>Unless a condition where doing otherwise is advisable, focus is initially set on the first focusable element.</li>
-              <li>
-                If content is large enough that focusing the first interactive element could cause the beginning of content to scroll out of view,
+              <li>If a dialog primarily serves to present structured content (including multiple paragraphs, lists, tables, etc.) which would not make much sense when just announced as a result of the <code>aria-describedby</code> attribute (as they would be announced as a single unbroken string of content by assistive technologies), it is advisable to omit the <code>aria-describedby</code> on the dialog itself, add <code>tabindex=<q>-1</q></code> to a static element at the start of the content, and initially focus that element.</li>
+              <li>If content is large enough that focusing the first interactive element could cause the beginning of content to scroll out of view,
                 it is advisable to add <code>tabindex=<q>-1</q></code> to a static element at the top of the dialog, such as the dialog title or first paragraph, and initially focus that element.
               </li>
               <li>
@@ -1183,7 +1181,7 @@ Some JavaScript and CSS may not function correctly in Internet Explorer.
           <li>
             Optionally, the <a href="#aria-describedby" class="property-reference">aria-describedby</a> property
             is set on the element with the <code>dialog</code> role to indicate which element or elements in the dialog contain content that describes the primary purpose or message of the dialog.
-            Specifying descriptive elements enables screen readers to announce the description along with the dialog title and initially focused element when the dialog opens.
+            Specifying descriptive elements enables screen readers to announce the description along with the dialog title and initially focused element when the dialog opens. As noted previously, for dialogs that primarily serve to present large amounts of structured content, it is advisable <em>not</em> to use <code>aria-describedby</code> to point to the content of the dialog, as this would result in assistive technologies announcing the entirety of the structured content as a single unbroken message.
           </li>
         </ul>
         <ul class="note">

--- a/aria-practices.html
+++ b/aria-practices.html
@@ -1132,7 +1132,7 @@ Some JavaScript and CSS may not function correctly in Internet Explorer.
             <ul>
               <li>If a dialog primarily serves to present structured content (including multiple paragraphs, lists, tables, etc.) which would not make sense when announced as a single unbroken string of content by assistive technologies, then it is advisable to omit <code>aria-describedby</code> on the dialog itself, add <code>tabindex="-1"</code> to a static element at the start of the content, and initially focus that element.</li>
               <li>If content is large enough that focusing the first interactive element could cause the beginning of content to scroll out of view,
-                it is advisable to add <code>tabindex=<q>-1</q></code> to a static element at the top of the dialog, such as the dialog title or first paragraph, and initially focus that element.
+                it is advisable to add <code>tabindex="-1"</code> to a static element at the top of the dialog, such as the dialog title or first paragraph, and initially focus that element.
               </li>
               <li>
                 If a dialog contains the final step in a process that is not easily reversible, such as deleting data or completing a financial transaction,

--- a/aria-practices.html
+++ b/aria-practices.html
@@ -1185,7 +1185,8 @@ Some JavaScript and CSS may not function correctly in Internet Explorer.
           <li>
             Optionally, the <a href="#aria-describedby" class="property-reference">aria-describedby</a> property
             is set on the element with the <code>dialog</code> role to indicate which element or elements in the dialog contain content that describes the primary purpose or message of the dialog.
-            Specifying descriptive elements enables screen readers to announce the description along with the dialog title and initially focused element when the dialog opens. As noted previously, for dialogs that primarily serve to present large amounts of structured content, it is advisable <em>not</em> to use <code>aria-describedby</code> to point to the content of the dialog, as this would result in assistive technologies announcing the entirety of the structured content as a single unbroken message.
+            Specifying descriptive elements enables screen readers to announce the description along with the dialog title and initially focused element when the dialog opens, which is typically helpful only when the descriptive content is simple and can easily be understood without structural information.
+            It is advisable to omit specifying <code>aria-describedby</code> if the dialog content includes semantic structures, such as lists, tables, or multiple paragraphs, that need to be perceived in order to easily understand the content, i.e., if the content would be difficult to understand when announced as a single unbroken string.
           </li>
         </ul>
         <ul class="note">

--- a/aria-practices.html
+++ b/aria-practices.html
@@ -1130,7 +1130,7 @@ Some JavaScript and CSS may not function correctly in Internet Explorer.
         <ol class="note">
           <li>When a dialog opens, focus moves to an element contained in the dialog. Generally, focus is initially set on the first focusable element. However, the most appropriate focus placement will depend on the nature and size of the content. Examples include:
             <ul>
-              <li>If a dialog primarily serves to present structured content (including multiple paragraphs, lists, tables, etc.) which would not make much sense when just announced as a result of the <code>aria-describedby</code> attribute (as they would be announced as a single unbroken string of content by assistive technologies), it is advisable to omit the <code>aria-describedby</code> on the dialog itself, add <code>tabindex=<q>-1</q></code> to a static element at the start of the content, and initially focus that element.</li>
+              <li>If a dialog primarily serves to present structured content (including multiple paragraphs, lists, tables, etc.) which would not make sense when announced as a single unbroken string of content by assistive technologies, then it is advisable to omit <code>aria-describedby</code> on the dialog itself, add <code>tabindex="-1"</code> to a static element at the start of the content, and initially focus that element.</li>
               <li>If content is large enough that focusing the first interactive element could cause the beginning of content to scroll out of view,
                 it is advisable to add <code>tabindex=<q>-1</q></code> to a static element at the top of the dialog, such as the dialog title or first paragraph, and initially focus that element.
               </li>


### PR DESCRIPTION
- reworks/expands the initial focus section for modal dialogs to include the case of structured content dialogs (not necessarily covered by the "large enough to cause scrolling")
- adds advice about `aria-describedby` and when it's best NOT to use it (for structure-heavy dialogs)

Closes https://github.com/w3c/aria-practices/issues/442


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/patrickhlauke/aria-practices/pull/1707.html" title="Last updated on Dec 30, 2020, 8:02 PM UTC (2e3a150)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria-practices/1707/2c38b7f...patrickhlauke:2e3a150.html" title="Last updated on Dec 30, 2020, 8:02 PM UTC (2e3a150)">Diff</a>