### PR TITLE
test/util/assertAttributeCanBeToggled.js: fix JSDoc param name warnings

### DIFF
--- a/test/util/assertAttributeCanBeToggled.js
+++ b/test/util/assertAttributeCanBeToggled.js
@@ -4,9 +4,9 @@ const { By } = require('selenium-webdriver');
  * Asserts that an attribute to an element can either be toggled to a custom value, or true/false
  *
  * @param {obj} t                     - ava execution object
- * @param {string} elementSelector    - element selector string
+ * @param {string} selector    - element selector string
  * @param {string} attribute          - attribute to test
- * @param {WebDriver.Key} attribute   - key to sent to element that will toggle attribute
+ * @param {WebDriver.Key} key   - key to sent to element that will toggle attribute
  */
 module.exports = async function assertAttributeCanBeToggled(
   t,


### PR DESCRIPTION
Didn't match function paramater names