### PR TITLE
Code guide: Use short encoding declaration and avoid />

### DIFF
--- a/.htmlhintrc
+++ b/.htmlhintrc
@@ -7,6 +7,7 @@
   "attr-value-not-empty": false,
   "doctype-first": true,
   "doctype-html5": true,
+  "empty-tag-not-self-closed": true,
   "head-script-disabled": false,
   "href-abs-or-rel": false,
   "id-class-ad-disabled": false,

--- a/aria-practices-DeletedSectionsArchive.html
+++ b/aria-practices-DeletedSectionsArchive.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+<html lang="en-US">
 <head>
   <title>Content Deleted From WAI-ARIA Authoring Practices 1.1</title>
-  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
   <script src="https://www.w3.org/Tools/respec/respec-w3c-common" class="remove"></script>
   <script src="common/script/resolveReferences.js" class="remove"></script>
   <script src="common/biblio.js" class="remove"></script>
@@ -166,7 +166,7 @@
       preProcess: [linkCrossReferences],
     };
   </script>
-  <link href="common/css/common.css" rel="stylesheet" type="text/css" />
+  <link href="common/css/common.css" rel="stylesheet">
 </head>
 <body>
     <section id="abstract">
@@ -2837,7 +2837,7 @@ field. </p>
         behavior of the element. The user agent's default behavior at the
         document element forms the controller. </p>
       <figure id="fig1">
-        <img alt="Accessibility information mapped to a DOM element in the Document Object Model" height="512" longdesc="#desc_fig1" src="img/accessibleelement.png" width="640"/>
+        <img alt="Accessibility information mapped to a DOM element in the Document Object Model" height="512" longdesc="#desc_fig1" src="img/accessibleelement.png" width="640">
         <figcaption>Accessibility Interoperability at a <abbr title="document object model">DOM</abbr> Node without JavaScript</figcaption>
       </figure>
       <p id="desc_fig1">The box between the DOM node
@@ -2850,7 +2850,7 @@ field. </p>
         information, and relations). For HTML and other W3C markup, the
         accessibility information provided solely depends upon what the element's tag name and any accessibility attributes that map to that tag provides. For  example, the accessible role of a table is <code>table</code>. The author provides  an accessible description by assigning a <code>title</code> attribute.</p>
       <p>In contrast, with JavaScript, user actions can trigger updates in the data and presentation, but the default accessibility information available in the element tags is no longer valid.</p>
-      <figure id="fig2"><img alt="DOM Element with JavaScript controller" height="502" longdesc="#desc_fig2" src="img/accessibleJSelement.png" width="476"/>
+      <figure id="fig2"><img alt="DOM Element with JavaScript controller" height="502" longdesc="#desc_fig2" src="img/accessibleJSelement.png" width="476">
         <figcaption>Accessibility
         Interoperability at a DOM Node with JavaScript</figcaption></figure>
       <p id="desc_fig2"> <a href="#fig2"></a> shows the same DOM node provided
@@ -3308,7 +3308,7 @@ field. </p>
       user to view a list of navigation landmarks.
       This tool, shown in <a href="#fig3"></a>, lists the  navigation sections on the page. Keyboard navigation of the list of navigation bars causes the
       corresponding document section to be highlighted. The title for each navigation region displays in the list.</p>
-      <figure id="fig3"><img alt="Table of Contents from Landmarks" height="813" longdesc="#desc_fig3" src="img/navlandmark.jpg" title="Table of Contents from Landmarks" width="877"/>
+      <figure id="fig3"><img alt="Table of Contents from Landmarks" height="813" longdesc="#desc_fig3" src="img/navlandmark.jpg" title="Table of Contents from Landmarks" width="877">
       <figcaption>Table of Contents generated from navigation landmarks in the header</figcaption>
       </figure>
     <p id="desc_fig3"> <a href="#fig3"></a> shows the <a href="http://firefox.cita.uiuc.edu/">accessibility
@@ -3332,7 +3332,7 @@ field. </p>
       W3C standards-based approach to represent this information.</p>
       <figure id="fig4">
       <!-- <embed src="resourcemap.svg" width="810" height="800"> -->
-      <img alt="Sample Semantic Map for Taxonomy" height="564" longdesc="#desc_fig4" src="img/taxonomy.png" title="Sample Semantic Map for Taxonomy" width="500"/>
+      <img alt="Sample Semantic Map for Taxonomy" height="564" longdesc="#desc_fig4" src="img/taxonomy.png" title="Sample Semantic Map for Taxonomy" width="500">
       <figcaption>Example, Partial RDF Map for a possible ButtonUndo role as an extended role to  WAI-ARIA</figcaption>
       </figure>
     <p id="desc_fig4"> <a href="#fig4"></a> shows a basic RDF mapping that
@@ -3372,7 +3372,7 @@ field. </p>
         The user uses arrow keys to navigates the data grid and among the page tabs.
         Using the Tab key, a user navigates between the notebook tab, the edit fields, buttons, and
         the data grid.</p>
-        <figure id="fig5"><img alt="DHTML example of GUI-like notebook tab with a data grid" height="633" longdesc="#desc_fig5" src="img/DHTMLexample.png" title="DHTML Example" width="844"/>
+        <figure id="fig5"><img alt="DHTML example of GUI-like notebook tab with a data grid" height="633" longdesc="#desc_fig5" src="img/DHTMLexample.png" title="DHTML Example" width="844">
         <figcaption>DHTML Example</figcaption>
         </figure>
       <p id="desc_fig5"> Accessible role and state
@@ -3383,7 +3383,7 @@ field. </p>
         the Microsoft Active Accessibility rendering of the new
         accessibility markup provided on the DataGrid page tab which has
         focus.</p>
-        <figure id="fig6"><img alt="MSAA Inspect Tool diagnostics for Notebook page tab" height="647" longdesc="#desc_fig6" src="img/inspectofpagetab.png" title="MSAA Inspect Tool diagnostics for Notebook page tab" width="490"/>
+        <figure id="fig6"><img alt="MSAA Inspect Tool diagnostics for Notebook page tab" height="647" longdesc="#desc_fig6" src="img/inspectofpagetab.png" title="MSAA Inspect Tool diagnostics for Notebook page tab" width="490">
         <figcaption>Microsoft Inspect Tool rendering of the page tab
         DataGrid</figcaption>
         </figure>
@@ -3502,7 +3502,7 @@ field. </p>
   </ol>
     <section id="exampletree">
     <h3>Example: Building a Tree Widget</h3>
-    <img alt="Graphic of an example tree view." class="role-screenshot" src="img/exampletree.png" width="188" height="327" />
+    <img alt="Graphic of an example tree view." class="role-screenshot" src="img/exampletree.png" width="188" height="327">
     <p>A basic tree view allows the user to select different list items and expand and collapse embedded lists. Arrow keys are used to navigate through a tree, including left/right to collapse/expand sub trees. Clicking the visible expander button with the mouse also toggles expansion. Further keyboard implementation details for tree widgets may found in the <a href="#aria_ex"></a>.</p>
     <p>To make this feature accessible we need to:</p>
     <ul>
@@ -3639,7 +3639,7 @@ field. </p>
     <p>WAI-ARIA and WCAG 2.0 coding techniques are useful for developing content and applications that can scale across a variety of user agents, including those on mobile devices. </p>
     <p>For all these reasons, adopting WAI-ARIA makes good technical as well as business sense. For a further illustration, compare how accessibility is achieved with WCAG techniques without and with WAI-ARIA, as shown in <a href="#fig7"></a>. </p>
       <figure id="fig7">
-        <!--<img alt="WAI-ARIA tree widget usability comparison" class="figure" src="img/style_aria.jpg" title="tree widget comparison"/>-->
+        <!--<img alt="WAI-ARIA tree widget usability comparison" class="figure" src="img/style_aria.jpg" title="tree widget comparison">-->
         <p class="ednote">Editor's Note: Figure 7, described as WAI-ARIA tree widget usability comparison, refers to a resource that has not yet been found.</p>
         <figcaption>Usability of Tree Widget Using WAI-ARIA Semantics to Implement WCAG 2.0 Guidelines Compared to WCAG 1.0 Without WAI-ARIA</figcaption>
       </figure>

--- a/aria-practices.html
+++ b/aria-practices.html
@@ -1,13 +1,13 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+<html lang="en-US">
 <head>
-  <meta charset="utf-8" />
+  <meta charset="utf-8">
   <title>WAI-ARIA Authoring Practices 1.2</title>
   <script src="common/script/resolveReferences.js" class="remove"></script>
   <script src="respec-config.js" class="remove"></script>
   <script src="common/biblio.js" class="remove"></script>
   <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
-  <link href="common/css/common.css" rel="stylesheet" type="text/css" />
+  <link href="common/css/common.css" rel="stylesheet" type="text/css">
 </head>
 <body>
   <section id="abstract">
@@ -2633,7 +2633,7 @@ Some JavaScript and CSS may not function correctly in Internet Explorer.
         Choose the role that best matches both the visual design and semantics of the user interface.
         For instance, there are some circumstances where the semantics of <q>on or off</q> would be easier for assistive technology users to understand than the semantics of <q>checked or unchecked</q>, and vice versa.
         Consider a widget for turning lights on or off.
-        In this case, screen reader output of <q>Lights switch on</q> is more user friendly than <q>Lights checkbox checked</q>. 
+        In this case, screen reader output of <q>Lights switch on</q> is more user friendly than <q>Lights checkbox checked</q>.
         However, if the same input were in a group of inputs labeled <q>Which of the following must be included in your pre-takeoff procedures?</q>, <q>Lights checkbox checked</q> would make more sense.
       </p>
       <p>

--- a/examples/accordion/accordion.html
+++ b/examples/accordion/accordion.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-<meta content="width=device-width, initial-scale=1.0" name="viewport" />
+<meta charset="UTF-8">
+<meta content="width=device-width, initial-scale=1.0" name="viewport">
 <title>Accordion Example | WAI-ARIA Authoring Practices 1.2</title>
 <!--  Core js and css shared by all examples; do not modify when using this template. -->
 <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/base.css">
@@ -12,7 +12,7 @@
 <script src="../js/app.js"></script>
 
 <!--  js and css for this example. -->
-<link rel="stylesheet" type="text/css" href="css/accordion.css" />
+<link rel="stylesheet" type="text/css" href="css/accordion.css">
 
 </head>
 <body>
@@ -96,23 +96,23 @@
             <fieldset>
               <p>
                 <label for="b-add1">Address 1:</label>
-                <input type="text" name="b-add1" id="b-add1" />
+                <input type="text" name="b-add1" id="b-add1">
               </p>
               <p>
                 <label for="b-add2">Address 2:</label>
-                <input type="text" name="b-add2" id="b-add2" />
+                <input type="text" name="b-add2" id="b-add2">
               </p>
               <p>
                 <label for="b-city">City:</label>
-                <input type="text" name="b-city" id="b-city" />
+                <input type="text" name="b-city" id="b-city">
               </p>
               <p>
                 <label for="b-state">State:</label>
-                <input type="text" name="b-state" id="b-state" />
+                <input type="text" name="b-state" id="b-state">
               </p>
               <p>
                 <label for="b-zip">Zip Code:</label>
