### PR TITLE
Editable Combobox Examples: Correct enter key documentation for the autocomplete none and list implementations

### DIFF
--- a/examples/combobox/combobox-autocomplete-list.html
+++ b/examples/combobox/combobox-autocomplete-list.html
@@ -203,7 +203,7 @@
           </tr>
           <tr data-test-id="textbox-key-enter">
             <th><kbd>Enter</kbd></th>
-            <td>Closes the listbox.</td>
+            <td>Closes the listbox if it is displayed.</td>
           </tr>
           <tr data-test-id="textbox-key-escape">
             <th><kbd>Escape</kbd></th>

--- a/examples/combobox/combobox-autocomplete-none.html
+++ b/examples/combobox/combobox-autocomplete-none.html
@@ -156,12 +156,7 @@
           </tr>
           <tr data-test-id="textbox-key-enter">
             <th><kbd>Enter</kbd></th>
-            <td>
-              <ul>
-                <li>Sets the textbox value to the content of the selected option.</li>
-                <li>Closes the listbox if it is displayed.</li>
-              </ul>
-            </td>
+            <td>Closes the listbox if it is displayed.</td>
           </tr>
           <tr data-test-id="standard-single-line-editing-keys">
             <th>Standard single line text editing keys</th>


### PR DESCRIPTION
For combobox examples with autocomplete set to none or list, when focus is in the textbox, Enter key closes the listbox if it is open. This commit resolves #855 by updatings the documentation for the Enter key to be consistent with that behavior.