### PR TITLE
All Example Pages: Update aria-at information in support notice

### DIFF
--- a/examples/js/notice.html
+++ b/examples/js/notice.html
@@ -15,8 +15,8 @@
         Testing code based on this example with assistive technologies is essential before considering use in production systems.
     </li>
     <li>
-        The <a href="https://github.com/w3c/aria-at/">ARIA-AT project</a>
-        plans to provide measurements of this example's assistive technology support by the end of 2020.
+        The <a href="https://aria-at.w3.org">ARIA and Assistive Technologies Project</a>
+        is developing measurements of assistive technology support for APG examples.
     </li>
     <li>
         Robust accessibility can be further optimized by choosing implementation patterns that


### PR DESCRIPTION
Provides link to the ARIA and Assistive Technology app home page instead of the aria-at repo and removes 2020 date.

[Preview in raw GitHack](https://raw.githack.com/w3c/aria-practices/update-support-notice/aria-practices.html)