### PR TITLE
Infrastructure: Restrict coverage report to issue-write

### DIFF
--- a/.github/workflows/coverage-report.yml
+++ b/.github/workflows/coverage-report.yml
@@ -7,6 +7,10 @@ on:
     - "test/**"
     - "!examples/landmarks/**"
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   report:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Use new syntax to restrict token scope so the job can be re-enabled https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#permissions