### PR TITLE
Feed Example Display Page: Change h2 to h1

### DIFF
--- a/examples/feed/feedDisplay.html
+++ b/examples/feed/feedDisplay.html
@@ -16,7 +16,7 @@
 </head>
 <body>
   <main>
-    <h2>Recommended Restaurants</h2>
+    <h1>Recommended Restaurants</h1>
     <section id="main-content">
       <div id="restaurant-feed" role="feed">
       </div>


### PR DESCRIPTION
Replace the h2 with an h1. There's no reason for that first heading to be an h2.