### PR TITLE
Infrastructure: chore: Enable and fix additional HTMLHint rules

### DIFF
--- a/.htmlhintrc
+++ b/.htmlhintrc
@@ -1,3 +1,25 @@
 {
-  "attr-lowercase": ["viewBox"]
+  "alt-require": false,
+  "attr-lowercase": ["viewBox"],
+  "attr-no-duplication": true,
+  "attr-unsafe-chars": true,
+  "attr-value-double-quotes": false,
+  "attr-value-not-empty": false,
+  "doctype-first": true,
+  "doctype-html5": false,
+  "head-script-disabled": false,
+  "href-abs-or-rel": false,
+  "id-class-ad-disabled": false,
+  "id-class-value": false,
+  "id-unique": true,
+  "inline-script-disabled": false,
+  "inline-style-disabled": false,
+  "space-tab-mixed-disabled": false,
+  "spec-char-escape": false,
+  "src-not-empty": true,
+  "style-disabled": false,
+  "tag-pair": false,
+  "tag-self-close": false,
+  "tagname-lowercase": true,
+  "title-require": true
 }

--- a/.htmlhintrc
+++ b/.htmlhintrc
@@ -18,7 +18,7 @@
   "spec-char-escape": true,
   "src-not-empty": true,
   "style-disabled": false,
-  "tag-pair": false,
+  "tag-pair": true,
   "tag-self-close": false,
   "tagname-lowercase": true,
   "title-require": true

--- a/.htmlhintrc
+++ b/.htmlhintrc
@@ -6,7 +6,7 @@
   "attr-value-double-quotes": true,
   "attr-value-not-empty": false,
   "doctype-first": true,
-  "doctype-html5": false,
+  "doctype-html5": true,
   "head-script-disabled": false,
   "href-abs-or-rel": false,
   "id-class-ad-disabled": false,

--- a/.htmlhintrc
+++ b/.htmlhintrc
@@ -14,7 +14,7 @@
   "id-unique": true,
   "inline-script-disabled": false,
   "inline-style-disabled": false,
-  "space-tab-mixed-disabled": false,
+  "space-tab-mixed-disabled": "space",
   "spec-char-escape": true,
   "src-not-empty": true,
   "style-disabled": false,

--- a/.htmlhintrc
+++ b/.htmlhintrc
@@ -3,7 +3,7 @@
   "attr-lowercase": ["viewBox"],
   "attr-no-duplication": true,
   "attr-unsafe-chars": true,
-  "attr-value-double-quotes": false,
+  "attr-value-double-quotes": true,
   "attr-value-not-empty": false,
   "doctype-first": true,
   "doctype-html5": false,

--- a/.htmlhintrc
+++ b/.htmlhintrc
@@ -15,7 +15,7 @@
   "inline-script-disabled": false,
   "inline-style-disabled": false,
   "space-tab-mixed-disabled": false,
-  "spec-char-escape": false,
+  "spec-char-escape": true,
   "src-not-empty": true,
   "style-disabled": false,
   "tag-pair": false,

--- a/aria-practices-DeletedSectionsArchive.html
+++ b/aria-practices-DeletedSectionsArchive.html
@@ -1,162 +1,162 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
 <head>
