### PR TITLE
Infrastructure: Move Depednabot updates weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,9 +3,9 @@ updates:
 - package-ecosystem: npm
   directory: "/"
   schedule:
-    interval: daily
+    interval: weekly
     time: "10:00"
-  open-pull-requests-limit: 10
+  open-pull-requests-limit: 99
   commit-message:
     prefix: "Infrastructure"
 - package-ecosystem: github-actions
@@ -13,6 +13,6 @@ updates:
   schedule:
     interval: daily
     time: "10:00"
-  open-pull-requests-limit: 10
+  open-pull-requests-limit: 99
   commit-message:
     prefix: "Infrastructure"


### PR DESCRIPTION
Removes the limit of 10, so some safe dependencies get PRs and
don't get stuck behind a list of 10 that might be harder to land.
Changes to a weekly schedule to at least there should be less
churn with the removed cap.