### PR TITLE
Listbox Pattern: Add option grouping and update selection guidance

### DIFF
--- a/aria-practices.html
+++ b/aria-practices.html
@@ -1902,14 +1902,46 @@ Some JavaScript and CSS may not function correctly in Internet Explorer.
         <h4>WAI-ARIA Roles, States, and Properties</h4>
         <ul>
           <li>An element that contains or owns all the listbox options has role <a href="#listbox" class="role-reference">listbox</a>.</li>
-          <li>Each option in the listbox has role <a href="#option" class="role-reference">option</a> and is a DOM  descendant of the element with role <code>listbox</code> or is referenced by an <a href="#aria-owns" class="property-reference">aria-owns</a> property on the listbox element.</li>
-          <li>If the listbox is not part of another widget, then it has a visible label referenced by <a href="#aria-labelledby" class="property-reference">aria-labelledby</a> on the element with role <code>listbox</code>.</li>
-          <li>In a single-select listbox, the selected option has <a href="#aria-selected" class="property-reference">aria-selected</a> set to <code>true</code>. </li>
-          <li>if the listbox supports multiple selection:
+          <li>
+            Each option in the listbox has role <a href="#option" class="role-reference">option</a> and is contained in or owned by either:
             <ul>
-              <li> The element with role <code>listbox</code> has <a href="#aria-multiselectable" class="property-reference">aria-multiselectable</a> set to <code>true</code>. </li>
-              <li>All selected options have <a href="#aria-selected" class="state-reference">aria-selected</a> set to <code>true</code>. </li>
-              <li>All options that are not selected have <a href="#aria-selected" class="state-reference">aria-selected</a> set to <code>false</code>. </li>
+              <li>The element with role <code>listbox</code>.</li>
+              <li>An element with role <a href="#group" class="role-reference">group</a> that is contained in or owned by the element with role <code>listbox</code>.</li>
+            </ul>
+          </li>
+          <li>
+            Options contained in a <code>group</code> are referred to as <q>grouped options</q> and form what is called an <q>option group.</q>
+            If a listbox contains grouped options, then:
+            <ul>
+              <li>The listbox contains at least two option groups.</li>
+              <li>At least one option group contains multiple options and all option groups contain at least one option.</li>
+              <li>Each option group has an accessible name provided via <a href="#aria-label" class="property-reference">aria-label</a> or <a href="#aria-labelledby" class="property-reference">aria-labelledby</a>.</li>
+            </ul>
+          </li>
+          <li>If the element with role <code>listbox</code> is not part of another widget, such as a combobox, then it has either a visible label referenced by <a href="#aria-labelledby" class="property-reference">aria-labelledby</a> or a value specified for <a href="#aria-label" class="property-reference">aria-label</a>.</li>
+          <li>
+            If the listbox supports selection of more than one option, the element with role <code>listbox</code> has <a class="property-reference" href="#aria-multiselectable">aria-multiselectable</a> set to <code>true</code>.
+            Otherwise, <code>aria-multiselectable</code> is either set to <code>false</code> or the default value of <code>false</code> is implied.
+          </li>
+          <li>
+            The selection state of each selectable option is indicated with either <a href="#aria-selected" class="state-reference">aria-selected</a> or <a href="#aria-checked" class="state-reference">aria-checked</a>:
+            <ul>
+              <li>
+                If the selection state is indicated with <code>aria-selected</code>, then <code>aria-checked</code> is not specified for any options.
+                Alternatively, if the selection state is indicated with <code>aria-checked</code>, then <code>aria-selected</code> is not specified for any options.
+                See notes below regarding considerations for which property to use and for details of the unusual conditions that might allow for both properties in the same listbox.
+              </li>
+              <li>
+                If any options are selected, each selected node has either <a href="#aria-selected" class="state-reference">aria-selected</a> or <a href="#aria-checked" class="state-reference">aria-checked</a> set to <code>true</code>.
+                No more than one option is selected at a time if the element with role <code>listbox</code> does <em>not</em> have <a class="property-reference" href="#aria-multiselectable">aria-multiselectable</a> set to <code>true</code>.
+              </li>
+              <li>
+                All options that are selectable but not selected have either <a href="#aria-selected" class="state-reference">aria-selected</a> or <a href="#aria-checked" class="state-reference">aria-checked</a> set to <code>false</code>.
+              </li>
+              <li>
+                Note that except in listboxes where selection follows focus, the selected state is distinct from focus.
+                For more details, see <a href="#kbd_focus_vs_selection">this description of differences between focus and selection</a> and <a href="#kbd_selection_follows_focus">Deciding When to Make Selection Automatically Follow Focus</a>.
+              </li>
             </ul>
           </li>
           <li>If the complete set of available options is not present in the DOM due to dynamic loading as the user scrolls, their <a href="#aria-setsize" class="property-reference">aria-setsize</a> and <a href="#aria-posinset" class="property-reference">aria-posinset</a> attributes are set appropriately. </li>
