### PR TITLE
Alert example: remove non-English text from alert content"

### DIFF
--- a/examples/alert/alert.html
+++ b/examples/alert/alert.html
@@ -50,7 +50,7 @@
 
         <!--  The following script element contains the content that will be inserted into the alert element. -->
         <script type="text/template" id="alert-template">
-          <p><span lang="da">Hej</span>, hello, <span lang="it">ciao</span>, <span lang="ja">こんにちは</span>, <span lang="ko">안녕</span></p>
+          <p>Hello</p>
         </script>
       </div>
       <div role="separator" id="ex_end_sep" aria-labelledby="ex_end_sep ex_label" aria-label="End of"></div>


### PR DESCRIPTION
While preparing tests for this example within the ARIA AT project, we determined that testing the different languages used within the alert text would be impossible because it can't be guaranteed that users will have speech engines installed that can voice all of them.  During discussion of how to proceed, the community group couldn't think of a real-world case where having an alert fire in multiple languages at once (rather than a single language expected by the user) would be appropriate or helpful, and so it was proposed that the non-English text just be removed.  This PR accomplishes that task, and capitalises the "H" in "Hello" given its new position at the beginning of the alert text.