### PR TITLE
Checkbox Examples: Update links and descriptions

### DIFF
--- a/aria-practices.html
+++ b/aria-practices.html
@@ -675,11 +675,11 @@ Some JavaScript and CSS may not function correctly in Internet Explorer.
         <h4>Examples</h4>
         <ul>
           <li>
-            <a href="examples/checkbox/checkbox-1/checkbox-1.html">Simple Two-State Checkbox Example</a>: Demonstrates a simple 2-state checkbox.
+            <a href="examples/checkbox/checkbox.html">Checkbox (Two-State) Example</a>: Demonstrates a simple 2-state checkbox.
           </li>
           <li>
-            <a href="examples/checkbox/checkbox-2/checkbox-2.html">Tri-State Checkbox Example</a>:
-            Demonstrates how to make a widget that uses the <code>mixed</code> value for <code>aria-checked</code> and group collection of checkboxes with a field set.
+            <a href="examples/checkbox/checkbox-mixed.html">Checkbox (Mixed-State) Example</a>:
+            Demonstrates  a checkbox that uses the mixed  value for aria-checked to reflect and control checked states within a group of two-state HTML checkboxes contained in  an HTML <code>fieldset</code>.
           </li>
         </ul>
       </section>

--- a/examples/checkbox/checkbox-mixed.html
+++ b/examples/checkbox/checkbox-mixed.html
@@ -34,7 +34,7 @@
       </p>
       <p>Similar examples include: </p>
       <ul>
-        <li><a href="../checkbox-1/checkbox-1.html">Checkbox (Two State)</a>: Simple two state checkbox.</li>
+        <li><a href="checkbox.html">Checkbox (Two State)</a>: Simple two state checkbox.</li>
       </ul>
       <section>
         <div class="example-header">

--- a/examples/checkbox/checkbox.html
+++ b/examples/checkbox/checkbox.html
@@ -29,7 +29,7 @@
 
     <p>Similar examples include: </p>
     <ul>
-      <li><a href="../checkbox-2/checkbox-2.html">Checkbox (Mixed-State)</a>: Mixed state checkbox controlling standard input checkboxes.</li>
+      <li><a href="checkbox-mixed.html">Checkbox (Mixed-State)</a>: Demonstrates  a checkbox that uses the mixed  value for aria-checked to reflect and control checked states within a group of two-state HTML checkboxes contained in  an HTML <code>fieldset</code>.</li>
     </ul>
 
     <section>


### PR DESCRIPTION
Fixes broken links from main document to checkbox example pages and updates the descriptions of the links.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/aria-practices/pull/2144.html" title="Last updated on Nov 15, 2021, 8:14 PM UTC (7b8d65d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/aria-practices/2144/0c74238...7b8d65d.html" title="Last updated on Nov 15, 2021, 8:14 PM UTC (7b8d65d)">Diff</a>