### PR TITLE
Appendix: Update change log for APG 1.2

### DIFF
--- a/aria-practices.html
+++ b/aria-practices.html
@@ -7062,11 +7062,13 @@ So, As advised by <a href="#naming_rule_avoid_fallback">Rule 4: Avoid Browser Fa
   <section id="change_log" class="appendix">
     <h2>Change History</h2>
     
-    <section id="change_log_2019_november" class="appendix">
-      <h3>Changes in November 2019 publication of the 3rd working draft of version 1.2</h3>
+    <section id="change_log_2021_november" class="appendix">
+      <h3>Changes in November 2021 Publication of Version 1.2</h3>
       <p>
-        APG 1.1 supported ARIA 1.1, and this version, APG 1.2, supports ARIA 1.2.
-        The following changes have been made to APG 1.1 in order to make this draft of APG 1.2.
+        APG 1.1 supported ARIA 1.1, and this version, APG 1.2, includes changes to support version 1.2 of the ARIA specification.
+        It also includes nearly 200 significant updates to improve the quality and breadth of content.
+        A <a href="https://github.com/w3c/aria-practices/wiki/Change-Log-for-November-2021-APG-1.2-Note-Release-1">detailed log of all changes</a> is available on the wiki of the w3c/aria-practices GitHub repository.
+        Highlights of major changes to support ARIA 1.2 as well as some of the improvements include the following.
       </p>
       <ul>
         <li>Added section to provide guidance related to 38 document structure roles, 18 of which are new in ARIA 1.2.</li>
@@ -7095,7 +7097,6 @@ So, As advised by <a href="#naming_rule_avoid_fallback">Rule 4: Avoid Browser Fa
           <a href="https://github.com/w3c/aria-practices/milestone/7">APG 1.2 Working Draft 1 milestone</a>:
           GitHub issues closed in the first working draft of APG 1.2 published on July 17, 2018.
         </li>
-        <li><a href="https://github.com/w3c/aria-practices/wiki/Change-Log-for-November-2019-APG-1.2-Working-Draft-3">Detailed change log with links to all commits in the November 2019 publication  of APG 1.2 that are not in the August 14, 2019 publication of APG 1.1 release 4.</a></li>
       </ul>
     </section>
     

--- a/aria-practices.html
+++ b/aria-practices.html
@@ -7075,14 +7075,22 @@ So, As advised by <a href="#naming_rule_avoid_fallback">Rule 4: Avoid Browser Fa
         <li>Revised guidance for roles where naming requirements changed in ARIA 1.2. ARIA 1.2 prohibits names on some roles. ARIA 1.2 removed naming requirements from some other roles.</li>
         <li>Added naming guidance for 18 roles that are new in ARIA 1.2.</li>
         <li>Revised the combobox pattern and 4 combobox examples to reflect the ARIA 1.2 revisions to combobox.</li>
-        <li>Added a design pattern and example implementation of the new meter role.</li>
+        <li>Added example illustrating changes in ARIA 1.2 that enable creation of custom select-only comboboxes, which are similar to HTML select elements. This replaces the Collapsible Listbox example, which is now deprecated.</li>
+        <li>Added a design pattern and example implementation of the meter role, which is new in ARIA 1.2.</li>
         <li>Added a new listbox example that illustrates new ARIA 1.2 support for named groups of options in a listbox.</li>
         <li>Revised the editor menubar example to illustrate new ARIA 1.2 support for named groups of items in a menu.</li>
         <li>Added a button example that illustrates use of the new ARIA 1.2 IDL interface.</li>
-        <li>Due to change in ARIA 1.2, removed Math role from list of roles that have presentational children.</li>
+        <li>Added example of a sortable table.</li>
+        <li>Added a switch design pattern and three example implementations: one made from a div element, one based on HTML button, and one that uses HTML checkbox input.</li>
+        <li>Added two examples that demonstrate how to create rating inputs, one based on slider and one based on radio group.</li>
+        <li>Added two other slider examples: a vertical temperature slider and a media seek slider.</li>
+        <li>Added a date picker example that illustrates choosing a date with a combobox.</li>
+        <li>Added another example of a disclosure navigation menu that demonstrates how to include top-level links.</li>
+        <li>Added guidance section describing how to use range related properties, such as aria-valuemin and aria-valuemax.</li>
         <li>Changed all example pages to include a button for opening in CodePen and added prominently placed warning with guidance about testing before re-using example code.</li>
         <li>Improved support for high contrast settings and added detailed documentation of high contrast support in many examples.</li>
         <li>Improved support for touch-based screen readers in several examples, most notably in sliders.</li>
+        <li>Due to change in ARIA 1.2, removed Math role from list of roles that have presentational children.</li>
         <li>Developed a <a href="https://github.com/w3c/aria-practices/wiki/Code-Guide#apg-coding-standards">comprehensive set of coding standards for HTML, CSS, and Javascript</a> for the APG and updated a significant portion of content to conform with the standards.</li>
         <li>In response to feedback, fixed many documentation errors and functional bugs in examples.</li>
       </ul>