-	<title>Content Deleted From WAI-ARIA Authoring Practices 1.1</title>
-	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-	<script src="https://www.w3.org/Tools/respec/respec-w3c-common" class="remove"></script>
-	<script src="common/script/resolveReferences.js" class="remove"></script>
-	<script src="common/biblio.js" class="remove"></script>
-	<script class="remove">
-		var respecConfig = {
-			// Embed RDFa data in the output.
-			doRDFa : '1.1',
-			includePermalinks : true,
-			permalinkEdge : true,
-			permalinkHide : false,
-			// Specification status (e.g., WD, LC, NOTE, etc.). If in doubt use ED.
-			specStatus : "ED",
-			// crEnd: "2012-04-30",
-			// perEnd: "2013-07-23",
-			// publishDate: "2013-08-22",
-			noRecTrack : true,
-			diffTool : "http://www.aptest.com/standards/htmldiff/htmldiff.pl",
+  <title>Content Deleted From WAI-ARIA Authoring Practices 1.1</title>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+  <script src="https://www.w3.org/Tools/respec/respec-w3c-common" class="remove"></script>
+  <script src="common/script/resolveReferences.js" class="remove"></script>
+  <script src="common/biblio.js" class="remove"></script>
+  <script class="remove">
+    var respecConfig = {
+      // Embed RDFa data in the output.
+      doRDFa : '1.1',
+      includePermalinks : true,
+      permalinkEdge : true,
+      permalinkHide : false,
+      // Specification status (e.g., WD, LC, NOTE, etc.). If in doubt use ED.
+      specStatus : "ED",
+      // crEnd: "2012-04-30",
+      // perEnd: "2013-07-23",
+      // publishDate: "2013-08-22",
+      noRecTrack : true,
+      diffTool : "http://www.aptest.com/standards/htmldiff/htmldiff.pl",
 
-			// The specifications short name, as in http://www.w3.org/TR/short-name/
-			shortName : "wai-aria-practices-1.1",
+      // The specifications short name, as in http://www.w3.org/TR/short-name/
+      shortName : "wai-aria-practices-1.1",
 
-			// If you wish the publication date to be other than today,
-			// set publishDate.
-			// publishDate: "2009-08-06",
-			copyrightStart : "2015",
+      // If you wish the publication date to be other than today,
+      // set publishDate.
+      // publishDate: "2009-08-06",
+      copyrightStart : "2015",
 
-			// If there is a previously published draft, uncomment this
-			// and set its YYYY-MM-DD date and its maturity status.
-			//
-			// previousPublishDate:  "",
-			// previousMaturity:  "",
-			// prevRecURI: "",
-			// previousDiffURI: "",
+      // If there is a previously published draft, uncomment this
+      // and set its YYYY-MM-DD date and its maturity status.
+      //
+      // previousPublishDate:  "",
+      // previousMaturity:  "",
+      // prevRecURI: "",
+      // previousDiffURI: "",
 
-			// If there a publicly available Editors Draft, this is the link
-			edDraftURI : "http://w3c.github.io/aria-practices/",
+      // If there a publicly available Editors Draft, this is the link
+      edDraftURI : "http://w3c.github.io/aria-practices/",
 
-			// If this is a LCWD, uncomment and set the end of its review period
-			// lcEnd: "2012-02-21",
+      // If this is a LCWD, uncomment and set the end of its review period
+      // lcEnd: "2012-02-21",
 
-			// Editors, add as many as you like.
-			// “name” is the only required field.
-			editors : [ {
-				name : "Matt King",
-				mailto : "mck@fb.com",
-				company : "Facebook",
-				companyURI : "http://www.facebook.com/"
-			}, {
-				name : "James Nurthen",
-				mailto : "james.nurthen@oracle.com",
-				company : "Oracle Corporation",
-				companyURI : "http://www.oracle.com/"
-			}, {
-				name : "Michael Cooper",
-				url : 'http://www.w3.org/People/cooper/',
-				mailto : "cooper@w3.org",
-				company : "W3C",
-				companyURI : "http://www.w3.org/"
-			}, {
-				name : "Michiel Bijl",
-				mailto : "mbijl@paciellogroup.com",
-				company : "The Paciello Group",
-				companyURI : "https://www.paciellogroup.com/"
-			}, {
-				name : "Joseph Scheuhammer",
-				company : "Inclusive Design Research Centre, OCAD University",
-				companyURI : "http://idrc.ocad.ca/",
-				note : "Previous Editor"
-			}, {
-				name : "Lisa Pappas",
-				company : "SAS",
-				companyURI : "http://www.sas.com/",
-				note : "Previous Editor"
-			}, {
-				name : "Rich Schwerdtfeger",
-				company : "IBM Corporation",
-				companyURI : "http://ibm.com/",
-				note : "Previous Editor"
-			}, ],
+      // Editors, add as many as you like.
+      // “name” is the only required field.
+      editors : [ {
+        name : "Matt King",
+        mailto : "mck@fb.com",
+        company : "Facebook",
+        companyURI : "http://www.facebook.com/"
+      }, {
+        name : "James Nurthen",
+        mailto : "james.nurthen@oracle.com",
+        company : "Oracle Corporation",
+        companyURI : "http://www.oracle.com/"
+      }, {
+        name : "Michael Cooper",
+        url : 'http://www.w3.org/People/cooper/',
+        mailto : "cooper@w3.org",
+        company : "W3C",
+        companyURI : "http://www.w3.org/"
+      }, {
+        name : "Michiel Bijl",
+        mailto : "mbijl@paciellogroup.com",
+        company : "The Paciello Group",
+        companyURI : "https://www.paciellogroup.com/"
+      }, {
+        name : "Joseph Scheuhammer",
+        company : "Inclusive Design Research Centre, OCAD University",
+        companyURI : "http://idrc.ocad.ca/",
+        note : "Previous Editor"
+      }, {
+        name : "Lisa Pappas",
+        company : "SAS",
+        companyURI : "http://www.sas.com/",
+        note : "Previous Editor"
+      }, {
+        name : "Rich Schwerdtfeger",
+        company : "IBM Corporation",
+        companyURI : "http://ibm.com/",
+        note : "Previous Editor"
+      }, ],
 
-			// Authors, add as many as you like.
-			// This is optional, uncomment if you have authors as well as editors.
-			// Same format and requirements as editors.
+      // Authors, add as many as you like.
+      // This is optional, uncomment if you have authors as well as editors.
+      // Same format and requirements as editors.
 
-			// authors: [
-			//   {
-			//     name: "Your Name",
-			//     url: "http://example.org/",
-			//     company: "Your Company",
-			//     companyURI: "http://example.com/"
-			//   },
-			// ],
+      // authors: [
+      //   {
+      //     name: "Your Name",
+      //     url: "http://example.org/",
+      //     company: "Your Company",
+      //     companyURI: "http://example.com/"
+      //   },
+      // ],
 
-			// Spec URLs
-			ariaSpecURLs : {
-				"ED" : "http://w3c.github.io/aria/aria/aria.html",
-				"FPWD" : "http://www.w3.org/TR/wai-aria-1.1/",
-				"WD" : "http://www.w3.org/TR/wai-aria-1.1/",
-				"REC" : "http://www.w3.org/TR/wai-aria/"
-			},
-			accNameURLs : {
-				"ED" : "http://w3c.github.io/aria/accname-aam/accname-aam.html",
-				"WD" : "http://www.w3.org/TR/accname-aam-1.1/",
-				"FPWD" : "http://www.w3.org/TR/accname-aam-1.1/",
-				"REC" : "http://www.w3.org/TR/accname-aam-1.1/"
-			},
-			coreMappingURLs : {
-				"ED" : "http://w3c.github.io/aria/core-aam/core-aam.html",
-				"WD" : "http://www.w3.org/TR/core-aam-1.1/",
-				"FPWD" : "http://www.w3.org/TR/core-aam-1.1/",
-				"REC" : "http://www.w3.org/TR/core-aam-1.1/"
-			},
+      // Spec URLs
+      ariaSpecURLs : {
+        "ED" : "http://w3c.github.io/aria/aria/aria.html",
+        "FPWD" : "http://www.w3.org/TR/wai-aria-1.1/",
+        "WD" : "http://www.w3.org/TR/wai-aria-1.1/",
+        "REC" : "http://www.w3.org/TR/wai-aria/"
+      },
+      accNameURLs : {
+        "ED" : "http://w3c.github.io/aria/accname-aam/accname-aam.html",
+        "WD" : "http://www.w3.org/TR/accname-aam-1.1/",
+        "FPWD" : "http://www.w3.org/TR/accname-aam-1.1/",
+        "REC" : "http://www.w3.org/TR/accname-aam-1.1/"
+      },
+      coreMappingURLs : {
+        "ED" : "http://w3c.github.io/aria/core-aam/core-aam.html",
+        "WD" : "http://www.w3.org/TR/core-aam-1.1/",
+        "FPWD" : "http://www.w3.org/TR/core-aam-1.1/",
+        "REC" : "http://www.w3.org/TR/core-aam-1.1/"
+      },
 
-			// alternateFormats: [
-			//   {
-			//     uri: 'aria-practices-diff.html',
-			//     label: "Diff from Previous Recommendation"
-			//   },
-			//   {
-			//     uri: 'aria-practices.ps',
-			//     label: "PostScript version"
-			//   },
-			//   {
-			//     uri: 'aria-practices.pdf',
-			//     label: "PDF version"
-			//   }
-			// ],
+      // alternateFormats: [
+      //   {
+      //     uri: 'aria-practices-diff.html',
+      //     label: "Diff from Previous Recommendation"
+      //   },
+      //   {
+      //     uri: 'aria-practices.ps',
+      //     label: "PostScript version"
+      //   },
+      //   {
+      //     uri: 'aria-practices.pdf',
+      //     label: "PDF version"
+      //   }
+      // ],
 
-			// errata: 'http://www.w3.org/2010/02/rdfa/errata.html',
+      // errata: 'http://www.w3.org/2010/02/rdfa/errata.html',
 
-			// name of the WG
-			wg : "Accessible Rich Internet Applications Working Group",
+      // name of the WG
+      wg : "Accessible Rich Internet Applications Working Group",
 
-			// URI of the public WG page
-			wgURI : "http://www.w3.org/WAI/ARIA/",
+      // URI of the public WG page
+      wgURI : "http://www.w3.org/WAI/ARIA/",
 
-			// Name (without the @w3c.org) of the public mailing
-			// to which comments are due.
-			wgPublicList : "public-aria",
+      // Name (without the @w3c.org) of the public mailing
+      // to which comments are due.
+      wgPublicList : "public-aria",
 
-			// URI of the patent status for this WG, for Rec-track documents
-			// !!!! IMPORTANT !!!!
-			// This is important for Rec-track documents, do not copy a patent URI
-			// from a random document unless you know what you're doing.
-			// If in doubt ask your friendly neighbourhood Team Contact.
-			wgPatentURI : "http://www.w3.org/2004/01/pp-impl/83726/status",
-			maxTocLevel : 4,
+      // URI of the patent status for this WG, for Rec-track documents
+      // !!!! IMPORTANT !!!!
+      // This is important for Rec-track documents, do not copy a patent URI
+      // from a random document unless you know what you're doing.
+      // If in doubt ask your friendly neighbourhood Team Contact.
+      wgPatentURI : "http://www.w3.org/2004/01/pp-impl/83726/status",
+      maxTocLevel : 4,
 
-			localBiblio : biblio,
+      localBiblio : biblio,
 
-			preProcess : [ linkCrossReferences ]
-		};
-	</script>
-	<link href="common/css/common.css" rel="stylesheet" type="text/css" />
+      preProcess : [ linkCrossReferences ]
+    };
+  </script>
+  <link href="common/css/common.css" rel="stylesheet" type="text/css" />
 </head>
 <body>
     <section id="abstract">

