### PR TITLE
Combobox example with grid popup: Correct documentation of aria-selected

### DIFF
--- a/examples/combobox/grid-combo.html
+++ b/examples/combobox/grid-combo.html
@@ -370,7 +370,7 @@
             <td><code>div</code></td>
             <td>
               <ul>
-                <li>Specified on a row in the grid when it is visually indicated as selected.</li>
+                <li>Specified on a cell when the row containing the cell is visually indicated as selected.</li>
                 <li>Occurs only when a cell in the grid is referenced by <code>aria-activedescendant</code>.</li>
               </ul>
             </td>


### PR DESCRIPTION
Resolves issue #859 by clarifying the element that that has aria-selected specified.