### PR TITLE
Fix a few minor accessibility issues

### DIFF
--- a/examples/feed/feedDisplay.html
+++ b/examples/feed/feedDisplay.html
@@ -16,7 +16,7 @@
 </head>
 <body>
   <main>
-    <h2>Recommended Restaurants</h2>
+    <h1>Recommended Restaurants</h1>
     <section id="main-content">
       <div id="restaurant-feed" role="feed">
       </div>

--- a/examples/landmarks/HTML5.html
+++ b/examples/landmarks/HTML5.html
@@ -26,7 +26,7 @@
       <div class="row">
         <div class="col-xs-12 col-sm-3 col-md-3 col-lg-2">
           <nav>
-            <ul class="nav nav-pills nav-stacked">
+            <ul class="nav nav-stacked">
               <li><a href="index.html">Principles</a></li>
               <li class="active"><a href="HTML5.html" aria-current="page">HTML</a></li>
               <li><a href="banner.html">Banner</a></li>

--- a/examples/landmarks/at.html
+++ b/examples/landmarks/at.html
@@ -25,7 +25,7 @@
       <div class="row">
         <div class="col-xs-12 col-sm-3 col-md-3 col-lg-2">
           <nav>
-            <ul class="nav nav-pills nav-stacked">
+            <ul class="nav nav-stacked">
               <li><a href="index.html">Principles</a></li>
               <li><a href="HTML5.html">HTML</a></li>
               <li><a href="banner.html">Banner</a></li>

--- a/examples/landmarks/banner.html
+++ b/examples/landmarks/banner.html
@@ -25,7 +25,7 @@
       <div class="row">
         <div class="col-xs-12 col-sm-3 col-md-3 col-lg-2">
           <nav>
-            <ul class="nav nav-pills nav-stacked">
+            <ul class="nav nav-stacked">
               <li><a href="index.html">Principles</a></li>
               <li><a href="HTML5.html">HTML</a></li>
               <li class="active"><a href="banner.html" aria-current="page">Banner</a></li>

--- a/examples/landmarks/complementary.html
+++ b/examples/landmarks/complementary.html
@@ -25,7 +25,7 @@
       <div class="row">
         <div class="col-xs-12 col-sm-3 col-md-3 col-lg-2">
           <nav>
-            <ul class="nav nav-pills nav-stacked">
+            <ul class="nav nav-stacked">
               <li><a href="index.html">Principles</a></li>
               <li><a href="HTML5.html">HTML</a></li>
               <li><a href="banner.html">Banner</a></li>

--- a/examples/landmarks/contentinfo.html
+++ b/examples/landmarks/contentinfo.html
@@ -25,7 +25,7 @@
       <div class="row">
         <div class="col-xs-12 col-sm-3 col-md-3 col-lg-2">
           <nav>
-            <ul class="nav nav-pills nav-stacked">
+            <ul class="nav nav-stacked">
               <li><a href="index.html">Principles</a></li>
               <li><a href="HTML5.html">HTML</a></li>
               <li><a href="banner.html">Banner</a></li>

--- a/examples/landmarks/form.html
+++ b/examples/landmarks/form.html
@@ -57,7 +57,7 @@
       <div class="row">
         <div class="col-xs-12 col-sm-3 col-md-3 col-lg-2">
           <nav>
-            <ul class="nav nav-pills nav-stacked">
+            <ul class="nav nav-stacked">
               <li><a href="index.html">Principles</a></li>
               <li><a href="HTML5.html">HTML</a></li>
               <li><a href="banner.html">Banner</a></li>

--- a/examples/landmarks/index.html
+++ b/examples/landmarks/index.html
@@ -25,7 +25,7 @@
       <div class="row">
         <div class="col-xs-12 col-sm-3 col-md-3 col-lg-2">
           <nav>
-            <ul class="nav nav-pills nav-stacked">
+            <ul class="nav nav-stacked">
               <li class="active"><a href="index.html" aria-current="page">Principles</a></li>
               <li><a href="HTML5.html">HTML</a></li>
               <li><a href="banner.html">Banner</a></li>

--- a/examples/landmarks/main.html
+++ b/examples/landmarks/main.html
@@ -26,7 +26,7 @@
       <div class="row">
         <div class="col-xs-12 col-sm-3 col-md-3 col-lg-2">
           <nav>
-            <ul class="nav nav-pills nav-stacked">
+            <ul class="nav nav-stacked">
               <li><a href="index.html">Principles</a></li>
               <li><a href="HTML5.html">HTML</a></li>
               <li><a href="banner.html">Banner</a></li>

