### PR TITLE
Infrastructure: Use npm cache in setup-node

### DIFF
--- a/.github/workflows/coverage-report.yml
+++ b/.github/workflows/coverage-report.yml
@@ -20,6 +20,11 @@ jobs:
         with:
           ref: refs/pull/${{ github.event.pull_request.number }}/head
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
+        with:
+          cache: npm
+
       - name: Install dependencies
         run: npm ci
 

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -23,6 +23,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
+        with:
+          cache: npm
+
       - name: Install dependencies
         run: npm ci
 

--- a/.github/workflows/lint-css.yml
+++ b/.github/workflows/lint-css.yml
@@ -29,7 +29,9 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set up Node.js
-        uses: actions/setup-node@v2.4.0
+        uses: actions/setup-node@v2
+        with:
+          cache: npm
 
       - uses: xt0rted/stylelint-problem-matcher@v1
 

--- a/.github/workflows/lint-html.yml
+++ b/.github/workflows/lint-html.yml
@@ -33,7 +33,9 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set up Node.js
-        uses: actions/setup-node@v2.4.0
+        uses: actions/setup-node@v2
+        with:
+          cache: npm
 
       - name: Install npm dependencies
         run: npm ci

--- a/.github/workflows/lint-js.yml
+++ b/.github/workflows/lint-js.yml
@@ -31,7 +31,9 @@ jobs:
       # setup-node task is used without a particular version in order to load
       # the ESLint problem matchers
       - name: Set up Node.js
-        uses: actions/setup-node@v2.4.0
+        uses: actions/setup-node@v2
+        with:
+          cache: npm
 
       - name: Install npm dependencies
         run: npm ci

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -35,7 +35,9 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v2.4.0
+        uses: actions/setup-node@v2
+        with:
+          cache: npm
 
       - name: Install npm dependencies
         run: npm ci

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -34,7 +34,9 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set up Node.js
-        uses: actions/setup-node@v2.4.0
+        uses: actions/setup-node@v2
+        with:
+          cache: npm
 
       - name: Install npm dependencies
         run: npm ci


### PR DESCRIPTION
- Add the action to all jobs using `npm ci`
- Unpin from a version to the main `@2` to avoid churn till the next major version