### PR TITLE
Infrastructure: Fix report.js unsupported buffer

### DIFF
--- a/test/util/report.js
+++ b/test/util/report.js
@@ -108,8 +108,8 @@ const processDocumentationInExampleFiles = function (
   exampleCoverage
 ) {
   for (let exampleFile of exampleFiles) {
-    var data = fs.readFileSync(exampleFile);
-    const dom = htmlparser2.parseDOM(data);
+    var data = fs.readFileSync(exampleFile).toString('utf-8');
+    const dom = htmlparser2.parseDocument(data);
     const $ = cheerio.load(dom);
 
     let dataTestIds = new Set();

--- a/test/util/report.js
+++ b/test/util/report.js
@@ -108,7 +108,7 @@ const processDocumentationInExampleFiles = function (
   exampleCoverage
 ) {
   for (let exampleFile of exampleFiles) {
-    var data = fs.readFileSync(exampleFile).toString('utf-8');
+    var data = fs.readFileSync(exampleFile, 'utf-8');
     const dom = htmlparser2.parseDocument(data);
     const $ = cheerio.load(dom);
 


### PR DESCRIPTION
Relevant to address an issue found when running the `npm run regression-report` command

> https://github.com/w3c/aria-practices/issues/959#issuecomment-973046818
>
> ```
> $ npm run regression-report
> 
> > aria-practices@0.0.0 regression-report
> > node test/util/report
> 
> Z:\aria-practices\node_modules\htmlparser2\lib\Tokenizer.js:628
>             var c = this.buffer.charCodeAt(this._index);
>                                 ^
> 
> TypeError: this.buffer.charCodeAt is not a function
>     at Tokenizer.parse (Z:\aria-practices\node_modules\htmlparser2\lib\Tokenizer.js:628:33)
>     at Tokenizer.write (Z:\aria-practices\node_modules\htmlparser2\lib\Tokenizer.js:111:14)
>     at Tokenizer.end (Z:\aria-practices\node_modules\htmlparser2\lib\Tokenizer.js:117:18)
>     at Parser.end (Z:\aria-practices\node_modules\htmlparser2\lib\Parser.js:390:24)
>     at parseDocument (Z:\aria-practices\node_modules\htmlparser2\lib\index.js:43:43)
>     at Object.parseDOM (Z:\aria-practices\node_modules\htmlparser2\lib\index.js:58:12)
>     at processDocumentationInExampleFiles (Z:\aria-practices\test\util\report.js:112:29)
>     at Object.<anonymous> (Z:\aria-practices\test\util\report.js:214:1)
>     at Module._compile (node:internal/modules/cjs/loader:1101:14)
>     at Object.Module._extensions..js (node:internal/modules/cjs/loader:1153:10)
> ```

- `htmlparser2.parseDOM` was never meant to take a buffer. Relevant comment: https://github.com/fb55/htmlparser2/issues/991#issuecomment-950325704.
- `htmlparser2.parseDOM` is deprecated. Now using `htmlparser2.parseDocument`.