### PR TITLE
Infrastructure: Fix regression test menu-button_links.js to wait for url change

### DIFF
--- a/test/tests/menu-button_links.js
+++ b/test/tests/menu-button_links.js
@@ -262,18 +262,27 @@ ariaTest('"enter" on role="menuitem"', exampleFile, 'menu-enter', async (t) => {
     const item = (await t.context.queryElements(t, ex.menuitemSelector))[index];
 
     // Update url to remove external reference for dependable testing
-    const newUrl = t.context.url + '#test-url-change';
+    const oldUrl = t.context.url;
+    const newUrl = oldUrl + '#test-url-change';
     await replaceExternalLink(t, newUrl, ex.menuitemSelector, index);
 
     await openMenu(t);
     await item.sendKeys(Key.ENTER);
+
+    await t.context.session.wait(
+      async function () {
+        return t.context.session.getCurrentUrl() !== oldUrl;
+      },
+      t.context.waitTime,
+      'The URL did not change'
+    );
 
     t.is(
       await t.context.session.getCurrentUrl(),
       newUrl,
       'Key enter when focus on list item at index ' +
         index +
-        'should active the link'
+        ' should active the link'
     );
   }
 });


### PR DESCRIPTION
In https://github.com/w3c/aria-practices/pull/1888 the regression test `menu-button_links.js` is repeatedly failing in CI, but I could not reproduce locally. Maybe it's a race condition? Here's an attempt at a fix, to see if it makes the test pass in CI.