### PR TITLE
Landmark Example Pages: Restore list structure in page navigation region

### DIFF
--- a/examples/landmarks/HTML5.html
+++ b/examples/landmarks/HTML5.html
@@ -26,7 +26,7 @@
       <div class="row">
         <div class="col-xs-12 col-sm-3 col-md-3 col-lg-2">
           <nav>
-            <ul class="nav nav-pills nav-stacked">
+            <ul class="nav nav-stacked">
               <li><a href="index.html">Principles</a></li>
               <li class="active"><a href="HTML5.html" aria-current="page">HTML</a></li>
               <li><a href="banner.html">Banner</a></li>

--- a/examples/landmarks/at.html
+++ b/examples/landmarks/at.html
@@ -25,7 +25,7 @@
       <div class="row">
         <div class="col-xs-12 col-sm-3 col-md-3 col-lg-2">
           <nav>
-            <ul class="nav nav-pills nav-stacked">
+            <ul class="nav nav-stacked">
               <li><a href="index.html">Principles</a></li>
               <li><a href="HTML5.html">HTML</a></li>
               <li><a href="banner.html">Banner</a></li>

--- a/examples/landmarks/banner.html
+++ b/examples/landmarks/banner.html
@@ -25,7 +25,7 @@
       <div class="row">
         <div class="col-xs-12 col-sm-3 col-md-3 col-lg-2">
           <nav>
-            <ul class="nav nav-pills nav-stacked">
+            <ul class="nav nav-stacked">
               <li><a href="index.html">Principles</a></li>
               <li><a href="HTML5.html">HTML</a></li>
               <li class="active"><a href="banner.html" aria-current="page">Banner</a></li>

--- a/examples/landmarks/complementary.html
+++ b/examples/landmarks/complementary.html
@@ -25,7 +25,7 @@
       <div class="row">
         <div class="col-xs-12 col-sm-3 col-md-3 col-lg-2">
           <nav>
-            <ul class="nav nav-pills nav-stacked">
+            <ul class="nav nav-stacked">
               <li><a href="index.html">Principles</a></li>
               <li><a href="HTML5.html">HTML</a></li>
               <li><a href="banner.html">Banner</a></li>

--- a/examples/landmarks/contentinfo.html
+++ b/examples/landmarks/contentinfo.html
@@ -25,7 +25,7 @@
       <div class="row">
         <div class="col-xs-12 col-sm-3 col-md-3 col-lg-2">
           <nav>
-            <ul class="nav nav-pills nav-stacked">
+            <ul class="nav nav-stacked">
               <li><a href="index.html">Principles</a></li>
               <li><a href="HTML5.html">HTML</a></li>
               <li><a href="banner.html">Banner</a></li>

--- a/examples/landmarks/css/bootstrap.css
+++ b/examples/landmarks/css/bootstrap.css
@@ -3970,9 +3970,9 @@ select[multiple].input-group-sm > .input-group-btn > .btn {
 .nav-pills > li + li {
   margin-left: 2px;
 }
-.nav-pills > li.active > a,
-.nav-pills > li.active > a:hover,
-.nav-pills > li.active > a:focus {
+nav a[aria-current="page"],
+nav a[aria-current="page"]:hover,
+nav a[aria-current="page"]:focus {
   color: #fff;
   background-color: #337ab7;
 }

--- a/examples/landmarks/form.html
+++ b/examples/landmarks/form.html
@@ -57,7 +57,7 @@
       <div class="row">
         <div class="col-xs-12 col-sm-3 col-md-3 col-lg-2">
           <nav>
-            <ul class="nav nav-pills nav-stacked">
+            <ul class="nav nav-stacked">
               <li><a href="index.html">Principles</a></li>
               <li><a href="HTML5.html">HTML</a></li>
               <li><a href="banner.html">Banner</a></li>

--- a/examples/landmarks/index.html
+++ b/examples/landmarks/index.html
@@ -25,7 +25,7 @@
       <div class="row">
         <div class="col-xs-12 col-sm-3 col-md-3 col-lg-2">
           <nav>
-            <ul class="nav nav-pills nav-stacked">
+            <ul class="nav nav-stacked">
               <li class="active"><a href="index.html" aria-current="page">Principles</a></li>
               <li><a href="HTML5.html">HTML</a></li>
               <li><a href="banner.html">Banner</a></li>

--- a/examples/landmarks/main.html
+++ b/examples/landmarks/main.html
@@ -26,7 +26,7 @@
       <div class="row">
         <div class="col-xs-12 col-sm-3 col-md-3 col-lg-2">
           <nav>
-            <ul class="nav nav-pills nav-stacked">
+            <ul class="nav nav-stacked">
               <li><a href="index.html">Principles</a></li>
               <li><a href="HTML5.html">HTML</a></li>
               <li><a href="banner.html">Banner</a></li>

--- a/examples/landmarks/navigation.html
+++ b/examples/landmarks/navigation.html
@@ -25,7 +25,7 @@
       <div class="row">
         <div class="col-xs-12 col-sm-3 col-md-3 col-lg-2">
           <nav>
-            <ul class="nav nav-pills nav-stacked">
+            <ul class="nav nav-stacked">
               <li><a href="index.html">Principles</a></li>
               <li><a href="HTML5.html">HTML</a></li>
               <li><a href="banner.html">Banner</a></li>

--- a/examples/landmarks/region.html
+++ b/examples/landmarks/region.html
@@ -25,7 +25,7 @@
       <div class="row">
         <div class="col-xs-12 col-sm-3 col-md-3 col-lg-2">
           <nav>
-            <ul class="nav nav-pills nav-stacked">
+            <ul class="nav nav-stacked">
               <li><a href="index.html">Principles</a></li>
               <li><a href="HTML5.html">HTML</a></li>
               <li><a href="banner.html">Banner</a></li>

--- a/examples/landmarks/resources.html
+++ b/examples/landmarks/resources.html
@@ -26,7 +26,7 @@
             <div class="row">
                  <div class="col-xs-12 col-sm-3 col-md-3 col-lg-2">
                     <nav>
-                        <ul class="nav nav-pills nav-stacked">
+                        <ul class="nav nav-stacked">
                             <li><a href="index.html">Principles</a></li>
                             <li><a href="HTML5.html">HTML</a></li>
                             <li><a href="banner.html">Banner</a></li>

--- a/examples/landmarks/search.html
+++ b/examples/landmarks/search.html
@@ -25,7 +25,7 @@
       <div class="row">
         <div class="col-xs-12 col-sm-3 col-md-3 col-lg-2">
           <nav>
-            <ul class="nav nav-pills nav-stacked">
+            <ul class="nav nav-stacked">
               <li><a href="index.html">Principles</a></li>
               <li><a href="HTML5.html">HTML</a></li>
               <li><a href="banner.html">Banner</a></li>


### PR DESCRIPTION
The bootstrap-accessibility.js file was putting role="presentation" on li element in the navigation for absolutely no reason. This causes the entire menu to end up as nav > ul > li[role=presentation]. This seemed unintentional. The fix is just to remove that .navpills class, which doesn't seem to be used in styles.

