### PR TITLE
fix: JSDoc warnings

### DIFF
--- a/examples/treeview/js/treeview-navigation.js
+++ b/examples/treeview/js/treeview-navigation.js
@@ -492,8 +492,9 @@ class TreeViewNavigation {
 
 /**
  * ARIA Treeview example
+ *
  * @function onload
- * @desc  after page has loaded initialize all treeitems based on the role=treeitem
+ * @description  after page has loaded initialize all treeitems based on the role=treeitem
  */
 
 window.addEventListener('load', function () {

--- a/test/util/assertAriaOwns.js
+++ b/test/util/assertAriaOwns.js
@@ -3,8 +3,8 @@ const assert = require('assert');
 /**
  * Confirm the aria-owns element.
  *
- * @param {obj} t                  - ava execution object
- * @param {String} elementSelector - the element with aria-owns set
+ * @param {object} t                  - ava execution object
+ * @param {string} elementSelector - the element with aria-owns set
  */
 
 module.exports = async function assertAriaOwns(t, elementSelector) {

--- a/test/util/assertAttributeCanBeToggled.js
+++ b/test/util/assertAttributeCanBeToggled.js
@@ -3,7 +3,7 @@ const { By } = require('selenium-webdriver');
 /**
  * Asserts that an attribute to an element can either be toggled to a custom value, or true/false
  *
- * @param {obj} t                     - ava execution object
+ * @param {object} t                     - ava execution object
  * @param {string} selector    - element selector string
  * @param {string} attribute          - attribute to test
  * @param {WebDriver.Key} key   - key to sent to element that will toggle attribute


### PR DESCRIPTION
- Newline after description
- desc -> description
- obj -> object
- String -> string