### PR TITLE
Add deprecation warning to Collapsible Listbox example

### DIFF
--- a/aria-practices.html
+++ b/aria-practices.html
@@ -1811,7 +1811,7 @@ Some JavaScript and CSS may not function correctly in Internet Explorer.
         <h4>Examples</h4>
         <ul>
           <li><a href="examples/listbox/listbox-scrollable.html">Scrollable Listbox Example</a>: Single-select listbox that scrolls to reveal more options, similar to HTML <code>select</code> with <code>size</code> attribute greater than one.</li>
-          <li><a href="examples/listbox/listbox-collapsible.html">Collapsible Dropdown Listbox Example</a>: Single-select collapsible listbox that expands when activated, similar to HTML <code>select</code> with the attribute <code>size=&quot;1&quot;</code>.</li>
+          <li><a href="examples/combobox/combobox-select-only.html">Collapsible Dropdown Listbox Example</a>: This example has been deprecated, and now points to the select-only combobox. The combobox pattern is recommended for controls similar to HTML <code>select</code> with the attribute <code>size=&quot;1&quot;</code>.</li>
           <li><a href="examples/listbox/listbox-rearrangeable.html">Example Listboxes with Rearrangeable Options</a>: Examples of both single-select and multi-select listboxes with accompanying toolbars where options can be added, moved, and removed.</li>
           <li><a href="examples/listbox/listbox-grouped.html">Listbox Example with Grouped Options</a>: Single-select listbox with grouped options, similar to an HTML <code>select</code> with <code>optgroup</code> children.</li>
         </ul>

--- a/aria-practices.html
+++ b/aria-practices.html
@@ -1811,7 +1811,6 @@ Some JavaScript and CSS may not function correctly in Internet Explorer.
         <h4>Examples</h4>
         <ul>
           <li><a href="examples/listbox/listbox-scrollable.html">Scrollable Listbox Example</a>: Single-select listbox that scrolls to reveal more options, similar to HTML <code>select</code> with <code>size</code> attribute greater than one.</li>
-          <li><a href="examples/combobox/combobox-select-only.html">Collapsible Dropdown Listbox Example</a>: This example has been deprecated, and now points to the select-only combobox. The combobox pattern is recommended for controls similar to HTML <code>select</code> with the attribute <code>size=&quot;1&quot;</code>.</li>
           <li><a href="examples/listbox/listbox-rearrangeable.html">Example Listboxes with Rearrangeable Options</a>: Examples of both single-select and multi-select listboxes with accompanying toolbars where options can be added, moved, and removed.</li>
           <li><a href="examples/listbox/listbox-grouped.html">Listbox Example with Grouped Options</a>: Single-select listbox with grouped options, similar to an HTML <code>select</code> with <code>optgroup</code> children.</li>
         </ul>

--- a/examples/listbox/listbox-collapsible.html
+++ b/examples/listbox/listbox-collapsible.html
@@ -28,6 +28,9 @@
   </nav>
   <main>
   <h1>Collapsible Dropdown Listbox Example</h1>
+  <div class="advisement">
+    <p><strong>DEPRECATION WARNING:</strong> this pattern has been deprecated, and will be removed in a future version of the Authoring Practices. The <a href="../combobox/combobox-select-only.html">select-only combobox</a> should be used as an alternative to this pattern.</p>
+  </div>
   <p>
     The following example implementation of the
     <a href="../../#Listbox">design pattern for listbox</a>
@@ -38,6 +41,7 @@
   </p>
   <p>Similar examples include:</p>
   <ul>
+    <li><a href="../combobox/combobox-select-only.html">Select-Only Combobox</a>: A single-select combobox with no text input that is functionally similar to an HTML <code>select</code> element.</li>
     <li><a href="listbox-scrollable.html">Scrollable Listbox Example</a>: Single-select listbox that scrolls to reveal more options, similar to HTML <code>select</code> with <code>size</code> attribute greater than one.</li>
     <li><a href="listbox-rearrangeable.html">Example Listboxes with Rearrangeable Options</a>: Examples of both single-select and multi-select listboxes with accompanying toolbars where options can be added, moved, and removed.</li>
     <li><a href="listbox-grouped.html">Listbox Example with Grouped Options</a>: Single-select listbox with grouped options, similar to an HTML <code>select</code> with <code>optgroup</code> children.</li>

--- a/examples/listbox/listbox-collapsible.html
+++ b/examples/listbox/listbox-collapsible.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8" />
-<title>Collapsible Dropdown Listbox Example | WAI-ARIA Authoring Practices 1.2</title>
+<title>(Deprecated) Collapsible Dropdown Listbox Example | WAI-ARIA Authoring Practices 1.2</title>
 
 <!--  Core js and css shared by all examples; do not modify when using this template. -->
 <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/base.css">
@@ -27,7 +27,7 @@
     </ul>
   </nav>
   <main>
-  <h1>Collapsible Dropdown Listbox Example</h1>
+  <h1>(Deprecated) Collapsible Dropdown Listbox Example</h1>
   <div class="advisement">
     <p><strong>DEPRECATION WARNING:</strong> This pattern has been deprecated, and will be removed in a future version of the ARIA Authoring Practices. The <a href="../combobox/combobox-select-only.html">select-only combobox</a> should be used as an alternative to this pattern.</p>
   </div>

--- a/examples/listbox/listbox-collapsible.html
+++ b/examples/listbox/listbox-collapsible.html
@@ -29,7 +29,7 @@
   <main>
   <h1>Collapsible Dropdown Listbox Example</h1>
   <div class="advisement">
