### PR TITLE
Fix broken links affecting redesign

### DIFF
--- a/examples/checkbox/checkbox-mixed.html
+++ b/examples/checkbox/checkbox-mixed.html
@@ -17,16 +17,16 @@
   <body>
     <nav aria-label="Related Links" class="feedback">
       <ul>
-        <li><a href="../../../#browser_and_AT_support">Browser and Assistive Technology Support</a></li>
+        <li><a href="../../#browser_and_AT_support">Browser and Assistive Technology Support</a></li>
         <li><a href="https://github.com/w3c/aria-practices/issues/new">Report Issue</a></li>
         <li><a href="https://github.com/w3c/aria-practices/projects/9">Related Issues</a></li>
-        <li><a href="../../../#checkbox">Design Pattern</a></li>
+        <li><a href="../../#checkbox">Design Pattern</a></li>
       </ul>
     </nav>
     <main>
       <h1>Checkbox Example (Mixed-State)</h1>
       <p>
-        This example demonstrates using the  <a href="../../../#checkbox">Checkbox Design Pattern</a> to create a tri-state, or mixed-state, checkbox.
+        This example demonstrates using the  <a href="../../#checkbox">Checkbox Design Pattern</a> to create a tri-state, or mixed-state, checkbox.
         In this implementation, the mixed-state checkbox represents the state of a set of standard HTML checkboxes.
         If none of the checkboxes in the set are checked, the mixed state checkbox is not checked, and if all members of the set are checked, the mixed state checkbox is checked.
         If the set contains both some checked and unchecked checkboxes, the mixed state checkbox is partially checked.
@@ -214,7 +214,7 @@
       </section>
   </main>
   <nav>
-    <a href="../../../#checkbox">Checkbox Design Pattern in WAI-ARIA Authoring Practices 1.2</a>
+    <a href="../../#checkbox">Checkbox Design Pattern in WAI-ARIA Authoring Practices 1.2</a>
   </nav>
 </body>
 </html>

--- a/examples/checkbox/checkbox.html
+++ b/examples/checkbox/checkbox.html
@@ -17,15 +17,15 @@
 <body>
   <nav aria-label="Related Links" class="feedback">
     <ul>
-      <li><a href="../../../#browser_and_AT_support">Browser and Assistive Technology Support</a></li>
+      <li><a href="../../#browser_and_AT_support">Browser and Assistive Technology Support</a></li>
       <li><a href="https://github.com/w3c/aria-practices/issues/new">Report Issue</a></li>
       <li><a href="https://github.com/w3c/aria-practices/projects/9">Related Issues</a></li>
-      <li><a href="../../../#checkbox">Design Pattern</a></li>
+      <li><a href="../../#checkbox">Design Pattern</a></li>
     </ul>
   </nav>
   <main>
     <h1>Checkbox Example (Two State)</h1>
-    <p>This example implements the  <a href="../../../#checkbox">Checkbox Design Pattern</a> for a two state checkbox using <code>div</code> elements.</p>
+    <p>This example implements the  <a href="../../#checkbox">Checkbox Design Pattern</a> for a two state checkbox using <code>div</code> elements.</p>
 
     <p>Similar examples include: </p>
     <ul>
@@ -201,7 +201,7 @@
       <div id="sc1_start_sep" role="separator" aria-labelledby="sc1_start_sep sc1_label" aria-label="Start of HTML for"></div>
       <pre><code id="sc1"></code></pre>
       <div id="sc1_end_sep" role="separator" aria-labelledby="sc1_end_sep sc1_label" aria-label="End of HTML for"></div>
-  
+
       <script>
           sourceCode.add('sc1', 'ex1', 'ex_label', 'css_js_files');
           sourceCode.make();
@@ -209,7 +209,7 @@
     </section>
   </main>
   <nav>
-    <a href="../../../#checkbox">Checkbox Design Pattern in WAI-ARIA Authoring Practices 1.2</a>
+    <a href="../../#checkbox">Checkbox Design Pattern in WAI-ARIA Authoring Practices 1.2</a>
   </nav>
 </body>
 </html>

--- a/examples/combobox/combobox-autocomplete-both.html
+++ b/examples/combobox/combobox-autocomplete-both.html
@@ -163,7 +163,7 @@
       <p>
       The example combobox on this page implements the following keyboard interface.
         Other variations and options for the keyboard interface are described in the
-        <a href="../../#combobox_kbd_interaction">Keyboard Interaction section of the combobox design pattern.</a>
+        <a href="../../#keyboard-interaction-6">Keyboard Interaction section of the combobox design pattern.</a>
       </p>
       <h3 id="kbd_label_textbox">Textbox</h3>
       <table aria-labelledby="kbd_label_textbox kbd_label" class="def">
@@ -323,7 +323,7 @@
       <p>
         The example combobox on this page implements the following ARIA roles, states, and properties.
         Information about other ways of applying ARIA roles, states, and properties is available in the
-        <a href="../../#combobox_roles_states_props">Roles, States, and Properties section of the combobox design pattern.</a>
+        <a href="../../#wai-aria-roles-states-and-properties-6">Roles, States, and Properties section of the combobox design pattern.</a>
       </p>
       <h3 id="rps_label_textbox">Textbox</h3>
       <table aria-labelledby="rps_label_textbox rps_label" class="data attributes">