-                <input type="text" name="b-zip" id="b-zip" />
+                <input type="text" name="b-zip" id="b-zip">
               </p>
             </fieldset>
           </div>
@@ -131,23 +131,23 @@
             <fieldset>
               <p>
                 <label for="m-add1">Address 1:</label>
-                <input type="text" name="m-add1" id="m-add1" />
+                <input type="text" name="m-add1" id="m-add1">
               </p>
               <p>
                 <label for="m-add2">Address 2:</label>
-                <input type="text" name="m-add2" id="m-add2" />
+                <input type="text" name="m-add2" id="m-add2">
               </p>
               <p>
                 <label for="m-city">City:</label>
-                <input type="text" name="m-city" id="m-city" />
+                <input type="text" name="m-city" id="m-city">
               </p>
               <p>
                 <label for="m-state">State:</label>
-                <input type="text" name="m-state" id="m-state" />
+                <input type="text" name="m-state" id="m-state">
               </p>
               <p>
                 <label for="m-zip">Zip Code:</label>
-                <input type="text" name="m-zip" id="m-zip" />
+                <input type="text" name="m-zip" id="m-zip">
               </p>
             </fieldset>
           </div>

--- a/examples/alert/alert.html
+++ b/examples/alert/alert.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <meta charset="utf-8" />
+    <meta charset="utf-8">
     <title>Alert Example | WAI-ARIA Authoring Practices 1.2</title>
 
     <!--  Core js and css shared by all examples; do not modify when using this template. -->

--- a/examples/breadcrumb/index.html
+++ b/examples/breadcrumb/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <meta charset="utf-8" />
+    <meta charset="utf-8">
     <title>Breadcrumb Example | WAI-ARIA Authoring Practices 1.2</title>
 
     <!--  Core js and css shared by all examples; do not modify when using this template. -->

--- a/examples/carousel/carousel-1-prev-next.html
+++ b/examples/carousel/carousel-1-prev-next.html
@@ -2,7 +2,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <meta charset="utf-8" />
+    <meta charset="utf-8">
     <title>Auto-Rotating Image Carousel Example with Buttons for Slide Control | WAI-ARIA Authoring Practices 1.2</title>
 
     <!--  Core js and css shared by all examples; do not modify when using this template. -->
@@ -126,7 +126,7 @@
 
                     <div class="carousel-image">
                       <a href="#">
-                        <img src="images/amsterdamslide__800x600.jpg" alt="Walking Tour in Amsterdam" />
+                        <img src="images/amsterdamslide__800x600.jpg" alt="Walking Tour in Amsterdam">
                       </a>
                     </div>
 
@@ -148,7 +148,7 @@
 
                     <div class="carousel-image">
                       <a href="#">
-                        <img src="images/lands-endslide__800x600.jpg" alt="Land&#039;s End in Cornwall"/>
+                        <img src="images/lands-endslide__800x600.jpg" alt="Land&#039;s End in Cornwall">
                       </a>
                     </div>
 
@@ -170,7 +170,7 @@
 
                     <div class="carousel-image">
                       <a href="#">
-                        <img src="images/trustslide-2__800x600.jpg" alt="Mom and daughter play Daniel Tiger game on notebook computer."/>
+                        <img src="images/trustslide-2__800x600.jpg" alt="Mom and daughter play Daniel Tiger game on notebook computer.">
                       </a>
                     </div>
 
@@ -192,7 +192,7 @@
 
                     <div class="carousel-image">
                       <a href="#">
-                        <img src="images/foyleswarslide__800x600.jpg" alt="A man in a suit and fedora and a woman with coiffed hair look sternly into the camera."/>
+                        <img src="images/foyleswarslide__800x600.jpg" alt="A man in a suit and fedora and a woman with coiffed hair look sternly into the camera.">
                       </a>
                     </div>
 
@@ -214,7 +214,7 @@
 
                     <div class="carousel-image">
                       <a href="#">
-                        <img src="images/britcomdavidslide__800x600.jpg" alt="British flag with WILL-TV host David Thiel."/>
+                        <img src="images/britcomdavidslide__800x600.jpg" alt="British flag with WILL-TV host David Thiel.">
                       </a>
                     </div>
 
@@ -235,7 +235,7 @@
 
                     <div class="carousel-image">
                       <a href="#">
-                        <img src="images/mag800-2__800x600.jpg" alt="Mid-American Gardener panelists on the set" />
+                        <img src="images/mag800-2__800x600.jpg" alt="Mid-American Gardener panelists on the set">
                       </a>
                     </div>
 

--- a/examples/carousel/carousel-2-tablist.html
+++ b/examples/carousel/carousel-2-tablist.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <meta charset="utf-8" />
+    <meta charset="utf-8">
     <title>Auto-Rotating Image Carousel with Tabs for Slide Control Example | WAI-ARIA Authoring Practices 1.2</title>
 
     <!--  Core js and css shared by all examples; do not modify when using this template. -->
@@ -190,7 +190,7 @@
 
                     <div class="carousel-image">
                       <a href="#" id="carousel-image-1">
-                        <img src="images/amsterdamslide__800x600.jpg" alt="Walking Tour in Amsterdam" />
+                        <img src="images/amsterdamslide__800x600.jpg" alt="Walking Tour in Amsterdam">
                       </a>
                     </div>
 
@@ -216,7 +216,7 @@
 
                     <div class="carousel-image">
                       <a href="#" id="carousel-image-2">
-                        <img src="images/lands-endslide__800x600.jpg" alt="Land&#039;s End in Cornwall"/>
+                        <img src="images/lands-endslide__800x600.jpg" alt="Land&#039;s End in Cornwall">
                       </a>
                     </div>
 
@@ -242,7 +242,7 @@
 
                     <div class="carousel-image">
                       <a href="#!" id="carousel-image-3">
-                        <img src="images/trustslide-2__800x600.jpg" alt="Mom and daughter play Daniel Tiger game on notebook computer."/>
+                        <img src="images/trustslide-2__800x600.jpg" alt="Mom and daughter play Daniel Tiger game on notebook computer.">
                       </a>
                     </div>
 
@@ -268,7 +268,7 @@
 
                     <div class="carousel-image">
                       <a href="#" id="carousel-image-4">
-                        <img src="images/foyleswarslide__800x600.jpg" alt="A man in a suit and fedora and a woman with coiffed hair look sternly into the camera."/>
+                        <img src="images/foyleswarslide__800x600.jpg" alt="A man in a suit and fedora and a woman with coiffed hair look sternly into the camera.">
                       </a>
                     </div>
 
@@ -294,7 +294,7 @@
 
                     <div class="carousel-image">
                       <a href="#" id="carousel-image-5">
-                        <img src="images/britcomdavidslide__800x600.jpg" alt="British flag with WILL-TV host David Thiel."/>
+                        <img src="images/britcomdavidslide__800x600.jpg" alt="British flag with WILL-TV host David Thiel.">
                       </a>
                     </div>
 
@@ -319,7 +319,7 @@
 
                     <div class="carousel-image">
                       <a href="#" id="carousel-image-6">
-                        <img src="images/mag800-2__800x600.jpg" alt="Mid-American Gardener panelists on the set" />
+                        <img src="images/mag800-2__800x600.jpg" alt="Mid-American Gardener panelists on the set">
                       </a>
                     </div>
 

--- a/examples/checkbox/checkbox-mixed.html
+++ b/examples/checkbox/checkbox-mixed.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
   <html lang="en">
   <head>
-    <meta charset="utf-8" />
+    <meta charset="utf-8">
     <title>Checkbox Example (Mixed-State) | WAI-ARIA Authoring Practices 1.2</title>
 
     <!--  Core js and css shared by all examples; do not modify when using this template. -->

--- a/examples/checkbox/checkbox.html
+++ b/examples/checkbox/checkbox.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="utf-8" />
+  <meta charset="utf-8">
   <title>Checkbox Example (Two State) | WAI-ARIA Authoring Practices 1.2</title>
 
   <!--  Core js and css shared by all examples; do not modify when using this template. -->

--- a/examples/coding-template/Depricated-MultipleImplementationExample-Template.html
+++ b/examples/coding-template/Depricated-MultipleImplementationExample-Template.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<meta charset="utf-8" />
+<meta charset="utf-8">
 <!--
   This template is deprecated.
   As of November 21, 2016, the task force agrees that:
@@ -260,9 +260,9 @@
   <section>
     <h2>HTML Source Code</h2>
     <h3 id="sc1_label">Example 1: title of this variation of the implementation</h3>
-    <div id="sc1_start_sep" role="separator" aria-labelledby="sc1_start_sep sc1_label" aria-label="Start of HTML for" ></div>
+    <div id="sc1_start_sep" role="separator" aria-labelledby="sc1_start_sep sc1_label" aria-label="Start of HTML for"></div>
     <pre><code id="sc1"></code></pre>
-    <div id="sc1_end_sep" role="separator" aria-labelledby="sc1_end_sep sc1_label" aria-label="End of HTML for" ></div>
+    <div id="sc1_end_sep" role="separator" aria-labelledby="sc1_end_sep sc1_label" aria-label="End of HTML for"></div>
     <!--
       The following script will show the reader the HTML source for the example that is in the div with ID 'ex1'.
       It renders the HTML in the preceding pre element with ID 'sc1'.
@@ -273,9 +273,9 @@
     </script>
 
     <h3 id="sc2_label">Example 2: title of this variation of the implementation</h3>
-    <div id="sc2_start_sep" role="separator" aria-labelledby="sc2_start_sep sc2_label" aria-label="Start of HTML for" ></div>
+    <div id="sc2_start_sep" role="separator" aria-labelledby="sc2_start_sep sc2_label" aria-label="Start of HTML for"></div>
     <pre id="sc2"></pre>
-    <div id="sc2_end_sep" role="separator" aria-labelledby="sc2_end_sep sc2_label" aria-label="End of HTML for" ></div>
+    <div id="sc2_end_sep" role="separator" aria-labelledby="sc2_end_sep sc2_label" aria-label="End of HTML for"></div>
     <!--
       The following script will show the reader the HTML source for the example that is in the div with ID 'ex2'.
       It renders the HTML in the preceding pre element with ID 'sc2'.
@@ -286,9 +286,9 @@
     </script>
 
     <h3 id="sc3_label">Example 3: title of this variation of the implementation</h3>
-    <div id="sc3_start_sep" role="separator" aria-labelledby="sc3_start_sep sc3_label" aria-label="Start of HTML for" ></div>
+    <div id="sc3_start_sep" role="separator" aria-labelledby="sc3_start_sep sc3_label" aria-label="Start of HTML for"></div>
     <pre id="sc3"></pre>
-    <div id="sc3_end_sep" role="separator" aria-labelledby="sc3_end_sep sc3_label" aria-label="End of HTML for" ></div>
+    <div id="sc3_end_sep" role="separator" aria-labelledby="sc3_end_sep sc3_label" aria-label="End of HTML for"></div>
     <!--
       The following script will show the reader the HTML source for the example that is in the div with ID 'ex3'.
       It renders the HTML in the preceding pre element with ID 'sc3'.