--- a/aria-practices.html
+++ b/aria-practices.html
@@ -5893,7 +5893,7 @@ So, As advised by <a href="#naming_rule_avoid_fallback">Rule 4: Avoid Browser Fa
             </li>
 
             <li> Activate an element without moving focus when the target context of the function is the context that contains the focus. This behavior is most common for command buttons and for functions associated with elements that are not visible, such as a "Save" option that is accessible via a menu. For example, if the focus is on an option in a listbox and a toolbar contains buttons for moving and removing options, it is most beneficial to keep focus in the listbox when the user presses a key shortcut for one of the buttons in the toolbar. This behavior can be particularly important for screen reader users because it provides confirmation of the action performed and makes performing multiple commands more efficient. For instance, when a screen reader user presses the shortcut for the "Up" button, the user will be able to hear the new position of the option in the list since it still has the focus. Similarly, when the user presses the shortcut for deleting an option, the user can
-								hear the next option in the list and immediately decide whether to press the delete shortcut again. </li>
+                hear the next option in the list and immediately decide whether to press the delete shortcut again. </li>
 
             <li>
               Move focus and activate when the target of the shortcut has a single function and the context of that function is the same as the target.
@@ -7076,66 +7076,66 @@ So, As advised by <a href="#naming_rule_avoid_fallback">Rule 4: Avoid Browser Fa
         <li>Simon Pieters of Bocoup and his sponsor, Facebook, for authoring of significant guidance sections, including comprehensive treatment of the topic of accessible names and descriptions.</li>
       </ul>
     </section>