--- a/examples/combobox/combobox-autocomplete-list.html
+++ b/examples/combobox/combobox-autocomplete-list.html
@@ -164,7 +164,7 @@
       <p>
       The example combobox on this page implements the following keyboard interface.
         Other variations and options for the keyboard interface are described in the
-        <a href="../../#combobox_kbd_interaction">Keyboard Interaction section of the combobox design pattern.</a>
+        <a href="../../#keyboard-interaction-6">Keyboard Interaction section of the combobox design pattern.</a>
       </p>
       <h3 id="kbd_label_textbox">Textbox</h3>
       <table aria-labelledby="kbd_label_textbox kbd_label" class="def">
@@ -318,7 +318,7 @@
       <p>
         The example combobox on this page implements the following ARIA roles, states, and properties.
         Information about other ways of applying ARIA roles, states, and properties is available in the
-        <a href="../../#combobox_roles_states_props">Roles, States, and Properties section of the combobox design pattern.</a>
+        <a href="../../#wai-aria-roles-states-and-properties-6">Roles, States, and Properties section of the combobox design pattern.</a>
       </p>
       <h3 id="rps_label_textbox">Textbox</h3>
       <table aria-labelledby="rps_label_textbox rps_label" class="data attributes">

--- a/examples/combobox/combobox-autocomplete-none.html
+++ b/examples/combobox/combobox-autocomplete-none.html
@@ -119,7 +119,7 @@
       <p>
       The example combobox on this page implements the following keyboard interface.
         Other variations and options for the keyboard interface are described in the
-        <a href="../../#combobox_kbd_interaction">Keyboard Interaction section of the combobox design pattern.</a>
+        <a href="../../#keyboard-interaction-6">Keyboard Interaction section of the combobox design pattern.</a>
       </p>
       <h3 id="kbd_label_textbox">Textbox</h3>
       <table aria-labelledby="kbd_label_textbox kbd_label" class="def">
@@ -262,7 +262,7 @@
       <p>
         The example combobox on this page implements the following ARIA roles, states, and properties.
         Information about other ways of applying ARIA roles, states, and properties is available in the
-        <a href="../../#combobox_roles_states_props">Roles, States, and Properties section of the combobox design pattern.</a>
+        <a href="../../#wai-aria-roles-states-and-properties-6">Roles, States, and Properties section of the combobox design pattern.</a>
       </p>
       <h3 id="rps_label_textbox">Textbox</h3>
       <table aria-labelledby="rps_label_textbox rps_label" class="data attributes">

--- a/examples/combobox/combobox-select-only.html
+++ b/examples/combobox/combobox-select-only.html
@@ -92,7 +92,7 @@
       <p>
       The example combobox on this page implements the following keyboard interface.
         Other variations and options for the keyboard interface are described in the
-        <a href="../../#combobox_kbd_interaction">Keyboard Interaction section of the combobox design pattern.</a>
+        <a href="../../#keyboard-interaction-6">Keyboard Interaction section of the combobox design pattern.</a>
       </p>
       <h3 id="kbd_label_combobox">Closed Combobox</h3>
       <table aria-labelledby="kbd_label_combobox kbd_label" class="def">
@@ -282,7 +282,7 @@
       <p>
         The example combobox on this page implements the following ARIA roles, states, and properties.
         Information about other ways of applying ARIA roles, states, and properties is available in the
-        <a href="../../#combobox_roles_states_props">Roles, States, and Properties section of the combobox design pattern.</a>
+        <a href="../../#wai-aria-roles-states-and-properties-6">Roles, States, and Properties section of the combobox design pattern.</a>
       </p>
       <h3 id="rps_label_combobox">Combobox</h3>
       <table aria-labelledby="rps_label_combobox rps_label" class="data attributes">

--- a/examples/combobox/grid-combo.html
+++ b/examples/combobox/grid-combo.html
@@ -92,7 +92,7 @@
       <p>
       The example combobox on this page implements the following keyboard interface.
         Other variations and options for the keyboard interface are described in the
-        <a href="../../#combobox_kbd_interaction">Keyboard Interaction section of the combobox design pattern.</a>
+        <a href="../../#keyboard-interaction-6">Keyboard Interaction section of the combobox design pattern.</a>
       </p>
       <h3 id="kbd_label_textbox">Textbox</h3>
       <table aria-labelledby="kbd_label_textbox kbd_label" class="def">
@@ -231,7 +231,7 @@
       <p>
         The example comboboxes on this page implement the following ARIA roles, states, and properties.
         Information about other ways of applying ARIA roles, states, and properties is available in the
-        <a href="../../#combobox_roles_states_props">Roles, States, and Properties section of the combobox design pattern.</a>
+        <a href="../../#wai-aria-roles-states-and-properties-6">Roles, States, and Properties section of the combobox design pattern.</a>
       </p>
       <h3 id="rps_label_textbox">Textbox</h3>
       <table aria-labelledby="rps_label_textbox rps_label" class="data attributes">