--- a/examples/coding-template/Example-Template.html
+++ b/examples/coding-template/Example-Template.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<meta charset="utf-8" />
+<meta charset="utf-8">
 <!--
   An example that was implemented with this template can be found in: examples/checkbox/checkbox-1.html.
   This template is for examples where only one implementation of the design pattern is demonstrated.

--- a/examples/combobox/combobox-autocomplete-both.html
+++ b/examples/combobox/combobox-autocomplete-both.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<meta charset="utf-8" />
+<meta charset="utf-8">
 <title>Editable Combobox With Both List and Inline Autocomplete Example | WAI-ARIA Authoring Practices 1.2</title>
 
 <!--  Core js and css shared by all examples; do not modify when using this template. -->

--- a/examples/combobox/combobox-autocomplete-list.html
+++ b/examples/combobox/combobox-autocomplete-list.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<meta charset="utf-8" />
+<meta charset="utf-8">
 <title>Editable Combobox With List Autocomplete Example | WAI-ARIA Authoring Practices 1.2</title>
 
 <!--  Core js and css shared by all examples; do not modify when using this template. -->

--- a/examples/combobox/combobox-autocomplete-none.html
+++ b/examples/combobox/combobox-autocomplete-none.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<meta charset="utf-8" />
+<meta charset="utf-8">
 <title>Editable Combobox without Autocomplete Example | WAI-ARIA Authoring Practices 1.2</title>
 
 <!--  Core js and css shared by all examples; do not modify when using this template. -->

--- a/examples/combobox/combobox-datepicker.html
+++ b/examples/combobox/combobox-datepicker.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<meta charset="utf-8" />
+<meta charset="utf-8">
 <title>Date Picker Combobox Example | WAI-ARIA Authoring Practices 1.2</title>
 
 <!--  Core js and css shared by all examples; do not modify when using this template. -->

--- a/examples/combobox/combobox-select-only.html
+++ b/examples/combobox/combobox-select-only.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<meta charset="utf-8" />
+<meta charset="utf-8">
 <title>Select-Only Combobox Example | WAI-ARIA Authoring Practices 1.2</title>
 
 <!--  Core js and css shared by all examples; do not modify when using this template. -->

--- a/examples/combobox/grid-combo.html
+++ b/examples/combobox/grid-combo.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<meta charset="utf-8" />
+<meta charset="utf-8">
 <title>Editable Combobox with Grid Popup Example | WAI-ARIA Authoring Practices 1.2</title>
 
 <!--  Core js and css shared by all examples; do not modify when using this template. -->

--- a/examples/dialog-modal/alertdialog.html
+++ b/examples/dialog-modal/alertdialog.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <meta charset="utf-8" />
+    <meta charset="utf-8">
     <title>Alert Dialog Example | WAI-ARIA Authoring Practices 1.2</title>
     <!--  Core js and css shared by all examples; do not modify when using this template. -->
     <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/base.css">

--- a/examples/dialog-modal/datepicker-dialog.html
+++ b/examples/dialog-modal/datepicker-dialog.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<meta charset="utf-8" />
+<meta charset="utf-8">
 <title>Date Picker Dialog Example | WAI-ARIA Authoring Practices 1.2</title>
 
 <!--  Core js and css shared by all examples; do not modify when using this template. -->

--- a/examples/dialog-modal/dialog.html
+++ b/examples/dialog-modal/dialog.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<meta charset="utf-8" />
+<meta charset="utf-8">
 <title>Modal Dialog Example | WAI-ARIA Authoring Practices 1.2</title>
 
 <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/examples/disclosure/disclosure-faq.html
+++ b/examples/disclosure/disclosure-faq.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<meta charset="utf-8" />
+<meta charset="utf-8">
 <title>Example Disclosure (Show/Hide) for Answers to Frequently Asked Questions | WAI-ARIA Authoring Practices 1.2</title>
 
   <!--  Core js and css shared by all examples; do not modify when using this template. -->
@@ -46,7 +46,7 @@
     <div class="example-header">
       <h2 id="ex_label">Example</h2>
     </div>
-    <div role="separator" id="ex_start_sep" aria-labelledby="ex_start_sep ex_label" aria-label="Start of" ></div>
+    <div role="separator" id="ex_start_sep" aria-labelledby="ex_start_sep ex_label" aria-label="Start of"></div>
     <div id="ex1">
       <h3>Parking <abbr title="Frequently Asked Questions">FAQ</abbr>s</h3>
       <dl class="faq">
@@ -245,9 +245,9 @@
 
   <section>
     <h2 id="sc1_label">HTML Source Code</h2>
-    <div role="separator" id="sc1_start_sep" aria-labelledby="sc1_start_sep sc1_label" aria-label="Start of" ></div>
+    <div role="separator" id="sc1_start_sep" aria-labelledby="sc1_start_sep sc1_label" aria-label="Start of"></div>
     <pre><code id="sc1"></code></pre>
-    <div role="separator" id="sc1_end_sep" aria-labelledby="sc1_end_sep sc1_label" aria-label="End of" ></div>
+    <div role="separator" id="sc1_end_sep" aria-labelledby="sc1_end_sep sc1_label" aria-label="End of"></div>
     <script>
       sourceCode.add('sc1', 'ex1', 'ex_label', 'css_js_files');
       sourceCode.make();

--- a/examples/disclosure/disclosure-faq.html
+++ b/examples/disclosure/disclosure-faq.html
@@ -142,7 +142,7 @@
         </tr>
         <tr data-test-id="key-enter-or-space">
           <th>
-            <kbd>Space</kbd> or <br />
+            <kbd>Space</kbd> or <br>
             <kbd>Enter</kbd>
           </th>
           <td>

--- a/examples/disclosure/disclosure-image-description.html
+++ b/examples/disclosure/disclosure-image-description.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<meta charset="utf-8" />
+<meta charset="utf-8">
 <title>Example Disclosure (Show/Hide) for Image Description | WAI-ARIA Authoring Practices 1.2</title>
 
 <!--  Core js and css shared by all examples; do not modify when using this template. -->
@@ -45,7 +45,7 @@
     <div class="example-header">
       <h2 id="ex_label">Example</h2>
     </div>
-    <div role="separator" id="ex_start_sep" aria-labelledby="ex_start_sep ex_label" aria-label="Start of" ></div>
+    <div role="separator" id="ex_start_sep" aria-labelledby="ex_start_sep ex_label" aria-label="Start of"></div>
     <div id="ex1">
       <figure>
         <img src="images/minard.png" alt="Charles Minard's 1869 chart showing the number of men in

--- a/examples/disclosure/disclosure-image-description.html
+++ b/examples/disclosure/disclosure-image-description.html
@@ -288,7 +288,7 @@
         </tr>
         <tr data-test-id="key-space-or-enter">
           <th>
-            <kbd>Space</kbd> or <br />
+            <kbd>Space</kbd> or <br>
             <kbd>Enter</kbd>
           </th>
           <td>

--- a/examples/disclosure/disclosure-navigation-hybrid.html
+++ b/examples/disclosure/disclosure-navigation-hybrid.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<meta charset="utf-8" />
+<meta charset="utf-8">
 <title>Example Disclosure Navigation Menu with Top-Level Links | WAI-ARIA Authoring Practices 1.2</title>
 
   <!--  Core js and css shared by all examples; do not modify when using this template. -->
@@ -62,7 +62,7 @@
     <div class="example-header">
       <h2 id="ex_label">Example</h2>
     </div>
-    <div role="separator" id="ex_start_sep" aria-labelledby="ex_start_sep ex_label" aria-label="Start of" ></div>
+    <div role="separator" id="ex_start_sep" aria-labelledby="ex_start_sep ex_label" aria-label="Start of"></div>
     <div id="ex1">
       <header class="sample-header">
         <div class="title" id="id_website_title">Mythical University</div>
@@ -376,9 +376,9 @@
 
   <section>
     <h2 id="sc1_label">HTML Source Code</h2>
-    <div role="separator" id="sc1_start_sep" aria-labelledby="sc1_start_sep sc1_label" aria-label="Start of" ></div>
+    <div role="separator" id="sc1_start_sep" aria-labelledby="sc1_start_sep sc1_label" aria-label="Start of"></div>
     <pre><code id="sc1"></code></pre>
-    <div role="separator" id="sc1_end_sep" aria-labelledby="sc1_end_sep sc1_label" aria-label="End of" ></div>
+    <div role="separator" id="sc1_end_sep" aria-labelledby="sc1_end_sep sc1_label" aria-label="End of"></div>
     <script>
       sourceCode.add('sc1', 'ex1', 'ex_label', 'css_js_files');
       sourceCode.make();

--- a/examples/disclosure/disclosure-navigation.html
+++ b/examples/disclosure/disclosure-navigation.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<meta charset="utf-8" />
+<meta charset="utf-8">
 <title>Example Disclosure Navigation Menu | WAI-ARIA Authoring Practices 1.2</title>
 
   <!--  Core js and css shared by all examples; do not modify when using this template. -->
@@ -13,7 +13,7 @@
 
   <!--  js and css for the disclosure example. -->
   <link href="css/disclosure-navigation.css" rel="stylesheet">
-  <script src="js/disclosureMenu.js" type="text/javascript"></script>
+  <script src="js/disclosureMenu.js"></script>
 
 </head>
 <body>
@@ -354,20 +354,20 @@
     <ul id="css_js_files">
       <li>
         CSS:
-        <a href="css/disclosure-navigation.css" type="tex/css">disclosure-navigation.css</a>
+        <a href="css/disclosure-navigation.css">disclosure-navigation.css</a>
       </li>
       <li>
         Javascript:
-        <a href="js/disclosureMenu.js" type="text/javascript">disclosureMenu.js</a>
+        <a href="js/disclosureMenu.js">disclosureMenu.js</a>
       </li>
     </ul>
   </section>
 
   <section>
     <h2 id="sc1_label">HTML Source Code</h2>
-    <div role="separator" id="sc1_start_sep" aria-labelledby="sc1_start_sep sc1_label" aria-label="Start of" ></div>
+    <div role="separator" id="sc1_start_sep" aria-labelledby="sc1_start_sep sc1_label" aria-label="Start of"></div>
     <pre><code id="sc1"></code></pre>
-    <div role="separator" id="sc1_end_sep" aria-labelledby="sc1_end_sep sc1_label" aria-label="End of" ></div>
+    <div role="separator" id="sc1_end_sep" aria-labelledby="sc1_end_sep sc1_label" aria-label="End of"></div>
     <script>
       sourceCode.add('sc1', 'ex1', 'ex_label', 'css_js_files');
       sourceCode.make();

--- a/examples/feed/feed.html
+++ b/examples/feed/feed.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<meta charset="utf-8" />
+<meta charset="utf-8">
 <title>Feed Example | WAI-ARIA Authoring Practices 1.2</title>
 
 <!--  Core js and css shared by all examples; do not modify when using this template. -->

--- a/examples/feed/feedDisplay.html
+++ b/examples/feed/feedDisplay.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<meta charset="utf-8" />
+<meta charset="utf-8">
 <title>Feed Display | WAI-ARIA Authoring Practices 1.2</title>
 
 <!--  Core js and css shared by all examples; do not modify when using this template. -->