-  	<section>
-  		<h3>Participants active in the ARIA Authoring Practices Task Force</h3>
-  		<ul>
-  			<li>Ann Abbott (Invited Expert)</li>
-  			<li>Shirisha Balusani (Microsoft Corporation)</li>
+    <section>
+      <h3>Participants active in the ARIA Authoring Practices Task Force</h3>
+      <ul>
+        <li>Ann Abbott (Invited Expert)</li>
+        <li>Shirisha Balusani (Microsoft Corporation)</li>
         <li>Dorothy Bass (Wells Fargo Bank N.A.)</li>
-  			<li>Curt Bellew (Oracle)</li>
-  			<li>Zoë Bijl (Invited Expert)</li>
-  			<li>Michael Cooper (W3C)</li>
-  			<li>Bryan Garaventa (Level Access)</li>
-  			<li>Jon Gunderson (University of Illinois at Urbana-Champaign)</li>
+        <li>Curt Bellew (Oracle)</li>
+        <li>Zoë Bijl (Invited Expert)</li>
+        <li>Michael Cooper (W3C)</li>
+        <li>Bryan Garaventa (Level Access)</li>
+        <li>Jon Gunderson (University of Illinois at Urbana-Champaign)</li>
         <li>Jesse Hausler(Salesforce)</li>
         <li>Sarah Higley (Microsoft Corporation)</li>
-  			<li>Hans Hillen (The Paciello Group, LLC)</li>
-  			<li>Matt King (Facebook)</li>
-  			<li>Jaeun Ku (University of Illinois at Urbana-Champaign)</li>
-  			<li>Aaron Leventhal (Google)</li>
+        <li>Hans Hillen (The Paciello Group, LLC)</li>
+        <li>Matt King (Facebook)</li>
+        <li>Jaeun Ku (University of Illinois at Urbana-Champaign)</li>
+        <li>Aaron Leventhal (Google)</li>
         <li>Carolyn MacLeod (IBM Corporation)</li>
-  			<li>Mark McCarthy (University of Illinois at Urbana-Champaign)</li>
-  			<li>James Nurthen (Adobe)</li>
+        <li>Mark McCarthy (University of Illinois at Urbana-Champaign)</li>
+        <li>James Nurthen (Adobe)</li>
         <li>Scott O'Hara (The Paciello Group, LLC)</li>
         <li>Simon Pieters (Bocoup)</li>
         <li>Scott Vinkle (Shopify)</li>
