### PR TITLE
add missing role none to li in editor menubar example

### DIFF
--- a/examples/menubar/menubar-editor.html
+++ b/examples/menubar/menubar-editor.html
@@ -110,7 +110,7 @@
               <li role="menuitem" data-option="font-smaller" aria-disabled="false">Smaller</li>
               <li role="menuitem" data-option="font-larger"  aria-disabled="false">Larger</li>
               <li role="separator"></li>
-              <li>
+              <li role="none">
                 <ul role="group" data-option="font-size" aria-label="Font Sizes">
                   <li role="menuitemradio" aria-checked="false">X-Small</li>
                   <li role="menuitemradio" aria-checked="false">Small</li>


### PR DESCRIPTION
Noticed a missing `role="none"` on an `<li>` containing `<ul role="group">` in the Size menu in the editor menubar example.

(No corresponding issue).