--- a/examples/landmarks/navigation.html
+++ b/examples/landmarks/navigation.html
@@ -25,7 +25,7 @@
       <div class="row">
         <div class="col-xs-12 col-sm-3 col-md-3 col-lg-2">
           <nav>
-            <ul class="nav nav-pills nav-stacked">
+            <ul class="nav nav-stacked">
               <li><a href="index.html">Principles</a></li>
               <li><a href="HTML5.html">HTML</a></li>
               <li><a href="banner.html">Banner</a></li>

--- a/examples/landmarks/region.html
+++ b/examples/landmarks/region.html
@@ -25,7 +25,7 @@
       <div class="row">
         <div class="col-xs-12 col-sm-3 col-md-3 col-lg-2">
           <nav>
-            <ul class="nav nav-pills nav-stacked">
+            <ul class="nav nav-stacked">
               <li><a href="index.html">Principles</a></li>
               <li><a href="HTML5.html">HTML</a></li>
               <li><a href="banner.html">Banner</a></li>

--- a/examples/landmarks/resources.html
+++ b/examples/landmarks/resources.html
@@ -26,7 +26,7 @@
             <div class="row">
                  <div class="col-xs-12 col-sm-3 col-md-3 col-lg-2">
                     <nav>
-                        <ul class="nav nav-pills nav-stacked">
+                        <ul class="nav nav-stacked">
                             <li><a href="index.html">Principles</a></li>
                             <li><a href="HTML5.html">HTML</a></li>
                             <li><a href="banner.html">Banner</a></li>

--- a/examples/landmarks/search.html
+++ b/examples/landmarks/search.html
@@ -25,7 +25,7 @@
       <div class="row">
         <div class="col-xs-12 col-sm-3 col-md-3 col-lg-2">
           <nav>
-            <ul class="nav nav-pills nav-stacked">
+            <ul class="nav nav-stacked">
               <li><a href="index.html">Principles</a></li>
               <li><a href="HTML5.html">HTML</a></li>
               <li><a href="banner.html">Banner</a></li>

--- a/examples/listbox/listbox-collapsible.html
+++ b/examples/listbox/listbox-collapsible.html
@@ -91,7 +91,7 @@
       </div>
     </div>
     <div role="separator" id="ex_end_sep" aria-labelledby="ex_end_sep ex_label" aria-label="End of"></div>
-    <h4>Notes</h4>
+    <h3>Notes</h3>
     <p>This listbox is scrollable; it has more options than its height can accommodate.</p>
     <ol>
       <li>

--- a/examples/listbox/listbox-rearrangeable.html
+++ b/examples/listbox/listbox-rearrangeable.html
@@ -81,7 +81,7 @@ while in the second example, they may select multiple options before activating 
         </div>
       </div>
       <div role="separator" id="ex1_end_sep" aria-labelledby="ex1_end_sep ex1_label" aria-label="End of"></div>
-      <h4>Notes</h4>
+      <h3>Notes</h3>
       <ol>
         <li>Assistive technologies are told which option in the list is visually focused by the value of <code>aria-activedescendant</code>:
           <ol>
@@ -149,7 +149,7 @@ while in the second example, they may select multiple options before activating 
         </div>
       </div>
       <div role="separator" id="ex2_end_sep" aria-labelledby="ex2_end_sep ex2_label" aria-label="End of"></div>
-      <h4>Notes</h4>
+      <h3>Notes</h3>
       <ol>
         <li>Like in example 1, assistive technologies are told which option in the list is visually focused by the value of <code>aria-activedescendant</code>:
           <ol>

--- a/examples/listbox/listbox-scrollable.html
+++ b/examples/listbox/listbox-scrollable.html
@@ -80,7 +80,7 @@
       </div>
     </div>
     <div role="separator" id="ex_end_sep" aria-labelledby="ex_end_sep ex_label" aria-label="End of"></div>
-    <h4>Notes</h4>
+    <h3>Notes</h3>
     <p>This listbox is scrollable; it has more options than its height can accommodate.</p>
     <ol>
       <li>


### PR DESCRIPTION
- The feedDisplay page used an h2 where it should have had an h1

- The bootstrap-accessibility.js file was putting role="presentation" on li element in the navigation for absolutely no reason. This causes the entire menu to end up as `nav > ul > li[role=presentation]`. This seemed unintentional. The fix was just to remove that `.navpills` class, which doesn't seem to be used in styles.

- The "Notes" heading in listbox pages skip a heading level. Going from h2 to h4. Doesn't seem necessary.