### PR TITLE
Listbox Examples: Correct skipped heading level issue; change some h4 to h3.

### DIFF
--- a/examples/listbox/listbox-collapsible.html
+++ b/examples/listbox/listbox-collapsible.html
@@ -91,7 +91,7 @@
       </div>
     </div>
     <div role="separator" id="ex_end_sep" aria-labelledby="ex_end_sep ex_label" aria-label="End of"></div>
-    <h4>Notes</h4>
+    <h3>Notes</h3>
     <p>This listbox is scrollable; it has more options than its height can accommodate.</p>
     <ol>
       <li>

--- a/examples/listbox/listbox-rearrangeable.html
+++ b/examples/listbox/listbox-rearrangeable.html
@@ -81,7 +81,7 @@ while in the second example, they may select multiple options before activating 
         </div>
       </div>
       <div role="separator" id="ex1_end_sep" aria-labelledby="ex1_end_sep ex1_label" aria-label="End of"></div>
-      <h4>Notes</h4>
+      <h3>Notes</h3>
       <ol>
         <li>Assistive technologies are told which option in the list is visually focused by the value of <code>aria-activedescendant</code>:
           <ol>
@@ -149,7 +149,7 @@ while in the second example, they may select multiple options before activating 
         </div>
       </div>
       <div role="separator" id="ex2_end_sep" aria-labelledby="ex2_end_sep ex2_label" aria-label="End of"></div>
-      <h4>Notes</h4>
+      <h3>Notes</h3>
       <ol>
         <li>Like in example 1, assistive technologies are told which option in the list is visually focused by the value of <code>aria-activedescendant</code>:
           <ol>

--- a/examples/listbox/listbox-scrollable.html
+++ b/examples/listbox/listbox-scrollable.html
@@ -80,7 +80,7 @@
       </div>
     </div>
     <div role="separator" id="ex_end_sep" aria-labelledby="ex_end_sep ex_label" aria-label="End of"></div>
-    <h4>Notes</h4>
+    <h3>Notes</h3>
     <p>This listbox is scrollable; it has more options than its height can accommodate.</p>
     <ol>
       <li>


### PR DESCRIPTION
Use h3 for these notes, so that the page doesn't skip from an h2 to an h4 heading.