@@ -1918,6 +1950,36 @@ Some JavaScript and CSS may not function correctly in Internet Explorer.
             The default value of <code>aria-orientation</code> for <code>listbox</code> is <code>vertical</code>.
           </li>
         </ul>
+        <ol class="note">
+          <li>Some factors to consider when choosing whether to indicate selection with <code>aria-selected</code> or <code>aria-checked</code> are:
+            <ul>
+              <li>
+                Some design systems use <code>aria-selected</code> for single-select widgets and <code>aria-checked</code> for multi-select widgets.
+                In the absence of factors that would make an alternative convention more appropriate, this is a recommended convention.
+              </li>
+              <li>
+                The language of instructions and the appearance of the interface might suggest one attribute is more appropriate than the other.
+                For instance, do instructions say to <q>select</q> items? Or, is the visual indicator of selection a check mark?
+              </li>
+              <li>It is important to adopt a consistent convention for selection models across a site or app.</li>
+            </ul>
+          </li>
+          <li>
+            Conditions that would permit a listbox to include both <code>aria-selected</code> and <code>aria-checked</code> are extremely rare.
+            It is strongly recommended to avoid designing a listbox widget that would have the need for more than one type of state.
+            If both states were to be used within a listbox, all the following conditions need to be satisfied:
+            <ul>
+              <li>The meaning and purpose of <code>aria-selected</code> is different from the meaning and purpose of <code>aria-checked</code> in the user interface.</li>
+              <li>The user interface makes the meaning and purpose of each state apparent.</li>
+              <li>The user interface provides a separate method for controlling each state.</li>
+            </ul>
+          </li>
+          <li>
+            If <a href="#aria-owns" class="property-reference">aria-owns</a> is set on the listbox element to include elements that are not DOM children of the container,
+            those elements will appear in the reading order in the sequence they are referenced and after any items that are DOM children.
+            Scripts that manage focus need to ensure the visual focus order matches this assistive technology reading order.
+          </li>
+        </ol>
       </section>
     </section>
 

--- a/aria-practices.html
+++ b/aria-practices.html
@@ -1858,7 +1858,7 @@ Some JavaScript and CSS may not function correctly in Internet Explorer.
                   <li><kbd>Control + A</kbd> (Optional): Selects all options in the list. Optionally, if all options are selected, it may also unselect all options.</li>
                 </ul>
               </li>
-              <li>Alternative selection model -- moving focus without holding a <kbd>Shift</kbd> or <kbd>Control</kbd> modifier unselects all selected nodes except the focused node:
+              <li>Alternative selection model -- moving focus without holding a <kbd>Shift</kbd> or <kbd>Control</kbd> modifier unselects all selected options except the focused option:
               <ul>
                   <li><kbd>Shift + Down Arrow</kbd>: Moves focus to and toggles the selection state of the next option.</li>
                   <li><kbd>Shift + Up Arrow</kbd>: Moves focus to and toggles the selection state of the previous option.</li>
@@ -1932,7 +1932,7 @@ Some JavaScript and CSS may not function correctly in Internet Explorer.
                 See notes below regarding considerations for which property to use and for details of the unusual conditions that might allow for both properties in the same listbox.
               </li>
               <li>
-                If any options are selected, each selected node has either <a href="#aria-selected" class="state-reference">aria-selected</a> or <a href="#aria-checked" class="state-reference">aria-checked</a> set to <code>true</code>.
+                If any options are selected, each selected option has either <a href="#aria-selected" class="state-reference">aria-selected</a> or <a href="#aria-checked" class="state-reference">aria-checked</a> set to <code>true</code>.
                 No more than one option is selected at a time if the element with role <code>listbox</code> does <em>not</em> have <a class="property-reference" href="#aria-multiselectable">aria-multiselectable</a> set to <code>true</code>.
               </li>
               <li>

--- a/aria-practices.html
+++ b/aria-practices.html
@@ -1913,8 +1913,7 @@ Some JavaScript and CSS may not function correctly in Internet Explorer.
             Options contained in a <code>group</code> are referred to as <q>grouped options</q> and form what is called an <q>option group.</q>
             If a listbox contains grouped options, then:
             <ul>
-              <li>The listbox contains at least two option groups.</li>
-              <li>At least one option group contains multiple options and all option groups contain at least one option.</li>
+                            <li>All option groups contain at least one option.</li>
               <li>Each option group has an accessible name provided via <a href="#aria-label" class="property-reference">aria-label</a> or <a href="#aria-labelledby" class="property-reference">aria-labelledby</a>.</li>
             </ul>
           </li>


### PR DESCRIPTION
Updates listbox pattern roles, states, and properties section to:
* Resolve #765 by adding requirements for grouped options.
* Update guidance for indicating selected states to reflect ARIA changes that allow either aria-checked or aria-selected.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria-practices/pull/2137.html" title="Last updated on Nov 15, 2021, 9:02 PM UTC (f19eca1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria-practices/2137/c214552...f19eca1.html" title="Last updated on Nov 15, 2021, 9:02 PM UTC (f19eca1)">Diff</a>