### PR TITLE
Multiple examples: Fix comments to satisfy JSDoc lint warnings

### DIFF
--- a/examples/combobox/js/grid-combo.js
+++ b/examples/combobox/js/grid-combo.js
@@ -9,11 +9,9 @@ var aria = aria || {};
 
 /**
  * @class
- *
  * @description
  *  Combobox object representing the state and interactions for a combobox
  *  widget
- *
  * @param input
  *  The input node
  * @param grid

--- a/examples/dialog-modal/js/dialog.js
+++ b/examples/dialog-modal/js/dialog.js
@@ -119,7 +119,6 @@ aria.Utils = aria.Utils || {};
    *
    * Assumptions: The element serving as the dialog container is present in the
    * DOM and hidden. The dialog container has role='dialog'.
-   *
    * @param dialogId
    *          The ID of the element serving as the dialog container.
    * @param focusAfterClosed
@@ -261,7 +260,6 @@ aria.Utils = aria.Utils || {};
   /**
    * @description
    *  Hides the current dialog and replaces it with another.
-   *
    * @param newDialogId
    *  ID of the dialog that will replace the currently open top dialog.
    * @param newFocusAfterClosed

--- a/examples/grid/js/dataGrid.js
+++ b/examples/grid/js/dataGrid.js
@@ -42,14 +42,12 @@ aria.CSSClass = {
 
 /**
  * @class
- *
  * @description
  *  Grid object representing the state and interactions for a grid widget
  *
  *  Assumptions:
  *  All focusable cells initially have tabindex="-1"
  *  Produces a fully filled in mxn grid (with no holes)
- *
  * @param gridNode
  *  The DOM node pointing to the grid
  */