--- a/examples/dialog-modal/datepicker-dialog.html
+++ b/examples/dialog-modal/datepicker-dialog.html
@@ -22,13 +22,13 @@
       <li><a href="../../#browser_and_AT_support">Browser and Assistive Technology Support</a></li>
       <li><a href="https://github.com/w3c/aria-practices/issues/new">Report Issue</a></li>
       <li><a href="https://github.com/w3c/aria-practices/projects/27">Related Issues</a></li>
-      <li><a href="../../#dialog-modal">Design Pattern</a></li>
+      <li><a href="../../#dialog_modal">Design Pattern</a></li>
     </ul>
   </nav>
   <main>
     <h1>Date Picker Dialog Example</h1>
     <p>
-      The example below includes a date input field and a button that opens a date picker that implements the <a href="../../#dialog-modal">dialog design pattern</a>.
+      The example below includes a date input field and a button that opens a date picker that implements the <a href="../../#dialog_modal">dialog design pattern</a>.
       The dialog contains a calendar that uses the <a href="../../#grid">grid pattern</a> to present buttons that enable the user to choose a day from the calendar.
       Choosing a date from the calendar closes the dialog and populates the date input field.
       When the dialog is opened, if the input field is empty, or does not contain a valid date, then the current date is focused in the calendar.
@@ -667,7 +667,7 @@
   </section>
   </main>
   <nav>
-    <a href="../../#dialog-modal">Dialog Design Pattern in WAI-ARIA Authoring Practices 1.2</a>
+    <a href="../../#dialog_modal">Dialog Design Pattern in WAI-ARIA Authoring Practices 1.2</a>
   </nav>
 </body>
 </html>

--- a/examples/listbox/listbox-collapsible.html
+++ b/examples/listbox/listbox-collapsible.html
@@ -258,7 +258,7 @@
               <li>Enables assistive technologies to know which element the application regards as focused while DOM focus remains on the <code>ul</code> element.</li>
               <li>
                 For more information about this focus management technique, see
-                <a href="../../../#kbd_focus_activedescendant">Using aria-activedescendant to Manage Focus.</a>
+                <a href="../../#kbd_focus_activedescendant">Using aria-activedescendant to Manage Focus.</a>
               </li>
             </ul>
           </td>

--- a/examples/meter/meter.html
+++ b/examples/meter/meter.html
@@ -20,7 +20,7 @@
 <body>
 <nav aria-label="Related Links" class="feedback">
   <ul>
-    <li><a href="../../../#browser_and_AT_support">Browser and Assistive Technology Support</a></li>
+    <li><a href="../../#browser_and_AT_support">Browser and Assistive Technology Support</a></li>
     <li><a href="https://github.com/w3c/aria-practices/issues/new">Report Issue</a></li>
     <li><a href="https://github.com/w3c/aria-practices/projects/30">Related Issues</a></li>
     <li><a href="../../#meter">Design Pattern</a></li>

--- a/examples/radio/radio-rating.html
+++ b/examples/radio/radio-rating.html
@@ -22,14 +22,14 @@
       <li><a href="../../#browser_and_AT_support">Browser and Assistive Technology Support</a></li>
       <li><a href="https://github.com/w3c/aria-practices/issues/new">Report Issue</a></li>
       <li><a href="https://github.com/w3c/aria-practices/projects/3">Related Issues</a></li>
-      <li><a href="../../#radio">Design Pattern</a></li>
+      <li><a href="../../#radiobutton">Design Pattern</a></li>
     </ul>
   </nav>
   <main>
     <h1>Rating Radio Group Example</h1>
     <p>
       Following is an example of a rating input that demonstrates the
-      <a href="../../#radio">Radio Group Design Pattern.</a>
+      <a href="../../#radiobutton">Radio Group Design Pattern.</a>
       The rating is indicated by the number of stars selected by the user.
     </p>
     <p>Similar examples include: </p>
@@ -291,7 +291,7 @@
 
   </main>
   <nav>
-    <a href="../../#radio">Slider Design Pattern in WAI-ARIA Authoring Practices 1.2</a>
+    <a href="../../#radiobutton">Slider Design Pattern in WAI-ARIA Authoring Practices 1.2</a>
   </nav>
 </body>
 </html>

--- a/examples/treegrid/treegrid-1.html
+++ b/examples/treegrid/treegrid-1.html
@@ -374,7 +374,7 @@
               <li>In this implementation, the first <code>row</code> in the <code>treegrid</code> is included in the tab sequence when the page loads.</li>
               <li>
                 When the user moves focus in the <code>treegrid</code>, the element included in the tab sequence changes to the element with focus as described in the section on
-                <a href="../../../#kbd_roving_tabindex">roving tabindex.</a>
+                <a href="../../#kbd_roving_tabindex">roving tabindex.</a>
               </li>
              </ul>
           </td>


### PR DESCRIPTION
My work on the [APG Redesign](https://github.com/bocoup/wai-aria-practices/) uncovered some broken links in the APG. As we discussed today in the APG Task Force meeting, these broken links are blocking us from completing the CI for the redesigned website, so we decided to fast-track the review of this PR!