-  			<li>Evan Yamanishi (W. W. Norton)</li>
-  			<li>Valerie Young (Bocoup)</li>
-  		</ul>
-  	</section>
-  	<section>
-  		<h3>Other commenters and contributors to Version 1.1</h3>
-  		<ul>
-  			<li>Vyacheslav Aristov</li>
-  			<li>J. Renée Beach</li>
-  			<li>Kasper Christensen</li>
-  			<li>Gerard K. Cohen</li>
-  			<li>Anne-Gaelle Colom</li>
-  			<li>Kevin Coughlin</li>
-  			<li>Cameron Cundiff</li>
-  			<li>Manish Dahamiwal</li>
-  			<li>Gilmore Davidson</li>
-  			<li>Boris Dušek</li>
-  			<li>Michael Fairchild</li>
-  			<li>Jeremy Felt</li>
-  			<li>Rob Fentress</li>
-  			<li>Geppy</li>
-  			<li>Tatiana Iskandar</li>
-  			<li>Patrick Lauke</li>
-  			<li>Marek Lewandowski</li>
-  			<li>Dan Matthew</li>
-  			<li>Shane McCarron</li>
-  			<li>Victor Meyer</li>
-  			<li>Jonathan Neal</li>
-  			<li>Philipp Rudloff</li>
-  			<li>Joseph Scheuhammer</li>
-  			<li>Nick Schonning</li>
-  			<li>thomascorthals</li>
-  			<li>Christopher Tryens</li>
-  		</ul>
-  	</section>
+        <li>Evan Yamanishi (W. W. Norton)</li>
+        <li>Valerie Young (Bocoup)</li>
+      </ul>
+    </section>
+    <section>
+      <h3>Other commenters and contributors to Version 1.1</h3>
+      <ul>
+        <li>Vyacheslav Aristov</li>
+        <li>J. Renée Beach</li>
+        <li>Kasper Christensen</li>
+        <li>Gerard K. Cohen</li>
+        <li>Anne-Gaelle Colom</li>
+        <li>Kevin Coughlin</li>
+        <li>Cameron Cundiff</li>
+        <li>Manish Dahamiwal</li>
+        <li>Gilmore Davidson</li>
+        <li>Boris Dušek</li>
+        <li>Michael Fairchild</li>
+        <li>Jeremy Felt</li>
+        <li>Rob Fentress</li>
+        <li>Geppy</li>
+        <li>Tatiana Iskandar</li>
+        <li>Patrick Lauke</li>
+        <li>Marek Lewandowski</li>
+        <li>Dan Matthew</li>
+        <li>Shane McCarron</li>
+        <li>Victor Meyer</li>
+        <li>Jonathan Neal</li>
+        <li>Philipp Rudloff</li>
+        <li>Joseph Scheuhammer</li>
+        <li>Nick Schonning</li>
+        <li>thomascorthals</li>
+        <li>Christopher Tryens</li>
+      </ul>
+    </section>
 
-  	<div data-include="common/acknowledgements/funders.html" data-include-replace="true"></div>
+    <div data-include="common/acknowledgements/funders.html" data-include-replace="true"></div>
 
   </section>
 </body>

--- a/coverage/index.html
+++ b/coverage/index.html
@@ -1144,7 +1144,7 @@
     </section>
 
     <section id="example_coding">
-      <h2 id="example_coding">Example Coding Practices</h2>
+      <h2>Example Coding Practices</h2>
 
       <h3 id="example_summary">Coding Summary</h3>
       <table aria-labelledby="example_summary" class="data attributes summary">

--- a/examples/index.html
+++ b/examples/index.html
@@ -262,6 +262,7 @@
               <ul>
                 <li><a href="menu-button/menu-button-links.html">Navigation Menu Button</a> (<abbr title="High Contrast Support">HC</abbr>)</li>
                 <li><a href="menubar/menubar-navigation.html">Navigation Menubar</a> (<abbr title="High Contrast Support">HC</abbr>)</li>
+                <li><a href="slider/slider-multithumb.html">Horizontal Multi-Thumb Slider</a> (<abbr title="High Contrast Support">HC</abbr>)</li>
                 <li><a href="slider/slider-seek.html">Media Seek Slider</a> (<abbr title="High Contrast Support">HC</abbr>)</li>
                 <li><a href="slider/slider-temperature.html">Vertical Temperature Slider</a> (<abbr title="High Contrast Support">HC</abbr>)</li>
                 <li><a href="treeview/treeview-navigation.html">Navigation Treeview</a> (<abbr title="High Contrast Support">HC</abbr>)</li>
@@ -344,6 +345,7 @@
             <td>
               <ul>
                 <li><a href="slider/slider-color-viewer.html">Color Viewer Slider</a> (<abbr title="High Contrast Support">HC</abbr>)</li>
+                <li><a href="slider/slider-multithumb.html">Horizontal Multi-Thumb Slider</a> (<abbr title="High Contrast Support">HC</abbr>)</li>
                 <li><a href="slider/slider-rating.html">Rating Slider</a> (<abbr title="High Contrast Support">HC</abbr>)</li>
                 <li><a href="slider/slider-seek.html">Media Seek Slider</a> (<abbr title="High Contrast Support">HC</abbr>)</li>
                 <li><a href="slider/slider-temperature.html">Vertical Temperature Slider</a> (<abbr title="High Contrast Support">HC</abbr>)</li>
@@ -609,6 +611,7 @@
               <ul>
                 <li><a href="button/button_idl.html">Button  (IDL Version)</a></li>
                 <li><a href="slider/slider-color-viewer.html">Color Viewer Slider</a> (<abbr title="High Contrast Support">HC</abbr>)</li>
+                <li><a href="slider/slider-multithumb.html">Horizontal Multi-Thumb Slider</a> (<abbr title="High Contrast Support">HC</abbr>)</li>
                 <li><a href="slider/slider-rating.html">Rating Slider</a> (<abbr title="High Contrast Support">HC</abbr>)</li>
                 <li><a href="slider/slider-seek.html">Media Seek Slider</a> (<abbr title="High Contrast Support">HC</abbr>)</li>
                 <li><a href="slider/slider-temperature.html">Vertical Temperature Slider</a> (<abbr title="High Contrast Support">HC</abbr>)</li>
