### PR TITLE
Infrastructure: remove pinst

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,6 @@
         "htmlparser2": "^7.2.0",
         "husky": "^7.0.4",
         "lint-staged": "^12.1.2",
-        "pinst": "^2.1.6",
         "prettier": "^2.4.1",
         "selenium-webdriver": "^4.1.0",
         "stylelint": "^14.1.0",
@@ -3985,26 +3984,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/fromentries": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/fromentries/-/fromentries-1.3.2.tgz",
-      "integrity": "sha512-cHEpEQHUg0f8XdtZCc2ZAhrHzKzT0MrFUTcvx+hfxYu7rGMDc5SKoXFh+n4YigxsHXRzc6OrCshdR1bWH6HHyg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
-    },
     "node_modules/fs-extra": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
@@ -6510,21 +6489,6 @@
       "dev": true,
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/pinst": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/pinst/-/pinst-2.1.6.tgz",
-      "integrity": "sha512-B4dYmf6nEXg1NpDSB+orYWvKa5Kfmz5KzWC29U59dpVM4S/+xp0ak/JMEsw04UQTNNKps7klu0BUalr343Gt9g==",
-      "dev": true,
-      "dependencies": {
-        "fromentries": "^1.3.2"
-      },
-      "bin": {
-        "pinst": "bin.js"
-      },
-      "engines": {
-        "node": ">=10.0.0"
       }
     },
     "node_modules/pkg-conf": {
@@ -11245,12 +11209,6 @@
         "mime-types": "^2.1.12"
       }
     },
-    "fromentries": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/fromentries/-/fromentries-1.3.2.tgz",
-      "integrity": "sha512-cHEpEQHUg0f8XdtZCc2ZAhrHzKzT0MrFUTcvx+hfxYu7rGMDc5SKoXFh+n4YigxsHXRzc6OrCshdR1bWH6HHyg==",
-      "dev": true
-    },
     "fs-extra": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
@@ -13090,15 +13048,6 @@
       "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
       "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
       "dev": true
-    },
-    "pinst": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/pinst/-/pinst-2.1.6.tgz",
-      "integrity": "sha512-B4dYmf6nEXg1NpDSB+orYWvKa5Kfmz5KzWC29U59dpVM4S/+xp0ak/JMEsw04UQTNNKps7klu0BUalr343Gt9g==",
-      "dev": true,
-      "requires": {
-        "fromentries": "^1.3.2"
-      }
     },
     "pkg-conf": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0",
   "description": "This repository maintains the WAI-ARIA Authoring Practices Guide. This is developed by the [ARIA Working Group](http://www.w3.org/WAI/ARIA/). The staff contact is [Michael Cooper](http://www.w3.org/People/cooper/). Please do not provide commit access to this repository without coordination.",
   "main": "index.js",
+  "private": true,
   "directories": {
     "example": "examples"
   },
@@ -21,9 +22,7 @@
     "test": "npm run lint && npm run regression",
     "vnu-jar": "java -jar node_modules/vnu-jar/build/dist/vnu.jar --filterfile .vnurc --no-langdetect --skip-non-html aria-practices.html examples/",
     "create-gh-project": "node ./scripts/create-gh-project.js",
-    "prepare": "husky install",
-    "prepublishOnly": "pinst --disable",
-    "postpublish": "pinst --enable"
+    "prepare": "husky install"
   },
   "repository": {
     "type": "git",
@@ -53,7 +52,6 @@
     "htmlparser2": "^7.2.0",
     "husky": "^7.0.4",
     "lint-staged": "^12.1.2",
-    "pinst": "^2.1.6",
     "prettier": "^2.4.1",
     "selenium-webdriver": "^4.1.0",
     "stylelint": "^14.1.0",


### PR DESCRIPTION
This is only required for husky for publicly published NPM packages that others consume.
Marked package as private to match