### PR TITLE
Infrastructure: Make 'npm run regression' run as headless by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lint:html": "npm run htmlhint && npm run vnu-jar",
     "lint:spelling": "cspell \"**/*.*\"",
     "reference-tables": "node scripts/reference-tables.js",
-    "regression": "ava --timeout=1m",
+    "regression": "echo 'Tip: use `DEBUG=1 npm run regression` to disable headless mode.'; ava --timeout=1m",
     "regression-report": "node test/util/report",
     "test": "npm run lint && npm run regression",
     "vnu-jar": "java -jar node_modules/vnu-jar/build/dist/vnu.jar --filterfile .vnurc --no-langdetect --skip-non-html aria-practices.html examples/",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lint:html": "npm run htmlhint && npm run vnu-jar",
     "lint:spelling": "cspell \"**/*.*\"",
     "reference-tables": "node scripts/reference-tables.js",
-    "regression": "echo 'Tip: use `DEBUG=1 npm run regression` to disable headless mode.'; ava --timeout=1m",
+    "regression": "ava --timeout=1m",
     "regression-report": "node test/util/report",
     "test": "npm run lint && npm run regression",
     "vnu-jar": "java -jar node_modules/vnu-jar/build/dist/vnu.jar --filterfile .vnurc --no-langdetect --skip-non-html aria-practices.html examples/",

--- a/test/index.js
+++ b/test/index.js
@@ -9,7 +9,7 @@ const queryElement = require('./util/queryElement');
 const queryElements = require('./util/queryElements');
 
 let session, geckodriver;
-const firefoxArgs = process.env.CI ? ['-headless'] : [];
+const firefoxArgs = process.env.DEBUG ? [] : ['-headless'];
 const testWaitTime = parseInt(process.env.TEST_WAIT_TIME) || 500;
 const coverageReportRun = process.env.REGRESSION_COVERAGE_REPORT;
 


### PR DESCRIPTION
Use 'DEBUG=1 npm run regression' to opt-in to non-headless.

Fixes #1885


---

[These docs](https://github.com/w3c/aria-practices/wiki/Regression-Tests-for-APG-Example-Pages#running-tests) should be updated when merging this.