@@ -632,6 +635,7 @@
                 <li><a href="link/link.html">Link</a></li>
                 <li><a href="menubar/menubar-editor.html">Editor Menubar</a> (<abbr title="High Contrast Support">HC</abbr>)</li>
                 <li><a href="menubar/menubar-navigation.html">Navigation Menubar</a> (<abbr title="High Contrast Support">HC</abbr>)</li>
+                <li><a href="slider/slider-multithumb.html">Horizontal Multi-Thumb Slider</a> (<abbr title="High Contrast Support">HC</abbr>)</li>
                 <li><a href="spinbutton/datepicker-spinbuttons.html">Date Picker Spin Button</a></li>
                 <li><a href="table/table.html">Table</a></li>
                 <li><a href="tabs/tabs-1/tabs.html">Tabs with Automatic Activation</a></li>
@@ -818,6 +822,7 @@
               <ul>
                 <li><a href="meter/meter.html">Meter</a></li>
                 <li><a href="slider/slider-color-viewer.html">Color Viewer Slider</a> (<abbr title="High Contrast Support">HC</abbr>)</li>
+                <li><a href="slider/slider-multithumb.html">Horizontal Multi-Thumb Slider</a> (<abbr title="High Contrast Support">HC</abbr>)</li>
                 <li><a href="slider/slider-rating.html">Rating Slider</a> (<abbr title="High Contrast Support">HC</abbr>)</li>
                 <li><a href="slider/slider-seek.html">Media Seek Slider</a> (<abbr title="High Contrast Support">HC</abbr>)</li>
                 <li><a href="slider/slider-temperature.html">Vertical Temperature Slider</a> (<abbr title="High Contrast Support">HC</abbr>)</li>
@@ -832,6 +837,7 @@
               <ul>
                 <li><a href="meter/meter.html">Meter</a></li>
                 <li><a href="slider/slider-color-viewer.html">Color Viewer Slider</a> (<abbr title="High Contrast Support">HC</abbr>)</li>
+                <li><a href="slider/slider-multithumb.html">Horizontal Multi-Thumb Slider</a> (<abbr title="High Contrast Support">HC</abbr>)</li>
                 <li><a href="slider/slider-rating.html">Rating Slider</a> (<abbr title="High Contrast Support">HC</abbr>)</li>
                 <li><a href="slider/slider-seek.html">Media Seek Slider</a> (<abbr title="High Contrast Support">HC</abbr>)</li>
                 <li><a href="slider/slider-temperature.html">Vertical Temperature Slider</a> (<abbr title="High Contrast Support">HC</abbr>)</li>
@@ -846,6 +852,7 @@
               <ul>
                 <li><a href="meter/meter.html">Meter</a></li>
                 <li><a href="slider/slider-color-viewer.html">Color Viewer Slider</a> (<abbr title="High Contrast Support">HC</abbr>)</li>
+                <li><a href="slider/slider-multithumb.html">Horizontal Multi-Thumb Slider</a> (<abbr title="High Contrast Support">HC</abbr>)</li>
                 <li><a href="slider/slider-rating.html">Rating Slider</a> (<abbr title="High Contrast Support">HC</abbr>)</li>
                 <li><a href="slider/slider-seek.html">Media Seek Slider</a> (<abbr title="High Contrast Support">HC</abbr>)</li>
                 <li><a href="slider/slider-temperature.html">Vertical Temperature Slider</a> (<abbr title="High Contrast Support">HC</abbr>)</li>

--- a/examples/landmarks/HTML5.html
+++ b/examples/landmarks/HTML5.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html >
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <title>HTML Sectioning Elements: ARIA Landmarks Example</title>

--- a/examples/landmarks/at.html
+++ b/examples/landmarks/at.html
@@ -192,7 +192,7 @@
             <section>
               <h2 id="skipto">SkipTo Landmarks &amp; Headings Browser Extension</h2>
 
-              <p>The SkipTo Landmarks & Headings browser extension implements the <a href="https://www.w3.org/TR/UAAG/">User Agent Accessibility Guidelines 1.0</a> requirement <q><a href="https://www.w3.org/TR/UAAG/guidelines.html#tech-nav-structure">9.9 Allow Structured Navigation</a></q>. It does this by providing keyboard navigation to landmarks and headings on any web page.  The keyboard shortcut to open the SkipTo menu is <kbd>alt+2</kbd> on Windows/Linux and <kbd>option+2</kbd> on Mac keyboards.</p>
+              <p>The SkipTo Landmarks &amp; Headings browser extension implements the <a href="https://www.w3.org/TR/UAAG/">User Agent Accessibility Guidelines 1.0</a> requirement <q><a href="https://www.w3.org/TR/UAAG/guidelines.html#tech-nav-structure">9.9 Allow Structured Navigation</a></q>. It does this by providing keyboard navigation to landmarks and headings on any web page.  The keyboard shortcut to open the SkipTo menu is <kbd>alt+2</kbd> on Windows/Linux and <kbd>option+2</kbd> on Mac keyboards.</p>
 
               <ul style="margin-top: 1em">
                 <li><a href="https://chrome.google.com/webstore/detail/skip-to-landmarks-and-hea/fjkpbfcodhflpdildjbmdhhmcoplghgf">Chrome Extension: Skip to Landmarks &amp; Headings</a></li>