-    <p><strong>DEPRECATION WARNING:</strong> this pattern has been deprecated, and will be removed in a future version of the Authoring Practices. The <a href="../combobox/combobox-select-only.html">select-only combobox</a> should be used as an alternative to this pattern.</p>
+    <p><strong>DEPRECATION WARNING:</strong> This pattern has been deprecated, and will be removed in a future version of the ARIA Authoring Practices. The <a href="../combobox/combobox-select-only.html">select-only combobox</a> should be used as an alternative to this pattern.</p>
   </div>
   <p>
     The following example implementation of the

--- a/examples/listbox/listbox-grouped.html
+++ b/examples/listbox/listbox-grouped.html
@@ -35,7 +35,6 @@
   <ul>
     <li><a href="listbox-scrollable.html">Scrollable Listbox Example</a>: Single-select listbox that scrolls to reveal more options, similar to HTML <code>select</code> with <code>size</code> attribute greater than one.</li>
     <li><a href="listbox-rearrangeable.html">Example Listboxes with Rearrangeable Options</a>: Examples of both single-select and multi-select listboxes with accompanying toolbars where options can be added, moved, and removed.</li>
-    <li><a href="listbox-collapsible.html">Collapsible Dropdown Listbox Example</a>: Single-select collapsible listbox that expands when activated, similar to HTML <code>select</code> with the attribute <code>size=&quot;1&quot;</code>.</li>
   </ul>
   <section>
     <div class="example-header">

--- a/examples/listbox/listbox-grouped.html
+++ b/examples/listbox/listbox-grouped.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8" />
-<title>Listbox Example with Grouped Options | WAI-ARIA Authoring Practices 1.2</title>
+<title>(Deprecated) Listbox Example with Grouped Options | WAI-ARIA Authoring Practices 1.2</title>
 
 <!--  Core js and css shared by all examples; do not modify when using this template. -->
 <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/base.css">
@@ -26,7 +26,7 @@
     </ul>
   </nav>
   <main>
-  <h1>Listbox Example with Grouped Options</h1>
+  <h1>(Deprecated) Listbox Example with Grouped Options</h1>
   <p>
     The following example implementation of the <a href="../../#Listbox">design pattern for listbox</a> demonstrates a single-select listbox widget with grouped options.
     This widget is functionally similar to an HTML <code>select</code> element with <code>size</code> greater than 1 and options grouped into categories with labeled <code>optgroup</code> elements.

--- a/examples/listbox/listbox-grouped.html
+++ b/examples/listbox/listbox-grouped.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8" />
-<title>(Deprecated) Listbox Example with Grouped Options | WAI-ARIA Authoring Practices 1.2</title>
+<title>Listbox Example with Grouped Options | WAI-ARIA Authoring Practices 1.2</title>
 
 <!--  Core js and css shared by all examples; do not modify when using this template. -->
 <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/base.css">
@@ -26,7 +26,7 @@
     </ul>
   </nav>
   <main>
-  <h1>(Deprecated) Listbox Example with Grouped Options</h1>
+  <h1>Listbox Example with Grouped Options</h1>
   <p>
     The following example implementation of the <a href="../../#Listbox">design pattern for listbox</a> demonstrates a single-select listbox widget with grouped options.
     This widget is functionally similar to an HTML <code>select</code> element with <code>size</code> greater than 1 and options grouped into categories with labeled <code>optgroup</code> elements.

--- a/examples/listbox/listbox-rearrangeable.html
+++ b/examples/listbox/listbox-rearrangeable.html
@@ -39,7 +39,6 @@ while in the second example, they may select multiple options before activating 
   <p>Similar examples include:</p>
   <ul>
     <li><a href="listbox-scrollable.html">Scrollable Listbox Example</a>: Single-select listbox that scrolls to reveal more options, similar to HTML <code>select</code> with <code>size</code> attribute greater than one.</li>
-    <li><a href="listbox-collapsible.html">Collapsible Dropdown Listbox Example</a>: Single-select collapsible listbox that expands when activated, similar to HTML <code>select</code> with the attribute <code>size=&quot;1&quot;</code>.</li>
     <li><a href="listbox-grouped.html">Listbox Example with Grouped Options</a>: Single-select listbox with grouped options, similar to an HTML <code>select</code> with <code>optgroup</code> children.</li>
   </ul>
   <section>

--- a/examples/listbox/listbox-scrollable.html
+++ b/examples/listbox/listbox-scrollable.html
@@ -36,7 +36,6 @@
   <p>Similar examples include:</p>
   <ul>
     <li><a href="listbox-rearrangeable.html">Example Listboxes with Rearrangeable Options</a>: Examples of both single-select and multi-select listboxes with accompanying toolbars where options can be added, moved, and removed.</li>
-    <li><a href="listbox-collapsible.html">Collapsible Dropdown Listbox Example</a>: Single-select collapsible listbox that expands when activated, similar to HTML <code>select</code> with the attribute <code>size=&quot;1&quot;</code>.</li>
     <li><a href="listbox-grouped.html">Listbox Example with Grouped Options</a>: Single-select listbox with grouped options, similar to an HTML <code>select</code> with <code>optgroup</code> children.</li>
   </ul>
   <section>


### PR DESCRIPTION
Resolves #657

Includes the following two changes:
- Updates the link on the main aria-practices.html page to point to the select-only combobox with a text note
- Adds a deprecation warning to the listbox example page

[Preview link for example page](https://raw.githack.com/w3c/aria-practices/remove-listbox/examples/listbox/listbox-collapsible.html)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria-practices/pull/1852.html" title="Last updated on Aug 30, 2021, 7:07 AM UTC (b41a23c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria-practices/1852/c8b1c8c...b41a23c.html" title="Last updated on Aug 30, 2021, 7:07 AM UTC (b41a23c)">Diff</a>