### PR TITLE
Disclosure: Distinguish the widget from the control

### DIFF
--- a/aria-practices.html
+++ b/aria-practices.html
@@ -1218,7 +1218,7 @@ Some JavaScript and CSS may not function correctly in Internet Explorer.
     <section class="widget" id="disclosure">
       <h3>Disclosure (Show/Hide)</h3>
       <p>
-        A disclosure is a widget used to disclose additional information or controls.
+        A disclosure is a widget that enables content to be either collapsed (hidden) or expanded (visible).
         Typically, a disclosure <a href="#button">button</a> controls the visibility of a section of content.
         When the controlled content is hidden, it is often styled as a typical push button with a right-pointing arrow or triangle to hint that activating the button will display additional content.
         When the content is visible, the arrow or triangle typically points down.

--- a/aria-practices.html
+++ b/aria-practices.html
@@ -1219,7 +1219,7 @@ Some JavaScript and CSS may not function correctly in Internet Explorer.
       <h3>Disclosure (Show/Hide)</h3>
       <p>
         A disclosure is a widget that enables content to be either collapsed (hidden) or expanded (visible).
-        Typically, a disclosure <a href="#button">button</a> controls the visibility of a section of content.
+        It has two elements: a disclosure <a href="#button">button</a> and a section of content whose visibility is controlled by the button.
         When the controlled content is hidden, it is often styled as a typical push button with a right-pointing arrow or triangle to hint that activating the button will display additional content.
         When the content is visible, the arrow or triangle typically points down.
       </p>

--- a/aria-practices.html
+++ b/aria-practices.html
@@ -1218,7 +1218,8 @@ Some JavaScript and CSS may not function correctly in Internet Explorer.
     <section class="widget" id="disclosure">
       <h3>Disclosure (Show/Hide)</h3>
       <p>
-        A disclosure is a <a href="#button">button</a> that controls visibility of a section of content.
+        A disclosure is a widget used to disclose additional information or controls.
+        Typically, a disclosure <a href="#button">button</a> controls the visibility of a section of content.
         When the controlled content is hidden, it is often styled as a typical push button with a right-pointing arrow or triangle to hint that activating the button will display additional content.
         When the content is visible, the arrow or triangle typically points down.
       </p>

--- a/aria-practices.html
+++ b/aria-practices.html
@@ -1220,7 +1220,7 @@ Some JavaScript and CSS may not function correctly in Internet Explorer.
       <p>
         A disclosure is a widget that enables content to be either collapsed (hidden) or expanded (visible).
         It has two elements: a disclosure <a href="#button">button</a> and a section of content whose visibility is controlled by the button.
-        When the controlled content is hidden, it is often styled as a typical push button with a right-pointing arrow or triangle to hint that activating the button will display additional content.
+        When the controlled content is hidden, the button is often styled as a typical push button with a right-pointing arrow or triangle to hint that activating the button will display additional content.
         When the content is visible, the arrow or triangle typically points down.
       </p>
 


### PR DESCRIPTION
This PR updates the document to distinguish the disclosure **widget** from the disclosure **control**.

At first, the document refers to the _disclosure_ as the **button**, but then later refers to that button as the disclosure **control**.

---

Note: If **widget** is not the appropriate term, the disclosure examples [[1](https://w3c.github.io/aria-practices/examples/disclosure/disclosure-img-long-description.html)] [[2](https://w3c.github.io/aria-practices/examples/disclosure/disclosure-faq.html)] [[3](https://w3c.github.io/aria-practices/examples/disclosure/disclosure-navigation.html)] [[4](https://w3c.github.io/aria-practices/examples/disclosure/disclosure-navigation-hybrid.html)] refer to it as a **design pattern**.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jonathantneal/aria-practices/pull/1880.html" title="Last updated on Jun 2, 2021, 3:41 PM UTC (c9bd16e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria-practices/1880/ea4ade3...jonathantneal:c9bd16e.html" title="Last updated on Jun 2, 2021, 3:41 PM UTC (c9bd16e)">Diff</a>