--- a/examples/landmarks/at.html
+++ b/examples/landmarks/at.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html >
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <title>Assistive Technology: ARIA Landmarks Example</title>

--- a/examples/landmarks/banner.html
+++ b/examples/landmarks/banner.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html >
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <title>Banner Landmark: ARIA Landmarks Example</title>

--- a/examples/landmarks/complementary.html
+++ b/examples/landmarks/complementary.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html >
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <title>Complementary Landmark: ARIA Landmarks Example</title>

--- a/examples/landmarks/contentinfo.html
+++ b/examples/landmarks/contentinfo.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html >
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <title>Contentinfo Landmark: ARIA Landmarks Example</title>

--- a/examples/landmarks/form.html
+++ b/examples/landmarks/form.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html >
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <title>Form Landmark: ARIA Landmarks Example</title>

--- a/examples/landmarks/index.html
+++ b/examples/landmarks/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html >
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <title>General Principles: Principles: ARIA Landmarks Example</title>

--- a/examples/landmarks/main.html
+++ b/examples/landmarks/main.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html >
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <title>Main Landmark: ARIA Landmarks Example</title>

--- a/examples/landmarks/navigation.html
+++ b/examples/landmarks/navigation.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html >
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <title>Navigation Landmark: ARIA Landmark Example</title>

--- a/examples/landmarks/region.html
+++ b/examples/landmarks/region.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html >
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <title>Region Landmark: ARIA Landmarks Example</title>

--- a/examples/landmarks/resources.html
+++ b/examples/landmarks/resources.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html >
+<!DOCTYPE html>
 <html lang="en">
     <head>
    <title>Resources: ARIA Landmarks Example</title>

--- a/examples/landmarks/search.html
+++ b/examples/landmarks/search.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html >
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <title>Search Landmark: ARIA Landmarks Example</title>

--- a/examples/menu-button/menu-button-actions.html
+++ b/examples/menu-button/menu-button-actions.html
@@ -314,7 +314,7 @@
 
         <ul id="css_js_files">
           <li>CSS: <a href="css/menu-button-actions.css" type="text/css">menu-button-actions.css</a></li>
-          <li>Javascript: <a href="js/menu-button-actions.js" type="text/javascript">menu-button-actions.js</a>
+          <li>Javascript: <a href="js/menu-button-actions.js" type="text/javascript">menu-button-actions.js</a></li>
         </ul>
       </section>
       <section>

--- a/examples/menu-button/menu-button-links.html
+++ b/examples/menu-button/menu-button-links.html
@@ -36,7 +36,7 @@
       <p>
         In this implementation, an HTML <code>button</code> element reveals a menu structure made with an HTML <code>ul</code> element.
         The <code>menuitem</code> role is on the HTML <code>a</code> element contained by each <code>li</code> element so link behaviors are available when focus is set on the menu item.
-        Another reason for applying the <code>menuitem</code> role to the <code>a</code>code> element instead of the <code>li</code> element is that the semantics of descendants of <code>menuitem</code> elements are not exposed in the accessibility tree.
+        Another reason for applying the <code>menuitem</code> role to the <code>a</code> element instead of the <code>li</code> element is that the semantics of descendants of <code>menuitem</code> elements are not exposed in the accessibility tree.
         That is, an item in a menu can only be a <code>menuitem</code> because accessibility APIs do not enable assistive technologies to render elements contained inside of an item in a menu.
         For a more detailed description of this constraint, see
         <a href="../../#children_presentational">Roles That Automatically Hide Semantics by Making Their Descendants Presentational.</a>

--- a/examples/menubar/menubar-navigation.html
+++ b/examples/menubar/menubar-navigation.html
@@ -268,6 +268,7 @@
           To optimize keyboard efficiency, this example locates the menubar immediately before the content display area in the Tab sequence.
         </li>
       </ul>
+      </li>
       <li>To help communicate that the arrow keys are available for directional navigation within the menubar and its submenus, a border is added to the menubar container when focus is within the menubar.</li>
       <li>To help users locate the menu item that loads the currently displayed page, visual indicators of the path to that menu item are added to the menu items in the path:
         <ul>
@@ -513,7 +514,7 @@
               <li>
                 NOTE: The <code>banner</code> role declaration is only necessary because it is an example that is nested inside the content of this page.
                 In an actual website, the header element would be a top level element, i.e., it would have the body as its scope.
-                If the scope of the header element were body, browsers would automatically treat the header as an ARIA banner, so the header would not need <code>role="banner"</code>.
+                If the scope of the header element were body, browsers would automatically treat the header as an ARIA banner, so the header would not need <code>role="banner"</code>.</li>
             </ul>
           </td>
         </tr>