--- a/examples/feed/js/feedDisplay.js
+++ b/examples/feed/js/feedDisplay.js
@@ -218,7 +218,7 @@ aria.FeedDisplay.prototype.renderItemData = function (itemData) {
       ' stars" ' +
       'src="imgs/rating-' +
       itemData.rating +
-      '.png" />' +
+      '.png">' +
       '</div>';
     describedbyIDs.push(ratingID);
   }

--- a/examples/grid/LayoutGrids.html
+++ b/examples/grid/LayoutGrids.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<meta charset="utf-8" />
+<meta charset="utf-8">
 <title>Layout Grid Examples | WAI-ARIA Authoring Practices 1.2</title>
 
 <!--  Core js and css shared by all examples; do not modify when using this template. -->
@@ -77,7 +77,7 @@
           </p>
           <p class="indicator_description">
             <img src="imgs/black_keys.png" width="100" alt="Arrow keypad"
-              class="indicator_graphic" />
+              class="indicator_graphic">
           </p>
           <p>
             This focus ring means arrow key navigation is available. Press arrow keys to move inside the component. Press Tab to jump to the next component.

--- a/examples/grid/advancedDataGrid.html
+++ b/examples/grid/advancedDataGrid.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<meta charset="utf-8" />
+<meta charset="utf-8">
 <title>Advanced Data Grid Example | WAI-ARIA Authoring Practices 1.2</title>
 
 <!--  Core js and css shared by all examples; do not modify when using this template. -->

--- a/examples/grid/dataGrids.html
+++ b/examples/grid/dataGrids.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<meta charset="utf-8" />
+<meta charset="utf-8">
 <title>Data Grid Examples | WAI-ARIA Authoring Practices 1.2</title>
 
 <!--  Core js and css shared by all examples; do not modify when using this template. -->
@@ -162,7 +162,7 @@
             <td>
               <div class="editable-text">
                 <span class="edit-text-button" tabindex="-1" role="button">Cash Deposit</span>
-                <input class="edit-text-input hidden" tabindex="-1" value="" />
+                <input class="edit-text-input hidden" tabindex="-1" value="">
               </div>
             </td>
             <td class="menu-wrapper">
@@ -186,7 +186,7 @@
               <div class="editable-text">
                 <span class="edit-text-button" tabindex="-1" role="button">Down Town
                   Grocery</span>
-                <input class="edit-text-input hidden" tabindex="-1" value="" />
+                <input class="edit-text-input hidden" tabindex="-1" value="">
               </div>
             </td>
             <td class="menu-wrapper">
@@ -210,7 +210,7 @@
             <td>
               <div class="editable-text">
                 <span class="edit-text-button" tabindex="-1" role="button">Hot Coffee</span>
-                <input class="edit-text-input hidden" tabindex="-1" value="" />
+                <input class="edit-text-input hidden" tabindex="-1" value="">
               </div>
             </td>
             <td class="menu-wrapper">
@@ -235,7 +235,7 @@
               <div class="editable-text">
                 <span class="edit-text-button" tabindex="-1" role="button">The Filling
                   Station</span>
-                <input class="edit-text-input hidden" tabindex="-1" value="" />
+                <input class="edit-text-input hidden" tabindex="-1" value="">
               </div>
             </td>
             <td class="menu-wrapper">
@@ -259,7 +259,7 @@
               <div class="editable-text">
                 <span class="edit-text-button" tabindex="-1" role="button">Tinker's
                   Hardware</span>
-                <input class="edit-text-input hidden" tabindex="-1" value="" />
+                <input class="edit-text-input hidden" tabindex="-1" value="">
               </div>
             </td>
             <td class="menu-wrapper">
@@ -283,7 +283,7 @@
             <td>
               <div class="editable-text">
                 <span class="edit-text-button" tabindex="-1" role="button">Cutey's Salon</span>
-                <input class="edit-text-input hidden" tabindex="-1" value="" />
+                <input class="edit-text-input hidden" tabindex="-1" value="">
               </div>
             </td>
             <td class="menu-wrapper">
@@ -307,7 +307,7 @@
               <div class="editable-text">
                 <span class="edit-text-button" tabindex="-1" role="button">My Chocolate
                   Shop</span>
-                <input class="edit-text-input hidden" tabindex="-1" value="" />
+                <input class="edit-text-input hidden" tabindex="-1" value="">
               </div>
             </td>
             <td class="menu-wrapper">

--- a/examples/index.html
+++ b/examples/index.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
-<head>
-  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<html lang="en-US"><head>
+  <meta charset="UTF-8">
   <meta content="width=device-width, initial-scale=1.0" name="viewport">
   <title>Index of ARIA Design Pattern Examples | WAI-ARIA Authoring Practices 1.2</title>
   <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/base.css">

--- a/examples/landmarks/HTML5.html
+++ b/examples/landmarks/HTML5.html
@@ -3,18 +3,18 @@
   <head>
     <title>HTML Sectioning Elements: ARIA Landmarks Example</title>
     <meta charset="utf-8">
-    <link href="css/bootstrap.css" rel="stylesheet" media="screen"/>
-    <link href="css/bootstrap-theme.css" rel="stylesheet" media="screen"/>
-    <link href="css/bootstrap-accessibility.css" rel="stylesheet" media="screen"/>
-    <link href="css/visua11y.css" rel="stylesheet" media="screen"/>
-    <link href="css/common.css" rel="stylesheet" media="screen"/>
+    <link href="css/bootstrap.css" rel="stylesheet" media="screen">
+    <link href="css/bootstrap-theme.css" rel="stylesheet" media="screen">
+    <link href="css/bootstrap-accessibility.css" rel="stylesheet" media="screen">
+    <link href="css/visua11y.css" rel="stylesheet" media="screen">
+    <link href="css/common.css" rel="stylesheet" media="screen">
 
   </head>
   <body>
     <div class="container">
       <header class="row">
         <div id="skip-to-attach" class="col-xs-12 col-sm-3 col-md-3 col-lg-2">
-          <img src="images/w3c.png" alt="W3C Logo" style="margin-top: 2em" />
+          <img src="images/w3c.png" alt="W3C Logo" style="margin-top: 2em">
         </div>
         <div class="col-xs-12 col-sm-9 col-md-9 col-lg-10">
           <h1>ARIA Landmarks Example</h1>
@@ -152,7 +152,7 @@
     <script type="text/javascript" src="js/bootstrap-accessibility-2.js"></script>
     <script type="text/javascript" src="js/visua11y.js"></script>
     <script type="text/javascript" src="js/show.js"></script>
