### PR TITLE
Add CodePen button to menubar-editor and avoid external SVG

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -622,6 +622,7 @@
             <td>
               <ul>
                 <li><a href="button/button_idl.html">Button  (IDL Version)</a></li>
+                <li><a href="menubar/menubar-editor.html">Editor Menubar</a> (<abbr title="High Contrast Support">HC</abbr>)</li>
                 <li><a href="slider/slider-color-viewer.html">Color Viewer Slider</a> (<abbr title="High Contrast Support">HC</abbr>)</li>
                 <li><a href="slider/slider-multithumb.html">Horizontal Multi-Thumb Slider</a> (<abbr title="High Contrast Support">HC</abbr>)</li>
                 <li><a href="slider/slider-rating.html">Rating Slider</a> (<abbr title="High Contrast Support">HC</abbr>)</li>

--- a/examples/menubar/css/menubar-editor.css
+++ b/examples/menubar/css/menubar-editor.css
@@ -45,7 +45,7 @@
   left: 1px;
 }
 
-.menubar-editor [role="menubar"] > li > [role="menuitem"]::after {
+.menubar-editor [role="menubar"] [role="menuitem"] > [aria-hidden]::before {
   content: "▼";
   padding-left: 0.25rem;
   font-size: 11px;
@@ -54,8 +54,8 @@
 
 .menubar-editor
   [role="menubar"]
-  > li
-  > [role="menuitem"][aria-expanded="true"]::after {
+  [role="menuitem"][aria-expanded="true"]
+  > [aria-hidden]::before {
   content: "▲";
 }
 
@@ -127,15 +127,17 @@
 
 .menubar-editor
   [role="menubar"]
-  [role="menuitemradio"][aria-checked="true"]::before {
-  content: "⦿";
+  [role="menuitemradio"][aria-checked="true"]
+  > [aria-hidden]::before {
+  content: "●";
   display: inline-block;
   width: 18px;
 }
 
 .menubar-editor
   [role="menubar"]
-  [role="menuitemcheckbox"][aria-checked="true"]::before {
+  [role="menuitemcheckbox"][aria-checked="true"]
+  > [aria-hidden]::before {
   content: "✓";
   display: inline-block;
   width: 18px;
@@ -155,10 +157,12 @@
 
 .menubar-editor
   [role="menubar"]
-  [role="menuitemradio"][aria-checked="true"]:focus::before,
+  [role="menuitemradio"][aria-checked="true"]:focus
+  > [aria-hidden]::before,
 .menubar-editor
   [role="menubar"]
-  [role="menuitemcheckbox"][aria-checked="true"]:focus::before {
+  [role="menuitemcheckbox"][aria-checked="true"]:focus
+  > [aria-hidden]::before {
   margin-left: -2px;
 }
 

--- a/examples/menubar/css/menubar-editor.css
+++ b/examples/menubar/css/menubar-editor.css
@@ -1,3 +1,5 @@
+@charset "utf-8";
+
 .menubar-editor {
   margin: 0;
   padding: 2px;
@@ -44,19 +46,17 @@
 }
 
 .menubar-editor [role="menubar"] > li > [role="menuitem"]::after {
-  content: url("../images/down-arrow.svg");
-  padding-left: 0.25em;
-}
-
-.menubar-editor [role="menubar"] > li > [role="menuitem"]:focus::after {
-  content: url("../images/down-arrow-focus.svg");
+  content: "▼";
+  padding-left: 0.25rem;
+  font-size: 11px;
+  vertical-align: middle;
 }
 
 .menubar-editor
   [role="menubar"]
   > li
   > [role="menuitem"][aria-expanded="true"]::after {
-  content: url("../images/up-arrow-focus.svg");
+  content: "▲";
 }
 
 .menubar-editor [role="menubar"] [role="menu"] {
@@ -80,7 +80,15 @@
 
 .menubar-editor [role="menubar"] [role="separator"] {
   padding-top: 3px;
-  background-image: url("../images/separator.svg");
+  background-image: linear-gradient(
+    transparent 0%,
+    transparent 50%,
+    black 50%,
+    black 60%,
+    transparent 60%,
+    transparent 100%
+  );
+  background-size: 10px 10px;
   background-position: center;
   background-repeat: repeat-x;
 }
@@ -120,15 +128,17 @@
 .menubar-editor
   [role="menubar"]
   [role="menuitemradio"][aria-checked="true"]::before {
-  content: url("../images/radio-checked.svg");
-  padding-right: 3px;
+  content: "⦿";
+  display: inline-block;
+  width: 18px;
 }
 
 .menubar-editor
   [role="menubar"]
   [role="menuitemcheckbox"][aria-checked="true"]::before {
-  content: url("../images/checkbox-checked.svg");
-  padding-right: 3px;
+  content: "✓";
+  display: inline-block;
+  width: 18px;
 }
 
 /* focus and hover styling */
@@ -145,16 +155,11 @@
 
 .menubar-editor
   [role="menubar"]
-  [role="menuitemradio"][aria-checked="true"]:focus::before {
-  content: url("../images/radio-checked-focus.svg");
-  padding-right: 3px;
-}
-
+  [role="menuitemradio"][aria-checked="true"]:focus::before,
 .menubar-editor
   [role="menubar"]
   [role="menuitemcheckbox"][aria-checked="true"]:focus::before {
-  content: url("../images/checkbox-checked-focus.svg");
-  padding-right: 3px;
+  margin-left: -2px;
 }
 
 .menubar-editor [role="menubar"] [role="menuitem"]:hover {

--- a/examples/menubar/css/menubar-editor.css
+++ b/examples/menubar/css/menubar-editor.css
@@ -80,14 +80,7 @@
 
 .menubar-editor [role="menubar"] [role="separator"] {
   padding-top: 3px;
-  background-image: linear-gradient(
-    transparent 0%,
-    transparent 50%,
-    black 50%,
-    black 60%,
-    transparent 60%,
-    transparent 100%
-  );
+  background-image: url("data:image/svg+xml,%3C%3Fxml version='1.0' encoding='utf-8'%3F%3E%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cline x1='0' y1='6' x2='12' y2='6' style='stroke:black;stroke-width:1' /%3E%3C/svg%3E%0A");
   background-size: 10px 10px;
   background-position: center;
   background-repeat: repeat-x;

--- a/examples/menubar/css/menubar-navigation.css
+++ b/examples/menubar/css/menubar-navigation.css
@@ -1,3 +1,5 @@
+@charset "utf-8";
+
 .page header {
   border: #005a9c solid 2px;
   background: #005a9c;
@@ -73,7 +75,15 @@
 
 .menubar-navigation [role="separator"] {
   padding-top: 3px;
-  background-image: url("data:image/svg+xml,%3C%3Fxml version='1.0' encoding='utf-8'%3F%3E%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cline x1='0' y1='6' x2='12' y2='6' style='stroke:black;stroke-width:1' /%3E%3C/svg%3E%0A");
+  background-image: linear-gradient(
+    transparent 0%,
+    transparent 50%,
+    black 50%,
+    black 60%,
+    transparent 60%,
+    transparent 100%
+  );
+  background-size: 10px 10px;
   background-position: center;
   background-repeat: repeat-x;
 }

--- a/examples/menubar/css/menubar-navigation.css
+++ b/examples/menubar/css/menubar-navigation.css
@@ -75,14 +75,7 @@
 
 .menubar-navigation [role="separator"] {
   padding-top: 3px;
-  background-image: linear-gradient(
-    transparent 0%,
-    transparent 50%,
-    black 50%,
-    black 60%,
-    transparent 60%,
-    transparent 100%
-  );
+  background-image: url("data:image/svg+xml,%3C%3Fxml version='1.0' encoding='utf-8'%3F%3E%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cline x1='0' y1='6' x2='12' y2='6' style='stroke:black;stroke-width:1' /%3E%3C/svg%3E%0A");
   background-size: 10px 10px;
   background-position: center;
   background-repeat: repeat-x;

--- a/examples/menubar/images/checkbox-checked-focus.svg
+++ b/examples/menubar/images/checkbox-checked-focus.svg
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="16" height="20" viewBox="0 0 16 20">
-  <polyline points="2,13  2,15 7,20 12,8 12,6 7,17 2,13" fill="#FFF" stroke-width="1" stroke="#FFF"/>
-</svg>

--- a/examples/menubar/images/checkbox-checked.svg
+++ b/examples/menubar/images/checkbox-checked.svg
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="16" height="20" viewBox="0 0 16 20">
-  <polyline points="2,13  2,15 7,20 12,8 12,6 7,17 2,13" fill="#034575" stroke-width="1" stroke="#034575"/>
-</svg>

--- a/examples/menubar/images/down-arrow-focus.svg
+++ b/examples/menubar/images/down-arrow-focus.svg
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="12" height="9" viewBox="0 0 12 9">
- <polygon points="1 0, 11 0, 6 8"  fill="#fff" stroke= "#fff" />
-</svg>

--- a/examples/menubar/images/down-arrow.svg
+++ b/examples/menubar/images/down-arrow.svg
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="12" height="9" viewBox="0 0 12 9">
- <polygon points="1 0, 11 0, 6 8"  fill="#444" stroke= "#444" />
-</svg>

--- a/examples/menubar/images/radio-checked-focus.svg
+++ b/examples/menubar/images/radio-checked-focus.svg
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="16" height="20" viewBox="0 0 16 20">
- <circle cx="8" cy="14" r="5"  fill="#FFF" stroke-width="1" stroke="#FFF"/>
-</svg>

--- a/examples/menubar/images/radio-checked.svg
+++ b/examples/menubar/images/radio-checked.svg
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="16" height="20" viewBox="0 0 16 20">
- <circle cx="8" cy="14" r="5"  fill="#034575" stroke-width="1" stroke="#034575"/>
-</svg>

--- a/examples/menubar/images/separator.svg
+++ b/examples/menubar/images/separator.svg
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12">
-  <line x1="0" y1="6" x2="12" y2="6" style="stroke:black;stroke-width:1" />
-</svg>

--- a/examples/menubar/images/up-arrow-focus.svg
+++ b/examples/menubar/images/up-arrow-focus.svg
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="12" height="9" viewBox="0 0 12 9">
- <polygon points="1 8, 11 8, 6 0" fill="#fff" stroke="#fff"/>
-</svg>

--- a/examples/menubar/images/up-arrow.svg
+++ b/examples/menubar/images/up-arrow.svg
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="12" height="9" viewBox="0 0 12 9">
- <polygon points="1 9, 11 9, 6 0" fill=" #034575" stroke= "#034575" />
-</svg>

--- a/examples/menubar/js/menubar-editor.js
+++ b/examples/menubar/js/menubar-editor.js
@@ -11,694 +11,682 @@
 
 'use strict';
 
-var MenubarEditor = function (domNode) {
-  this.domNode = domNode;
-  this.menubarNode = domNode.querySelector('[role=menubar]');
-  this.textareaNode = domNode.querySelector('textarea');
-  this.actionManager = new StyleManager(this.textareaNode);
+class MenubarEditor {
+  constructor(domNode) {
+    this.domNode = domNode;
+    this.menubarNode = domNode.querySelector('[role=menubar]');
+    this.textareaNode = domNode.querySelector('textarea');
+    this.actionManager = new StyleManager(this.textareaNode);
 
-  this.popups = [];
-  this.menuitemGroups = {};
-  this.menuOrientation = {};
-  this.isPopup = {};
+    this.popups = [];
+    this.menuitemGroups = {};
+    this.menuOrientation = {};
+    this.isPopup = {};
 
-  this.firstChars = {}; // see Menubar init method
-  this.firstMenuitem = {}; // see Menubar init method
-  this.lastMenuitem = {}; // see Menubar init method
+    this.firstChars = {}; // see Menubar init method
+    this.firstMenuitem = {}; // see Menubar init method
+    this.lastMenuitem = {}; // see Menubar init method
 
-  this.initMenu(this.menubarNode);
-  this.domNode.addEventListener('focusin', this.handleFocusin.bind(this));
-  this.domNode.addEventListener('focusout', this.handleFocusout.bind(this));
+    this.initMenu(this.menubarNode);
+    this.domNode.addEventListener('focusin', this.handleFocusin.bind(this));
+    this.domNode.addEventListener('focusout', this.handleFocusout.bind(this));
 
-  window.addEventListener(
-    'mousedown',
-    this.handleBackgroundMousedown.bind(this),
-    true
-  );
-};
-
-MenubarEditor.prototype.getMenuitems = function (domNode) {
-  var nodes = [];
-
-  var initMenu = this.initMenu.bind(this);
-  var getGroupId = this.getGroupId.bind(this);
-  var menuitemGroups = this.menuitemGroups;
-  var popups = this.popups;
-
-  function findMenuitems(node, group) {
-    var role, flag, groupId;
-
-    while (node) {
-      flag = true;
-      role = node.getAttribute('role');
-
-      switch (role) {
-        case 'menu':
-          node.tabIndex = -1;
-          initMenu(node);
-          flag = false;
-          break;
-
-        case 'group':
-          groupId = getGroupId(node);
-          menuitemGroups[groupId] = [];
-          break;
-
-        case 'menuitem':
-        case 'menuitemradio':
-        case 'menuitemcheckbox':
-          if (node.getAttribute('aria-haspopup') === 'true') {
-            popups.push(node);
-          }
-          nodes.push(node);
-          if (group) {
-            group.push(node);
-          }
-          break;
-
-        default:
-          break;
-      }
-
-      if (flag && node.firstElementChild) {
-        findMenuitems(node.firstElementChild, menuitemGroups[groupId]);
-      }
-
-      node = node.nextElementSibling;
-    }
-  }
-
-  findMenuitems(domNode.firstElementChild, false);
-
-  return nodes;
-};
-
-MenubarEditor.prototype.initMenu = function (menu) {
-  var i, menuitems, menuitem, role;
-
-  var menuId = this.getMenuId(menu);
-
-  menuitems = this.getMenuitems(menu);
-  this.menuOrientation[menuId] = this.getMenuOrientation(menu);
-  this.isPopup[menuId] = menu.getAttribute('role') === 'menu';
-
-  this.menuitemGroups[menuId] = [];
-  this.firstChars[menuId] = [];
-  this.firstMenuitem[menuId] = null;
-  this.lastMenuitem[menuId] = null;
-
-  for (i = 0; i < menuitems.length; i++) {
-    menuitem = menuitems[i];
-    role = menuitem.getAttribute('role');
-
-    if (role.indexOf('menuitem') < 0) {
-      continue;
-    }
-
-    menuitem.tabIndex = -1;
-    this.menuitemGroups[menuId].push(menuitem);
-    this.firstChars[menuId].push(menuitem.textContent[0].toLowerCase());
-
-    menuitem.addEventListener('keydown', this.handleKeydown.bind(this));
-    menuitem.addEventListener('click', this.handleMenuitemClick.bind(this));
-
-    menuitem.addEventListener(
-      'mouseover',
-      this.handleMenuitemMouseover.bind(this)
+    window.addEventListener(
+      'mousedown',
+      this.handleBackgroundMousedown.bind(this),
+      true
     );
-
-    if (!this.firstMenuitem[menuId]) {
-      if (this.hasPopup(menuitem)) {
-        menuitem.tabIndex = 0;
-      }
-      this.firstMenuitem[menuId] = menuitem;
-    }
-    this.lastMenuitem[menuId] = menuitem;
-  }
-};
-
-/* MenubarEditor FOCUS MANAGEMENT METHODS */
-
-MenubarEditor.prototype.setFocusToMenuitem = function (menuId, newMenuitem) {
-  var isAnyPopupOpen = this.isAnyPopupOpen();
-
-  this.closePopupAll(newMenuitem);
-
-  if (this.hasPopup(newMenuitem)) {
-    if (isAnyPopupOpen) {
-      this.openPopup(newMenuitem);
-    }
-  } else {
-    var menu = this.getMenu(newMenuitem);
-    var cmi = menu.previousElementSibling;
-    if (!this.isOpen(cmi)) {
-      this.openPopup(cmi);
-    }
   }
 
-  if (this.hasPopup(newMenuitem)) {
-    if (this.menuitemGroups[menuId]) {
-      this.menuitemGroups[menuId].forEach(function (item) {
-        item.tabIndex = -1;
-      });
-    }
-    newMenuitem.tabIndex = 0;
-  }
+  getMenuitems(domNode) {
+    var nodes = [];
 
-  newMenuitem.focus();
-};
+    var initMenu = this.initMenu.bind(this);
+    var getGroupId = this.getGroupId.bind(this);
+    var menuitemGroups = this.menuitemGroups;
+    var popups = this.popups;
 
-MenubarEditor.prototype.setFocusToFirstMenuitem = function (menuId) {
-  this.setFocusToMenuitem(menuId, this.firstMenuitem[menuId]);
-};
+    function findMenuitems(node, group) {
+      var role, flag, groupId;
 
-MenubarEditor.prototype.setFocusToLastMenuitem = function (menuId) {
-  this.setFocusToMenuitem(menuId, this.lastMenuitem[menuId]);
-};
-
-MenubarEditor.prototype.setFocusToPreviousMenuitem = function (
-  menuId,
-  currentMenuitem
-) {
-  var newMenuitem, index;
-
-  if (currentMenuitem === this.firstMenuitem[menuId]) {
-    newMenuitem = this.lastMenuitem[menuId];
-  } else {
-    index = this.menuitemGroups[menuId].indexOf(currentMenuitem);
-    newMenuitem = this.menuitemGroups[menuId][index - 1];
-  }
-
-  this.setFocusToMenuitem(menuId, newMenuitem);
-
-  return newMenuitem;
-};
-
-MenubarEditor.prototype.setFocusToNextMenuitem = function (
-  menuId,
-  currentMenuitem
-) {
-  var newMenuitem, index;
-
-  if (currentMenuitem === this.lastMenuitem[menuId]) {
-    newMenuitem = this.firstMenuitem[menuId];
-  } else {
-    index = this.menuitemGroups[menuId].indexOf(currentMenuitem);
-    newMenuitem = this.menuitemGroups[menuId][index + 1];
-  }
-  this.setFocusToMenuitem(menuId, newMenuitem);
-
-  return newMenuitem;
-};
-
-MenubarEditor.prototype.setFocusByFirstCharacter = function (
-  menuId,
-  currentMenuitem,
-  char
-) {
-  var start, index;
-
-  char = char.toLowerCase();
-
-  // Get start index for search based on position of currentItem
-  start = this.menuitemGroups[menuId].indexOf(currentMenuitem) + 1;
-  if (start >= this.menuitemGroups[menuId].length) {
-    start = 0;
-  }
-
-  // Check remaining slots in the menu
-  index = this.getIndexFirstChars(menuId, start, char);
-
-  // If not found in remaining slots, check from beginning
-  if (index === -1) {
-    index = this.getIndexFirstChars(menuId, 0, char);
-  }
-
-  // If match was found...
-  if (index > -1) {
-    this.setFocusToMenuitem(menuId, this.menuitemGroups[menuId][index]);
-  }
-};
-
-// Utilities
-
-MenubarEditor.prototype.getIndexFirstChars = function (
-  menuId,
-  startIndex,
-  char
-) {
-  for (var i = startIndex; i < this.firstChars[menuId].length; i++) {
-    if (char === this.firstChars[menuId][i]) {
-      return i;
-    }
-  }
-  return -1;
-};
-
-MenubarEditor.prototype.isPrintableCharacter = function (str) {
-  return str.length === 1 && str.match(/\S/);
-};
-
-MenubarEditor.prototype.getIdFromAriaLabel = function (node) {
-  var id = node.getAttribute('aria-label');
-  if (id) {
-    id = id.trim().toLowerCase().replace(' ', '-').replace('/', '-');
-  }
-  return id;
-};
-
-MenubarEditor.prototype.getMenuOrientation = function (node) {
-  var orientation = node.getAttribute('aria-orientation');
-
-  if (!orientation) {
-    var role = node.getAttribute('role');
-
-    switch (role) {
-      case 'menubar':
-        orientation = 'horizontal';
-        break;
-
-      case 'menu':
-        orientation = 'vertical';
-        break;
-
-      default:
-        break;
-    }
-  }
-
-  return orientation;
-};
-
-MenubarEditor.prototype.getDataOption = function (node) {
-  var option = false;
-  var hasOption = node.hasAttribute('data-option');
-  var role = node.hasAttribute('role');
-
-  if (!hasOption) {
-    while (node && !hasOption && role !== 'menu' && role !== 'menubar') {
-      node = node.parentNode;
-      if (node) {
+      while (node) {
+        flag = true;
         role = node.getAttribute('role');
-        hasOption = node.hasAttribute('data-option');
-      }
-    }
-  }
 
-  if (node) {
-    option = node.getAttribute('data-option');
-  }
-
-  return option;
-};
-
-MenubarEditor.prototype.getGroupId = function (node) {
-  var id = false;
-  var role = node.getAttribute('role');
-
-  while (node && role !== 'group' && role !== 'menu' && role !== 'menubar') {
-    node = node.parentNode;
-    if (node) {
-      role = node.getAttribute('role');
-    }
-  }
-
-  if (node) {
-    id = role + '-' + this.getIdFromAriaLabel(node);
-  }
-
-  return id;
-};
-
-MenubarEditor.prototype.getMenuId = function (node) {
-  var id = false;
-  var role = node.getAttribute('role');
-
-  while (node && role !== 'menu' && role !== 'menubar') {
-    node = node.parentNode;
-    if (node) {
-      role = node.getAttribute('role');
-    }
-  }
-
-  if (node) {
-    id = role + '-' + this.getIdFromAriaLabel(node);
-  }
-
-  return id;
-};
-
-MenubarEditor.prototype.getMenu = function (menuitem) {
-  var menu = menuitem;
-  var role = menuitem.getAttribute('role');
-
-  while (menu && role !== 'menu' && role !== 'menubar') {
-    menu = menu.parentNode;
-    if (menu) {
-      role = menu.getAttribute('role');
-    }
-  }
-
-  return menu;
-};
-
-MenubarEditor.prototype.toggleCheckbox = function (menuitem) {
-  if (menuitem.getAttribute('aria-checked') === 'true') {
-    menuitem.setAttribute('aria-checked', 'false');
-    return false;
-  }
-  menuitem.setAttribute('aria-checked', 'true');
-  return true;
-};
-
-MenubarEditor.prototype.setRadioButton = function (menuitem) {
-  var groupId = this.getGroupId(menuitem);
-  var radiogroupItems = this.menuitemGroups[groupId];
-  radiogroupItems.forEach(function (item) {
-    item.setAttribute('aria-checked', 'false');
-  });
-  menuitem.setAttribute('aria-checked', 'true');
-  return menuitem.textContent;
-};
-
-MenubarEditor.prototype.updateFontSizeMenu = function (menuId) {
-  var fontSizeMenuitems = this.menuitemGroups[menuId];
-  var currentValue = this.actionManager.getFontSize();
-
-  for (var i = 0; i < fontSizeMenuitems.length; i++) {
-    var mi = fontSizeMenuitems[i];
-    var dataOption = mi.getAttribute('data-option');
-    var value = mi.textContent.trim().toLowerCase();
-
-    switch (dataOption) {
-      case 'font-smaller':
-        if (currentValue === 'x-small') {
-          mi.setAttribute('aria-disabled', 'true');
-        } else {
-          mi.removeAttribute('aria-disabled');
-        }
-        break;
-
-      case 'font-larger':
-        if (currentValue === 'x-large') {
-          mi.setAttribute('aria-disabled', 'true');
-        } else {
-          mi.removeAttribute('aria-disabled');
-        }
-        break;
-
-      default:
-        if (currentValue === value) {
-          mi.setAttribute('aria-checked', 'true');
-        } else {
-          mi.setAttribute('aria-checked', 'false');
-        }
-        break;
-    }
-  }
-};
-
-// Popup menu methods
-
-MenubarEditor.prototype.isAnyPopupOpen = function () {
-  for (var i = 0; i < this.popups.length; i++) {
-    if (this.popups[i].getAttribute('aria-expanded') === 'true') {
-      return true;
-    }
-  }
-  return false;
-};
-
-MenubarEditor.prototype.openPopup = function (menuitem) {
-  // set aria-expanded attribute
-  var popupMenu = menuitem.nextElementSibling;
-
-  var rect = menuitem.getBoundingClientRect();
-
-  // set CSS properties
-  popupMenu.style.position = 'absolute';
-  popupMenu.style.top = rect.height - 3 + 'px';
-  popupMenu.style.left = '0px';
-  popupMenu.style.zIndex = 100;
-  popupMenu.style.display = 'block';
-
-  menuitem.setAttribute('aria-expanded', 'true');
-
-  return this.getMenuId(popupMenu);
-};
-
-MenubarEditor.prototype.closePopup = function (menuitem) {
-  var menu, cmi;
-
-  if (this.hasPopup(menuitem)) {
-    if (this.isOpen(menuitem)) {
-      menuitem.setAttribute('aria-expanded', 'false');
-      menuitem.nextElementSibling.style.display = 'none';
-      menuitem.nextElementSibling.style.zIndex = 0;
-    }
-  } else {
-    menu = this.getMenu(menuitem);
-    cmi = menu.previousElementSibling;
-    cmi.setAttribute('aria-expanded', 'false');
-    cmi.focus();
-    menu.style.display = 'none';
-    menu.style.zIndex = 0;
-  }
-  return cmi;
-};
-
-MenubarEditor.prototype.doesNotContain = function (popup, menuitem) {
-  if (menuitem) {
-    return !popup.nextElementSibling.contains(menuitem);
-  }
-  return true;
-};
-
-MenubarEditor.prototype.closePopupAll = function (menuitem) {
-  if (typeof menuitem !== 'object') {
-    menuitem = false;
-  }
-
-  for (var i = 0; i < this.popups.length; i++) {
-    var popup = this.popups[i];
-    if (this.isOpen(popup) && this.doesNotContain(popup, menuitem)) {
-      this.closePopup(popup);
-    }
-  }
-};
-
-MenubarEditor.prototype.hasPopup = function (menuitem) {
-  return menuitem.getAttribute('aria-haspopup') === 'true';
-};
-
-MenubarEditor.prototype.isOpen = function (menuitem) {
-  return menuitem.getAttribute('aria-expanded') === 'true';
-};
-
-// Menu event handlers
-
-MenubarEditor.prototype.handleFocusin = function () {
-  this.domNode.classList.add('focus');
-};
-
-MenubarEditor.prototype.handleFocusout = function () {
-  this.domNode.classList.remove('focus');
-};
-
-MenubarEditor.prototype.handleBackgroundMousedown = function (event) {
-  if (!this.menubarNode.contains(event.target)) {
-    this.closePopupAll();
-  }
-};
-
-MenubarEditor.prototype.handleKeydown = function (event) {
-  var tgt = event.currentTarget,
-    key = event.key,
-    flag = false,
-    menuId = this.getMenuId(tgt),
-    id,
-    popupMenuId,
-    mi,
-    role,
-    option,
-    value;
-
-  switch (key) {
-    case ' ':
-    case 'Enter':
-      if (this.hasPopup(tgt)) {
-        popupMenuId = this.openPopup(tgt);
-        this.setFocusToFirstMenuitem(popupMenuId);
-      } else {
-        role = tgt.getAttribute('role');
-        option = this.getDataOption(tgt);
         switch (role) {
+          case 'menu':
+            node.tabIndex = -1;
+            initMenu(node);
+            flag = false;
+            break;
+
+          case 'group':
+            groupId = getGroupId(node);
+            menuitemGroups[groupId] = [];
+            break;
+
           case 'menuitem':
-            this.actionManager.setOption(option, tgt.textContent);
-            break;
-
-          case 'menuitemcheckbox':
-            value = this.toggleCheckbox(tgt);
-            this.actionManager.setOption(option, value);
-            break;
-
           case 'menuitemradio':
-            value = this.setRadioButton(tgt);
-            this.actionManager.setOption(option, value);
+          case 'menuitemcheckbox':
+            if (node.getAttribute('aria-haspopup') === 'true') {
+              popups.push(node);
+            }
+            nodes.push(node);
+            if (group) {
+              group.push(node);
+            }
             break;
 
           default:
             break;
         }
 
-        if (this.getMenuId(tgt) === 'menu-size') {
-          this.updateFontSizeMenu('menu-size');
+        if (flag && node.firstElementChild) {
+          findMenuitems(node.firstElementChild, menuitemGroups[groupId]);
         }
-        this.closePopup(tgt);
-      }
-      flag = true;
-      break;
 
-    case 'ArrowDown':
-    case 'Down':
-      if (this.menuOrientation[menuId] === 'vertical') {
-        this.setFocusToNextMenuitem(menuId, tgt);
-        flag = true;
-      } else {
+        node = node.nextElementSibling;
+      }
+    }
+
+    findMenuitems(domNode.firstElementChild, false);
+
+    return nodes;
+  }
+
+  initMenu(menu) {
+    var i, menuitems, menuitem, role;
+
+    var menuId = this.getMenuId(menu);
+
+    menuitems = this.getMenuitems(menu);
+    this.menuOrientation[menuId] = this.getMenuOrientation(menu);
+    this.isPopup[menuId] = menu.getAttribute('role') === 'menu';
+
+    this.menuitemGroups[menuId] = [];
+    this.firstChars[menuId] = [];
+    this.firstMenuitem[menuId] = null;
+    this.lastMenuitem[menuId] = null;
+
+    for (i = 0; i < menuitems.length; i++) {
+      menuitem = menuitems[i];
+      role = menuitem.getAttribute('role');
+
+      if (role.indexOf('menuitem') < 0) {
+        continue;
+      }
+
+      menuitem.tabIndex = -1;
+      this.menuitemGroups[menuId].push(menuitem);
+      this.firstChars[menuId].push(menuitem.textContent[0].toLowerCase());
+
+      menuitem.addEventListener('keydown', this.handleKeydown.bind(this));
+      menuitem.addEventListener('click', this.handleMenuitemClick.bind(this));
+
+      menuitem.addEventListener(
+        'mouseover',
+        this.handleMenuitemMouseover.bind(this)
+      );
+
+      if (!this.firstMenuitem[menuId]) {
+        if (this.hasPopup(menuitem)) {
+          menuitem.tabIndex = 0;
+        }
+        this.firstMenuitem[menuId] = menuitem;
+      }
+      this.lastMenuitem[menuId] = menuitem;
+    }
+  }
+
+  /* MenubarEditor FOCUS MANAGEMENT METHODS */
+
+  setFocusToMenuitem(menuId, newMenuitem) {
+    var isAnyPopupOpen = this.isAnyPopupOpen();
+
+    this.closePopupAll(newMenuitem);
+
+    if (this.hasPopup(newMenuitem)) {
+      if (isAnyPopupOpen) {
+        this.openPopup(newMenuitem);
+      }
+    } else {
+      var menu = this.getMenu(newMenuitem);
+      var cmi = menu.previousElementSibling;
+      if (!this.isOpen(cmi)) {
+        this.openPopup(cmi);
+      }
+    }
+
+    if (this.hasPopup(newMenuitem)) {
+      if (this.menuitemGroups[menuId]) {
+        this.menuitemGroups[menuId].forEach(function (item) {
+          item.tabIndex = -1;
+        });
+      }
+      newMenuitem.tabIndex = 0;
+    }
+
+    newMenuitem.focus();
+  }
+
+  setFocusToFirstMenuitem(menuId) {
+    this.setFocusToMenuitem(menuId, this.firstMenuitem[menuId]);
+  }
+
+  setFocusToLastMenuitem(menuId) {
+    this.setFocusToMenuitem(menuId, this.lastMenuitem[menuId]);
+  }
+
+  setFocusToPreviousMenuitem(menuId, currentMenuitem) {
+    var newMenuitem, index;
+
+    if (currentMenuitem === this.firstMenuitem[menuId]) {
+      newMenuitem = this.lastMenuitem[menuId];
+    } else {
+      index = this.menuitemGroups[menuId].indexOf(currentMenuitem);
+      newMenuitem = this.menuitemGroups[menuId][index - 1];
+    }
+
+    this.setFocusToMenuitem(menuId, newMenuitem);
+
+    return newMenuitem;
+  }
+
+  setFocusToNextMenuitem(menuId, currentMenuitem) {
+    var newMenuitem, index;
+
+    if (currentMenuitem === this.lastMenuitem[menuId]) {
+      newMenuitem = this.firstMenuitem[menuId];
+    } else {
+      index = this.menuitemGroups[menuId].indexOf(currentMenuitem);
+      newMenuitem = this.menuitemGroups[menuId][index + 1];
+    }
+    this.setFocusToMenuitem(menuId, newMenuitem);
+
+    return newMenuitem;
+  }
+
+  setFocusByFirstCharacter(menuId, currentMenuitem, char) {
+    var start, index;
+
+    char = char.toLowerCase();
+
+    // Get start index for search based on position of currentItem
+    start = this.menuitemGroups[menuId].indexOf(currentMenuitem) + 1;
+    if (start >= this.menuitemGroups[menuId].length) {
+      start = 0;
+    }
+
+    // Check remaining slots in the menu
+    index = this.getIndexFirstChars(menuId, start, char);
+
+    // If not found in remaining slots, check from beginning
+    if (index === -1) {
+      index = this.getIndexFirstChars(menuId, 0, char);
+    }
+
+    // If match was found...
+    if (index > -1) {
+      this.setFocusToMenuitem(menuId, this.menuitemGroups[menuId][index]);
+    }
+  }
+
+  // Utilities
+
+  getIndexFirstChars(menuId, startIndex, char) {
+    for (var i = startIndex; i < this.firstChars[menuId].length; i++) {
+      if (char === this.firstChars[menuId][i]) {
+        return i;
+      }
+    }
+    return -1;
+  }
+
+  isPrintableCharacter(str) {
+    return str.length === 1 && str.match(/\S/);
+  }
+
+  getIdFromAriaLabel(node) {
+    var id = node.getAttribute('aria-label');
+    if (id) {
+      id = id.trim().toLowerCase().replace(' ', '-').replace('/', '-');
+    }
+    return id;
+  }
+
+  getMenuOrientation(node) {
+    var orientation = node.getAttribute('aria-orientation');
+
+    if (!orientation) {
+      var role = node.getAttribute('role');
+
+      switch (role) {
+        case 'menubar':
+          orientation = 'horizontal';
+          break;
+
+        case 'menu':
+          orientation = 'vertical';
+          break;
+
+        default:
+          break;
+      }
+    }
+
+    return orientation;
+  }
+
+  getDataOption(node) {
+    var option = false;
+    var hasOption = node.hasAttribute('data-option');
+    var role = node.hasAttribute('role');
+
+    if (!hasOption) {
+      while (node && !hasOption && role !== 'menu' && role !== 'menubar') {
+        node = node.parentNode;
+        if (node) {
+          role = node.getAttribute('role');
+          hasOption = node.hasAttribute('data-option');
+        }
+      }
+    }
+
+    if (node) {
+      option = node.getAttribute('data-option');
+    }
+
+    return option;
+  }
+
+  getGroupId(node) {
+    var id = false;
+    var role = node.getAttribute('role');
+
+    while (node && role !== 'group' && role !== 'menu' && role !== 'menubar') {
+      node = node.parentNode;
+      if (node) {
+        role = node.getAttribute('role');
+      }
+    }
+
+    if (node) {
+      id = role + '-' + this.getIdFromAriaLabel(node);
+    }
+
+    return id;
+  }
+
+  getMenuId(node) {
+    var id = false;
+    var role = node.getAttribute('role');
+
+    while (node && role !== 'menu' && role !== 'menubar') {
+      node = node.parentNode;
+      if (node) {
+        role = node.getAttribute('role');
+      }
+    }
+
+    if (node) {
+      id = role + '-' + this.getIdFromAriaLabel(node);
+    }
+
+    return id;
+  }
+
+  getMenu(menuitem) {
+    var menu = menuitem;
+    var role = menuitem.getAttribute('role');
+
+    while (menu && role !== 'menu' && role !== 'menubar') {
+      menu = menu.parentNode;
+      if (menu) {
+        role = menu.getAttribute('role');
+      }
+    }
+
+    return menu;
+  }
+
+  toggleCheckbox(menuitem) {
+    if (menuitem.getAttribute('aria-checked') === 'true') {
+      menuitem.setAttribute('aria-checked', 'false');
+      return false;
+    }
+    menuitem.setAttribute('aria-checked', 'true');
+    return true;
+  }
+
+  setRadioButton(menuitem) {
+    var groupId = this.getGroupId(menuitem);
+    var radiogroupItems = this.menuitemGroups[groupId];
+    radiogroupItems.forEach(function (item) {
+      item.setAttribute('aria-checked', 'false');
+    });
+    menuitem.setAttribute('aria-checked', 'true');
+    return menuitem.textContent;
+  }
+
+  updateFontSizeMenu(menuId) {
+    var fontSizeMenuitems = this.menuitemGroups[menuId];
+    var currentValue = this.actionManager.getFontSize();
+
+    for (var i = 0; i < fontSizeMenuitems.length; i++) {
+      var mi = fontSizeMenuitems[i];
+      var dataOption = mi.getAttribute('data-option');
+      var value = mi.textContent.trim().toLowerCase();
+
+      switch (dataOption) {
+        case 'font-smaller':
+          if (currentValue === 'x-small') {
+            mi.setAttribute('aria-disabled', 'true');
+          } else {
+            mi.removeAttribute('aria-disabled');
+          }
+          break;
+
+        case 'font-larger':
+          if (currentValue === 'x-large') {
+            mi.setAttribute('aria-disabled', 'true');
+          } else {
+            mi.removeAttribute('aria-disabled');
+          }
+          break;
+
+        default:
+          if (currentValue === value) {
+            mi.setAttribute('aria-checked', 'true');
+          } else {
+            mi.setAttribute('aria-checked', 'false');
+          }
+          break;
+      }
+    }
+  }
+
+  // Popup menu methods
+
+  isAnyPopupOpen() {
+    for (var i = 0; i < this.popups.length; i++) {
+      if (this.popups[i].getAttribute('aria-expanded') === 'true') {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  openPopup(menuitem) {
+    // set aria-expanded attribute
+    var popupMenu = menuitem.nextElementSibling;
+
+    var rect = menuitem.getBoundingClientRect();
+
+    // set CSS properties
+    popupMenu.style.position = 'absolute';
+    popupMenu.style.top = rect.height - 3 + 'px';
+    popupMenu.style.left = '0px';
+    popupMenu.style.zIndex = 100;
+    popupMenu.style.display = 'block';
+
+    menuitem.setAttribute('aria-expanded', 'true');
+
+    return this.getMenuId(popupMenu);
+  }
+
+  closePopup(menuitem) {
+    var menu, cmi;
+
+    if (this.hasPopup(menuitem)) {
+      if (this.isOpen(menuitem)) {
+        menuitem.setAttribute('aria-expanded', 'false');
+        menuitem.nextElementSibling.style.display = 'none';
+        menuitem.nextElementSibling.style.zIndex = 0;
+      }
+    } else {
+      menu = this.getMenu(menuitem);
+      cmi = menu.previousElementSibling;
+      cmi.setAttribute('aria-expanded', 'false');
+      cmi.focus();
+      menu.style.display = 'none';
+      menu.style.zIndex = 0;
+    }
+    return cmi;
+  }
+
+  doesNotContain(popup, menuitem) {
+    if (menuitem) {
+      return !popup.nextElementSibling.contains(menuitem);
+    }
+    return true;
+  }
+
+  closePopupAll(menuitem) {
+    if (typeof menuitem !== 'object') {
+      menuitem = false;
+    }
+
+    for (var i = 0; i < this.popups.length; i++) {
+      var popup = this.popups[i];
+      if (this.isOpen(popup) && this.doesNotContain(popup, menuitem)) {
+        this.closePopup(popup);
+      }
+    }
+  }
+
+  hasPopup(menuitem) {
+    return menuitem.getAttribute('aria-haspopup') === 'true';
+  }
+
+  isOpen(menuitem) {
+    return menuitem.getAttribute('aria-expanded') === 'true';
+  }
+
+  // Menu event handlers
+
+  handleFocusin() {
+    this.domNode.classList.add('focus');
+  }
+
+  handleFocusout() {
+    this.domNode.classList.remove('focus');
+  }
+
+  handleBackgroundMousedown(event) {
+    if (!this.menubarNode.contains(event.target)) {
+      this.closePopupAll();
+    }
+  }
+
+  handleKeydown(event) {
+    var tgt = event.currentTarget,
+      key = event.key,
+      flag = false,
+      menuId = this.getMenuId(tgt),
+      id,
+      popupMenuId,
+      mi,
+      role,
+      option,
+      value;
+
+    switch (key) {
+      case ' ':
+      case 'Enter':
         if (this.hasPopup(tgt)) {
           popupMenuId = this.openPopup(tgt);
           this.setFocusToFirstMenuitem(popupMenuId);
-          flag = true;
+        } else {
+          role = tgt.getAttribute('role');
+          option = this.getDataOption(tgt);
+          switch (role) {
+            case 'menuitem':
+              this.actionManager.setOption(option, tgt.textContent);
+              break;
+
+            case 'menuitemcheckbox':
+              value = this.toggleCheckbox(tgt);
+              this.actionManager.setOption(option, value);
+              break;
+
+            case 'menuitemradio':
+              value = this.setRadioButton(tgt);
+              this.actionManager.setOption(option, value);
+              break;
+
+            default:
+              break;
+          }
+
+          if (this.getMenuId(tgt) === 'menu-size') {
+            this.updateFontSizeMenu('menu-size');
+          }
+          this.closePopup(tgt);
         }
-      }
-      break;
-
-    case 'Esc':
-    case 'Escape':
-      this.closePopup(tgt);
-      flag = true;
-      break;
-
-    case 'Left':
-    case 'ArrowLeft':
-      if (this.menuOrientation[menuId] === 'horizontal') {
-        this.setFocusToPreviousMenuitem(menuId, tgt);
         flag = true;
-      } else {
-        mi = this.closePopup(tgt);
-        id = this.getMenuId(mi);
-        mi = this.setFocusToPreviousMenuitem(id, mi);
-        this.openPopup(mi);
-      }
-      break;
-
-    case 'Right':
-    case 'ArrowRight':
-      if (this.menuOrientation[menuId] === 'horizontal') {
-        this.setFocusToNextMenuitem(menuId, tgt);
-        flag = true;
-      } else {
-        mi = this.closePopup(tgt);
-        id = this.getMenuId(mi);
-        mi = this.setFocusToNextMenuitem(id, mi);
-        this.openPopup(mi);
-      }
-      break;
-
-    case 'Up':
-    case 'ArrowUp':
-      if (this.menuOrientation[menuId] === 'vertical') {
-        this.setFocusToPreviousMenuitem(menuId, tgt);
-        flag = true;
-      } else {
-        if (this.hasPopup(tgt)) {
-          popupMenuId = this.openPopup(tgt);
-          this.setFocusToLastMenuitem(popupMenuId);
-          flag = true;
-        }
-      }
-      break;
-
-    case 'Home':
-    case 'PageUp':
-      this.setFocusToFirstMenuitem(menuId, tgt);
-      flag = true;
-      break;
-
-    case 'End':
-    case 'PageDown':
-      this.setFocusToLastMenuitem(menuId, tgt);
-      flag = true;
-      break;
-
-    case 'Tab':
-      this.closePopup(tgt);
-      break;
-
-    default:
-      if (this.isPrintableCharacter(key)) {
-        this.setFocusByFirstCharacter(menuId, tgt, key);
-        flag = true;
-      }
-      break;
-  }
-
-  if (flag) {
-    event.stopPropagation();
-    event.preventDefault();
-  }
-};
-
-MenubarEditor.prototype.handleMenuitemClick = function (event) {
-  var tgt = event.currentTarget;
-  var value;
-
-  if (this.hasPopup(tgt)) {
-    if (this.isOpen(tgt)) {
-      this.closePopup(tgt);
-    } else {
-      var menuId = this.openPopup(tgt);
-      this.setFocusToMenuitem(menuId, tgt);
-    }
-  } else {
-    var role = tgt.getAttribute('role');
-    var option = this.getDataOption(tgt);
-    switch (role) {
-      case 'menuitem':
-        this.actionManager.setOption(option, tgt.textContent);
         break;
 
-      case 'menuitemcheckbox':
-        value = this.toggleCheckbox(tgt);
-        this.actionManager.setOption(option, value);
+      case 'ArrowDown':
+      case 'Down':
+        if (this.menuOrientation[menuId] === 'vertical') {
+          this.setFocusToNextMenuitem(menuId, tgt);
+          flag = true;
+        } else {
+          if (this.hasPopup(tgt)) {
+            popupMenuId = this.openPopup(tgt);
+            this.setFocusToFirstMenuitem(popupMenuId);
+            flag = true;
+          }
+        }
         break;
 
-      case 'menuitemradio':
-        value = this.setRadioButton(tgt);
-        this.actionManager.setOption(option, value);
+      case 'Esc':
+      case 'Escape':
+        this.closePopup(tgt);
+        flag = true;
+        break;
+
+      case 'Left':
+      case 'ArrowLeft':
+        if (this.menuOrientation[menuId] === 'horizontal') {
+          this.setFocusToPreviousMenuitem(menuId, tgt);
+          flag = true;
+        } else {
+          mi = this.closePopup(tgt);
+          id = this.getMenuId(mi);
+          mi = this.setFocusToPreviousMenuitem(id, mi);
+          this.openPopup(mi);
+        }
+        break;
+
+      case 'Right':
+      case 'ArrowRight':
+        if (this.menuOrientation[menuId] === 'horizontal') {
+          this.setFocusToNextMenuitem(menuId, tgt);
+          flag = true;
+        } else {
+          mi = this.closePopup(tgt);
+          id = this.getMenuId(mi);
+          mi = this.setFocusToNextMenuitem(id, mi);
+          this.openPopup(mi);
+        }
+        break;
+
+      case 'Up':
+      case 'ArrowUp':
+        if (this.menuOrientation[menuId] === 'vertical') {
+          this.setFocusToPreviousMenuitem(menuId, tgt);
+          flag = true;
+        } else {
+          if (this.hasPopup(tgt)) {
+            popupMenuId = this.openPopup(tgt);
+            this.setFocusToLastMenuitem(popupMenuId);
+            flag = true;
+          }
+        }
+        break;
+
+      case 'Home':
+      case 'PageUp':
+        this.setFocusToFirstMenuitem(menuId, tgt);
+        flag = true;
+        break;
+
+      case 'End':
+      case 'PageDown':
+        this.setFocusToLastMenuitem(menuId, tgt);
+        flag = true;
+        break;
+
+      case 'Tab':
+        this.closePopup(tgt);
         break;
 
       default:
+        if (this.isPrintableCharacter(key)) {
+          this.setFocusByFirstCharacter(menuId, tgt, key);
+          flag = true;
+        }
         break;
     }
 
-    if (this.getMenuId(tgt) === 'menu-size') {
-      this.updateFontSizeMenu('menu-size');
+    if (flag) {
+      event.stopPropagation();
+      event.preventDefault();
     }
-    this.closePopup(tgt);
   }
 
-  event.stopPropagation();
-  event.preventDefault();
-};
+  handleMenuitemClick(event) {
+    var tgt = event.currentTarget;
+    var value;
 
-MenubarEditor.prototype.handleMenuitemMouseover = function (event) {
-  var tgt = event.currentTarget;
+    if (this.hasPopup(tgt)) {
+      if (this.isOpen(tgt)) {
+        this.closePopup(tgt);
+      } else {
+        var menuId = this.openPopup(tgt);
+        this.setFocusToMenuitem(menuId, tgt);
+      }
+    } else {
+      var role = tgt.getAttribute('role');
+      var option = this.getDataOption(tgt);
+      switch (role) {
+        case 'menuitem':
+          this.actionManager.setOption(option, tgt.textContent);
+          break;
 
-  if (this.isAnyPopupOpen() && this.getMenu(tgt)) {
-    this.setFocusToMenuitem(this.getMenu(tgt), tgt);
+        case 'menuitemcheckbox':
+          value = this.toggleCheckbox(tgt);
+          this.actionManager.setOption(option, value);
+          break;
+
+        case 'menuitemradio':
+          value = this.setRadioButton(tgt);
+          this.actionManager.setOption(option, value);
+          break;
+
+        default:
+          break;
+      }
+
+      if (this.getMenuId(tgt) === 'menu-size') {
+        this.updateFontSizeMenu('menu-size');
+      }
+      this.closePopup(tgt);
+    }
+
+    event.stopPropagation();
+    event.preventDefault();
   }
-};
+
+  handleMenuitemMouseover(event) {
+    var tgt = event.currentTarget;
+
+    if (this.isAnyPopupOpen() && this.getMenu(tgt)) {
+      this.setFocusToMenuitem(this.getMenu(tgt), tgt);
+    }
+  }
+}
 
 // Initialize menubar editor
 

--- a/examples/menubar/js/menubar-editor.js
+++ b/examples/menubar/js/menubar-editor.js
@@ -32,8 +32,8 @@ class MenubarEditor {
     this.domNode.addEventListener('focusout', this.onFocusout.bind(this));
 
     window.addEventListener(
-      'mousedown',
-      this.onBackgroundMousedown.bind(this),
+      'pointerdown',
+      this.onBackgroundPointerdown.bind(this),
       true
     );
   }
@@ -124,8 +124,8 @@ class MenubarEditor {
       menuitem.addEventListener('click', this.onMenuitemClick.bind(this));
 
       menuitem.addEventListener(
-        'mouseover',
-        this.onMenuitemMouseover.bind(this)
+        'pointerover',
+        this.onMenuitemPointerover.bind(this)
       );
 
       if (!this.firstMenuitem[menuId]) {
@@ -492,7 +492,7 @@ class MenubarEditor {
     this.domNode.classList.remove('focus');
   }
 
-  onBackgroundMousedown(event) {
+  onBackgroundPointerdown(event) {
     if (!this.menubarNode.contains(event.target)) {
       this.closePopupAll();
     }
@@ -679,7 +679,7 @@ class MenubarEditor {
     event.preventDefault();
   }
 
-  onMenuitemMouseover(event) {
+  onMenuitemPointerover(event) {
     var tgt = event.currentTarget;
 
     if (this.isAnyPopupOpen() && this.getMenu(tgt)) {

--- a/examples/menubar/js/menubar-editor.js
+++ b/examples/menubar/js/menubar-editor.js
@@ -482,7 +482,7 @@ class MenubarEditor {
     return menuitem.getAttribute('aria-expanded') === 'true';
   }
 
-  // Menu event onrs
+  // Menu event handlers
 
   onFocusin() {
     this.domNode.classList.add('focus');

--- a/examples/menubar/js/menubar-editor.js
+++ b/examples/menubar/js/menubar-editor.js
@@ -28,12 +28,12 @@ class MenubarEditor {
     this.lastMenuitem = {}; // see Menubar init method
 
     this.initMenu(this.menubarNode);
-    this.domNode.addEventListener('focusin', this.handleFocusin.bind(this));
-    this.domNode.addEventListener('focusout', this.handleFocusout.bind(this));
+    this.domNode.addEventListener('focusin', this.onFocusin.bind(this));
+    this.domNode.addEventListener('focusout', this.onFocusout.bind(this));
 
     window.addEventListener(
       'mousedown',
-      this.handleBackgroundMousedown.bind(this),
+      this.onBackgroundMousedown.bind(this),
       true
     );
   }
@@ -120,12 +120,12 @@ class MenubarEditor {
       this.menuitemGroups[menuId].push(menuitem);
       this.firstChars[menuId].push(menuitem.textContent[0].toLowerCase());
 
-      menuitem.addEventListener('keydown', this.handleKeydown.bind(this));
-      menuitem.addEventListener('click', this.handleMenuitemClick.bind(this));
+      menuitem.addEventListener('keydown', this.onKeydown.bind(this));
+      menuitem.addEventListener('click', this.onMenuitemClick.bind(this));
 
       menuitem.addEventListener(
         'mouseover',
-        this.handleMenuitemMouseover.bind(this)
+        this.onMenuitemMouseover.bind(this)
       );
 
       if (!this.firstMenuitem[menuId]) {
@@ -482,23 +482,23 @@ class MenubarEditor {
     return menuitem.getAttribute('aria-expanded') === 'true';
   }
 
-  // Menu event handlers
+  // Menu event onrs
 
-  handleFocusin() {
+  onFocusin() {
     this.domNode.classList.add('focus');
   }
 
-  handleFocusout() {
+  onFocusout() {
     this.domNode.classList.remove('focus');
   }
 
-  handleBackgroundMousedown(event) {
+  onBackgroundMousedown(event) {
     if (!this.menubarNode.contains(event.target)) {
       this.closePopupAll();
     }
   }
 
-  handleKeydown(event) {
+  onKeydown(event) {
     var tgt = event.currentTarget,
       key = event.key,
       flag = false,
@@ -636,7 +636,7 @@ class MenubarEditor {
     }
   }
 
-  handleMenuitemClick(event) {
+  onMenuitemClick(event) {
     var tgt = event.currentTarget;
     var value;
 
@@ -679,7 +679,7 @@ class MenubarEditor {
     event.preventDefault();
   }
 
-  handleMenuitemMouseover(event) {
+  onMenuitemMouseover(event) {
     var tgt = event.currentTarget;
 
     if (this.isAnyPopupOpen() && this.getMenu(tgt)) {

--- a/examples/menubar/js/menubar-navigation.js
+++ b/examples/menubar/js/menubar-navigation.js
@@ -58,8 +58,8 @@ class MenubarNavigation {
     domNode.addEventListener('focusout', this.onMenubarFocusout.bind(this));
 
     window.addEventListener(
-      'mousedown',
-      this.onBackgroundMousedown.bind(this),
+      'pointerdown',
+      this.onBackgroundPointerdown.bind(this),
       true
     );
 
@@ -239,8 +239,8 @@ class MenubarNavigation {
       });
 
       menuitem.addEventListener(
-        'mouseover',
-        this.onMenuitemMouseover.bind(this)
+        'pointerover',
+        this.onMenuitemPointerover.bind(this)
       );
 
       if (!this.firstMenuitem[menuId]) {
@@ -706,7 +706,7 @@ class MenubarNavigation {
     event.preventDefault();
   }
 
-  onMenuitemMouseover(event) {
+  onMenuitemPointerover(event) {
     var tgt = event.currentTarget;
     var menuId = this.getMenuId(tgt);
 
@@ -722,7 +722,7 @@ class MenubarNavigation {
     }
   }
 
-  onBackgroundMousedown(event) {
+  onBackgroundPointerdown(event) {
     if (!this.domNode.contains(event.target)) {
       this.closePopupAll();
     }

--- a/examples/menubar/js/menubar-navigation.js
+++ b/examples/menubar/js/menubar-navigation.js
@@ -537,7 +537,7 @@ class MenubarNavigation {
     return this.domNode.classList.contains('focus');
   }
 
-  // Menu event onrs
+  // Menu event handlers
 
   onMenubarFocusin() {
     // if the menubar or any of its menus has focus, add styling hook for hover

--- a/examples/menubar/js/menubar-navigation.js
+++ b/examples/menubar/js/menubar-navigation.js
@@ -54,12 +54,12 @@ class MenubarNavigation {
 
     this.initMenu(domNode, 0);
 
-    domNode.addEventListener('focusin', this.handleMenubarFocusin.bind(this));
-    domNode.addEventListener('focusout', this.handleMenubarFocusout.bind(this));
+    domNode.addEventListener('focusin', this.onMenubarFocusin.bind(this));
+    domNode.addEventListener('focusout', this.onMenubarFocusout.bind(this));
 
     window.addEventListener(
       'mousedown',
-      this.handleBackgroundMousedown.bind(this),
+      this.onBackgroundMousedown.bind(this),
       true
     );
 
@@ -233,14 +233,14 @@ class MenubarNavigation {
         menuitem.textContent.trim().toLowerCase()[0]
       );
 
-      menuitem.addEventListener('keydown', this.handleKeydown.bind(this));
-      menuitem.addEventListener('click', this.handleMenuitemClick.bind(this), {
+      menuitem.addEventListener('keydown', this.onKeydown.bind(this));
+      menuitem.addEventListener('click', this.onMenuitemClick.bind(this), {
         capture: true,
       });
 
       menuitem.addEventListener(
         'mouseover',
-        this.handleMenuitemMouseover.bind(this)
+        this.onMenuitemMouseover.bind(this)
       );
 
       if (!this.firstMenuitem[menuId]) {
@@ -537,19 +537,19 @@ class MenubarNavigation {
     return this.domNode.classList.contains('focus');
   }
 
-  // Menu event handlers
+  // Menu event onrs
 
-  handleMenubarFocusin() {
+  onMenubarFocusin() {
     // if the menubar or any of its menus has focus, add styling hook for hover
     this.domNode.classList.add('focus');
   }
 
-  handleMenubarFocusout() {
+  onMenubarFocusout() {
     // remove styling hook for hover on menubar item
     this.domNode.classList.remove('focus');
   }
 
-  handleKeydown(event) {
+  onKeydown(event) {
     var tgt = event.currentTarget,
       key = event.key,
       flag = false,
@@ -687,7 +687,7 @@ class MenubarNavigation {
     }
   }
 
-  handleMenuitemClick(event) {
+  onMenuitemClick(event) {
     var tgt = event.currentTarget;
     var menuId = this.getMenuId(tgt);
 
@@ -706,7 +706,7 @@ class MenubarNavigation {
     event.preventDefault();
   }
 
-  handleMenuitemMouseover(event) {
+  onMenuitemMouseover(event) {
     var tgt = event.currentTarget;
     var menuId = this.getMenuId(tgt);
 
@@ -722,7 +722,7 @@ class MenubarNavigation {
     }
   }
 
-  handleBackgroundMousedown(event) {
+  onBackgroundMousedown(event) {
     if (!this.domNode.contains(event.target)) {
       this.closePopupAll();
     }

--- a/examples/menubar/js/style-manager.js
+++ b/examples/menubar/js/style-manager.js
@@ -9,150 +9,154 @@
 
 'use strict';
 
-var StyleManager = function (node) {
-  this.node = node;
-  this.fontSize = 'medium';
-};
+/* exported StyleManager */
 
-StyleManager.prototype.setFontFamily = function (value) {
-  this.node.style.fontFamily = value;
-};
-
-StyleManager.prototype.setTextDecoration = function (value) {
-  this.node.style.textDecoration = value;
-};
-
-StyleManager.prototype.setTextAlign = function (value) {
-  this.node.style.textAlign = value;
-};
-
-StyleManager.prototype.setFontSize = function (value) {
-  this.fontSize = value;
-  this.node.style.fontSize = value;
-};
-
-StyleManager.prototype.setColor = function (value) {
-  this.node.style.color = value;
-};
-
-StyleManager.prototype.setBold = function (flag) {
-  if (flag) {
-    this.node.style.fontWeight = 'bold';
-  } else {
-    this.node.style.fontWeight = 'normal';
-  }
-};
-
-StyleManager.prototype.setItalic = function (flag) {
-  if (flag) {
-    this.node.style.fontStyle = 'italic';
-  } else {
-    this.node.style.fontStyle = 'normal';
-  }
-};
-
-StyleManager.prototype.fontSmaller = function () {
-  switch (this.fontSize) {
-    case 'small':
-      this.setFontSize('x-small');
-      break;
-
-    case 'medium':
-      this.setFontSize('small');
-      break;
-
-    case 'large':
-      this.setFontSize('medium');
-      break;
-
-    case 'x-large':
-      this.setFontSize('large');
-      break;
-
-    default:
-      break;
-  } // end switch
-};
-
-StyleManager.prototype.fontLarger = function () {
-  switch (this.fontSize) {
-    case 'x-small':
-      this.setFontSize('small');
-      break;
-
-    case 'small':
-      this.setFontSize('medium');
-      break;
-
-    case 'medium':
-      this.setFontSize('large');
-      break;
-
-    case 'large':
-      this.setFontSize('x-large');
-      break;
-
-    default:
-      break;
-  } // end switch
-};
-
-StyleManager.prototype.isMinFontSize = function () {
-  return this.fontSize === 'x-small';
-};
-
-StyleManager.prototype.isMaxFontSize = function () {
-  return this.fontSize === 'x-large';
-};
-
-StyleManager.prototype.getFontSize = function () {
-  return this.fontSize;
-};
-
-StyleManager.prototype.setOption = function (option, value) {
-  option = option.toLowerCase();
-  if (typeof value === 'string') {
-    value = value.toLowerCase();
+class StyleManager {
+  constructor(node) {
+    this.node = node;
+    this.fontSize = 'medium';
   }
 
-  switch (option) {
-    case 'font-bold':
-      this.setBold(value);
-      break;
+  setFontFamily(value) {
+    this.node.style.fontFamily = value;
+  }
 
-    case 'font-color':
-      this.setColor(value);
-      break;
+  setTextDecoration(value) {
+    this.node.style.textDecoration = value;
+  }
 
-    case 'font-family':
-      this.setFontFamily(value);
-      break;
+  setTextAlign(value) {
+    this.node.style.textAlign = value;
+  }
 
-    case 'font-smaller':
-      this.fontSmaller();
-      break;
+  setFontSize(value) {
+    this.fontSize = value;
+    this.node.style.fontSize = value;
+  }
 
-    case 'font-larger':
-      this.fontLarger();
-      break;
+  setColor(value) {
+    this.node.style.color = value;
+  }
 
-    case 'font-size':
-      this.setFontSize(value);
-      break;
+  setBold(flag) {
+    if (flag) {
+      this.node.style.fontWeight = 'bold';
+    } else {
+      this.node.style.fontWeight = 'normal';
+    }
+  }
 
-    case 'font-italic':
-      this.setItalic(value);
-      break;
+  setItalic(flag) {
+    if (flag) {
+      this.node.style.fontStyle = 'italic';
+    } else {
+      this.node.style.fontStyle = 'normal';
+    }
+  }
 
-    case 'text-align':
-      this.setTextAlign(value);
-      break;
+  fontSmaller() {
+    switch (this.fontSize) {
+      case 'small':
+        this.setFontSize('x-small');
+        break;
 
-    case 'text-decoration':
-      this.setTextDecoration(value);
-      break;
+      case 'medium':
+        this.setFontSize('small');
+        break;
 
-    default:
-      break;
-  } // end switch
-};
+      case 'large':
+        this.setFontSize('medium');
+        break;
+
+      case 'x-large':
+        this.setFontSize('large');
+        break;
+
+      default:
+        break;
+    } // end switch
+  }
+
+  fontLarger() {
+    switch (this.fontSize) {
+      case 'x-small':
+        this.setFontSize('small');
+        break;
+
+      case 'small':
+        this.setFontSize('medium');
+        break;
+
+      case 'medium':
+        this.setFontSize('large');
+        break;
+
+      case 'large':
+        this.setFontSize('x-large');
+        break;
+
+      default:
+        break;
+    } // end switch
+  }
+
+  isMinFontSize() {
+    return this.fontSize === 'x-small';
+  }
+
+  isMaxFontSize() {
+    return this.fontSize === 'x-large';
+  }
+
+  getFontSize() {
+    return this.fontSize;
+  }
+
+  setOption(option, value) {
+    option = option.toLowerCase();
+    if (typeof value === 'string') {
+      value = value.toLowerCase();
+    }
+
+    switch (option) {
+      case 'font-bold':
+        this.setBold(value);
+        break;
+
+      case 'font-color':
+        this.setColor(value);
+        break;
+
+      case 'font-family':
+        this.setFontFamily(value);
+        break;
+
+      case 'font-smaller':
+        this.fontSmaller();
+        break;
+
+      case 'font-larger':
+        this.fontLarger();
+        break;
+
+      case 'font-size':
+        this.setFontSize(value);
+        break;
+
+      case 'font-italic':
+        this.setItalic(value);
+        break;
+
+      case 'text-align':
+        this.setTextAlign(value);
+        break;
+
+      case 'text-decoration':
+        this.setTextDecoration(value);
+        break;
+
+      default:
+        break;
+    } // end switch
+  }
+}

--- a/examples/menubar/menubar-editor.html
+++ b/examples/menubar/menubar-editor.html
@@ -27,18 +27,19 @@
     </ul>
   </nav>
   <main>
-  <h1>Editor Menubar Example</h1>
-  <p>
-    The following example demonstrates using the
-    <a href="../../#menu">menubar design pattern</a>
-    to provide access to sets of actions.
-    Each item in the below menubar identifies a category of text formatting actions that can be executed from its submenu.
-    The submenus also demonstrate <code>menuitemradio</code> and <code>menuitemcheckbox</code> elements.
-  </p>
-  <p>Similar examples include: </p>
-  <ul>
-    <li><a href="menubar-navigation.html">Navigation Menubar Example</a>: A menubar that presents site navigation menus.</li>
-  </ul>
+    <h1>Editor Menubar Example</h1>
+    <p>
+      The following example demonstrates using the
+      <a href="../../#menu">menubar design pattern</a>
+      to provide access to editing actions for a text area.
+      Each item in the menubar identifies a category of text formatting actions that can be executed from its submenu.
+      The submenus demonstrate <code>menuitemradio</code> and <code>menuitemcheckbox</code> elements.
+    </p>
+    <p>Similar examples include: </p>
+    <ul>
+      <li><a href="examples/toolbar/toolbar.html">Toolbar Example</a>: A text formatting toolbar that uses roving tabindex to manage focus and contains several types of controls, including toggle buttons, radio buttons, a menu button, a spin button, a checkbox, and a link.</li>
+      <li><a href="menubar-navigation.html">Navigation Menubar Example</a>: A menubar that presents site navigation menus.</li>
+    </ul>
 
   <section id="code-ex-1">
     <div class="example-header">

--- a/examples/menubar/menubar-editor.html
+++ b/examples/menubar/menubar-editor.html
@@ -49,67 +49,67 @@
       <div class="menubar-editor">
         <ul role="menubar" aria-label="Text Formatting">
           <li role="none">
-            <span role="menuitem" aria-haspopup="true" aria-expanded="false" tabindex="0">Font</span>
+            <span role="menuitem" aria-haspopup="true" aria-expanded="false" tabindex="0">Font<span aria-hidden="true"></span></span>
             <ul role="menu" data-option="font-family" aria-label="Font" >
-              <li role="menuitemradio" aria-checked="true">Sans-serif</li>
-              <li role="menuitemradio" aria-checked="false">Serif</li>
-              <li role="menuitemradio" aria-checked="false">Monospace</li>
-              <li role="menuitemradio" aria-checked="false">Fantasy</li>
+              <li role="menuitemradio" aria-checked="true"><span aria-hidden="true"></span>Sans-serif</li>
+              <li role="menuitemradio" aria-checked="false"><span aria-hidden="true"></span>Serif</li>
+              <li role="menuitemradio" aria-checked="false"><span aria-hidden="true"></span>Monospace</li>
+              <li role="menuitemradio" aria-checked="false"><span aria-hidden="true"></span>Fantasy</li>
             </ul>
           </li>
           <li role="none">
-            <span role="menuitem" aria-haspopup="true" aria-expanded="false" tabindex="-1">Style/Color</span>
+            <span role="menuitem" aria-haspopup="true" aria-expanded="false" tabindex="-1">Style/Color<span aria-hidden="true"></span></span>
             <ul role="menu" aria-label="Style/Color">
               <li role="none">
                 <ul role="group" data-option="font-style" aria-label="Font Style">
-                  <li role="menuitemcheckbox" data-option="font-bold" aria-checked="false">Bold</li>
-                  <li role="menuitemcheckbox" data-option="font-italic" aria-checked="false">Italic</li>
+                  <li role="menuitemcheckbox" data-option="font-bold" aria-checked="false"><span aria-hidden="true"></span>Bold</li>
+                  <li role="menuitemcheckbox" data-option="font-italic" aria-checked="false"><span aria-hidden="true"></span>Italic</li>
                 </ul>
               </li>
               <li role="separator"></li>
               <li role="none">
                 <ul role="group" data-option="font-color" aria-label="Text Color">
-                  <li role="menuitemradio" aria-checked="true">Black</li>
-                  <li role="menuitemradio" aria-checked="false">Blue</li>
-                  <li role="menuitemradio" aria-checked="false">Red</li>
-                  <li role="menuitemradio" aria-checked="false">Green</li>
+                  <li role="menuitemradio" aria-checked="true"><span aria-hidden="true"></span>Black</li>
+                  <li role="menuitemradio" aria-checked="false"><span aria-hidden="true"></span>Blue</li>
+                  <li role="menuitemradio" aria-checked="false"><span aria-hidden="true"></span>Red</li>
+                  <li role="menuitemradio" aria-checked="false"><span aria-hidden="true"></span>Green</li>
                 </ul>
               </li>
               <li role="separator"></li>
               <li role="none">
                 <ul role="group" data-option="text-decoration" aria-label="Text Decoration">
-                  <li role="menuitemradio" aria-checked="true">None</li>
-                  <li role="menuitemradio" aria-checked="false">Overline</li>
-                  <li role="menuitemradio" aria-checked="false">Line-through</li>
-                  <li role="menuitemradio" aria-checked="false">Underline</li>
+                  <li role="menuitemradio" aria-checked="true"><span aria-hidden="true"></span>None</li>
+                  <li role="menuitemradio" aria-checked="false"><span aria-hidden="true"></span>Overline</li>
+                  <li role="menuitemradio" aria-checked="false"><span aria-hidden="true"></span>Line-through</li>
+                  <li role="menuitemradio" aria-checked="false"><span aria-hidden="true"></span>Underline</li>
                 </ul>
               </li>
             </ul>
           </li>
 
           <li role="none">
-            <span role="menuitem" aria-haspopup="true" aria-expanded="false" tabindex="-1">Text Align</span>
+            <span role="menuitem" aria-haspopup="true" aria-expanded="false" tabindex="-1">Text Align<span aria-hidden="true"></span></span>
             <ul role="menu" data-option="text-align" aria-label="Text Align">
-              <li role="menuitemradio" aria-checked="true">Left</li>
-              <li role="menuitemradio" aria-checked="false">Center</li>
-              <li role="menuitemradio" aria-checked="false">Right</li>
-              <li role="menuitemradio" aria-checked="false">Justify</li>
+              <li role="menuitemradio" aria-checked="true"><span aria-hidden="true"></span>Left</li>
+              <li role="menuitemradio" aria-checked="false"><span aria-hidden="true"></span>Center</li>
+              <li role="menuitemradio" aria-checked="false"><span aria-hidden="true"></span>Right</li>
+              <li role="menuitemradio" aria-checked="false"><span aria-hidden="true"></span>Justify</li>
             </ul>
           </li>
 
           <li role="none">
-            <span role="menuitem" aria-haspopup="true" aria-expanded="false" tabindex="-1">Size</span>
+            <span role="menuitem" aria-haspopup="true" aria-expanded="false" tabindex="-1">Size<span aria-hidden="true"></span></span>
             <ul role="menu" aria-label="Size" >
               <li role="menuitem" data-option="font-smaller" aria-disabled="false">Smaller</li>
               <li role="menuitem" data-option="font-larger"  aria-disabled="false">Larger</li>
               <li role="separator"></li>
               <li role="none">
                 <ul role="group" data-option="font-size" aria-label="Font Sizes">
-                  <li role="menuitemradio" aria-checked="false">X-Small</li>
-                  <li role="menuitemradio" aria-checked="false">Small</li>
-                  <li role="menuitemradio" aria-checked="true">Medium</li>
-                  <li role="menuitemradio" aria-checked="false">Large</li>
-                  <li role="menuitemradio" aria-checked="false">X-Large</li>
+                  <li role="menuitemradio" aria-checked="false"><span aria-hidden="true"></span>X-Small</li>
+                  <li role="menuitemradio" aria-checked="false"><span aria-hidden="true"></span>Small</li>
+                  <li role="menuitemradio" aria-checked="true"><span aria-hidden="true"></span>Medium</li>
+                  <li role="menuitemradio" aria-checked="false"><span aria-hidden="true"></span>Large</li>
+                  <li role="menuitemradio" aria-checked="false"><span aria-hidden="true"></span>X-Large</li>
                 </ul>
               </li>
             </ul>

--- a/examples/menubar/menubar-editor.html
+++ b/examples/menubar/menubar-editor.html
@@ -138,26 +138,30 @@
 
   <section>
     <h2>Accessibility Features</h2>
-    <ol>
-      <li>Users of assistive technologies can identify which format settings are selected because they are represented by menu item radio and menu item checkbox elements that have a checked state.</li>
-      <li>Disabled menu items are demonstrated in the font size menu, which  includes two disabled menuitems.</li>
-      <li>To help communicate that the arrow keys are available for directional navigation within the menubar and its submenus, a border is added to the menubar container when focus is within the menubar.</li>
-      <li>To support operating system high contrast settings, focus is highlighted by adding and removing a border around the menu item with focus.</li>
-      <li>The down arrow and checked icons are made compatible with operating system high contrast settings and hidden from screen readers by using <code>aria-hidden</code> attribute.</li>
+    <ul>
       <li>
-        Like desktop menubars, submenus open on mouse hover over a parent item in the menubar only if another submenu is already open.
+        Disabled menu items are demonstrated in the font size menu.
+        If the font is set to its smallest size, the <q>Smaller</q> menu item is disabled.
+        Similarly, if the font is set to its largest size, the <q>Larger</q> menu item is disabled.
+      </li>
+      <li>Users of assistive technologies can identify the currently active format options because they are represented by menu item radio and menu item checkbox elements that have a checked state.</li>
+      <li>To prevent the character entities that visually represent The down arrow and checked icons from being announced by screen readers, they are hidden from the accessible name computation with the <code>aria-hidden</code> attribute.</li>
+      <li>To help communicate that the arrow keys are available for directional navigation within the menubar and its submenus, a border is added to the menubar container when focus is within the menubar.</li>
+      <li>
+        Like most desktop menubars, submenus open on mouse hover over a parent item in the menubar only if another submenu is already open.
         That is, if all submenus are closed, a click on a parent menu item is required to display a submenu.
-        Minimizing automatic popups makes exploring with a screen magnifier easier.
+        Minimizing automatic popups triggered by hover makes exploring with a screen magnifier easier.
       </li>
       <li>
         In general, moving focus in response to mouse hover is avoided in accessible widgets; it causes unexpected context changes for keyboard users.
         However, like desktop menubars, there are two conditions in this example menubar where focus moves in response to hover in order to help maintain context for users who use both keyboard and mouse:
-        <ol>
+        <ul>
           <li>After a parent menu item in the menubar has been activated and the user hovers over a different parent item in the menubar, focus will follow hover.</li>
           <li>When a submenu is open and the user hovers over an item in the submenu, focus follows hover.</li>
-        </ol>
+        </ul>
       </li>
-    </ol>
+      <li>To support operating system high contrast settings, focus is highlighted by adding and removing a border around the menu item with focus.</li>
+    </ul>
   </section>
 
   <section>

--- a/examples/menubar/menubar-editor.html
+++ b/examples/menubar/menubar-editor.html
@@ -413,7 +413,7 @@
           <tr data-test-id="menubar-menuitem-tabindex">
             <td></td>
             <th scope="row">
-              <code>tabindex=&quot;-1&quot;</code>
+              <code>tabindex="-1"</code>
             </th>
             <td>
               <code>span</code>
@@ -426,7 +426,7 @@
           <tr data-test-id="menubar-menuitem-tabindex">
             <td></td>
             <th scope="row">
-              <code>tabindex=&quot;0&quot;</code>
+              <code>tabindex="0"</code>
             </th>
             <td>
               <code>span</code>
@@ -438,10 +438,10 @@
                   part of the <kbd>tab</kbd> sequence of the page.
                 </li>
                 <li>
-                  Only one <code>menuitem</code> in the <code>menubar</code> has <code>tabindex=&quot;0&quot;</code>.
+                  Only one <code>menuitem</code> in the <code>menubar</code> has <code>tabindex="0"</code>.
                 </li>
                 <li>
-                  When the page loads, the first item in the menubar has <code>tabindex=&quot;0&quot;</code>.
+                  When the page loads, the first item in the menubar has <code>tabindex="0"</code>.
                 </li>
                 <li>
                   Focus is managed using <a href="../../#kbd_roving_tabindex">roving tabindex</a>.
@@ -452,7 +452,7 @@
           <tr data-test-id="menubar-menuitem-aria-haspopup">
             <td></td>
             <th scope="row">
-              <code>aria-haspopup=&quot;true&quot;</code>
+              <code>aria-haspopup="true"</code>
             </th>
             <td>
               <code>span</code>
@@ -464,7 +464,7 @@
           <tr data-test-id="menubar-menuitem-aria-expanded">
             <td></td>
             <th scope="row">
-              <code>aria-expanded=&quot;true&quot;</code>
+              <code>aria-expanded="true"</code>
             </th>
             <td>
               <code>span</code>
@@ -481,7 +481,7 @@
           <tr data-test-id="menubar-menuitem-aria-expanded">
             <td></td>
             <th scope="row">
-              <code>aria-expanded=&quot;false&quot;</code>
+              <code>aria-expanded="false"</code>
             </th>
             <td>
               <code>span</code>
@@ -498,7 +498,7 @@
           <tr data-test-id="menubar-menuitem-aria-hidden">
             <td></td>
             <th scope="row">
-              <code>aria-hidden=&quot;true&quot;</code>
+              <code>aria-hidden="true"</code>
             </th>
             <td>
               <code>span</code>
@@ -538,7 +538,7 @@
           <tr data-test-id="menu-aria-label">
             <td></td>
             <th scope="row">
-              <code>aria-label=&quot;<em>string</em>&quot;</code>
+              <code>aria-label="<em>string</em>"</code>
             </th>
             <td>
               <code>ul</code>
@@ -565,7 +565,7 @@
           <tr data-test-id="submenu-menuitem-tabindex">
             <td></td>
             <th scope="row">
-              <code>tabindex=&quot;-1&quot;</code>
+              <code>tabindex="-1"</code>
             </th>
             <td>
               <code>li</code>
@@ -577,7 +577,7 @@
           <tr data-test-id="submenu-menuitem-aria-disabled">
             <td></td>
             <th scope="row">
-              <code>aria-disabled=&quot;false&quot;</code>
+              <code>aria-disabled="false"</code>
             </th>
             <td>
               <code>li</code>
@@ -589,7 +589,7 @@
           <tr data-test-id="submenu-menuitem-aria-disabled">
             <td></td>
             <th scope="row">
-              <code>aria-disabled=&quot;true&quot;</code>
+              <code>aria-disabled="true"</code>
             </th>
             <td>
               <code>li</code>
@@ -616,7 +616,7 @@
           <tr data-test-id="menuitemcheckbox-tabindex">
             <td></td>
             <th scope="row">
-              <code>tabindex=&quot;-1&quot;</code>
+              <code>tabindex="-1"</code>
             </th>
             <td>
               <code>li</code>
@@ -628,7 +628,7 @@
           <tr data-test-id="menuitemcheckbox-aria-checked">
             <td></td>
             <th scope="row">
-              <code>aria-checked=&quot;true&quot;</code>
+              <code>aria-checked="true"</code>
             </th>
             <td>
               <code>li</code>
@@ -647,7 +647,7 @@
           <tr data-test-id="menuitemcheckbox-aria-checked">
             <td></td>
             <th scope="row">
-              <code>aria-checked=&quot;false&quot;</code>
+              <code>aria-checked="false"</code>
             </th>
             <td>
               <code>li</code>
@@ -666,7 +666,7 @@
           <tr data-test-id="menuitemcheckbox-aria-hidden">
             <td></td>
             <th scope="row">
-              <code>aria-hidden=&quot;true&quot;</code>
+              <code>aria-hidden="true"</code>
             </th>
             <td>
               <code>span</code>
@@ -712,7 +712,7 @@
           <tr data-test-id="group-aria-label">
             <td></td>
             <th scope="row">
-              <code>aria-label=&quot;string&quot;</code>
+              <code>aria-label="string"</code>
             </th>
             <td>
               <code>ul</code>
@@ -747,7 +747,7 @@
           <tr data-test-id="menuitemradio-tabindex">
             <td></td>
             <th scope="row">
-              <code>tabindex=&quot;-1&quot;</code>
+              <code>tabindex="-1"</code>
             </th>
             <td>
               <code>li</code>
@@ -759,7 +759,7 @@
           <tr data-test-id="menuitemradio-aria-checked">
             <td></td>
             <th scope="row">
-              <code>aria-checked=&quot;true&quot;</code>
+              <code>aria-checked="true"</code>
             </th>
             <td>
               <code>li</code>
@@ -778,7 +778,7 @@
           <tr data-test-id="menuitemradio-aria-checked">
             <td></td>
             <th scope="row">
-              <code>aria-checked=&quot;false&quot;</code>
+              <code>aria-checked="false"</code>
             </th>
             <td>
               <code>li</code>
@@ -797,7 +797,7 @@
           <tr data-test-id="menuitemradio-aria-hidden">
             <td></td>
             <th scope="row">
-              <code>aria-hidden=&quot;true&quot;</code>
+              <code>aria-hidden="true"</code>
             </th>
             <td>
               <code>span</code>
@@ -822,7 +822,7 @@
         <tr data-test-id="textarea-aria-label">
           <td></td>
           <th scope="row">
-            <code>aria-label=&quot;<em>string</em>&quot;</code>
+            <code>aria-label="<em>string</em>"</code>
           </th>
           <td>
             <code>textarea</code>

--- a/examples/menubar/menubar-editor.html
+++ b/examples/menubar/menubar-editor.html
@@ -16,15 +16,6 @@
   <script src="js/menubar-editor.js"    type="text/javascript"></script>
   <script src="js/style-manager.js"    type="text/javascript"></script>
 
-  <!-- Preload images -->
-  <link rel="preload" as="image" href="images/checkbox-checked-focus.svg">
-  <link rel="preload" as="image" href="images/checkbox-checked.svg">
-  <link rel="preload" as="image" href="images/down-arrow-focus.svg">
-  <link rel="preload" as="image" href="images/down-arrow.svg">
-  <link rel="preload" as="image" href="images/radio-checked-focus.svg">
-  <link rel="preload" as="image" href="images/radio-checked.svg">
-  <link rel="preload" as="image" href="images/separator.svg">
-  <link rel="preload" as="image" href="images/up-arrow-focus.svg">
 </head>
 <body>
   <nav aria-label="Related Links" class="feedback">

--- a/examples/menubar/menubar-editor.html
+++ b/examples/menubar/menubar-editor.html
@@ -504,309 +504,309 @@
               <code>span</code>
             </td>
             <td>
-              Removes the character entities for the expanded state of <code>menuitem</code> from the accessibility tree to prevent them from being included in the accessible name of the sort buttons.
+              Removes the character entities used to represent the down arrow icons for parent menu items from the accessibility tree to prevent them from being included in the accessible name of the menu item.
             </td>
           </tr>
         </tbody>
       </table>
       <h3 id="rps2_label">Submenu</h3>
       <table aria-labelledby="rps2_label rps_label" class="data attributes">
-      <thead>
-        <tr>
-          <th scope="col">Role</th>
-          <th scope="col">Attribute</th>
-          <th scope="col">Element</th>
-          <th scope="col">Usage</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr data-test-id="menu-role">
-          <th scope="row">
-            <code>menu</code>
-          </th>
-          <td></td>
-          <td>
-            <code>ul</code>
-          </td>
-          <td>
-            <ul>
-              <li>Identifies the element as a menu container for a set of menu items.</li>
-              <li>Is not focusable because focus is managed using <a href="../../#kbd_roving_tabindex">roving tabindex.</a></li>
-            </ul>
-          </td>
-        </tr>
-        <tr data-test-id="menu-aria-label">
-          <td></td>
-          <th scope="row">
-            <code>aria-label=&quot;<em>string</em>&quot;</code>
-          </th>
-          <td>
-            <code>ul</code>
-          </td>
-          <td>
-            Defines an accessible name for the <code>menu</code>.
-          </td>
-        </tr>
-        <tr data-test-id="submenu-menuitem-role">
-          <th scope="row">
-            <code>menuitem</code>
-          </th>
-          <td></td>
-          <td>
-            <code>li</code>
-          </td>
-          <td>
-            <ul>
-              <li>Identifies the element as an item in the submenu.</li>
-              <li>Accessible name comes from the text content.</li>
-            </ul>
-          </td>
-        </tr>
-        <tr data-test-id="submenu-menuitem-tabindex">
-          <td></td>
-          <th scope="row">
-            <code>tabindex=&quot;-1&quot;</code>
-          </th>
-          <td>
-            <code>li</code>
-          </td>
-          <td>
-            Makes the item focusable but <strong>not</strong> part of the page <kbd>tab</kbd> sequence.
-          </td>
-        </tr>
-        <tr data-test-id="submenu-menuitem-aria-disabled">
-          <td></td>
-          <th scope="row">
-            <code>aria-disabled=&quot;false&quot;</code>
-          </th>
-          <td>
-            <code>li</code>
-          </td>
-          <td>
-            Used on the font size "Smaller" and "Larger" options to indicate they are active.
-          </td>
-        </tr>
-        <tr data-test-id="submenu-menuitem-aria-disabled">
-          <td></td>
-          <th scope="row">
-            <code>aria-disabled=&quot;true&quot;</code>
-          </th>
-          <td>
-            <code>li</code>
-          </td>
-          <td>
-            Used on the font size "Smaller" and "Larger" options to indicate one of the options is <strong>not</strong> active because the largest or smallest font has been selected.
-          </td>
-        </tr>
-        <tr data-test-id="menuitemcheckbox-role">
-          <th scope="row">
-            <code>menuitemcheckbox</code>
-          </th>
-          <td></td>
-          <td>
-            <code>li</code>
-          </td>
-          <td>
-            <ul>
-              <li>Identifies the element as a <code>menuitemcheckbox</code>.</li>
-              <li>Accessible name comes from the text content.</li>
-            </ul>
-          </td>
-        </tr>
-        <tr data-test-id="menuitemcheckbox-tabindex">
-          <td></td>
-          <th scope="row">
-            <code>tabindex=&quot;-1&quot;</code>
-          </th>
-          <td>
-            <code>li</code>
-          </td>
-          <td>
-            Makes the menuitemcheckbox focusable but <strong>not</strong> part of the page <kbd>tab</kbd> sequence.
-          </td>
-        </tr>
-        <tr data-test-id="menuitemcheckbox-aria-checked">
-          <td></td>
-          <th scope="row">
-            <code>aria-checked=&quot;true&quot;</code>
-          </th>
-          <td>
-            <code>li</code>
-          </td>
-          <td>
-            <ul>
-              <li>
-                Indicates that the <code>menuitemcheckbox</code> is checked.
-              </li>
-              <li>
-                The visual appearance of the selected state is synchronized with the <code>aria-checked</code> value using CSS attribute selectors and hidden from screen readers with <code>aria-hidden="true"</code>.
-              </li>
-            </ul>
-          </td>
-        </tr>
-        <tr data-test-id="menuitemcheckbox-aria-checked">
-          <td></td>
-          <th scope="row">
-            <code>aria-checked=&quot;false&quot;</code>
-          </th>
-          <td>
-            <code>li</code>
-          </td>
-          <td>
-            <ul>
-              <li>
-                Indicates that the <code>menuitemcheckbox</code> is <strong>NOT</strong> checked.
-              </li>
-              <li>
-                The visual appearance of the selected state is synchronized with the <code>aria-checked</code> value using CSS attribute selectors and hidden from screen readers with <code>aria-hidden="true"</code>.
-              </li>
-            </ul>
-          </td>
-        </tr>
-        <tr data-test-id="menuitemcheckbox-aria-hidden">
-          <td></td>
-          <th scope="row">
-            <code>aria-hidden=&quot;true&quot;</code>
-          </th>
-          <td>
-            <code>span</code>
-          </td>
-          <td>
-            Removes the character entities for the checked state of <code>menuitemcheckbox</code> from the accessibility tree to prevent them from being included in the accessible name of the checked item.
-          </td>
-        </tr>
-        <tr data-test-id="separator-role">
-          <th scope="row">
-            <code>separator</code>
-          </th>
-          <td></td>
-          <td>
-            <code>li</code>
-          </td>
-          <td>
-            <ul>
-              <li>Identifies the element as a visual separator between groups of items within a menu, such as groups of <code>menuitemradio</code> or <code>menuitemcheckbox</code> elements.</li>
-              <li>Is not focusable but may be perceivable by a screen reader user when using a reading cursor that does not depend on focus.</li>
-            </ul>
-          </td>
-        </tr>
-        <tr data-test-id="group-role">
-          <th scope="row">
-            <code>group</code>
-          </th>
-          <td></td>
-          <td>
-            <code>ul</code>
-          </td>
-          <td>
-            <ul>
-              <li>
-                Identifies the element as a container for a set of <code>menuitemradio</code> elements.
-              </li>
-              <li>
-                Enables browsers to compute values of <code>aria-setsize</code> and <code>aria-posinset</code>.
-              </li>
-            </ul>
-          </td>
-        </tr>
-        <tr data-test-id="group-aria-label">
-          <td></td>
-          <th scope="row">
-            <code>aria-label=&quot;string&quot;</code>
-          </th>
-          <td>
-            <code>ul</code>
-          </td>
-          <td>
-            Provides an accessible name for the group of menu items.
-          </td>
-        </tr>
-        <tr data-test-id="menuitemradio-role">
-          <th scope="row">
-            <code>menuitemradio</code>
-          </th>
-          <td></td>
-          <td>
-            <code>li</code>
-          </td>
-          <td>
-            <ul>
-              <li>
-                Identifies the element as a <code>menuitemradio</code> element.
-              </li>
-              <li>
-                When all items in a submenu are members of the same radio group,
-                the group is defined by the <code>menu</code> element; a <code>group</code> element is not necessary.
-              </li>
-              <li>
-                Accessible name is computed from the text content.
-              </li>
-            </ul>
-          </td>
-        </tr>
-        <tr data-test-id="menuitemradio-tabindex">
-          <td></td>
-          <th scope="row">
-            <code>tabindex=&quot;-1&quot;</code>
-          </th>
-          <td>
-            <code>li</code>
-          </td>
-          <td>
-            Makes the menuitemradio focusable but <strong>not</strong> part of the page <kbd>tab</kbd> sequence.
-          </td>
-        </tr>
-        <tr data-test-id="menuitemradio-aria-checked">
-          <td></td>
-          <th scope="row">
-            <code>aria-checked=&quot;true&quot;</code>
-          </th>
-          <td>
-            <code>li</code>
-          </td>
-          <td>
-            <ul>
-              <li>
-                Indicates the  <code>menuitemradio</code> is checked.
-              </li>
-              <li>
-                The visual appearance of the selected state is synchronized with the <code>aria-checked</code> value using CSS attribute selectors and hidden from screen readers with <code>aria-hidden="true"</code>.
-              </li>
-            </ul>
-          </td>
-        </tr>
-        <tr data-test-id="menuitemradio-aria-checked">
-          <td></td>
-          <th scope="row">
-            <code>aria-checked=&quot;false&quot;</code>
-          </th>
-          <td>
-            <code>li</code>
-          </td>
-          <td>
-            <ul>
-              <li>
-                Indicates that  the <code>menuitemradio</code> is <strong>NOT</strong> checked.
-              </li>
-              <li>
-                The visual appearance of the selected state is synchronized with the <code>aria-checked</code> value using CSS attribute selectors and hidden from screen readers with <code>aria-hidden="true"</code>.
-              </li>
-            </ul>
-          </td>
-        </tr>
-        <tr data-test-id="menuitemradio-aria-hidden">
-          <td></td>
-          <th scope="row">
-            <code>aria-hidden=&quot;true&quot;</code>
-          </th>
-          <td>
-            <code>span</code>
-          </td>
-          <td>
-            Removes the character entities for the checked state of <code>menuitemradio</code> from the accessibility tree to prevent them from being included in the accessible name of the checked item.
-          </td>
-        </tr>
-      </tbody>
+        <thead>
+          <tr>
+            <th scope="col">Role</th>
+            <th scope="col">Attribute</th>
+            <th scope="col">Element</th>
+            <th scope="col">Usage</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr data-test-id="menu-role">
+            <th scope="row">
+              <code>menu</code>
+            </th>
+            <td></td>
+            <td>
+              <code>ul</code>
+            </td>
+            <td>
+              <ul>
+                <li>Identifies the element as a menu container for a set of menu items.</li>
+                <li>Is not focusable because focus is managed using <a href="../../#kbd_roving_tabindex">roving tabindex.</a></li>
+              </ul>
+            </td>
+          </tr>
+          <tr data-test-id="menu-aria-label">
+            <td></td>
+            <th scope="row">
+              <code>aria-label=&quot;<em>string</em>&quot;</code>
+            </th>
+            <td>
+              <code>ul</code>
+            </td>
+            <td>
+              Defines an accessible name for the <code>menu</code>.
+            </td>
+          </tr>
+          <tr data-test-id="submenu-menuitem-role">
+            <th scope="row">
+              <code>menuitem</code>
+            </th>
+            <td></td>
+            <td>
+              <code>li</code>
+            </td>
+            <td>
+              <ul>
+                <li>Identifies the element as an item in the submenu.</li>
+                <li>Accessible name comes from the text content.</li>
+              </ul>
+            </td>
+          </tr>
+          <tr data-test-id="submenu-menuitem-tabindex">
+            <td></td>
+            <th scope="row">
+              <code>tabindex=&quot;-1&quot;</code>
+            </th>
+            <td>
+              <code>li</code>
+            </td>
+            <td>
+              Makes the item focusable but <strong>not</strong> part of the page <kbd>tab</kbd> sequence.
+            </td>
+          </tr>
+          <tr data-test-id="submenu-menuitem-aria-disabled">
+            <td></td>
+            <th scope="row">
+              <code>aria-disabled=&quot;false&quot;</code>
+            </th>
+            <td>
+              <code>li</code>
+            </td>
+            <td>
+              Used on the font size "Smaller" and "Larger" options to indicate they are active.
+            </td>
+          </tr>
+          <tr data-test-id="submenu-menuitem-aria-disabled">
+            <td></td>
+            <th scope="row">
+              <code>aria-disabled=&quot;true&quot;</code>
+            </th>
+            <td>
+              <code>li</code>
+            </td>
+            <td>
+              Used on the font size "Smaller" and "Larger" options to indicate one of the options is <strong>not</strong> active because the largest or smallest font has been selected.
+            </td>
+          </tr>
+          <tr data-test-id="menuitemcheckbox-role">
+            <th scope="row">
+              <code>menuitemcheckbox</code>
+            </th>
+            <td></td>
+            <td>
+              <code>li</code>
+            </td>
+            <td>
+              <ul>
+                <li>Identifies the element as a <code>menuitemcheckbox</code>.</li>
+                <li>Accessible name comes from the text content.</li>
+              </ul>
+            </td>
+          </tr>
+          <tr data-test-id="menuitemcheckbox-tabindex">
+            <td></td>
+            <th scope="row">
+              <code>tabindex=&quot;-1&quot;</code>
+            </th>
+            <td>
+              <code>li</code>
+            </td>
+            <td>
+              Makes the menuitemcheckbox focusable but <strong>not</strong> part of the page <kbd>tab</kbd> sequence.
+            </td>
+          </tr>
+          <tr data-test-id="menuitemcheckbox-aria-checked">
+            <td></td>
+            <th scope="row">
+              <code>aria-checked=&quot;true&quot;</code>
+            </th>
+            <td>
+              <code>li</code>
+            </td>
+            <td>
+              <ul>
+                <li>
+                  Indicates that the <code>menuitemcheckbox</code> is checked.
+                </li>
+                <li>
+                  The visual appearance of the selected state is synchronized with the <code>aria-checked</code> value using CSS attribute selectors and hidden from screen readers with <code>aria-hidden="true"</code>.
+                </li>
+              </ul>
+            </td>
+          </tr>
+          <tr data-test-id="menuitemcheckbox-aria-checked">
+            <td></td>
+            <th scope="row">
+              <code>aria-checked=&quot;false&quot;</code>
+            </th>
+            <td>
+              <code>li</code>
+            </td>
+            <td>
+              <ul>
+                <li>
+                  Indicates that the <code>menuitemcheckbox</code> is <strong>NOT</strong> checked.
+                </li>
+                <li>
+                  The visual appearance of the selected state is synchronized with the <code>aria-checked</code> value using CSS attribute selectors and hidden from screen readers with <code>aria-hidden="true"</code>.
+                </li>
+              </ul>
+            </td>
+          </tr>
+          <tr data-test-id="menuitemcheckbox-aria-hidden">
+            <td></td>
+            <th scope="row">
+              <code>aria-hidden=&quot;true&quot;</code>
+            </th>
+            <td>
+              <code>span</code>
+            </td>
+            <td>
+              Removes the character entities that visually represent the checked state of <code>menuitemcheckbox</code> elements from the accessibility tree to prevent them from being included in the accessible name of the menu item.
+            </td>
+          </tr>
+          <tr data-test-id="separator-role">
+            <th scope="row">
+              <code>separator</code>
+            </th>
+            <td></td>
+            <td>
+              <code>li</code>
+            </td>
+            <td>
+              <ul>
+                <li>Identifies the element as a visual separator between groups of items within a menu, such as groups of <code>menuitemradio</code> or <code>menuitemcheckbox</code> elements.</li>
+                <li>Is not focusable but may be perceivable by a screen reader user when using a reading cursor that does not depend on focus.</li>
+              </ul>
+            </td>
+          </tr>
+          <tr data-test-id="group-role">
+            <th scope="row">
+              <code>group</code>
+            </th>
+            <td></td>
+            <td>
+              <code>ul</code>
+            </td>
+            <td>
+              <ul>
+                <li>
+                  Identifies the element as a container for a set of <code>menuitemradio</code> elements.
+                </li>
+                <li>
+                  Enables browsers to compute values of <code>aria-setsize</code> and <code>aria-posinset</code>.
+                </li>
+              </ul>
+            </td>
+          </tr>
+          <tr data-test-id="group-aria-label">
+            <td></td>
+            <th scope="row">
+              <code>aria-label=&quot;string&quot;</code>
+            </th>
+            <td>
+              <code>ul</code>
+            </td>
+            <td>
+              Provides an accessible name for the group of menu items.
+            </td>
+          </tr>
+          <tr data-test-id="menuitemradio-role">
+            <th scope="row">
+              <code>menuitemradio</code>
+            </th>
+            <td></td>
+            <td>
+              <code>li</code>
+            </td>
+            <td>
+              <ul>
+                <li>
+                  Identifies the element as a <code>menuitemradio</code> element.
+                </li>
+                <li>
+                  When all items in a submenu are members of the same radio group,
+                  the group is defined by the <code>menu</code> element; a <code>group</code> element is not necessary.
+                </li>
+                <li>
+                  Accessible name is computed from the text content.
+                </li>
+              </ul>
+            </td>
+          </tr>
+          <tr data-test-id="menuitemradio-tabindex">
+            <td></td>
+            <th scope="row">
+              <code>tabindex=&quot;-1&quot;</code>
+            </th>
+            <td>
+              <code>li</code>
+            </td>
+            <td>
+              Makes the menuitemradio focusable but <strong>not</strong> part of the page <kbd>tab</kbd> sequence.
+            </td>
+          </tr>
+          <tr data-test-id="menuitemradio-aria-checked">
+            <td></td>
+            <th scope="row">
+              <code>aria-checked=&quot;true&quot;</code>
+            </th>
+            <td>
+              <code>li</code>
+            </td>
+            <td>
+              <ul>
+                <li>
+                  Indicates the  <code>menuitemradio</code> is checked.
+                </li>
+                <li>
+                  The visual appearance of the selected state is synchronized with the <code>aria-checked</code> value using CSS attribute selectors and hidden from screen readers with <code>aria-hidden="true"</code>.
+                </li>
+              </ul>
+            </td>
+          </tr>
+          <tr data-test-id="menuitemradio-aria-checked">
+            <td></td>
+            <th scope="row">
+              <code>aria-checked=&quot;false&quot;</code>
+            </th>
+            <td>
+              <code>li</code>
+            </td>
+            <td>
+              <ul>
+                <li>
+                  Indicates that  the <code>menuitemradio</code> is <strong>NOT</strong> checked.
+                </li>
+                <li>
+                  The visual appearance of the selected state is synchronized with the <code>aria-checked</code> value using CSS attribute selectors and hidden from screen readers with <code>aria-hidden="true"</code>.
+                </li>
+              </ul>
+            </td>
+          </tr>
+          <tr data-test-id="menuitemradio-aria-hidden">
+            <td></td>
+            <th scope="row">
+              <code>aria-hidden=&quot;true&quot;</code>
+            </th>
+            <td>
+              <code>span</code>
+            </td>
+            <td>
+              Removes the character entities that visually represent the checked state of <code>menuitemradio</code> elements from the accessibility tree to prevent them from being included in the accessible name of the menu item.
+            </td>
+          </tr>
+        </tbody>
     </table>
       <h3 id="rps3_label">Textarea</h3>
       <table aria-labelledby="rps3_label rps_label" class="data attributes">

--- a/examples/menubar/menubar-editor.html
+++ b/examples/menubar/menubar-editor.html
@@ -490,6 +490,18 @@
               </ul>
             </td>
           </tr>
+          <tr data-test-id="menubar-menuitem-aria-hidden">
+            <td></td>
+            <th scope="row">
+              <code>aria-hidden=&quot;true&quot;</code>
+            </th>
+            <td>
+              <code>span</code>
+            </td>
+            <td>
+              Removes the character entities for the expanded state of <code>menuitem</code> from the accessibility tree to prevent them from being included in the accessible name of the sort buttons.
+            </td>
+          </tr>
         </tbody>
       </table>
       <h3 id="rps2_label">Submenu</h3>
@@ -646,6 +658,18 @@
             </ul>
           </td>
         </tr>
+        <tr data-test-id="menuitemcheckbox-aria-hidden">
+          <td></td>
+          <th scope="row">
+            <code>aria-hidden=&quot;true&quot;</code>
+          </th>
+          <td>
+            <code>span</code>
+          </td>
+          <td>
+            Removes the character entities for the checked state of <code>menuitemcheckbox</code> from the accessibility tree to prevent them from being included in the accessible name of the checked item.
+          </td>
+        </tr>
         <tr data-test-id="separator-role">
           <th scope="row">
             <code>separator</code>
@@ -763,6 +787,18 @@
                 The visual appearance of the selected state is synchronized with the <code>aria-checked</code> value using CSS attribute selectors and hidden from screen readers with <code>aria-hidden="true"</code>.
               </li>
             </ul>
+          </td>
+        </tr>
+        <tr data-test-id="menuitemradio-aria-hidden">
+          <td></td>
+          <th scope="row">
+            <code>aria-hidden=&quot;true&quot;</code>
+          </th>
+          <td>
+            <code>span</code>
+          </td>
+          <td>
+            Removes the character entities for the checked state of <code>menuitemradio</code> from the accessibility tree to prevent them from being included in the accessible name of the checked item.
           </td>
         </tr>
       </tbody>

--- a/examples/menubar/menubar-editor.html
+++ b/examples/menubar/menubar-editor.html
@@ -50,7 +50,9 @@
   </ul>
 
   <section id="code-ex-1">
-    <h2 id="ex1_label">Example</h2>
+    <div class="example-header">
+      <h2 id="ex1_label">Example</h2>
+    </div>
     <div role="separator" id="ex1_start_sep" aria-labelledby="ex1_start_sep ex1_label" aria-label="Start of"></div>
     <div id="ex1">
       <div class="menubar-editor">
@@ -789,7 +791,7 @@
 
   <section>
     <h2>Javascript and CSS Source Code</h2>
-    <ul>
+    <ul id="css_js_files">
       <li>
         CSS:
         <a href="css/menubar-editor.css" type="tex/css">menubar-editor.css</a>
@@ -809,12 +811,9 @@
     <pre><code id="sc1"></code></pre>
     <div id="sc1_end_sep" role="separator" aria-labelledby="sc1_end_sep sc1_label" aria-label="End of" ></div>
     <script>
-sourceCode.add('sc1', 'ex1');
-</script>
-    <!--  After all source has been added, run make to do the insert.  -->
-    <script>
-sourceCode.make();
-</script>
+      sourceCode.add('sc1', 'ex1', 'ex1_label', 'css_js_files');
+      sourceCode.make();
+    </script>
   </section>
   </main>
   <nav>

--- a/examples/menubar/menubar-editor.html
+++ b/examples/menubar/menubar-editor.html
@@ -142,7 +142,7 @@
       <li>Disabled menu items are demonstrated in the font size menu, which  includes two disabled menuitems.</li>
       <li>To help communicate that the arrow keys are available for directional navigation within the menubar and its submenus, a border is added to the menubar container when focus is within the menubar.</li>
       <li>To support operating system high contrast settings, focus is highlighted by adding and removing a border around the menu item with focus.</li>
-      <li>The down arrow and checked icons are made compatible with operating system high contrast settings and hidden from screen readers by using the CSS <code>content</code> property to render images.</li>
+      <li>The down arrow and checked icons are made compatible with operating system high contrast settings and hidden from screen readers by using <code>aria-hidden</code> attribute.</li>
       <li>
         Like desktop menubars, submenus open on mouse hover over a parent item in the menubar only if another submenu is already open.
         That is, if all submenus are closed, a click on a parent menu item is required to display a submenu.
@@ -464,7 +464,14 @@
             <td>
               <code>span</code>
             </td>
-            <td>Indicates the menu is open.</td>
+            <td>
+              <ul>
+                <li>Indicates the submenu is open.</li>
+                <li>
+                  The visual appearance of the expanded state is synchronized with the <code>aria-expanded</code> value using CSS attribute selectors and hidden from screen readers with <code>aria-hidden="true"</code>.
+                </li>
+              </ul>
+            </td>
           </tr>
           <tr data-test-id="menubar-menuitem-aria-expanded">
             <td></td>
@@ -474,7 +481,14 @@
             <td>
               <code>span</code>
             </td>
-            <td>Indicates the submenu is closed.</td>
+            <td>
+              <ul>
+                <li>Indicates the submenu is closed.</li>
+                <li>
+                  The visual appearance of the expanded state is synchronized with the <code>aria-expanded</code> value using CSS attribute selectors and hidden from screen readers with <code>aria-hidden="true"</code>.
+                </li>
+              </ul>
+            </td>
           </tr>
         </tbody>
       </table>
@@ -608,7 +622,7 @@
                 Indicates that the <code>menuitemcheckbox</code> is checked.
               </li>
               <li>
-                The visual appearance of the selected state is synchronized with the <code>aria-checked</code> value using CSS attribute selectors.
+                The visual appearance of the selected state is synchronized with the <code>aria-checked</code> value using CSS attribute selectors and hidden from screen readers with <code>aria-hidden="true"</code>.
               </li>
             </ul>
           </td>
@@ -627,7 +641,7 @@
                 Indicates that the <code>menuitemcheckbox</code> is <strong>NOT</strong> checked.
               </li>
               <li>
-                The visual appearance of the selected state is synchronized with the <code>aria-checked</code> value using CSS attribute selectors.
+                The visual appearance of the selected state is synchronized with the <code>aria-checked</code> value using CSS attribute selectors and hidden from screen readers with <code>aria-hidden="true"</code>.
               </li>
             </ul>
           </td>
@@ -727,7 +741,7 @@
                 Indicates the  <code>menuitemradio</code> is checked.
               </li>
               <li>
-                The visual appearance of the selected state is synchronized with the <code>aria-checked</code> value using CSS attribute selectors.
+                The visual appearance of the selected state is synchronized with the <code>aria-checked</code> value using CSS attribute selectors and hidden from screen readers with <code>aria-hidden="true"</code>.
               </li>
             </ul>
           </td>
@@ -746,7 +760,7 @@
                 Indicates that  the <code>menuitemradio</code> is <strong>NOT</strong> checked.
               </li>
               <li>
-                The visual appearance of the selected state is synchronized with the <code>aria-checked</code> value using CSS attribute selectors.
+                The visual appearance of the selected state is synchronized with the <code>aria-checked</code> value using CSS attribute selectors and hidden from screen readers with <code>aria-hidden="true"</code>.
               </li>
             </ul>
           </td>

--- a/examples/menubar/menubar-navigation.html
+++ b/examples/menubar/menubar-navigation.html
@@ -14,9 +14,6 @@
   <!--  CSS and JS specific to this example  -->
   <link href="css/menubar-navigation.css" rel="stylesheet">
   <script src="js/menubar-navigation.js" type="text/javascript"></script>
-
-  <!--  Pre-load images used in the example  -->
-  <link rel="preload" as="image" href="images/separator.svg">
 </head>
 <body>
   <nav aria-label="Related Links" class="feedback">

--- a/test/tests/menubar_menubar-editor.js
+++ b/test/tests/menubar_menubar-editor.js
@@ -16,6 +16,7 @@ const ex = {
   menuitemcheckboxSelector: '#ex1 [role="menuitemcheckbox"]',
   groupSelector: '#ex1 [role="group"]',
   menuitemradioSelector: '#ex1 [role="menuitemradio"]',
+  ariaHiddenSpanSelector: '#ex1 [aria-hidden]',
   numMenus: 4,
   numSubmenuItems: [4, 10, 4, 7],
   allSubmenuItems: [
@@ -266,6 +267,20 @@ ariaTest(
       // Send the ESCAPE to close submenu
       await menuitems[menuIndex].sendKeys(Key.ESCAPE);
     }
+  }
+);
+
+ariaTest(
+  'Visual character entities to show expanded state on role="menuitem" is hidden from assistive technology',
+  exampleFile,
+  'menubar-menuitem-aria-hidden',
+  async (t) => {
+    await assertAttributeValues(
+      t,
+      ex.ariaHiddenSpanSelector,
+      'aria-hidden',
+      'true'
+    );
   }
 );
 
@@ -525,6 +540,20 @@ ariaTest(
 );
 
 ariaTest(
+  'Visual character entities to show checked state on role="menuitemcheckbox" is hidden from assistive technology',
+  exampleFile,
+  'menuitemcheckbox-aria-hidden',
+  async (t) => {
+    await assertAttributeValues(
+      t,
+      ex.ariaHiddenSpanSelector,
+      'aria-hidden',
+      'true'
+    );
+  }
+);
+
+ariaTest(
   'Test role="separator" exists',
   exampleFile,
   'separator-role',
@@ -630,6 +659,20 @@ ariaTest(
         );
       }
     }
+  }
+);
+
+ariaTest(
+  'Visual character entities to show checked state on role="menuitemradio" is hidden from assistive technology',
+  exampleFile,
+  'menuitemradio-aria-hidden',
+  async (t) => {
+    await assertAttributeValues(
+      t,
+      ex.ariaHiddenSpanSelector,
+      'aria-hidden',
+      'true'
+    );
   }
 );
 

--- a/test/tests/menubar_menubar-editor.js
+++ b/test/tests/menubar_menubar-editor.js
@@ -76,7 +76,10 @@ const checkmarkVisible = async function (t, selector, index) {
     function () {
       const [selector, index] = arguments;
       const checkmarkContent = window
-        .getComputedStyle(document.querySelectorAll(selector)[index], ':before')
+        .getComputedStyle(
+          document.querySelectorAll(`${selector} > [aria-hidden]`)[index],
+          ':before'
+        )
         .getPropertyValue('content');
       if (checkmarkContent == 'none') {
         return false;


### PR DESCRIPTION
The approach taken here with Unicode symbols in CSS generated content is different from what `menubar-navigation.html` does (which uses inline SVG, without any ARIA attributes). It's further possible to use SVG-in-CSS by using `data:` URLs, as `menubar-navigation.css ` did for the separator (but this patch  changes it to a CSS `linear-gradient` to be consistent with `menubar-editor.css`).

What are the accessibility implications of using Unicode symbols in CSS generated content? Is it good, acceptable, or bad?



[Preview editor menubar in compare branch in raw githack](https://raw.githack.com/w3c/aria-practices/bocoup/menubar-editor-codepen/examples/menubar/menubar-editor.html)

<!--

    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria-practices/pull/1876.html" title="Last updated on Nov 9, 2021, 3:40 PM UTC (478933f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria-practices/1876/0972a83...478933f.html" title="Last updated on Nov 9, 2021, 3:40 PM UTC (478933f)">Diff</a>