--- a/examples/slider/slider-multithumb.html
+++ b/examples/slider/slider-multithumb.html
@@ -46,7 +46,7 @@
         <li><a href="slider-rating.html">Rating Slider Example</a>: Horizontal slider that demonstrates using <code>aria-valuetext</code> to communicate current and maximum value of a rating input for a five star rating scale.</li>
         <li><a href="slider-seek.html">Media Seek Slider Example</a>: Horizontal slider that demonstrates using <code>aria-valuetext</code> to communicate current and maximum values of time in media to make the values easy to understand for assistive technology users by converting the total number of seconds to minutes and seconds.</li>
       </ul>
-      
+
       <section>
         <div class="example-header">
           <h2 id="ex_label">Example</h2>
@@ -174,6 +174,7 @@
             <td>
               The use of the <code>none</code> role on the SVG element ensures assistive technologies do not interpret the SVG element as an image or some other role.
             </td>
+            </tr>
             <tr data-test-id="slider-role">
               <th scope="row">
                 <code>slider</code>
@@ -252,7 +253,7 @@
           </tbody>
         </table>
       </section>
-      
+
       <section>
         <h2>Javascript and CSS Source Code</h2>
         <ul id="css_js_files">
@@ -260,7 +261,7 @@
           <li>Javascript: <a href="js/slider-multithumb.js" type="text/javascript">slider-multithumb.js</a></li>
         </ul>
       </section>
-      
+
       <section>
         <h2 id="sc1_label">HTML Source Code</h2>
         <div role="separator" id="sc1_start_sep" aria-labelledby="sc1_start_sep sc1_label" aria-label="Start of"></div>

--- a/examples/treeview/treeview-navigation.html
+++ b/examples/treeview/treeview-navigation.html
@@ -73,7 +73,7 @@
                   <li role="none">
                     <a role="treeitem"
                        href="#home"
-                       aria-current='page'>
+                       aria-current="page">
                       <span class="label">Home</span>
                     </a>
                   </li>

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "fix": "npm run lint:es -- --fix && npm run lint:css -- --fix",
-    "htmlhint": "htmlhint \"**/*.html\" -i \"common/**/*.html\" -f unix",
+    "htmlhint": "htmlhint \"**/*.html\" \"**/*.template\" -i \"common/**/*.html\" -f unix",
     "lint": "npm run lint:es && npm run lint:css && npm run lint:html && npm run lint:spelling",
     "lint:css": "stylelint **/*.css",
     "lint:es": "eslint . --report-unused-disable-directives",

--- a/scripts/coverage-report.template
+++ b/scripts/coverage-report.template
@@ -22,9 +22,9 @@
     <h1>ARIA Roles, Properties and States Referenced in Guidance and Examples</h1>
 
     <p>
-      This page includes information on number of guidance and example references in the <a href="../">WAI-ARIA Authoring Practices</a> for each ARIA role, property and state.</a>  The guidance column is determined
+      This page includes information on number of guidance and example references in the <a href="../">WAI-ARIA Authoring Practices</a> for each ARIA role, property and state. The guidance column is determined
       by either the role, property or state being in the text content of a heading (e.g. <code>h2</code>-<code>h6</code>) or through the use of <code>
-      data-aria-roles</code> or <code>data-aria-props</code> attributes on any heading within the practices.  The <code>data-aria-roles</code> or <code>data-aria-props</code> attributes should contain a space separated list of values.  The use of the data attribute overrides the identification of roles, properties or states from the text content of a heading.  The suffix <strong>"(D)"</strong> indicates a reference came from a data attribute, otherwise the reference came from the text content of a heading.</p>
+      data-aria-roles</code> or <code>data-aria-props</code> attributes on any heading within the practices.  The <code>data-aria-roles</code> or <code>data-aria-props</code> attributes should contain a space separated list of values.  The use of the data attribute overrides the identification of roles, properties or states from the text content of a heading.  The suffix <strong>"(D)"</strong> indicates a reference came from a data attribute, otherwise the reference came from the text content of a heading.
     </p>
     <ul>
       <li><a href="#csv_files">CSV Files of Role, Properties and States Coverage</a></li>
@@ -228,5 +228,6 @@
   <nav aria-label="ARIA Practices">
     <a href="../">WAI-ARIA Authoring Practices</a>
   </nav>
+  </main>
 </body>
 </html>

--- a/scripts/coverage-report.template
+++ b/scripts/coverage-report.template
@@ -123,7 +123,7 @@
     </section>
 
     <section id="example_coding">
-      <h2 id="example_coding">Example Coding Practices</h2>
+      <h2>Example Coding Practices</h2>
 
       <h3 id="example_summary">Coding Summary</h3>
       <table aria-labelledby="example_summary" class="data attributes summary">


### PR DESCRIPTION
Realized that HTMLHint behaves a little differently, and all rules are opt-in


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/nschonni/aria-practices/pull/1782.html" title="Last updated on Oct 18, 2021, 1:27 AM UTC (4f4ac21)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria-practices/1782/45e9a6c...nschonni:4f4ac21.html" title="Last updated on Oct 18, 2021, 1:27 AM UTC (4f4ac21)">Diff</a>