-    <script type="text/javascript" >
+    <script type="text/javascript">
       // Use the SkipTo defaults, but just showing custom configuration
       var SkipToConfig = {
         settings: {

--- a/examples/landmarks/at.html
+++ b/examples/landmarks/at.html
@@ -3,17 +3,17 @@
   <head>
     <title>Assistive Technology: ARIA Landmarks Example</title>
     <meta charset="utf-8">
-    <link href="css/bootstrap.css" rel="stylesheet" media="screen"/>
-    <link href="css/bootstrap-theme.css" rel="stylesheet" media="screen"/>
-    <link href="css/bootstrap-accessibility.css" rel="stylesheet" media="screen"/>
-    <link href="css/visua11y.css" rel="stylesheet" media="screen"/>
-    <link href="css/common.css" rel="stylesheet" media="screen"/>
+    <link href="css/bootstrap.css" rel="stylesheet" media="screen">
+    <link href="css/bootstrap-theme.css" rel="stylesheet" media="screen">
+    <link href="css/bootstrap-accessibility.css" rel="stylesheet" media="screen">
+    <link href="css/visua11y.css" rel="stylesheet" media="screen">
+    <link href="css/common.css" rel="stylesheet" media="screen">
   </head>
   <body>
     <div class="container">
       <header class="row">
         <div id="skip-to-attach" class="col-xs-12 col-sm-3 col-md-3 col-lg-2">
-          <img src="images/w3c.png" alt="W3C Logo" style="margin-top: 2em" />
+          <img src="images/w3c.png" alt="W3C Logo" style="margin-top: 2em">
         </div>
         <div class="col-xs-12 col-sm-9 col-md-9 col-lg-10">
           <h1>ARIA Landmarks Example</h1>
@@ -253,7 +253,7 @@
     <script type="text/javascript" src="js/bootstrap-accessibility-2.js"></script>
     <script type="text/javascript" src="js/visua11y.js"></script>
     <script type="text/javascript" src="js/show.js"></script>
-    <script type="text/javascript" >
+    <script type="text/javascript">
       // Use the SkipTo defaults, but just showing custom configuration
       var SkipToConfig = {
         settings: {

--- a/examples/landmarks/banner.html
+++ b/examples/landmarks/banner.html
@@ -3,17 +3,17 @@
   <head>
     <title>Banner Landmark: ARIA Landmarks Example</title>
     <meta charset="utf-8">
-    <link href="css/bootstrap.css" rel="stylesheet" media="screen"/>
-    <link href="css/bootstrap-theme.css" rel="stylesheet" media="screen"/>
-    <link href="css/bootstrap-accessibility.css" rel="stylesheet" media="screen"/>
-    <link href="css/visua11y.css" rel="stylesheet" media="screen"/>
-    <link href="css/common.css" rel="stylesheet" media="screen"/>
+    <link href="css/bootstrap.css" rel="stylesheet" media="screen">
+    <link href="css/bootstrap-theme.css" rel="stylesheet" media="screen">
+    <link href="css/bootstrap-accessibility.css" rel="stylesheet" media="screen">
+    <link href="css/visua11y.css" rel="stylesheet" media="screen">
+    <link href="css/common.css" rel="stylesheet" media="screen">
   </head>
   <body>
     <div class="container">
       <header class="row">
         <div id="skip-to-attach" class="col-xs-12 col-sm-3 col-md-3 col-lg-2">
-          <img src="images/w3c.png" alt="W3C Logo" style="margin-top: 2em" />
+          <img src="images/w3c.png" alt="W3C Logo" style="margin-top: 2em">
         </div>
         <div class="col-xs-12 col-sm-9 col-md-9 col-lg-10">
           <h1>ARIA Landmarks Example</h1>
@@ -85,7 +85,7 @@
                             <strong>&lt;/header&gt;</strong>
                   </div>
                 </div>
-                <div id="tabpanel1" aria-labelledby="tab1" role="tabpanel" class="tab-pane" >
+                <div id="tabpanel1" aria-labelledby="tab1" role="tabpanel" class="tab-pane">
                   <p>A <code>role="banner"</code> attribute is used to define a <code>banner</code> landmark.</p>
                   <h3>ARIA Example</h3>
                   <div class="code">
@@ -147,7 +147,7 @@
     <script type="text/javascript" src="js/bootstrap-accessibility-2.js"></script>
     <script type="text/javascript" src="js/visua11y.js"></script>
     <script type="text/javascript" src="js/show.js"></script>
-    <script type="text/javascript" >
+    <script type="text/javascript">
       // Use the SkipTo defaults, but just showing custom configuration
       var SkipToConfig = {
         settings: {

--- a/examples/landmarks/complementary.html
+++ b/examples/landmarks/complementary.html
@@ -3,17 +3,17 @@
   <head>
     <title>Complementary Landmark: ARIA Landmarks Example</title>
     <meta charset="utf-8">
-    <link href="css/bootstrap.css" rel="stylesheet" media="screen"/>
-    <link href="css/bootstrap-theme.css" rel="stylesheet" media="screen"/>
-    <link href="css/bootstrap-accessibility.css" rel="stylesheet" media="screen"/>
-    <link href="css/visua11y.css" rel="stylesheet" media="screen"/>
-    <link href="css/common.css" rel="stylesheet" media="screen"/>
+    <link href="css/bootstrap.css" rel="stylesheet" media="screen">
+    <link href="css/bootstrap-theme.css" rel="stylesheet" media="screen">
+    <link href="css/bootstrap-accessibility.css" rel="stylesheet" media="screen">
+    <link href="css/visua11y.css" rel="stylesheet" media="screen">
+    <link href="css/common.css" rel="stylesheet" media="screen">
   </head>
   <body>
     <div class="container">
       <header class="row">
         <div id="skip-to-attach" class="col-xs-12 col-sm-3 col-md-3 col-lg-2">
-          <img src="images/w3c.png" alt="W3C Logo" style="margin-top: 2em" />
+          <img src="images/w3c.png" alt="W3C Logo" style="margin-top: 2em">
         </div>
         <div class="col-xs-12 col-sm-9 col-md-9 col-lg-10">
           <h1>ARIA Landmarks Example</h1>
@@ -209,7 +209,7 @@
     <script type="text/javascript" src="js/bootstrap-accessibility-2.js"></script>
     <script type="text/javascript" src="js/visua11y.js"></script>
     <script type="text/javascript" src="js/show.js"></script>
-    <script type="text/javascript" >
+    <script type="text/javascript">
       // Use the SkipTo defaults, except just show h1 and h2 headings
       var SkipToConfig = {
         settings: {

--- a/examples/landmarks/contentinfo.html
+++ b/examples/landmarks/contentinfo.html
@@ -3,17 +3,17 @@
   <head>
     <title>Contentinfo Landmark: ARIA Landmarks Example</title>
     <meta charset="utf-8">
-    <link href="css/bootstrap.css" rel="stylesheet" media="screen"/>
-    <link href="css/bootstrap-theme.css" rel="stylesheet" media="screen"/>
-    <link href="css/bootstrap-accessibility.css" rel="stylesheet" media="screen"/>
-    <link href="css/visua11y.css" rel="stylesheet" media="screen"/>
-    <link href="css/common.css" rel="stylesheet" media="screen"/>
+    <link href="css/bootstrap.css" rel="stylesheet" media="screen">
+    <link href="css/bootstrap-theme.css" rel="stylesheet" media="screen">
+    <link href="css/bootstrap-accessibility.css" rel="stylesheet" media="screen">
+    <link href="css/visua11y.css" rel="stylesheet" media="screen">
+    <link href="css/common.css" rel="stylesheet" media="screen">
   </head>
   <body>
     <div class="container">
       <header class="row">
         <div id="skip-to-attach" class="col-xs-12 col-sm-3 col-md-3 col-lg-2">
-          <img src="images/w3c.png" alt="W3C Logo" style="margin-top: 2em" />
+          <img src="images/w3c.png" alt="W3C Logo" style="margin-top: 2em">
         </div>
         <div class="col-xs-12 col-sm-9 col-md-9 col-lg-10">
           <h1>ARIA Landmarks Example</h1>
@@ -152,7 +152,7 @@
     <script type="text/javascript" src="js/bootstrap-accessibility-2.js"></script>
     <script type="text/javascript" src="js/visua11y.js"></script>
     <script type="text/javascript" src="js/show.js"></script>
-    <script type="text/javascript" >
+    <script type="text/javascript">
       // Use the SkipTo defaults, but just showing custom configuration
       var SkipToConfig = {
         settings: {

--- a/examples/landmarks/form.html
+++ b/examples/landmarks/form.html
@@ -143,26 +143,26 @@
                   <div class="code">
 
                     &nbsp;&nbsp;&lt;<strong>form aria-labelledby="contact"</strong>&gt;
-                    <br/>
+                    <br>
                     &nbsp;&nbsp;&nbsp;&nbsp;&lt;fieldset&gt;<br>
-                    <br/>
+                    <br>
                     &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&lt;legend <strong>id="contact"</strong>&gt;Add Contact &lt;/legend&gt;
-                    <br/>
-                    <br/>
+                    <br>
+                    <br>
                     &nbsp;&nbsp;&nbsp;&nbsp;... <em>form controls add contact</em> ...
-                    <br/>
-                    <br/>
+                    <br>
+                    <br>
                     &nbsp;&nbsp;&nbsp;&nbsp;&lt;/fieldset&gt;
-                    <br/>
+                    <br>
                     &nbsp;&nbsp;&lt;<strong>/form</strong>&gt;
-                    <br/>
-                    <br/> &nbsp;&nbsp;...............
-                    <br/>
-                    <br/>
+                    <br>
+                    <br> &nbsp;&nbsp;...............
+                    <br>
+                    <br>
                     &nbsp;&nbsp;&lt;<strong>form aria-labelledby="organization"</strong>&gt;
-                    <br/>
+                    <br>
                     &nbsp;&nbsp;&nbsp;&nbsp;&lt;fieldset&gt;<br>
-                    <br/>
+                    <br>
                     &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&lt;legend <strong>id="organization"</strong>&gt;Add Organization &lt;/legend&gt;
                     <br>
                     <br>
@@ -221,26 +221,26 @@
                   <div class="code">
 
                     &nbsp;&nbsp;&lt;div <strong>role="form" aria-labelledby="contact"</strong>&gt;
-                    <br/>
+                    <br>
                     &nbsp;&nbsp;&nbsp;&nbsp;&lt;fieldset&gt;<br>
-                    <br/>
+                    <br>
                     &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&lt;legend <strong>id="contact"</strong>&gt;Add Contact &lt;/legend&gt;
-                    <br/>
-                    <br/>
+                    <br>
+                    <br>
                     &nbsp;&nbsp;&nbsp;&nbsp;... <em>form controls add contact</em> ...
-                    <br/>
-                    <br/>
+                    <br>
+                    <br>
                     &nbsp;&nbsp;&nbsp;&nbsp;&lt;/fieldset&gt;
-                    <br/>
+                    <br>
                     &nbsp;&nbsp;&lt;/div&gt;
-                    <br/>
-                    <br/> &nbsp;&nbsp;...............
-                    <br/>
-                    <br/>
+                    <br>
+                    <br> &nbsp;&nbsp;...............
+                    <br>
+                    <br>
                     &nbsp;&nbsp;&lt;div <strong>role="form" aria-labelledby="organization"</strong>&gt;
-                    <br/>
+                    <br>
                     &nbsp;&nbsp;&nbsp;&nbsp;&lt;fieldset&gt;<br>
-                    <br/>
+                    <br>
                     &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&lt;legend <strong>id="organization"</strong>&gt;Add Organization &lt;/legend&gt;
                     <br>
                     <br>

--- a/examples/landmarks/form.html
+++ b/examples/landmarks/form.html
@@ -3,11 +3,11 @@
   <head>
     <title>Form Landmark: ARIA Landmarks Example</title>
     <meta charset="utf-8">
-    <link href="css/bootstrap.css" rel="stylesheet" media="screen"/>
-    <link href="css/bootstrap-theme.css" rel="stylesheet" media="screen"/>
-    <link href="css/bootstrap-accessibility.css" rel="stylesheet" media="screen"/>
-    <link href="css/visua11y.css" rel="stylesheet" media="screen"/>
-    <link href="css/common.css" rel="stylesheet" media="screen"/>
+    <link href="css/bootstrap.css" rel="stylesheet" media="screen">
+    <link href="css/bootstrap-theme.css" rel="stylesheet" media="screen">
+    <link href="css/bootstrap-accessibility.css" rel="stylesheet" media="screen">
+    <link href="css/visua11y.css" rel="stylesheet" media="screen">
+    <link href="css/common.css" rel="stylesheet" media="screen">
     <style>
       label,
       input[type=submit] {
@@ -45,7 +45,7 @@
     <div class="container">
       <header class="row">
         <div id="skip-to-attach" class="col-xs-12 col-sm-3 col-md-3 col-lg-2">
-          <img src="images/w3c.png" alt="W3C Logo" style="margin-top: 2em" />
+          <img src="images/w3c.png" alt="W3C Logo" style="margin-top: 2em">
         </div>
         <div class="col-xs-12 col-sm-9 col-md-9 col-lg-10">
           <h1>ARIA Landmarks Example</h1>
@@ -305,7 +305,7 @@
     <script type="text/javascript" src="js/bootstrap-accessibility-2.js"></script>
     <script type="text/javascript" src="js/visua11y.js"></script>
     <script type="text/javascript" src="js/show.js"></script>
-    <script type="text/javascript" >
+    <script type="text/javascript">
       // Use the SkipTo defaults, but just showing custom configuration
       var SkipToConfig = {
         settings: {

--- a/examples/landmarks/index.html
+++ b/examples/landmarks/index.html
@@ -3,17 +3,17 @@
   <head>
     <title>General Principles: Principles: ARIA Landmarks Example</title>
     <meta charset="utf-8">
-    <link href="css/bootstrap.css" rel="stylesheet" media="screen"/>
-    <link href="css/bootstrap-theme.css" rel="stylesheet" media="screen"/>
-    <link href="css/bootstrap-accessibility.css" rel="stylesheet" media="screen"/>
-    <link href="css/visua11y.css" rel="stylesheet" media="screen"/>
-    <link href="css/common.css" rel="stylesheet" media="screen"/>
+    <link href="css/bootstrap.css" rel="stylesheet" media="screen">
+    <link href="css/bootstrap-theme.css" rel="stylesheet" media="screen">
+    <link href="css/bootstrap-accessibility.css" rel="stylesheet" media="screen">
+    <link href="css/visua11y.css" rel="stylesheet" media="screen">
+    <link href="css/common.css" rel="stylesheet" media="screen">
   </head>
   <body>
     <div class="container">
       <header class="row">
         <div id="skip-to-attach" class="col-xs-12 col-sm-3 col-md-3 col-lg-2">
-          <img src="images/w3c.png" alt="W3C Logo" style="margin-top: 2em"/>
+          <img src="images/w3c.png" alt="W3C Logo" style="margin-top: 2em">
         </div>
         <div class="col-xs-12 col-sm-9 col-md-9 col-lg-10">
           <h1>ARIA Landmarks Example</h1>
@@ -147,7 +147,7 @@
     <script type="text/javascript" src="js/bootstrap-accessibility-2.js"></script>
     <script type="text/javascript" src="js/visua11y.js"></script>
     <script type="text/javascript" src="js/show.js"></script>
-    <script type="text/javascript" >
+    <script type="text/javascript">
       // Use the SkipTo defaults, but just showing custom configuration
       var SkipToConfig = {
         settings: {

--- a/examples/landmarks/main.html
+++ b/examples/landmarks/main.html
@@ -3,18 +3,18 @@
   <head>
     <title>Main Landmark: ARIA Landmarks Example</title>
     <meta charset="utf-8">
-    <link href="css/bootstrap.css" rel="stylesheet" media="screen"/>
-    <link href="css/bootstrap-theme.css" rel="stylesheet" media="screen"/>
-    <link href="css/bootstrap-accessibility.css" rel="stylesheet" media="screen"/>
-    <link href="css/bootstrap-accessibility.css" rel="stylesheet" media="screen"/>
-    <link href="css/visua11y.css" rel="stylesheet" media="screen"/>
-    <link href="css/common.css" rel="stylesheet" media="screen"/>
+    <link href="css/bootstrap.css" rel="stylesheet" media="screen">
+    <link href="css/bootstrap-theme.css" rel="stylesheet" media="screen">
+    <link href="css/bootstrap-accessibility.css" rel="stylesheet" media="screen">
+    <link href="css/bootstrap-accessibility.css" rel="stylesheet" media="screen">
+    <link href="css/visua11y.css" rel="stylesheet" media="screen">
+    <link href="css/common.css" rel="stylesheet" media="screen">
   </head>
   <body>
     <div class="container">
       <header class="row">
         <div id="skip-to-attach" class="col-xs-12 col-sm-3 col-md-3 col-lg-2">
-          <img src="images/w3c.png" alt="W3C Logo" style="margin-top: 2em" />
+          <img src="images/w3c.png" alt="W3C Logo" style="margin-top: 2em">
         </div>
         <div class="col-xs-12 col-sm-9 col-md-9 col-lg-10">
           <h1>ARIA Landmarks Example</h1>
@@ -207,7 +207,7 @@
     <script type="text/javascript" src="js/bootstrap-accessibility-2.js"></script>
     <script type="text/javascript" src="js/visua11y.js"></script>
     <script type="text/javascript" src="js/show.js"></script>
-    <script type="text/javascript" >
+    <script type="text/javascript">
       // Use the SkipTo defaults, but just showing custom configuration
       var SkipToConfig = {
         settings: {

--- a/examples/landmarks/navigation.html
+++ b/examples/landmarks/navigation.html
@@ -3,17 +3,17 @@
   <head>
     <title>Navigation Landmark: ARIA Landmark Example</title>
     <meta charset="utf-8">
-    <link href="css/bootstrap.css" rel="stylesheet" media="screen"/>
-    <link href="css/bootstrap-theme.css" rel="stylesheet" media="screen"/>
-    <link href="css/bootstrap-accessibility.css" rel="stylesheet" media="screen"/>
-    <link href="css/visua11y.css" rel="stylesheet" media="screen"/>
-    <link href="css/common.css" rel="stylesheet" media="screen"/>
+    <link href="css/bootstrap.css" rel="stylesheet" media="screen">
+    <link href="css/bootstrap-theme.css" rel="stylesheet" media="screen">
+    <link href="css/bootstrap-accessibility.css" rel="stylesheet" media="screen">
+    <link href="css/visua11y.css" rel="stylesheet" media="screen">
+    <link href="css/common.css" rel="stylesheet" media="screen">
   </head>
   <body>
     <div class="container">
       <header class="row">
         <div id="skip-to-attach" class="col-xs-12 col-sm-3 col-md-3 col-lg-2">
-          <img src="images/w3c.png" alt="W3C Logo" style="margin-top: 2em" />
+          <img src="images/w3c.png" alt="W3C Logo" style="margin-top: 2em">
         </div>
         <div class="col-xs-12 col-sm-9 col-md-9 col-lg-10">
           <h1>ARIA Landmark Example</h1>
@@ -220,7 +220,7 @@
     <script type="text/javascript" src="js/bootstrap-accessibility-2.js"></script>
     <script type="text/javascript" src="js/visua11y.js"></script>
     <script type="text/javascript" src="js/show.js"></script>
-    <script type="text/javascript" >
+    <script type="text/javascript">
       // Use the SkipTo defaults, but just showing custom configuration
       var SkipToConfig = {
         settings: {

--- a/examples/landmarks/region.html
+++ b/examples/landmarks/region.html
@@ -3,17 +3,17 @@
   <head>
     <title>Region Landmark: ARIA Landmarks Example</title>
     <meta charset="utf-8">
-    <link href="css/bootstrap.css" rel="stylesheet" media="screen"/>
-    <link href="css/bootstrap-theme.css" rel="stylesheet" media="screen"/>
-    <link href="css/bootstrap-accessibility.css" rel="stylesheet" media="screen"/>
-    <link href="css/visua11y.css" rel="stylesheet" media="screen"/>
-    <link href="css/common.css" rel="stylesheet" media="screen"/>
+    <link href="css/bootstrap.css" rel="stylesheet" media="screen">
+    <link href="css/bootstrap-theme.css" rel="stylesheet" media="screen">
+    <link href="css/bootstrap-accessibility.css" rel="stylesheet" media="screen">
+    <link href="css/visua11y.css" rel="stylesheet" media="screen">
+    <link href="css/common.css" rel="stylesheet" media="screen">
   </head>
   <body>
     <div class="container">
       <header class="row">
         <div id="skip-to-attach" class="col-xs-12 col-sm-3 col-md-3 col-lg-2">
-          <img src="images/w3c.png" alt="W3C Logo" style="margin-top: 2em" />
+          <img src="images/w3c.png" alt="W3C Logo" style="margin-top: 2em">
         </div>
         <div class="col-xs-12 col-sm-9 col-md-9 col-lg-10">
           <h1>ARIA Landmarks Example</h1>
@@ -256,7 +256,7 @@
     <script type="text/javascript" src="js/bootstrap-accessibility-2.js"></script>
     <script type="text/javascript" src="js/visua11y.js"></script>
     <script type="text/javascript" src="js/show.js"></script>
-    <script type="text/javascript" >
+    <script type="text/javascript">
       // Use the SkipTo defaults, but just showing custom configuration
       var SkipToConfig = {
         settings: {

--- a/examples/landmarks/resources.html
+++ b/examples/landmarks/resources.html
@@ -4,17 +4,17 @@
    <title>Resources: ARIA Landmarks Example</title>
     <meta charset="utf-8">
 
-      <link href="css/bootstrap.css" rel="stylesheet" media="screen"/>
-      <link href="css/bootstrap-theme.css" rel="stylesheet" media="screen"/>
-      <link href="css/bootstrap-accessibility.css" rel="stylesheet" media="screen"/>
-      <link href="css/visua11y.css" rel="stylesheet" media="screen"/>
-      <link href="css/common.css" rel="stylesheet" media="screen"/>
+      <link href="css/bootstrap.css" rel="stylesheet" media="screen">
+      <link href="css/bootstrap-theme.css" rel="stylesheet" media="screen">
+      <link href="css/bootstrap-accessibility.css" rel="stylesheet" media="screen">
+      <link href="css/visua11y.css" rel="stylesheet" media="screen">
+      <link href="css/common.css" rel="stylesheet" media="screen">
     </head>
     <body>
         <div class="container">
              <header class="row">
                 <div id="skip-to-attach" class="col-xs-12 col-sm-3 col-md-3 col-lg-2">
-                  <img src="images/w3c.png" alt="W3C Logo" style="margin-top: 2em" />
+                  <img src="images/w3c.png" alt="W3C Logo" style="margin-top: 2em">
                 </div>
                 <div class="col-xs-12 col-sm-9 col-md-9 col-lg-10">
                   <h1>ARIA Landmarks Example</h1>
@@ -128,7 +128,7 @@
         <script type="text/javascript" src="js/show.js"></script>
 
 
-        <script type="text/javascript" >
+        <script type="text/javascript">
             // Use the SkipTo defaults, but just showing custom configuration
             var SkipToConfig = {
               settings: {

--- a/examples/landmarks/search.html
+++ b/examples/landmarks/search.html
@@ -3,17 +3,17 @@
   <head>
     <title>Search Landmark: ARIA Landmarks Example</title>
     <meta charset="utf-8">
-    <link href="css/bootstrap.css" rel="stylesheet" media="screen"/>
-    <link href="css/bootstrap-theme.css" rel="stylesheet" media="screen"/>
-    <link href="css/bootstrap-accessibility.css" rel="stylesheet" media="screen"/>
-    <link href="css/visua11y.css" rel="stylesheet" media="screen"/>
-    <link href="css/common.css" rel="stylesheet" media="screen"/>
+    <link href="css/bootstrap.css" rel="stylesheet" media="screen">
+    <link href="css/bootstrap-theme.css" rel="stylesheet" media="screen">
+    <link href="css/bootstrap-accessibility.css" rel="stylesheet" media="screen">
+    <link href="css/visua11y.css" rel="stylesheet" media="screen">
+    <link href="css/common.css" rel="stylesheet" media="screen">
   </head>
   <body>
     <div class="container">
       <header class="row">
         <div id="skip-to-attach" class="col-xs-12 col-sm-3 col-md-3 col-lg-2">
-          <img src="images/w3c.png" alt="W3C Logo" style="margin-top: 2em" />
+          <img src="images/w3c.png" alt="W3C Logo" style="margin-top: 2em">
         </div>
         <div class="col-xs-12 col-sm-9 col-md-9 col-lg-10">
           <h1>ARIA Landmarks Example</h1>
@@ -139,7 +139,7 @@
     <script type="text/javascript" src="js/bootstrap-accessibility-2.js"></script>
     <script type="text/javascript" src="js/visua11y.js"></script>
     <script type="text/javascript" src="js/show.js"></script>
-    <script type="text/javascript" >
+    <script type="text/javascript">
       // Use the SkipTo defaults, but just showing custom configuration
       var SkipToConfig = {
         settings: {

--- a/examples/link/link.html
+++ b/examples/link/link.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<meta charset="utf-8" />
+<meta charset="utf-8">
 
 <title>Link Examples | WAI-ARIA Authoring Practices 1.2</title>
 

--- a/examples/link/link.html
+++ b/examples/link/link.html
@@ -150,7 +150,7 @@
         <tr data-test-id="tabindex">
           <td></td>
           <th scope="row"><code>tabindex=&quot;0&quot;</code></th>
-          <td><code>span</code>, <br/><code>img</code></td>
+          <td><code>span</code>, <br><code>img</code></td>
           <td>Includes the link element in the page tab sequence.</td>
         </tr>
         <tr data-test-id="alt">

--- a/examples/listbox/listbox-collapsible.html
+++ b/examples/listbox/listbox-collapsible.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<meta charset="utf-8" />
+<meta charset="utf-8">
 <title>(Deprecated) Collapsible Dropdown Listbox Example | WAI-ARIA Authoring Practices 1.2</title>
 
 <!--  Core js and css shared by all examples; do not modify when using this template. -->

--- a/examples/listbox/listbox-grouped.html
+++ b/examples/listbox/listbox-grouped.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<meta charset="utf-8" />
+<meta charset="utf-8">
 <title>Listbox Example with Grouped Options | WAI-ARIA Authoring Practices 1.2</title>
 
 <!--  Core js and css shared by all examples; do not modify when using this template. -->

--- a/examples/listbox/listbox-rearrangeable.html
+++ b/examples/listbox/listbox-rearrangeable.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<meta charset="utf-8" />
+<meta charset="utf-8">
 <title>Example Listboxes with Rearrangeable Options | WAI-ARIA Authoring Practices 1.2</title>
 
 <!--  Core js and css shared by all examples; do not modify when using this template. -->

--- a/examples/listbox/listbox-scrollable.html
+++ b/examples/listbox/listbox-scrollable.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<meta charset="utf-8" />
+<meta charset="utf-8">
 <title>Scrollable Listbox Example | WAI-ARIA Authoring Practices 1.2</title>
 
 <!--  Core js and css shared by all examples; do not modify when using this template. -->

--- a/examples/menu-button/menu-button-actions-active-descendant.html
+++ b/examples/menu-button/menu-button-actions-active-descendant.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html lang="en"><head>
-    <meta http-equiv="content-type" content="text/html; charset=UTF-8">
+    <meta charset="UTF-8">
     <title>Actions Menu Button Example Using aria-activedescendant | WAI-ARIA Authoring Practices 1.2</title>
 
     <!--  Core js and css shared by all examples; do not modify when using this template. -->

--- a/examples/menu-button/menu-button-actions.html
+++ b/examples/menu-button/menu-button-actions.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html lang="en"><head>
-    <meta http-equiv="content-type" content="text/html; charset=UTF-8">
+    <meta charset="UTF-8">
     <title>Actions Menu Button Example Using element.focus() | WAI-ARIA Authoring Practices 1.2</title>
 
     <!--  Core js and css shared by all examples; do not modify when using this template. -->

--- a/examples/menu-button/menu-button-links.html
+++ b/examples/menu-button/menu-button-links.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <meta http-equiv="content-type" content="text/html; charset=UTF-8">
+    <meta charset="UTF-8">
     <title>Navigation Menu Button Example | WAI-ARIA Authoring Practices 1.2</title>
 
     <!--  Core js and css shared by all examples; do not modify when using this template. -->

--- a/examples/menubar/menubar-editor.html
+++ b/examples/menubar/menubar-editor.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta http-equiv="content-type" content="text/html; charset=UTF-8">
+  <meta charset="UTF-8">
   <title>Editor Menubar Example | WAI-ARIA Authoring Practices 1.2</title>
 
   <!--  Core js and css shared by all examples; do not modify when using this template. -->
@@ -51,7 +51,7 @@
         <ul role="menubar" aria-label="Text Formatting">
           <li role="none">
             <span role="menuitem" aria-haspopup="true" aria-expanded="false" tabindex="0">Font<span aria-hidden="true"></span></span>
-            <ul role="menu" data-option="font-family" aria-label="Font" >
+            <ul role="menu" data-option="font-family" aria-label="Font">
               <li role="menuitemradio" aria-checked="true"><span aria-hidden="true"></span>Sans-serif</li>
               <li role="menuitemradio" aria-checked="false"><span aria-hidden="true"></span>Serif</li>
               <li role="menuitemradio" aria-checked="false"><span aria-hidden="true"></span>Monospace</li>
@@ -100,7 +100,7 @@
 
           <li role="none">
             <span role="menuitem" aria-haspopup="true" aria-expanded="false" tabindex="-1">Size<span aria-hidden="true"></span></span>
-            <ul role="menu" aria-label="Size" >
+            <ul role="menu" aria-label="Size">
               <li role="menuitem" data-option="font-smaller" aria-disabled="false">Smaller</li>
               <li role="menuitem" data-option="font-larger"  aria-disabled="false">Larger</li>
               <li role="separator"></li>
@@ -133,7 +133,7 @@
 
 
     </div>
-    <div role="separator" id="ex1_end_sep" aria-labelledby="ex1_end_sep ex1_label" aria-label="End of" ></div>
+    <div role="separator" id="ex1_end_sep" aria-labelledby="ex1_end_sep ex1_label" aria-label="End of"></div>
   </section>
 
   <section>
@@ -853,9 +853,9 @@
 
   <section>
     <h2 id="sc1_label">HTML Source Code</h2>
-    <div id="sc1_start_sep" role="separator" aria-labelledby="sc1_start_sep sc1_label" aria-label="Start of" ></div>
+    <div id="sc1_start_sep" role="separator" aria-labelledby="sc1_start_sep sc1_label" aria-label="Start of"></div>
     <pre><code id="sc1"></code></pre>
-    <div id="sc1_end_sep" role="separator" aria-labelledby="sc1_end_sep sc1_label" aria-label="End of" ></div>
+    <div id="sc1_end_sep" role="separator" aria-labelledby="sc1_end_sep sc1_label" aria-label="End of"></div>
     <script>
       sourceCode.add('sc1', 'ex1', 'ex1_label', 'css_js_files');
       sourceCode.make();

--- a/examples/menubar/menubar-navigation.html
+++ b/examples/menubar/menubar-navigation.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta http-equiv="content-type" content="text/html; charset=UTF-8">
+  <meta charset="UTF-8">
   <title>Navigation Menubar Example | WAI-ARIA Authoring Practices 1.2</title>
 
   <!--  Core js and css shared by all examples; do not modify when using this template. -->

--- a/examples/radio/radio-activedescendant.html
+++ b/examples/radio/radio-activedescendant.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
   <html lang="en">
   <head>
-    <meta charset="utf-8" />
+    <meta charset="utf-8">
     <title>Radio Group Example Using aria-activedescendant | WAI-ARIA Authoring Practices 1.2</title>
 
     <!--  Core js and css shared by all examples; do not modify when using this template. -->

--- a/examples/radio/radio-activedescendant.html
+++ b/examples/radio/radio-activedescendant.html
@@ -159,7 +159,7 @@
               </td>
             </tr>
             <tr data-test-id="key-down-right-arrow">
-              <th><kbd>Down arrow</kbd><br/><kbd>Right arrow</kbd></th>
+              <th><kbd>Down arrow</kbd><br><kbd>Right arrow</kbd></th>
               <td>
                 <ul>
                   <li>Moves focus to and checks the next <code>radio</code> button in the group.</li>
@@ -169,7 +169,7 @@
               </td>
             </tr>
             <tr data-test-id="key-up-left-arrow">
-              <th><kbd>Up arrow</kbd><br/><kbd>Left arrow</kbd></th>
+              <th><kbd>Up arrow</kbd><br><kbd>Left arrow</kbd></th>
               <td>
                 <ul>
                   <li>Moves focus to and checks the previous <code>radio</code> button in the group.</li>

--- a/examples/radio/radio-rating.html
+++ b/examples/radio/radio-rating.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="utf-8" />
+  <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Rating Radio Group Example | WAI-ARIA Authoring Practices 1.2</title>
 
@@ -38,7 +38,7 @@
       <li><a href="radio-activedescendant.html">Radio Group Example Using aria-activedescendant</a>: Radio button group that uses <code>aria-activedescendant</code> for managing keyboard focus.</li>
       <li><a href="radio.html">Radio Group Example Using Roving tabindex</a>: A radio button group that uses roving <code>tabindex</code> for managing keyboard focus.</li>
     </ul>
-    
+
     <section>
       <div class="example-header">
         <h2 id="ex_label">Example</h2>
@@ -137,7 +137,7 @@
             </td>
           </tr>
           <tr data-test-id="key-down-right-arrow">
-            <th><kbd>Down arrow</kbd><br/><kbd>Right arrow</kbd></th>
+            <th><kbd>Down arrow</kbd><br><kbd>Right arrow</kbd></th>
             <td>
               <ul>
                 <li>Moves focus to and checks the next <code>radio</code> button in the group.</li>
@@ -147,7 +147,7 @@
             </td>
           </tr>
           <tr data-test-id="key-up-left-arrow">
-            <th><kbd>Up arrow</kbd><br/><kbd>Left arrow</kbd></th>
+            <th><kbd>Up arrow</kbd><br><kbd>Left arrow</kbd></th>
             <td>
               <ul>
                 <li>Moves focus to and checks the previous <code>radio</code> button in the group.</li>

--- a/examples/radio/radio.html
+++ b/examples/radio/radio.html
@@ -131,7 +131,7 @@
               </td>
             </tr>
             <tr data-test-id="key-down-right-arrow">
-              <th><kbd>Down arrow</kbd><br/><kbd>Right arrow</kbd></th>
+              <th><kbd>Down arrow</kbd><br><kbd>Right arrow</kbd></th>
               <td>
                 <ul>
                   <li>Moves focus to and checks the next <code>radio</code> button in the group.</li>
@@ -141,7 +141,7 @@
               </td>
             </tr>
             <tr data-test-id="key-up-left-arrow">
-              <th><kbd>Up arrow</kbd><br/><kbd>Left arrow</kbd></th>
+              <th><kbd>Up arrow</kbd><br><kbd>Left arrow</kbd></th>
               <td>
                 <ul>
                   <li>Moves focus to and checks the previous <code>radio</code> button in the group.</li>

--- a/examples/radio/radio.html
+++ b/examples/radio/radio.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
   <html lang="en">
   <head>
-    <meta charset="utf-8" />
+    <meta charset="utf-8">
     <title>Radio Group Example Using Roving tabindex | WAI-ARIA Authoring Practices 1.2</title>
 
     <!--  Core js and css shared by all examples; do not modify when using this template. -->

--- a/examples/slider/slider-color-viewer.html
+++ b/examples/slider/slider-color-viewer.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="utf-8" />
+  <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Color Viewer Slider Example | WAI-ARIA Authoring Practices 1.2</title>
 

--- a/examples/slider/slider-multithumb.html
+++ b/examples/slider/slider-multithumb.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <meta charset="utf-8" />
+    <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Horizontal Multi-Thumb Slider Example | WAI-ARIA Authoring Practices 1.2</title>
     <!--  Core js and css shared by all examples; do not modify when using this template. -->

--- a/examples/slider/slider-rating.html
+++ b/examples/slider/slider-rating.html
@@ -120,7 +120,7 @@
           For example, the color of the star borders is set to match the foreground color of  high contrast mode text by specifying the CSS <code>currentColor</code> value for the <code>stroke</code> property of each inline SVG <code>polygon</code> element.
           To enable the high contrast background color to be the used as the contrasting color when a star is not fully or partially filled, the <code>fill-opacity</code> attribute of the <code>polygon</code> is set to zero.
           If specific colors were used to specify the <code>stroke</code> and <code>fill</code> properties, the color of these elements would remain the same in high contrast mode, which could lead to insufficient contrast between them and their background or even make them invisible if their color were to match the high contrast mode background.
-          <br/>Note: The SVG element needs to have the CSS <code>forced-color-adjust</code> property set to the value <code>auto</code> for the <code>currentColor</code> value to be updated in high contrast modes.
+          <br>Note: The SVG element needs to have the CSS <code>forced-color-adjust</code> property set to the value <code>auto</code> for the <code>currentColor</code> value to be updated in high contrast modes.
           Some browsers do not use <code>auto</code> for the default value.
         </li>
       </ul>

--- a/examples/slider/slider-rating.html
+++ b/examples/slider/slider-rating.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="utf-8" />
+  <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Rating Slider Example | WAI-ARIA Authoring Practices 1.2</title>
 

--- a/examples/slider/slider-seek.html
+++ b/examples/slider/slider-seek.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="utf-8" />
+  <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
   <title>Media Seek Slider Example | WAI-ARIA Authoring Practices 1.2</title>

--- a/examples/slider/slider-temperature.html
+++ b/examples/slider/slider-temperature.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="utf-8" />
+  <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
   <title>Vertical Temperature Slider Example | WAI-ARIA Authoring Practices 1.2</title>
@@ -58,7 +58,7 @@
           <div id="id-temp-label" class="label">Temperature</div>
 
           <svg role="none" class="slider-group"  width="145" height="360">
-            <text class="temp-value" x="28" y="35" >25°C</text>
+            <text class="temp-value" x="28" y="35">25°C</text>
             <rect class="rail" x="60" y="47" width="8" height="300" rx="5"  aria-hidden="true"/>
             <g role="slider"
               id="id-temp-slider"

--- a/examples/spinbutton/datepicker-spinbuttons.html
+++ b/examples/spinbutton/datepicker-spinbuttons.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<meta charset="utf-8" />
+<meta charset="utf-8">
 <title>Date Picker Spin Button Example | WAI-ARIA Authoring Practices 1.2</title>
 
 <!--  Core js and css shared by all examples; do not modify when using this template. -->

--- a/examples/switch/switch-button.html
+++ b/examples/switch/switch-button.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="utf-8" />
+  <meta charset="utf-8">
   <title>Switch Example Using HTML Button | WAI-ARIA Authoring Practices 1.2</title>
 
   <!--  Core js and css shared by all examples; do not modify when using this template. -->
@@ -82,7 +82,7 @@
         <li>To help assistive technology users understand that the <q>Environmental Controls</q> are a group of two switches, the switches are wrapped in a <code>group</code> labeled by the heading that labels the set of switches.</li>
         <li>
           To make understanding the state of the switch easier for users with visual or cognitive disabilities, a text equivalent of the state (<q>on</q> or <q>off</q>) is displayed adjacent to the graphical state indicator.
-          CSS attribute selectors ensure the label displayed is synchronized with the value of the <code>aria-checked</code> attribute.<br/>
+          CSS attribute selectors ensure the label displayed is synchronized with the value of the <code>aria-checked</code> attribute.<br>
           <strong>NOTE:</strong> To prevent redundant announcement of the state by screen readers, the text indicators of state are hidden from assistive technologies with <code>aria-hidden</code>.
         </li>
         <li>Spacing, stroke widths, and fill are important to ensure the graphical states will be visible and discernible to people with visual impairments, including when browser or operating system high contrast settings are enabled:
@@ -102,7 +102,7 @@
           To ensure the SVG graphics have sufficient contrast with the background when high contrast settings invert colors, the CSS <code>currentColor</code> value for the <code>stroke</code> and <code>fill</code> properties is used to synchronize the colors with text content.
           If specific colors were used to specify the <code>stroke</code> and <code>fill</code> properties, the color of these elements would remain the same in high contrast mode, which could lead to insufficient contrast between them and their background or even make them invisible if their color were to match the high contrast mode background.
           The <code>fill-opacity</code> of the container <code>rect</code> is set to zero for the background color of the page to provide the contrasting color to the <code>stroke</code> and <code>fill</code> colors.
-          <br/>NOTE: The SVG elements need to set the CSS <code>forced-color-adjust</code> property to <code>auto</code> for some browsers to support the <code>currentColor</code> value.
+          <br>NOTE: The SVG elements need to set the CSS <code>forced-color-adjust</code> property to <code>auto</code> for some browsers to support the <code>currentColor</code> value.
         </li>
       </ul>
     </section>

--- a/examples/switch/switch.html
+++ b/examples/switch/switch.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="utf-8" />
+  <meta charset="utf-8">
   <title>Switch Example | WAI-ARIA Authoring Practices 1.2</title>
 
   <!--  Core js and css shared by all examples; do not modify when using this template. -->

--- a/examples/switch/switch.html
+++ b/examples/switch/switch.html
@@ -62,7 +62,7 @@
       <ul>
         <li>
           To make understanding the state of the switch easier for users with visual or cognitive disabilities, a text equivalent of the state (<q>on</q> or <q>off</q>) is displayed adjacent to the graphical state indicator.
-          CSS attribute selectors ensure the label displayed is synchronized with the value of the <code>aria-checked</code> attribute.<br/>
+          CSS attribute selectors ensure the label displayed is synchronized with the value of the <code>aria-checked</code> attribute.<br>
           <strong>NOTE:</strong> To prevent redundant announcement of the state by screen readers, the text indicators of state are hidden from assistive technologies with <code>aria-hidden</code>.
         </li>
         <li>Spacing, border widths and fill are important to ensure the graphical states are visible and discernible to people with visual impairments, including when browser or operating system high contrast settings are enabled:

--- a/examples/table/sortable-table.html
+++ b/examples/table/sortable-table.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<meta charset="utf-8" />
+<meta charset="utf-8">
 <title>Sortable Table Example | WAI-ARIA Authoring Practices 1.2</title>
 
 <!--  Core js and css shared by all examples; do not modify when using this template. -->

--- a/examples/table/table.html
+++ b/examples/table/table.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<meta charset="utf-8" />
+<meta charset="utf-8">
 <title>Table Example | WAI-ARIA Authoring Practices 1.2</title>
 
 <!--  Core js and css shared by all examples; do not modify when using this template. -->

--- a/examples/tabs/tabs-1/tabs.html
+++ b/examples/tabs/tabs-1/tabs.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <meta charset="utf-8" />
+    <meta charset="utf-8">
     <title>Example of Tabs with Automatic Activation | WAI-ARIA Authoring Practices 1.2</title>
 
     <!--  Core js and css shared by all examples; do not modify when using this template. -->

--- a/examples/tabs/tabs-2/tabs.html
+++ b/examples/tabs/tabs-2/tabs.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <meta charset="utf-8" />
+    <meta charset="utf-8">
     <title>Example of Tabs with Manual Activation | WAI-ARIA Authoring Practices 1.2</title>
 
     <!--  Core js and css shared by all examples; do not modify when using this template. -->

--- a/examples/toolbar/help.html
+++ b/examples/toolbar/help.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<meta charset="utf-8" />
+<meta charset="utf-8">
 <title>Toolbar Example | WAI-ARIA Authoring Practices 1.2</title>
 
 <!--  Core js and css shared by all examples; do not modify when using this template. -->

--- a/examples/toolbar/toolbar.html
+++ b/examples/toolbar/toolbar.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<meta charset="utf-8" />
+<meta charset="utf-8">
 <title>Toolbar Example | WAI-ARIA Authoring Practices 1.2</title>
 
 <!--  Core js and css shared by all examples; do not modify when using this template. -->
@@ -126,7 +126,7 @@
                 Cut
             </button>
           </div>
-          <div class="menu-popup group" >
+          <div class="menu-popup group">
             <button type="button"
               aria-haspopup="true"
               aria-controls="menu1"

--- a/examples/treegrid/treegrid-1.html
+++ b/examples/treegrid/treegrid-1.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<meta charset="utf-8" />
+<meta charset="utf-8">
 
 <title>Treegrid Email Inbox Example | WAI-ARIA Authoring Practices 1.2</title>
 

--- a/examples/treeview/treeview-1/treeview-1a.html
+++ b/examples/treeview/treeview-1/treeview-1a.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <meta http-equiv="content-type" content="text/html; charset=UTF-8">
+    <meta charset="UTF-8">
     <title>File Directory Treeview Example Using Computed Properties | WAI-ARIA Authoring Practices 1.2</title>
 
     <!--  Core js and css shared by all examples; do not modify when using this template. -->

--- a/examples/treeview/treeview-1/treeview-1b.html
+++ b/examples/treeview/treeview-1/treeview-1b.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <meta http-equiv="content-type" content="text/html; charset=UTF-8">
+    <meta charset="UTF-8">
     <title>File Directory Treeview Example Using Declared Properties | WAI-ARIA Authoring Practices 1.2</title>
 
     <!--  Core js and css shared by all examples; do not modify when using this template. -->

--- a/examples/treeview/treeview-navigation.html
+++ b/examples/treeview/treeview-navigation.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <meta http-equiv="content-type" content="text/html; charset=UTF-8">
+    <meta charset="UTF-8">
     <title>Navigation Treeview Example | WAI-ARIA Authoring Practices 1.2</title>
 
     <!--  Core js and css shared by all examples; do not modify when using this template. -->

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "fix": "npm run lint:es -- --fix && npm run lint:css -- --fix",
-    "htmlhint": "htmlhint \"aria-practices.html\" -i \"**/*.html\" \"**/*.template\" -i \"common/**/*.html\" -f unix",
+    "htmlhint": "htmlhint \"**/*.html\" \"**/*.template\" --ignore \"common/**/*.html\" --format unix",
     "lint": "npm run lint:es && npm run lint:css && npm run lint:html && npm run lint:spelling",
     "lint:css": "stylelint **/*.css",
     "lint:es": "eslint . --report-unused-disable-directives",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "fix": "npm run lint:es -- --fix && npm run lint:css -- --fix",
-    "htmlhint": "htmlhint \"**/*.html\" \"**/*.template\" -i \"common/**/*.html\" -f unix",
+    "htmlhint": "htmlhint \"aria-practices.html\" -i \"**/*.html\" \"**/*.template\" -i \"common/**/*.html\" -f unix",
     "lint": "npm run lint:es && npm run lint:css && npm run lint:html && npm run lint:spelling",
     "lint:css": "stylelint **/*.css",
     "lint:es": "eslint . --report-unused-disable-directives",

--- a/scripts/coverage-report.template
+++ b/scripts/coverage-report.template
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+<html lang="en-US">
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-  <meta content="width=device-width, initial-scale=1.0" name="viewport" />
+  <meta charset="UTF-8">
+  <meta content="width=device-width, initial-scale=1.0" name="viewport">
   <title>ARIA Roles, Properties and States Referenced in Guidance and Examples | WAI-ARIA Authoring Practices</title>
   <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/base.css">
   <link rel="stylesheet" href="css/core.css">

--- a/scripts/reference-tables.template
+++ b/scripts/reference-tables.template
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+<html lang="en-US">
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-  <meta content="width=device-width, initial-scale=1.0" name="viewport" />
+  <meta charset="UTF-8">
+  <meta content="width=device-width, initial-scale=1.0" name="viewport">
   <title>Index of ARIA Design Pattern Examples | WAI-ARIA Authoring Practices 1.2</title>
   <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/base.css">
   <link rel="stylesheet" href="css/core.css">


### PR DESCRIPTION
- `<meta charset="UTF-8">` https://github.com/w3c/aria-practices/wiki/Code-Guide#character-encoding
- "Don't include a trailing slash in self-closing elements—the HTML standard says they're optional." https://github.com/w3c/aria-practices/wiki/Code-Guide#syntax

I looked into adding a lint for `/>` with `htmlhint`, but it seems to not be implemented: https://github.com/htmlhint/HTMLHint/pull/337#issuecomment-951417418


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria-practices/pull/2069.html" title="Last updated on Nov 23, 2021, 1:06 AM UTC (edccb22)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria-practices/2069/93c9a26...edccb22.html" title="Last updated on Nov 23, 2021, 1:06 AM UTC (edccb22)">Diff</a>