@@ -130,13 +128,10 @@ aria.Grid.prototype.setupFocusGrid = function () {
 /**
  * @description
  *  If possible, set focus pointer to the cell with the specified coordinates
- *
  * @param row
  *  The index of the cell's row
- *
  * @param col
  *  The index of the cell's column
- *
  * @returns {boolean}
  *  Returns whether or not the focus could be set on the cell.
  */
@@ -172,10 +167,8 @@ aria.Grid.prototype.setFocusPointer = function (row, col) {
 /**
  * @param row
  *  The index of the cell's row
- *
  * @param col
  *  The index of the cell's column
- *
  * @returns {boolean}
  *  Returns whether or not the coordinates are within the grid's boundaries.
  */
@@ -195,10 +188,8 @@ aria.Grid.prototype.isValidCell = function (row, col) {
 /**
  * @param row
  *  The index of the cell's row
- *
  * @param col
  *  The index of the cell's column
- *
  * @returns {boolean}
  *  Returns whether or not the cell has been hidden.
  */
@@ -261,10 +252,8 @@ aria.Grid.prototype.registerEvents = function () {
 /**
  * @description
  *  Focus on the cell in the specified row and column
- *
  * @param row
  *  The index of the cell's row
- *
  * @param col
  *  The index of the cell's column
  */
@@ -293,7 +282,6 @@ aria.Grid.prototype.hideKeysIndicator = function () {
  * @description
  *  Triggered on keydown. Checks if an arrow key was pressed, and (if possible)
  *  moves focus to the next valid cell in the direction of the arrow key.
- *
  * @param event
  *  Keydown event
  */
@@ -363,7 +351,6 @@ aria.Grid.prototype.checkFocusChange = function (event) {
 /**
  * @description
  *  Reset focused row and col if it doesn't match focusedRow and focusedCol
- *
  * @param focusedTarget
  *  Element that is currently focused by browser
  */
@@ -390,7 +377,6 @@ aria.Grid.prototype.findFocusedItem = function (focusedTarget) {
 /**
  * @description
  *  Triggered on click. Finds the cell that was clicked on and focuses on it.
- *
  * @param event
  *  Keydown event
  */
@@ -417,7 +403,6 @@ aria.Grid.prototype.focusClickedCell = function (event) {
  * @description
  *  Triggered on click. Checks if user clicked on a header with aria-sort.
  *  If so, it sorts the column based on the aria-sort attribute.
- *
  * @param event
  *  Keydown event
  */
@@ -464,13 +449,10 @@ aria.Grid.prototype.delegateButtonHandler = function (event) {
  * @description
  *  Toggles the mode of an editable cell between displaying the edit button
  *  and displaying the editable input.
- *
  * @param editCell
  *  Cell to toggle
- *
  * @param toggleOn
  *  Whether to show or hide edit input
- *
  * @param updateText
  *  Whether or not to update the button text with the input text
  */
@@ -503,7 +485,6 @@ aria.Grid.prototype.toggleEditMode = function (editCell, toggleOn, updateText) {
  *  All other headers with aria-sort are reset to "none"
  *
  *  Note: This implementation assumes that there is no pagination on the grid.
- *
  * @param headerNode
  *  Header DOM node
  */
@@ -546,7 +527,6 @@ aria.Grid.prototype.handleSort = function (headerNode) {
 /**
  * @description
  *  Sorts the grid's rows according to the specified compareFn
- *
  * @param compareFn
  *  Comparison function to sort the rows
  */
@@ -599,7 +579,6 @@ aria.Grid.prototype.setPaginationChangeHandler = function (onPaginationChange) {
 /**
  * @description
  *  Check if page up or page down was pressed, and show the next page if so.
- *
  * @param event
  *  Keydown event
  */
@@ -634,10 +613,8 @@ aria.Grid.prototype.movePageDown = function () {
 /**
  * @description
  *  Scroll the specified row into view in the specified direction
- *
  * @param startIndex
  *  Row index to use as the start index
- *
  * @param scrollDown
  *  Whether to scroll the new page above or below the row index
  */
@@ -848,10 +825,8 @@ aria.Grid.prototype.getNextVisibleCell = function (directionX, directionY) {
 /**
  * @description
  *  Show or hide the cells in the specified column
- *
  * @param columnIndex
  *  Index of the column to toggle
- *
  * @param isShown
  *  Whether or not to show the column
  */
@@ -880,13 +855,10 @@ aria.Grid.prototype.toggleColumn = function (columnIndex, isShown) {
  * @description
  *  Find the closest element matching the selector. Only checks parent and
  *  direct children.
- *
  * @param element
  *  Element to start searching from
- *
  * @param selector
  *  Index of the column to toggle
- *
  * @returns {object} matching element
  */
 aria.Grid.prototype.findClosest = function (element, selector) {

--- a/examples/grid/js/menuButton.js
+++ b/examples/grid/js/menuButton.js
@@ -39,9 +39,7 @@ var aria = aria || {};
 
 /**
  * @class Menu
- *
  * @memberof aria.Utils
- *
  * @description  Computes absolute position of an element
  */
 
@@ -71,9 +69,7 @@ aria.widget = aria.widget || {};
 
 /**
  * @class Menu
- *
  * @memberof aria.Widget
- *
  * @description  Creates a Menu Button widget using ARIA
  */
 
@@ -109,9 +105,7 @@ aria.widget.Menu = function (node, menuButton) {
 
 /**
  * @function initMenuButton
- *
  * @memberof aria.widget.Menu
- *
  * @description  Adds event handlers to button elements
  */
 
@@ -156,9 +150,7 @@ aria.widget.Menu.prototype.initMenu = function () {
 
 /**
  * @function nextMenuItem
- *
  * @memberof aria.widget.Menu
- *
  * @description  Moves focus to next menuItem
  */
 
@@ -183,9 +175,7 @@ aria.widget.Menu.prototype.nextMenuItem = function (currentMenuItem) {
 
 /**
  * @function previousMenuItem
- *
  * @memberof aria.widget.Menu
- *
  * @description  Moves focus to previous menuItem
  */
 
@@ -210,9 +200,7 @@ aria.widget.Menu.prototype.previousMenuItem = function (currentMenuItem) {
 
 /**
  * @function eventKeyDown
- *
  * @memberof aria.widget.Menu
- *
  * @description  Keydown event handler for Menu Object
  *        NOTE: The menu parameter is needed to provide a reference to the specific
  *               menu
@@ -264,9 +252,7 @@ aria.widget.Menu.prototype.eventKeyDown = function (event, menu) {
 
 /**
  * @function eventMouseClick
- *
  * @memberof aria.widget.Menu
- *
  * @description  onclick event handler for Menu Object
  *        NOTE: The menu parameter is needed to provide a reference to the specific
  *               menu
@@ -315,9 +301,7 @@ aria.widget.Menu.prototype.eventFocus = function (event, menu) {
 
 /**
  * @class Menu Button
- *
  * @memberof aria.Widget
- *
  * @description  Creates a Menu Button widget using ARIA
  */
 
@@ -352,9 +336,7 @@ aria.widget.MenuButton = function (node) {
 
 /**
  * @function initMenuButton
- *
  * @memberof aria.widget.MenuButton
- *
  * @description  Adds event handlers to button elements
  */
 
@@ -388,9 +370,7 @@ aria.widget.MenuButton.prototype.initMenuButton = function () {
 
 /**
  * @function openMenu
- *
  * @memberof aria.widget.MenuButton
- *
  * @description  Opens the menu
  */
 
@@ -403,9 +383,7 @@ aria.widget.MenuButton.prototype.openMenu = function () {
 
 /**
  * @function closeMenu
- *
  * @memberof aria.widget.MenuButton
- *
  * @description  Close the menu
  */
 
@@ -434,9 +412,7 @@ aria.widget.MenuButton.prototype.closeMenu = function (force, focusMenuButton) {
 
 /**
  * @function toggleMenu
- *
  * @memberof aria.widget.MenuButton
- *
  * @description  Close or open the menu depending on current state
  */
 
@@ -452,9 +428,7 @@ aria.widget.MenuButton.prototype.toggleMenu = function () {
 
 /**
  * @function moveFocusToFirstMenuItem
- *
  * @memberof aria.widget.MenuButton
- *
  * @description  Move keyboard focus to first menu item
  */
 
@@ -467,9 +441,7 @@ aria.widget.MenuButton.prototype.moveFocusToFirstMenuItem = function () {
 
 /**
  * @function moveFocusToLastMenuItem
- *
  * @memberof aria.widget.MenuButton
- *
  * @description  Move keyboard focus to last menu item
  */
 
@@ -482,9 +454,7 @@ aria.widget.MenuButton.prototype.moveFocusToLastMenuItem = function () {
 
 /**
  * @function eventKeyDown
- *
  * @memberof aria.widget.MenuButton
- *
  * @description  Keydown event handler for MenuButton Object
  *        NOTE: The menuButton parameter is needed to provide a reference to the specific
  *               menuButton

--- a/examples/js/examples.js
+++ b/examples/js/examples.js
@@ -63,7 +63,6 @@ aria.widget.SourceCode = function () {
  * @param {string} codeId          - ID of element containing only and all of the html used to render the example widget
  * @param {string} exampleHeaderId - ID of header element under which the "Open in Codepen" button belongs
  * @param {string} cssJsFilesId    - ID of element containing links to all the relevant js and css files used for the example widget
- *
  * @function add
  * @memberof aria.widget.SourceCode
  */
@@ -117,7 +116,6 @@ aria.widget.SourceCode.prototype.make = function () {
  * @param {object} node DOM Element node to use to generate the source code
  * @param {number} indentLevel Level of indentation
  * @param {boolean} skipFirst Whether to skip the first node
- *
  * @function createCode
  * @memberof aria.widget.SourceCode
  */
@@ -293,11 +291,11 @@ function stripIndentation(textContent) {
  *
  * Algorithm:
  *
- * **Case 1: `textContent` is on the same line as opening and closing tag**:
+ * Case 1: `textContent` is on the same line as opening and closing tag**:
  *
  * In other words, the text doesn’t contain any newline. Return 0.
  *
- * **Case 2: `textContent` is on the same line as opening tag**:
+ * Case 2: `textContent` is on the same line as opening tag**:
  *
  * We already know there is at least one newline, because case 1 didn’t return.
  * We can now find the first indented line that contains any non-whitespace

--- a/examples/listbox/js/listbox.js
+++ b/examples/listbox/js/listbox.js
@@ -12,10 +12,8 @@ var aria = aria || {};
 
 /**
  * @class
- *
  * @description
  *  Listbox object representing the state and interactions for a listbox widget
- *
  * @param listboxNode
  *  The DOM node pointing to the listbox
  */
@@ -92,7 +90,6 @@ aria.Listbox.prototype.focusLastItem = function () {
  * @description
  *  Handle various keyboard controls; UP/DOWN will shift focus; SPACE selects
  *  an item.
- *
  * @param evt
  *  The keydown event object
  */
@@ -340,7 +337,6 @@ aria.Listbox.prototype.findMatchInRange = function (
 /**
  * @description
  *  Check if an item is clicked on. If so, focus on it and select it.
- *
  * @param evt
  *  The click event object
  */
@@ -376,7 +372,6 @@ aria.Listbox.prototype.checkMouseDown = function (evt) {
 /**
  * @description
  *  Toggle the aria-selected value
- *
  * @param element
  *  The element to select
  */
@@ -394,7 +389,6 @@ aria.Listbox.prototype.toggleSelectItem = function (element) {
 /**
  * @description
  *  Defocus the specified item
- *
  * @param element
  *  The element to defocus
  */
@@ -411,7 +405,6 @@ aria.Listbox.prototype.defocusItem = function (element) {
 /**
  * @description
  *  Focus on the specified item
- *
  * @param element
  *  The element to focus
  */
@@ -542,7 +535,6 @@ aria.Listbox.prototype.checkUpDownButtons = function () {
 /**
  * @description
  *  Add the specified items to the listbox. Assumes items are valid options.
- *
  * @param items
  *  An array of items to add to the listbox
  */
@@ -571,7 +563,6 @@ aria.Listbox.prototype.addItems = function (items) {
  *  Remove all of the selected items from the listbox; Removes the focused items
  *  in a single select listbox and the items with aria-selected in a multi
  *  select listbox.
- *
  * @returns {Array}
  *  An array of items that were removed from the listbox
  */
@@ -669,10 +660,8 @@ aria.Listbox.prototype.moveItems = function () {
 /**
  * @description
  *  Enable Up/Down controls to shift items up and down.
- *
  * @param upButton
  *   Up button to trigger up shift
- *
  * @param downButton
  *   Down button to trigger down shift
  */
@@ -688,10 +677,8 @@ aria.Listbox.prototype.enableMoveUpDown = function (upButton, downButton) {
  * @description
  *  Enable Move controls. Moving removes selected items from the current
  *  list and adds them to the sibling list.
- *
  * @param button
  *   Move button to trigger delete
- *
  * @param siblingList
  *   Listbox to move items to
  */

--- a/examples/listbox/js/toolbar.js
+++ b/examples/listbox/js/toolbar.js
@@ -12,10 +12,8 @@ var aria = aria || {};
 
 /**
  * @class
- *
  * @description
  *  Toolbar object representing the state and interactions for a toolbar widget
- *
  * @param toolbarNode
  *  The DOM node pointing to the toolbar
  */
@@ -42,7 +40,6 @@ aria.Toolbar.prototype.registerEvents = function () {
  * @description
  *  Handle various keyboard controls; LEFT/RIGHT will shift focus; DOWN
  *  activates a menu button if it is the focused item.
- *
  * @param evt
  *  The keydown event object
  */
@@ -74,7 +71,6 @@ aria.Toolbar.prototype.checkFocusChange = function (evt) {
 /**
  * @description
  *  Selects a toolbar item if it is clicked
- *
  * @param evt
  *  The click event object
  */
@@ -87,7 +83,6 @@ aria.Toolbar.prototype.checkClickItem = function (evt) {
 /**
  * @description
  *  Deselect the specified item
- *
  * @param element
  *  The item to deselect
  */
@@ -100,7 +95,6 @@ aria.Toolbar.prototype.deselectItem = function (element) {
 /**
  * @description
  *  Deselect the currently selected item and select the specified item
- *
  * @param element
  *  The item to select
  */
@@ -115,7 +109,6 @@ aria.Toolbar.prototype.selectItem = function (element) {
 /**
  * @description
  *  Focus on the specified item
- *
  * @param element
  *  The item to focus on
  */

--- a/examples/toolbar/js/FormatToolbar.js
+++ b/examples/toolbar/js/FormatToolbar.js
@@ -11,11 +11,9 @@
 
 /**
  * @class
- *
  * @description
  *  Format Toolbar object representing the state and interactions for a toolbar widget
  *  to format the text in a textarea element
- *
  * @param domNode
  *  The DOM node pointing to the element with the toolbar tole
  */
@@ -303,7 +301,6 @@ FormatToolbar.prototype.activateItem = function (toolbarItem) {
 /**
  * @description
  *  Focus on the specified item
- *
  * @param item
  *  The item to focus on
  */

--- a/test/util/assertNoElements.js
+++ b/test/util/assertNoElements.js
@@ -6,7 +6,6 @@ const { By } = require('selenium-webdriver');
  * @param {ExecutionContext} t - Test execution context
  * @param {string} selector - CSS selector string
  * @param {Element} message - Element to query within, defaulting to t.context.session
- *
  * @returns {Promise} Resolves to array of elements
  */
 module.exports = async function assertNoElements(t, selector, message) {

--- a/test/util/force-serial.js
+++ b/test/util/force-serial.js
@@ -26,7 +26,6 @@ function bindPort(port) {
  *
  * @param {number} port - TCP/IP port to use as a resource lock
  * @param {Function} safe - function that will be executed in isolation
- *
  * @returns {Promise} eventual value which shares the resolution of the
  *                    provided operation
  */

--- a/test/util/queryElement.js
+++ b/test/util/queryElement.js
@@ -6,7 +6,6 @@ const { By } = require('selenium-webdriver');
  * @param {ExecutionContext} t - Test execution context
  * @param {string} selector - CSS selector string
  * @param {Element} context - Element to query within, defaulting to t.context.session
- *
  * @returns {Promise} Resolves to an element
  */
 module.exports = async function queryElement(t, selector, context) {

--- a/test/util/queryElements.js
+++ b/test/util/queryElements.js
@@ -6,7 +6,6 @@ const { By } = require('selenium-webdriver');
  * @param {ExecutionContext} t - Test execution context
  * @param {string} selector - CSS selector string
  * @param {Element} context - Element to query within, defaulting to t.context.session
- *
  * @returns {Promise} Resolves to array of elements
  */
 module.exports = async function queryElements(t, selector, context) {

--- a/test/util/replaceExternalLink.js
+++ b/test/util/replaceExternalLink.js
@@ -5,7 +5,6 @@
  * @param {string} newUrl - the url to replace the external url
  * @param {string} linkSelector - CSS selector string
  * @param {number} index - if the link selector returns a list, the index of the item to test
- *
  * @returns {Promise} Resolves to array of elements
  */
 module.exports = async function replaceExternalLinks(

--- a/test/util/start-geckodriver.js
+++ b/test/util/start-geckodriver.js
@@ -65,7 +65,6 @@ const startOnAnyPort = (port, timeout) => {
  * @param {number} port - the TCP/IP port from which to begin search
  * @param {number} timeout - the number of milliseconds to attempt to create a
  *                           server before reporting a failure
- *
  * @returns {Promise<object>} - an eventual value for interfacing with the
  *                               server. The `port` property is the numeric
  *                               TCP/IP port to which the server is bound. The


### PR DESCRIPTION
Autofixed with `npm run lint:es -- --fix`