--- a/aria-practices.html
+++ b/aria-practices.html
@@ -7074,18 +7074,17 @@ So, As advised by <a href="#naming_rule_avoid_fallback">Rule 4: Avoid Browser Fa
         <li>Added section to provide guidance related to 38 document structure roles, 18 of which are new in ARIA 1.2.</li>
         <li>Revised guidance for roles where naming requirements changed in ARIA 1.2. ARIA 1.2 prohibits names on some roles. ARIA 1.2 removed naming requirements from some other roles.</li>
         <li>Added naming guidance for 18 roles that are new in ARIA 1.2.</li>
-        <li>Revised the combobox pattern and 4 combobox examples to reflect changes made in ARIA 1.2.</li>
+        <li>Revised the combobox pattern and 4 combobox examples to reflect the ARIA 1.2 revisions to combobox.</li>
         <li>Added a design pattern and example implementation of the new meter role.</li>
         <li>Added a new listbox example that illustrates new ARIA 1.2 support for named groups of options in a listbox.</li>
         <li>Revised the editor menubar example to illustrate new ARIA 1.2 support for named groups of items in a menu.</li>
         <li>Added a button example that illustrates use of the new ARIA 1.2 IDL interface.</li>
         <li>Due to change in ARIA 1.2, removed Math role from list of roles that have presentational children.</li>
-        <li>In response to feedback, revise description of Escape behavior in the combobox Pattern.</li>
-        <li>Corrected color contrast in accordion and date picker examples.</li>
-        <li>Fixed 4 bugs in the date picker dialog example.</li>
-        <li>Fixed 2 bugs in the spin button date picker example related to incrementing past limits.</li>
-        <li>Changed all Examples with buttons to add button type to non-submit buttons.</li>
-        <li>Changed tabs examples to hide panels with display: none instead of the hidden attribute.</li>
+        <li>Changed all example pages to include a button for opening in CodePen and added prominently placed warning with guidance about testing before re-using example code.</li>
+        <li>Improved support for high contrast settings and added detailed documentation of high contrast support in many examples.</li>
+        <li>Improved support for touch-based screen readers in several examples, most notably in sliders.</li>
+        <li>Developed a <a href="https://github.com/w3c/aria-practices/wiki/Code-Guide#apg-coding-standards">comprehensive set of coding standards for HTML, CSS, and Javascript</a> for the APG and updated a significant portion of content to conform with the standards.</li>
+        <li>In response to feedback, fixed many documentation errors and functional bugs in examples.</li>
       </ul>
       <p>Comprehensive lists of closed issues included in APG 1.2 release 1 are tracked in the following GitHub milestones.</p>
       <ul>

--- a/aria-practices.html
+++ b/aria-practices.html
@@ -7354,9 +7354,9 @@ So, As advised by <a href="#naming_rule_avoid_fallback">Rule 4: Avoid Browser Fa
   <section id="acknowledgements" class="appendix">
     <h2>Acknowledgements</h2>
     <section>
-      <h3>Major Contributors to Version 1.1</h3>
+      <h3>Major Contributors</h3>
       <p>
-        While WAI-ARIA Authoring Practices 1.1 is the work of the entire Authoring Practices Task Force and also benefits from many people throughout the open source community who both contribute significant work and provide valuable feedback,
+        While WAI-ARIA Authoring Practices is the work of the entire Authoring Practices Task Force and also benefits from many people throughout the open source community who both contribute significant work and provide valuable feedback,
         special thanks goes to the following people who provided distinctly large portions of the content and code in version 1.1.
       </p>
       <ul>

--- a/aria-practices.html
+++ b/aria-practices.html
@@ -7087,8 +7087,12 @@ So, As advised by <a href="#naming_rule_avoid_fallback">Rule 4: Avoid Browser Fa
         <li>Changed all Examples with buttons to add button type to non-submit buttons.</li>
         <li>Changed tabs examples to hide panels with display: none instead of the hidden attribute.</li>
       </ul>
-      <p>For more detail, see:</p>
+      <p>Comprehensive lists of closed issues included in APG 1.2 release 1 are tracked in the following GitHub milestones.</p>
       <ul>
+        <li>
+          <a href="https://github.com/w3c/aria-practices/milestone/2?closed=1">APG 1.2 Release 1 Milestone</a>:
+          Github issues closed in the first publication of APG 1.2 as a W3C Note in November 2021.
+        </li>
         <li>
           <a href="https://github.com/w3c/aria-practices/milestone/10">APG 1.2 Working Draft 3 Milestone</a>:
           Github issues closed in the third working draft of APG 1.2 published in November 2019.


### PR DESCRIPTION
Updates the appendix in the apg-1.2 publication branch to provide a change log for the 1.2 release.

[Preview of appendix in compare branch](https://raw.githack.com/w3c/aria-practices/change-log-1.2/aria-practices.html#change_log_2021_november)

<!--
no preview
-->
