### PR TITLE
Infrastructure: decrease frequency of dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,7 @@ updates:
 - package-ecosystem: github-actions
   directory: "/"
   schedule:
-    interval: monthly
+    interval: daily
     time: "10:00"
   open-pull-requests-limit: 99
   commit-message:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
 - package-ecosystem: npm
   directory: "/"
   schedule:
-    interval: weekly
+    interval: monthly
     time: "10:00"
   open-pull-requests-limit: 99
   commit-message:
@@ -11,7 +11,7 @@ updates:
 - package-ecosystem: github-actions
   directory: "/"
   schedule:
-    interval: daily
+    interval: monthly
     time: "10:00"
   open-pull-requests-limit: 99
   commit-message:


### PR DESCRIPTION
Decrease dependabot update frequency checks for `npm` packages from _weekly_ to _monthly_.