### PR TITLE
Multiple Examples: Change CSS currentColor to currentcolor

### DIFF
--- a/examples/accordion/css/accordion.css
+++ b/examples/accordion/css/accordion.css
@@ -78,7 +78,7 @@ button {
 }
 
 .accordion-icon {
-  border: solid currentColor;
+  border: solid currentcolor;
   border-width: 0 2px 2px 0;
   height: 0.5rem;
   pointer-events: none;

--- a/examples/breadcrumb/css/breadcrumb.css
+++ b/examples/breadcrumb/css/breadcrumb.css
@@ -19,7 +19,7 @@ nav.breadcrumb li + li::before {
   display: inline-block;
   margin: 0 0.25em;
   transform: rotate(15deg);
-  border-right: 0.1em solid currentColor;
+  border-right: 0.1em solid currentcolor;
   height: 0.8em;
   content: "";
 }

--- a/examples/button/button.html
+++ b/examples/button/button.html
@@ -65,25 +65,25 @@
               <polygon
                  id="polygon1"
                  points="39.389,13.769 22.235,28.606 6,28.606 6,47.699 21.989,47.699 39.389,62.75 39.389,13.769"
-                 style="stroke:currentColor;stroke-width:5;stroke-linejoin:round;fill:currentColor;" />
+                 style="stroke:currentcolor;stroke-width:5;stroke-linejoin:round;fill:currentcolor;" />
               <path
                  id="path3003"
                  d="M 48.651772,50.269646 69.395223,25.971024"
-                 style="fill:none;stroke:currentColor;stroke-width:5;stroke-linecap:round" />
+                 style="fill:none;stroke:currentcolor;stroke-width:5;stroke-linecap:round" />
               <path
                  id="path3003-1"
                  d="M 69.395223,50.269646 48.651772,25.971024"
-                 style="fill:none;stroke:currentColor;stroke-width:5;stroke-linecap:round"/>
+                 style="fill:none;stroke:currentcolor;stroke-width:5;stroke-linecap:round"/>
             </symbol>
             <symbol id="icon-sound" viewBox="0 0 75 75">
               <polygon points="39.389,13.769 22.235,28.606 6,28.606 6,47.699 21.989,47.699 39.389,62.75 39.389,13.769"
-                style="stroke:currentColor;stroke-width:5;stroke-linejoin:round;fill:currentColor;"/>
+                style="stroke:currentcolor;stroke-width:5;stroke-linejoin:round;fill:currentcolor;"/>
               <path d="M 48.128,49.03 C 50.057,45.934 51.19,42.291 51.19,38.377 C 51.19,34.399 50.026,30.703 48.043,27.577"
-                style="fill:none;stroke:currentColor;stroke-width:5;stroke-linecap:round"/>
+                style="fill:none;stroke:currentcolor;stroke-width:5;stroke-linecap:round"/>
               <path d="M 55.082,20.537 C 58.777,25.523 60.966,31.694 60.966,38.377 C 60.966,44.998 58.815,51.115 55.178,56.076"
-                style="fill:none;stroke:currentColor;stroke-width:5;stroke-linecap:round"/>
+                style="fill:none;stroke:currentcolor;stroke-width:5;stroke-linecap:round"/>
               <path d="M 61.71,62.611 C 66.977,55.945 70.128,47.531 70.128,38.378 C 70.128,29.161 66.936,20.696 61.609,14.01"
-                style="fill:none;stroke:currentColor;stroke-width:5;stroke-linecap:round"/>
+                style="fill:none;stroke:currentcolor;stroke-width:5;stroke-linecap:round"/>
             </symbol>
           </defs>
         </svg>

--- a/examples/button/button_idl.html
+++ b/examples/button/button_idl.html
@@ -43,7 +43,7 @@
       </div>
 
       <div role="separator" id="ex_start_sep" aria-labelledby="ex_start_sep ex_label" aria-label="Start of"></div>
-      
+
       <div id="example">
         <p class="advisement">
           <strong>IMPORTANT:</strong> This example is coded using syntax that was not introduced until version 1.2 of the ARIA specification.
@@ -67,25 +67,25 @@
               <polygon
                  id="polygon1"
                  points="39.389,13.769 22.235,28.606 6,28.606 6,47.699 21.989,47.699 39.389,62.75 39.389,13.769"
-                 style="stroke:currentColor;stroke-width:5;stroke-linejoin:round;fill:currentColor;" />
+                 style="stroke:currentcolor;stroke-width:5;stroke-linejoin:round;fill:currentcolor;" />
               <path
                  id="path3003"
                  d="M 48.651772,50.269646 69.395223,25.971024"
-                 style="fill:none;stroke:currentColor;stroke-width:5;stroke-linecap:round" />
+                 style="fill:none;stroke:currentcolor;stroke-width:5;stroke-linecap:round" />
               <path
                  id="path3003-1"
                  d="M 69.395223,50.269646 48.651772,25.971024"
-                 style="fill:none;stroke:currentColor;stroke-width:5;stroke-linecap:round"/>
+                 style="fill:none;stroke:currentcolor;stroke-width:5;stroke-linecap:round"/>
             </symbol>
             <symbol id="icon-sound" viewBox="0 0 75 75">
               <polygon points="39.389,13.769 22.235,28.606 6,28.606 6,47.699 21.989,47.699 39.389,62.75 39.389,13.769"
-                style="stroke:currentColor;stroke-width:5;stroke-linejoin:round;fill:currentColor;"/>
+                style="stroke:currentcolor;stroke-width:5;stroke-linejoin:round;fill:currentcolor;"/>
               <path d="M 48.128,49.03 C 50.057,45.934 51.19,42.291 51.19,38.377 C 51.19,34.399 50.026,30.703 48.043,27.577"
-                style="fill:none;stroke:currentColor;stroke-width:5;stroke-linecap:round"/>
+                style="fill:none;stroke:currentcolor;stroke-width:5;stroke-linecap:round"/>
               <path d="M 55.082,20.537 C 58.777,25.523 60.966,31.694 60.966,38.377 C 60.966,44.998 58.815,51.115 55.178,56.076"
-                style="fill:none;stroke:currentColor;stroke-width:5;stroke-linecap:round"/>
+                style="fill:none;stroke:currentcolor;stroke-width:5;stroke-linecap:round"/>
               <path d="M 61.71,62.611 C 66.977,55.945 70.128,47.531 70.128,38.378 C 70.128,29.161 66.936,20.696 61.609,14.01"
-                style="fill:none;stroke:currentColor;stroke-width:5;stroke-linecap:round"/>
+                style="fill:none;stroke:currentcolor;stroke-width:5;stroke-linecap:round"/>
             </symbol>
           </defs>
         </svg>

--- a/examples/checkbox/checkbox-mixed.html
+++ b/examples/checkbox/checkbox-mixed.html
@@ -78,10 +78,10 @@
         </li>
         <li>
           To ensure the borders of the inline SVG checkbox graphics in the CSS have sufficient contrast with the background when high contrast settings invert colors, the color of the borders are synchronized with the color of the text content.
-          For example, the color of the checkbox borders is set to match the foreground color of high contrast mode text by specifying the CSS <code>currentColor</code> value for the <code>stroke</code> property of the <code>rect</code> and <code>polyline</code> elements used to draw the checkbox.
+          For example, the color of the checkbox borders is set to match the foreground color of high contrast mode text by specifying the CSS <code>currentcolor</code> value for the <code>stroke</code> property of the <code>rect</code> and <code>polyline</code> elements used to draw the checkbox.
            To make the background of the checkbox graphics match the high contrast background color, the <code>fill-opacity</code> attribute of the <code>rect</code> element is set to zero.
           If specific colors were instead used to specify the <code>stroke</code> and <code>fill</code> properties, those colors would remain the same in high contrast mode, which could lead to insufficient contrast between the checkbox and the background or even make the checkbox invisible if the color matched the high contrast mode background.<br>
-          Note: The SVG element needs to have the CSS <code>forced-color-adjust</code> property set to <code>auto</code> for the <code>currentColor</code> value to be updated in high contrast mode.
+          Note: The SVG element needs to have the CSS <code>forced-color-adjust</code> property set to <code>auto</code> for the <code>currentcolor</code> value to be updated in high contrast mode.
           Some browsers do not use <code>auto</code> for the default value.
         </li>
       </ul>

--- a/examples/checkbox/checkbox.html
+++ b/examples/checkbox/checkbox.html
@@ -69,10 +69,10 @@
         </li>
         <li>
           To ensure the borders of the inline SVG checkbox graphics in the CSS have sufficient contrast with the background when high contrast settings invert colors, the color of the borders are synchronized with the color of the text content.
-          For example, the color of the checkbox borders is set to match the foreground color of high contrast mode text by specifying the CSS <code>currentColor</code> value for the <code>stroke</code> property of the <code>rect</code> and <code>polyline</code> elements used to draw the checkbox.
+          For example, the color of the checkbox borders is set to match the foreground color of high contrast mode text by specifying the CSS <code>currentcolor</code> value for the <code>stroke</code> property of the <code>rect</code> and <code>polyline</code> elements used to draw the checkbox.
           To make the background of the checkbox graphics match the high contrast background color, the <code>fill-opacity</code> attribute of the <code>rect</code> element is set to zero.
           If specific colors were instead used to specify the <code>stroke</code> and <code>fill</code> properties, those colors would remain the same in high contrast mode, which could lead to insufficient contrast between the checkbox and the background or even make the checkbox invisible if the color matched the high contrast mode background.<br>
-          Note: The SVG element needs to have the CSS <code>forced-color-adjust</code> property set to <code>auto</code> for the <code>currentColor</code> value to be updated in high contrast mode.
+          Note: The SVG element needs to have the CSS <code>forced-color-adjust</code> property set to <code>auto</code> for the <code>currentcolor</code> value to be updated in high contrast mode.
           Some browsers do not use <code>auto</code> for the default value.
         </li>
       </ul>

--- a/examples/checkbox/css/checkbox-mixed.css
+++ b/examples/checkbox/css/checkbox-mixed.css
@@ -24,19 +24,19 @@
 .checkbox-mixed [role="checkbox"]::before {
   position: relative;
   top: 1px;
-  content: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' height='16' width='16' style='forced-color-adjust: auto;'%3E%3Crect x='2' y='2' height='13' width='13' rx='2' stroke='currentColor' stroke-width='1' fill-opacity='0' /%3E%3C/svg%3E");
+  content: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' height='16' width='16' style='forced-color-adjust: auto;'%3E%3Crect x='2' y='2' height='13' width='13' rx='2' stroke='currentcolor' stroke-width='1' fill-opacity='0' /%3E%3C/svg%3E");
 }
 
 .checkbox-mixed [role="checkbox"][aria-checked="true"]::before {
   position: relative;
   top: 1px;
-  content: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' height='16' width='16' style='forced-color-adjust: auto;'%3E%3Crect x='2' y='2' height='13' width='13' rx='2' stroke='currentColor' stroke-width='1' fill-opacity='0' /%3E%3Cpolyline points='4,8 7,12 12,5' fill='none' stroke='currentColor' stroke-width='2' /%3E%3C/svg%3E");
+  content: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' height='16' width='16' style='forced-color-adjust: auto;'%3E%3Crect x='2' y='2' height='13' width='13' rx='2' stroke='currentcolor' stroke-width='1' fill-opacity='0' /%3E%3Cpolyline points='4,8 7,12 12,5' fill='none' stroke='currentcolor' stroke-width='2' /%3E%3C/svg%3E");
 }
 
 .checkbox-mixed [role="checkbox"][aria-checked="mixed"]::before {
   position: relative;
   top: 1px;
-  content: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' height='16' width='16' style='forced-color-adjust: auto;'%3E%3Crect x='2' y='2' height='13' width='13' rx='2' stroke='currentColor' stroke-width='1' fill-opacity='0' /%3E%3Cline x1='5' y1='5' x2='12' y2='12' stroke='currentColor' stroke-width='2' /%3E%3C/svg%3E");
+  content: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' height='16' width='16' style='forced-color-adjust: auto;'%3E%3Crect x='2' y='2' height='13' width='13' rx='2' stroke='currentcolor' stroke-width='1' fill-opacity='0' /%3E%3Cline x1='5' y1='5' x2='12' y2='12' stroke='currentcolor' stroke-width='2' /%3E%3C/svg%3E");
 }
 
 .checkbox-mixed input:focus,

--- a/examples/checkbox/css/checkbox.css
+++ b/examples/checkbox/css/checkbox.css
@@ -21,13 +21,13 @@ ul.checkboxes li {
   position: relative;
   top: 1px;
   left: -4px;
-  content: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' height='16' width='16' style='forced-color-adjust: auto;'%3E%3Crect x='2' y='2' height='13' width='13' rx='2' stroke='currentColor' stroke-width='1' fill-opacity='0' /%3E%3C/svg%3E");
+  content: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' height='16' width='16' style='forced-color-adjust: auto;'%3E%3Crect x='2' y='2' height='13' width='13' rx='2' stroke='currentcolor' stroke-width='1' fill-opacity='0' /%3E%3C/svg%3E");
 }
 
 [role="checkbox"][aria-checked="true"]::before {
   position: relative;
   top: 1px;
-  content: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' height='16' width='16' style='forced-color-adjust: auto;'%3E%3Crect x='2' y='2' height='13' width='13' rx='2' stroke='currentColor' stroke-width='1' fill-opacity='0' /%3E%3Cpolyline points='4,8 7,12 12,5' fill='none' stroke='currentColor' stroke-width='2' /%3E%3C/svg%3E");
+  content: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' height='16' width='16' style='forced-color-adjust: auto;'%3E%3Crect x='2' y='2' height='13' width='13' rx='2' stroke='currentcolor' stroke-width='1' fill-opacity='0' /%3E%3Cpolyline points='4,8 7,12 12,5' fill='none' stroke='currentcolor' stroke-width='2' /%3E%3C/svg%3E");
 }
 
 [role="checkbox"]:focus,

--- a/examples/combobox/combobox-autocomplete-both.html
+++ b/examples/combobox/combobox-autocomplete-both.html
@@ -58,7 +58,7 @@
               aria-expanded="false" aria-controls="cb1-listbox">
             <button type="button" id="cb1-button" aria-label="States" aria-expanded="false" aria-controls="cb1-listbox" tabindex="-1">
               <svg width="18" height="16" aria-hidden="true" focusable="false" style="forced-color-adjust: auto">
-                <polygon class="arrow" stroke-width="0" fill-opacity="0.75" fill="currentColor" points="3,6 15,6 9,14"></polygon>
+                <polygon class="arrow" stroke-width="0" fill-opacity="0.75" fill="currentcolor" points="3,6 15,6 9,14"></polygon>
               </svg>
             </button>
           </div>
@@ -150,7 +150,7 @@
         </li>
         <li>
           To ensure the inline SVG graphic used for the arrow in the open button has sufficient contrast with the background when high contrast settings change the color of text content,
-          CSS <code>forced-color-adjust</code> is set to <code>auto</code> on the <code>svg</code> element and and the <code>fill</code> attribute of the <code>polygon</code> element is set to <code>currentColor</code>.
+          CSS <code>forced-color-adjust</code> is set to <code>auto</code> on the <code>svg</code> element and and the <code>fill</code> attribute of the <code>polygon</code> element is set to <code>currentcolor</code>.
           This causes the colors of the <code>fill</code> of the polygon elements to be overridden by the high contrast color setting.
           If <code>forced-color-adjust</code> were not used to override the colors specified for the <code>fill</code> property, the color would remain the same in high contrast mode, which could lead to insufficient contrast between the arrow and the background or even make it invisible if the color matched the high contrast mode background.<br>
           Note: The explicit setting of <code>forced-color-adjust</code> is necessary because some browsers do not use <code>auto</code> as the default value for SVG graphics.

--- a/examples/combobox/combobox-autocomplete-list.html
+++ b/examples/combobox/combobox-autocomplete-list.html
@@ -59,7 +59,7 @@
               aria-expanded="false" aria-controls="cb1-listbox">
             <button id="cb1-button" tabindex="-1" aria-label="States" aria-expanded="false" aria-controls="cb1-listbox">
               <svg width="18" height="16" aria-hidden="true" focusable="false" style="forced-color-adjust: auto">
-                <polygon class="arrow" stroke-width="0" fill-opacity="0.75" fill="currentColor" points="3,6 15,6 9,14"></polygon>
+                <polygon class="arrow" stroke-width="0" fill-opacity="0.75" fill="currentcolor" points="3,6 15,6 9,14"></polygon>
               </svg>
             </button>
           </div>
@@ -151,7 +151,7 @@
         </li>
         <li>
           To ensure the inline SVG graphic used for the arrow in the open button has sufficient contrast with the background when high contrast settings change the color of text content,
-          CSS <code>forced-color-adjust</code> is set to <code>auto</code> on the <code>svg</code> element and and the <code>fill</code> attribute of the <code>polygon</code> element is set to <code>currentColor</code>.
+          CSS <code>forced-color-adjust</code> is set to <code>auto</code> on the <code>svg</code> element and and the <code>fill</code> attribute of the <code>polygon</code> element is set to <code>currentcolor</code>.
           This causes the colors of the <code>fill</code> of the polygon elements to be overridden by the high contrast color setting.
           If <code>forced-color-adjust</code> were not used to override the colors specified for the <code>fill</code> property, the color would remain the same in high contrast mode, which could lead to insufficient contrast between the arrow and the background or even make it invisible if the color matched the high contrast mode background.<br>
           Note: The explicit setting of <code>forced-color-adjust</code> is necessary because some browsers do not use <code>auto</code> as the default value for SVG graphics.

--- a/examples/combobox/combobox-autocomplete-none.html
+++ b/examples/combobox/combobox-autocomplete-none.html
@@ -59,7 +59,7 @@
                    aria-controls="cb1-listbox">
             <button type="button" id="cb1-button" tabindex="-1" aria-label="Previous Searches" aria-expanded="false" aria-controls="cb1-listbox" >
               <svg width="18" height="16" aria-hidden="true" focusable="false" style="forced-color-adjust: auto">
-                <polygon class="arrow" stroke-width="0" fill-opacity="0.75" fill="currentColor" points="3,6 15,6 9,14"></polygon>
+                <polygon class="arrow" stroke-width="0" fill-opacity="0.75" fill="currentcolor" points="3,6 15,6 9,14"></polygon>
               </svg>
             </button>
           </div>
@@ -106,7 +106,7 @@
         </li>
         <li>
           To ensure the inline SVG graphic used for the arrow in the open button has sufficient contrast with the background when high contrast settings change the color of text content,
-          CSS <code>forced-color-adjust</code> is set to <code>auto</code> on the <code>svg</code> element and and the <code>fill</code> attribute of the <code>polygon</code> element is set to <code>currentColor</code>.
+          CSS <code>forced-color-adjust</code> is set to <code>auto</code> on the <code>svg</code> element and and the <code>fill</code> attribute of the <code>polygon</code> element is set to <code>currentcolor</code>.
           This causes the colors of the <code>fill</code> of the polygon elements to be overridden by the high contrast color setting.
           If <code>forced-color-adjust</code> were not used to override the colors specified for the <code>fill</code> property, the color would remain the same in high contrast mode, which could lead to insufficient contrast between the arrow and the background or even make it invisible if the color matched the high contrast mode background.<br>
           Note: The explicit setting of <code>forced-color-adjust</code> is necessary because some browsers do not use <code>auto</code> as the default value for SVG graphics.

--- a/examples/combobox/css/combobox-autocomplete.css
+++ b/examples/combobox/css/combobox-autocomplete.css
@@ -51,7 +51,7 @@ ul[role="listbox"] {
   background-color: white;
   display: none;
   box-sizing: border-box;
-  border: 2px currentColor solid;
+  border: 2px currentcolor solid;
   max-height: 250px;
   width: 168px;
   overflow: scroll;
@@ -73,7 +73,7 @@ ul[role="listbox"] li[role="option"] {
 .combobox .group.focus,
 .combobox .group:hover {
   padding: 2px;
-  border: 2px solid currentColor;
+  border: 2px solid currentcolor;
   border-radius: 4px;
 }
 
@@ -94,6 +94,6 @@ ul[role="listbox"] li[role="option"] {
   background-color: #def;
   padding-top: 0;
   padding-bottom: 0;
-  border-top: 2px solid currentColor;
-  border-bottom: 2px solid currentColor;
+  border-top: 2px solid currentcolor;
+  border-bottom: 2px solid currentcolor;
 }

--- a/examples/disclosure/css/disclosure-faq.css
+++ b/examples/disclosure/css/disclosure-faq.css
@@ -35,13 +35,13 @@ dl.faq button:focus {
 }
 
 dl.faq button[aria-expanded="false"]::before {
-  content: url("data:image/svg+xml,%3C%3Fxml version='1.0' encoding='utf-8'%3F%3E%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12' style='forced-color-adjust: auto;'%3E%3Cpolygon points='1 1, 1 11, 8 6' fill='currentColor' stroke= 'currentColor' /%3E%3C/svg%3E%0A");
+  content: url("data:image/svg+xml,%3C%3Fxml version='1.0' encoding='utf-8'%3F%3E%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12' style='forced-color-adjust: auto;'%3E%3Cpolygon points='1 1, 1 11, 8 6' fill='currentcolor' stroke= 'currentcolor' /%3E%3C/svg%3E%0A");
   position: relative;
   left: -2px;
 }
 
 dl.faq button[aria-expanded="true"]::before {
-  content: url("data:image/svg+xml,%3C%3Fxml version='1.0' encoding='utf-8'%3F%3E%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12' style='forced-color-adjust: auto;'%3E%3Cpolygon points='1 1, 11 1, 6 8' fill='currentColor' stroke= 'currentColor' /%3E%3C/svg%3E ");
+  content: url("data:image/svg+xml,%3C%3Fxml version='1.0' encoding='utf-8'%3F%3E%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12' style='forced-color-adjust: auto;'%3E%3Cpolygon points='1 1, 11 1, 6 8' fill='currentcolor' stroke= 'currentcolor' /%3E%3C/svg%3E ");
   position: relative;
   left: -4px;
   top: 2px;

--- a/examples/disclosure/css/disclosure-image-description.css
+++ b/examples/disclosure/css/disclosure-image-description.css
@@ -18,13 +18,13 @@ figure button:focus {
 }
 
 figure button[aria-expanded="false"]::before {
-  content: url("data:image/svg+xml,%3C%3Fxml version='1.0' encoding='utf-8'%3F%3E%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12' style='forced-color-adjust: auto;'%3E%3Cpolygon points='1 1, 1 11, 8 6' fill='currentColor' stroke= 'currentColor' /%3E%3C/svg%3E%0A");
+  content: url("data:image/svg+xml,%3C%3Fxml version='1.0' encoding='utf-8'%3F%3E%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12' style='forced-color-adjust: auto;'%3E%3Cpolygon points='1 1, 1 11, 8 6' fill='currentcolor' stroke= 'currentcolor' /%3E%3C/svg%3E%0A");
   position: relative;
   left: -2px;
 }
 
 figure button[aria-expanded="true"]::before {
-  content: url("data:image/svg+xml,%3C%3Fxml version='1.0' encoding='utf-8'%3F%3E%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12' style='forced-color-adjust: auto;'%3E%3Cpolygon points='1 1, 11 1, 6 8' fill='currentColor' stroke= 'currentColor' /%3E%3C/svg%3E ");
+  content: url("data:image/svg+xml,%3C%3Fxml version='1.0' encoding='utf-8'%3F%3E%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12' style='forced-color-adjust: auto;'%3E%3Cpolygon points='1 1, 11 1, 6 8' fill='currentcolor' stroke= 'currentcolor' /%3E%3C/svg%3E ");
   position: relative;
   left: -4px;
   top: 2px;

--- a/examples/disclosure/disclosure-faq.html
+++ b/examples/disclosure/disclosure-faq.html
@@ -114,9 +114,9 @@
       </li>
       <li>
         To ensure the inline SVG arrow graphics in the CSS have sufficient contrast with the background when high contrast settings invert colors, the color of the arrows are synchronized with the color of the text content.
-        For example, the color of the arrow is set to match the foreground color of high contrast mode text by specifying the CSS <code>currentColor</code> value for the <code>stroke</code> and <code>fill</code> properties of the <code>polygon</code> elements used to draw the arrows.
+        For example, the color of the arrow is set to match the foreground color of high contrast mode text by specifying the CSS <code>currentcolor</code> value for the <code>stroke</code> and <code>fill</code> properties of the <code>polygon</code> elements used to draw the arrows.
         If specific colors were instead used to specify the <code>polygon</code> properties, those colors would remain the same in high contrast mode, which could lead to insufficient contrast between the arrows and the background or even make the arrows invisible if the color matched the high contrast mode background.<br>
-        Note: The SVG element needs to have the CSS <code>forced-color-adjust</code> property set to <code>auto</code> for the <code>currentColor</code> value to be updated in high contrast mode.
+        Note: The SVG element needs to have the CSS <code>forced-color-adjust</code> property set to <code>auto</code> for the <code>currentcolor</code> value to be updated in high contrast mode.
         Some browsers do not use <code>auto</code> for the default value.
       </li>
     </ul>

--- a/examples/disclosure/disclosure-image-description.html
+++ b/examples/disclosure/disclosure-image-description.html
@@ -260,9 +260,9 @@
       </li>
       <li>
         To ensure the inline SVG arrow graphics in the CSS have sufficient contrast with the background when high contrast settings invert colors, the color of the arrows are synchronized with the color of the text content.
-        For example, the color of the arrow is set to match the foreground color of high contrast mode text by specifying the CSS <code>currentColor</code> value for the <code>stroke</code> and <code>fill</code> properties of the <code>polygon</code> elements used to draw the arrows.
+        For example, the color of the arrow is set to match the foreground color of high contrast mode text by specifying the CSS <code>currentcolor</code> value for the <code>stroke</code> and <code>fill</code> properties of the <code>polygon</code> elements used to draw the arrows.
         If specific colors were instead used to specify the <code>polygon</code> properties, those colors would remain the same in high contrast mode, which could lead to insufficient contrast between the arrows and the background or even make the arrows invisible if the color matched the high contrast mode background.<br>
-        Note: The SVG element needs to have the CSS <code>forced-color-adjust</code> property set to <code>auto</code> for the <code>currentColor</code> value to be updated in high contrast mode.
+        Note: The SVG element needs to have the CSS <code>forced-color-adjust</code> property set to <code>auto</code> for the <code>currentcolor</code> value to be updated in high contrast mode.
         Some browsers do not use <code>auto</code> for the default value.
       </li>
     </ul>

--- a/examples/listbox/css/listbox.css
+++ b/examples/listbox/css/listbox.css
@@ -73,7 +73,7 @@ button[aria-haspopup="listbox"]::after {
   width: 0;
   height: 0;
   border: 8px solid transparent;
-  border-top-color: currentColor;
+  border-top-color: currentcolor;
   border-bottom: 0;
   content: "";
 }
@@ -86,7 +86,7 @@ button[aria-haspopup="listbox"][aria-expanded="true"]::after {
   height: 0;
   border: 8px solid transparent;
   border-top: 0;
-  border-bottom-color: currentColor;
+  border-bottom-color: currentcolor;
   content: "";
 }
 

--- a/examples/menu-button/css/menu-button-actions.css
+++ b/examples/menu-button/css/menu-button-actions.css
@@ -45,8 +45,8 @@
 
 .menu-button-actions button svg.down {
   padding-left: 0.125em;
-  fill: currentColor;
-  stroke: currentColor;
+  fill: currentcolor;
+  stroke: currentcolor;
 }
 
 .menu-button-actions button[aria-expanded="true"] svg.down {

--- a/examples/menu-button/css/menu-button-links.css
+++ b/examples/menu-button/css/menu-button-links.css
@@ -47,8 +47,8 @@
 
 .menu-button-links button svg.down {
   padding-left: 0.125em;
-  fill: currentColor;
-  stroke: currentColor;
+  fill: currentcolor;
+  stroke: currentcolor;
 }
 
 .menu-button-links button[aria-expanded="true"] svg.down {

--- a/examples/menu-button/menu-button-actions-active-descendant.html
+++ b/examples/menu-button/menu-button-actions-active-descendant.html
@@ -90,7 +90,7 @@
               </li>
               <li>Because background color and text color styles can be overridden by operating system high contrast settings, a border is used to ensure the button has a visible boundary when high contrast mode is enabled.</li>
               <li>
-                To ensure the arrow icons used to indicate the expanded or collapsed state have sufficient contrast with the background when high contrast settings invert colors, the CSS <code>currentColor</code> value for the <code>fill</code> and <code>stroke</code> properties of the SVG <code>polygon</code> element is used to synchronize the color with text content.
+                To ensure the arrow icons used to indicate the expanded or collapsed state have sufficient contrast with the background when high contrast settings invert colors, the CSS <code>currentcolor</code> value for the <code>fill</code> and <code>stroke</code> properties of the SVG <code>polygon</code> element is used to synchronize the color with text content.
                 If specific colors are used to specify the <code>fill</code> and <code>stroke</code> properties, these colors will remain the same in high contrast mode, which could lead to insufficient contrast between the icon and the background or even make the icon invisible if its color matches the high contrast mode background.
               </li>
             </ul>

--- a/examples/menu-button/menu-button-actions.html
+++ b/examples/menu-button/menu-button-actions.html
@@ -87,7 +87,7 @@
               </li>
               <li>Because background color and text color styles can be overridden by operating system high contrast settings, a border is used to ensure the button has a visible boundary when high contrast mode is enabled.</li>
               <li>
-                To ensure the arrow icons used to indicate the expanded or collapsed state have sufficient contrast with the background when high contrast settings invert colors, the CSS <code>currentColor</code> value for the <code>fill</code> and <code>stroke</code> properties of the SVG <code>polygon</code> element is used to synchronize the color with text content.
+                To ensure the arrow icons used to indicate the expanded or collapsed state have sufficient contrast with the background when high contrast settings invert colors, the CSS <code>currentcolor</code> value for the <code>fill</code> and <code>stroke</code> properties of the SVG <code>polygon</code> element is used to synchronize the color with text content.
                 If specific colors are used to specify the <code>fill</code> and <code>stroke</code> properties, these colors will remain the same in high contrast mode, which could lead to insufficient contrast between the icon and the background or even make the icon invisible if its color matches the high contrast mode background.
               </li>
             </ul>

--- a/examples/menu-button/menu-button-links.html
+++ b/examples/menu-button/menu-button-links.html
@@ -115,7 +115,7 @@
               </li>
               <li>Because background color and text color styles can be overridden by operating system high contrast settings, a border is used to ensure the button has a visible boundary when high contrast mode is enabled.</li>
               <li>
-                To ensure the arrow icons used to indicate the expanded or collapsed state have sufficient contrast with the background when high contrast settings invert colors, the CSS <code>currentColor</code> value for the <code>fill</code> and <code>stroke</code> properties of the SVG <code>polygon</code> element is used to synchronize the color with text content.
+                To ensure the arrow icons used to indicate the expanded or collapsed state have sufficient contrast with the background when high contrast settings invert colors, the CSS <code>currentcolor</code> value for the <code>fill</code> and <code>stroke</code> properties of the SVG <code>polygon</code> element is used to synchronize the color with text content.
                 If specific colors are used to specify the <code>fill</code> and <code>stroke</code> properties, these colors will remain the same in high contrast mode, which could lead to insufficient contrast between the icon and the background or even make the icon invisible if its color matches the high contrast mode background.
               </li>
             </ul>

--- a/examples/menubar/css/menubar-navigation.css
+++ b/examples/menubar/css/menubar-navigation.css
@@ -94,8 +94,8 @@
 }
 
 .menubar-navigation [role="menuitem"] svg {
-  fill: currentColor;
-  stroke: currentColor;
+  fill: currentcolor;
+  stroke: currentcolor;
 }
 
 .menubar-navigation [role="menuitem"] svg.down {

--- a/examples/menubar/menubar-navigation.html
+++ b/examples/menubar/menubar-navigation.html
@@ -283,7 +283,7 @@
             When an element loses focus, its border changes from 2 to 0 pixels and padding is increased by 2 pixels.
           </li>
           <li>
-            To ensure the arrow icons used to indicate the expanded or collapsed state have sufficient contrast with the background when high contrast settings invert colors, the CSS <code>currentColor</code> value for the <code>fill</code> and <code>stroke</code> properties of the SVG <code>polygon</code> element is used to synchronize the color with text content.
+            To ensure the arrow icons used to indicate the expanded or collapsed state have sufficient contrast with the background when high contrast settings invert colors, the CSS <code>currentcolor</code> value for the <code>fill</code> and <code>stroke</code> properties of the SVG <code>polygon</code> element is used to synchronize the color with text content.
             If specific colors are used to specify the <code>fill</code> and <code>stroke</code> properties, these colors will remain the same in high contrast mode, which could lead to insufficient contrast between the icon and the background or even make the icon invisible if its color matches the high contrast mode background.
           </li>
         </ul>

--- a/examples/meter/meter.html
+++ b/examples/meter/meter.html
@@ -44,7 +44,7 @@
       </p>
       <div role="meter" aria-valuenow="90" aria-valuemin="0" aria-valuemax="100" aria-labelledby="cpu_usage_label">
         <svg width="100" height="100" class="fill" aria-hidden="true" version="1.1" xmlns="http://www.w3.org/2000/svg">
-          <rect x="0" y="0" width="100%" height="100%" fill="currentColor" />
+          <rect x="0" y="0" width="100%" height="100%" fill="currentcolor" />
         </svg>
       </div>
     </div>

--- a/examples/radio/css/radio-rating.css
+++ b/examples/radio/css/radio-rating.css
@@ -21,38 +21,38 @@
 
 .rating-radio svg .star {
   stroke-width: 2px;
-  stroke: currentColor;
+  stroke: currentcolor;
   fill-opacity: 0;
 }
 
 .rating-radio svg .star-none {
   stroke-width: 3px;
-  stroke: currentColor;
+  stroke: currentcolor;
   fill-opacity: 0;
 }
 
 .rating-radio[data-rating-value="5"] svg .star {
-  fill: currentColor;
+  fill: currentcolor;
   fill-opacity: 1;
 }
 
 .rating-radio[data-rating-value="1"] svg .star-1 .star {
-  fill: currentColor;
+  fill: currentcolor;
   fill-opacity: 1;
 }
 
 .rating-radio[data-rating-value="2"] svg .star-2 .star {
-  fill: currentColor;
+  fill: currentcolor;
   fill-opacity: 1;
 }
 
 .rating-radio[data-rating-value="3"] svg .star-3 .star {
-  fill: currentColor;
+  fill: currentcolor;
   fill-opacity: 1;
 }
 
 .rating-radio[data-rating-value="4"] svg .star-4 .star {
-  fill: currentColor;
+  fill: currentcolor;
   fill-opacity: 1;
 }
 
@@ -68,7 +68,7 @@
 
 .rating-radio svg g:focus .focus-ring {
   stroke-width: 2px;
-  stroke: currentColor;
+  stroke: currentcolor;
 }
 
 .rating-radio:hover {

--- a/examples/radio/radio-rating.html
+++ b/examples/radio/radio-rating.html
@@ -98,10 +98,10 @@
         </li>
         <li>
           To ensure the borders of the stars and the focus ring have sufficient contrast with the background when high contrast settings invert colors, the color of the borders are synchronized with the color of the text content.
-          For example, the color of the focus ring border is set to match the foreground color of  high contrast mode text by specifying the CSS <code>currentColor</code> value for the <code>stroke</code> property of the inline SVG <code>polygon</code> to draw the star borders and <code>rect</code> element used to draw the focus ring border.
+          For example, the color of the focus ring border is set to match the foreground color of  high contrast mode text by specifying the CSS <code>currentcolor</code> value for the <code>stroke</code> property of the inline SVG <code>polygon</code> to draw the star borders and <code>rect</code> element used to draw the focus ring border.
           To make the background of the <code>polygon</code> and <code>rect</code> elements match the high contrast background color, the <code>fill-opacity</code> attribute of the <code>rect</code> is set to zero.
           If specific colors were instead used to specify the <code>stroke</code> and <code>fill</code> properties, those colors would remain the same in high contrast mode, which could lead to insufficient contrast between the star and the background or even make them invisible if their color matched the high contrast mode background.<br>
-          Note: The SVG element needs to have the CSS <code>forced-color-adjust</code> property set to <code>auto</code> for the <code>currentColor</code> value to be updated in high contrast mode.
+          Note: The SVG element needs to have the CSS <code>forced-color-adjust</code> property set to <code>auto</code> for the <code>currentcolor</code> value to be updated in high contrast mode.
           Some browsers do not use <code>auto</code> for the default value.
         </li>
       </ul>

--- a/examples/slider/css/slider-color-viewer.css
+++ b/examples/slider/css/slider-color-viewer.css
@@ -44,8 +44,8 @@
 }
 
 .color-slider .value {
-  color: currentColor;
-  fill: currentColor;
+  color: currentcolor;
+  fill: currentcolor;
 }
 
 .color-slider .valueBackground {
@@ -55,7 +55,7 @@
 
 .color-slider .rail {
   fill: #bbb;
-  stroke: currentColor;
+  stroke: currentcolor;
   stroke-width: 2px;
   opacity: 0.8;
 }
@@ -80,7 +80,7 @@
 
 .color-slider .thumb {
   fill: #666;
-  stroke: currentColor;
+  stroke: currentcolor;
   stroke-width: 2px;
 }
 
@@ -103,18 +103,18 @@
 .color-slider:focus .rail,
 .color-slider:hover .rail {
   fill: transparent;
-  stroke: currentColor;
+  stroke: currentcolor;
   opacity: 1;
 }
 
 .color-slider:focus .thumb,
 .color-slider:hover .thumb {
   fill: #ddd;
-  stroke: currentColor;
+  stroke: currentcolor;
   opacity: 1;
 }
 
 .color-slider:focus .focus,
 .color-slider:hover .focus {
-  stroke: currentColor;
+  stroke: currentcolor;
 }

--- a/examples/slider/css/slider-multithumb.css
+++ b/examples/slider/css/slider-multithumb.css
@@ -16,25 +16,25 @@
 
 .slider-multithumb .slider-group .value {
   font-size: 80%;
-  color: currentColor;
-  fill: currentColor;
+  color: currentcolor;
+  fill: currentcolor;
 }
 
 .slider-multithumb .slider-group .rail {
-  stroke: currentColor;
+  stroke: currentcolor;
   stroke-width: 2px;
   fill-opacity: 0;
 }
 
 .slider-multithumb .slider-group .range {
-  fill: currentColor;
+  fill: currentcolor;
   opacity: 0.4;
 }
 
 .slider-multithumb .slider-group .thumb {
   stroke-opacity: 0;
   stroke-width: 2px;
-  fill: currentColor;
+  fill: currentcolor;
 }
 
 .slider-multithumb .slider-group .focus-ring {
@@ -48,7 +48,7 @@
 
 .slider-multithumb .slider-group g.rail,
 .slider-multithumb .slider-group g.focus {
-  color: currentColor;
+  color: currentcolor;
 }
 
 .slider-multithumb .slider-group.active g.rail {
@@ -66,23 +66,23 @@
 }
 
 .slider-multithumb [role="slider"]:hover .focus-ring {
-  stroke: currentColor;
+  stroke: currentcolor;
   stroke-width: 1px;
   stroke-opacity: 0.8;
 }
 
 .slider-multithumb [role="slider"]:hover .focus-ring,
 .slider-multithumb [role="slider"]:focus .focus-ring {
-  stroke: currentColor;
+  stroke: currentcolor;
   stroke-opacity: 1;
   stroke-width: 3px;
 }
 
 .slider-multithumb [role="slider"]:focus .thumb {
-  stroke: currentColor;
+  stroke: currentcolor;
 }
 
 .slider-multithumb [role="slider"]:focus .value {
-  color: currentColor;
+  color: currentcolor;
   font-weight: bold;
 }

--- a/examples/slider/css/slider-rating.css
+++ b/examples/slider/css/slider-rating.css
@@ -21,7 +21,7 @@
 
 .rating-slider svg .star {
   stroke-width: 2px;
-  stroke: currentColor;
+  stroke: currentcolor;
   fill-opacity: 0;
 }
 
@@ -32,56 +32,56 @@
 }
 
 .rating-slider[aria-valuenow="5"] svg .star {
-  fill: currentColor;
+  fill: currentcolor;
   fill-opacity: 1;
 }
 
 .rating-slider[aria-valuenow="0.5"] svg .star-1 .fill-left {
-  fill: currentColor;
+  fill: currentcolor;
   fill-opacity: 1;
 }
 
 .rating-slider[aria-valuenow="1"] svg .star-1 .star {
-  fill: currentColor;
+  fill: currentcolor;
   fill-opacity: 1;
 }
 
 .rating-slider[aria-valuenow="1.5"] svg .star-1 .star,
 .rating-slider[aria-valuenow="1.5"] svg .star-2 .fill-left {
-  fill: currentColor;
+  fill: currentcolor;
   fill-opacity: 1;
 }
 
 .rating-slider[aria-valuenow="2"] svg .star-2 .star {
-  fill: currentColor;
+  fill: currentcolor;
   fill-opacity: 1;
 }
 
 .rating-slider[aria-valuenow="2.5"] svg .star-2 .star,
 .rating-slider[aria-valuenow="2.5"] svg .star-3 .fill-left {
-  fill: currentColor;
+  fill: currentcolor;
   fill-opacity: 1;
 }
 
 .rating-slider[aria-valuenow="3"] svg .star-3 .star {
-  fill: currentColor;
+  fill: currentcolor;
   fill-opacity: 1;
 }
 
 .rating-slider[aria-valuenow="3.5"] svg .star-3 .star,
 .rating-slider[aria-valuenow="3.5"] svg .star-4 .fill-left {
-  fill: currentColor;
+  fill: currentcolor;
   fill-opacity: 1;
 }
 
 .rating-slider[aria-valuenow="4"] svg .star-4 .star {
-  fill: currentColor;
+  fill: currentcolor;
   fill-opacity: 1;
 }
 
 .rating-slider[aria-valuenow="4.5"] svg .star-4 .star,
 .rating-slider[aria-valuenow="4.5"] svg .star-5 .fill-left {
-  fill: currentColor;
+  fill: currentcolor;
   fill-opacity: 1;
 }
 
@@ -93,5 +93,5 @@
 
 .rating-slider:focus svg .focus-ring {
   stroke-width: 2px;
-  stroke: currentColor;
+  stroke: currentcolor;
 }

--- a/examples/slider/css/slider-seek.css
+++ b/examples/slider/css/slider-seek.css
@@ -11,7 +11,7 @@
 
 .slider-seek text {
   font-weight: bold;
-  fill: currentColor;
+  fill: currentcolor;
   font-family: sans-serif;
 }
 
@@ -34,19 +34,19 @@
 }
 
 .slider-seek .rail {
-  stroke: currentColor;
+  stroke: currentcolor;
   stroke-width: 2px;
-  fill: currentColor;
+  fill: currentcolor;
   fill-opacity: 25%;
 }
 
 .slider-seek .thumb {
   stroke-width: 0;
-  fill: currentColor;
+  fill: currentcolor;
 }
 
 .slider-seek .focus-ring {
-  stroke: currentColor;
+  stroke: currentcolor;
   stroke-opacity: 0;
   fill-opacity: 0;
   stroke-width: 3px;

--- a/examples/slider/css/slider-temperature.css
+++ b/examples/slider/css/slider-temperature.css
@@ -20,7 +20,7 @@
 .slider-temperature text,
 .slider-seek text {
   font-weight: bold;
-  fill: currentColor;
+  fill: currentcolor;
   font-family: sans-serif;
 }
 
@@ -51,21 +51,21 @@
 
 .slider-temperature .rail,
 .slider-seek .rail {
-  stroke: currentColor;
+  stroke: currentcolor;
   stroke-width: 2px;
-  fill: currentColor;
+  fill: currentcolor;
   fill-opacity: 25%;
 }
 
 .slider-temperature .thumb,
 .slider-seek .thumb {
   stroke-width: 0;
-  fill: currentColor;
+  fill: currentcolor;
 }
 
 .slider-temperature .focus-ring,
 .slider-seek .focus-ring {
-  stroke: currentColor;
+  stroke: currentcolor;
   stroke-opacity: 0;
   fill-opacity: 0;
   stroke-width: 3px;

--- a/examples/slider/slider-color-viewer.html
+++ b/examples/slider/slider-color-viewer.html
@@ -141,9 +141,9 @@
         <li>The placement of the slider value above the thumb makes it easier for users with low vision   to see the current value while dragging the thumb.</li>
         <li>To highlight the interactive nature of the thumb, the focus ring is drawn around the thumb and the value.</li>
         <li>
-          To ensure the borders of the slider rail, thumb and focus ring have sufficient contrast with the background when high contrast settings invert colors, the CSS <code>currentColor</code> value for the <code>stroke</code> property is used for the SVG <code>rect</code> elements to synchronize the border color with text content.
+          To ensure the borders of the slider rail, thumb and focus ring have sufficient contrast with the background when high contrast settings invert colors, the CSS <code>currentcolor</code> value for the <code>stroke</code> property is used for the SVG <code>rect</code> elements to synchronize the border color with text content.
           If specific colors were used to specify the <code>stroke</code> property, the color of these elements would remain the same in high contrast mode, which could lead to insufficient contrast between them and their background or even make them invisible if their color were to match the high contrast mode background.
-          NOTE: The SVG elements need to be inline to use <code>currentColor</code>.
+          NOTE: The SVG elements need to be inline to use <code>currentcolor</code>.
                   </li>
       </ul>
     </section>

--- a/examples/slider/slider-multithumb.html
+++ b/examples/slider/slider-multithumb.html
@@ -97,10 +97,10 @@
           <li>To highlight the interactive nature of the thumb, the focus ring is drawn around the thumb and the value.</li>
           <li>
           To ensure the borders of the slider rail, thumb and focus ring have sufficient contrast with the background when high contrast settings invert colors, the color of the borders are synchronized with the color of the text content.
-          For example, the color of the focus ring border is set to match the foreground color of  high contrast mode text by specifying the CSS <code>currentColor</code> value for the <code>stroke</code> property of the inline SVG <code>rect</code> element used to draw the focus ring border.
+          For example, the color of the focus ring border is set to match the foreground color of  high contrast mode text by specifying the CSS <code>currentcolor</code> value for the <code>stroke</code> property of the inline SVG <code>rect</code> element used to draw the focus ring border.
           To make the background of the <code>rect</code> match the high contrast background color, the <code>fill-opacity</code> attribute of the <code>rect</code> is set to zero.
           If specific colors were instead used to specify the <code>stroke</code> and <code>fill</code> properties, those colors would remain the same in high contrast mode, which could lead to insufficient contrast between the rail and the thumb or even make them invisible if their color matched the high contrast mode background.<br>
-          Note: The SVG element needs to have the CSS <code>forced-color-adjust</code> property set to <code>auto</code> for the <code>currentColor</code> value to be updated in high contrast mode.
+          Note: The SVG element needs to have the CSS <code>forced-color-adjust</code> property set to <code>auto</code> for the <code>currentcolor</code> value to be updated in high contrast mode.
           Some browsers do not use <code>auto</code> for the default value.
         </li>
         </ul>

--- a/examples/slider/slider-rating.html
+++ b/examples/slider/slider-rating.html
@@ -117,10 +117,10 @@
         <li>To highlight the interactive nature of the rating stars, a focus ring appears around the group of stars when the thumb has focus.</li>
         <li>
           To ensure the borders of the stars and focus ring have sufficient contrast with the background when high contrast settings invert colors, the color of the borders are synchronized with the color of the text content.
-          For example, the color of the star borders is set to match the foreground color of  high contrast mode text by specifying the CSS <code>currentColor</code> value for the <code>stroke</code> property of each inline SVG <code>polygon</code> element.
+          For example, the color of the star borders is set to match the foreground color of  high contrast mode text by specifying the CSS <code>currentcolor</code> value for the <code>stroke</code> property of each inline SVG <code>polygon</code> element.
           To enable the high contrast background color to be the used as the contrasting color when a star is not fully or partially filled, the <code>fill-opacity</code> attribute of the <code>polygon</code> is set to zero.
           If specific colors were used to specify the <code>stroke</code> and <code>fill</code> properties, the color of these elements would remain the same in high contrast mode, which could lead to insufficient contrast between them and their background or even make them invisible if their color were to match the high contrast mode background.
-          <br>Note: The SVG element needs to have the CSS <code>forced-color-adjust</code> property set to the value <code>auto</code> for the <code>currentColor</code> value to be updated in high contrast modes.
+          <br>Note: The SVG element needs to have the CSS <code>forced-color-adjust</code> property set to the value <code>auto</code> for the <code>currentcolor</code> value to be updated in high contrast modes.
           Some browsers do not use <code>auto</code> for the default value.
         </li>
       </ul>

--- a/examples/slider/slider-seek.html
+++ b/examples/slider/slider-seek.html
@@ -118,10 +118,10 @@
         <li>The display of the slider's current value remains adjacent to the thumb as the thumb is moved, so people with a small field of view (e.g., due to magnification) can easily see the value while focusing on the thumb as they move it.</li>
         <li>
           To ensure the borders of the slider rail, thumb and focus ring have sufficient contrast with the background when high contrast settings invert colors, the color of the borders are synchronized with the color of the text content.
-          For example, the color of the focus ring border is set to match the foreground color of  high contrast mode text by specifying the CSS <code>currentColor</code> value for the <code>stroke</code> property of the inline SVG <code>rect</code> element used to draw the focus ring border.
+          For example, the color of the focus ring border is set to match the foreground color of  high contrast mode text by specifying the CSS <code>currentcolor</code> value for the <code>stroke</code> property of the inline SVG <code>rect</code> element used to draw the focus ring border.
           To make the background of the <code>rect</code> match the high contrast background color, the <code>fill-opacity</code> attribute of the <code>rect</code> is set to zero.
           If specific colors were instead used to specify the <code>stroke</code> and <code>fill</code> properties, those colors would remain the same in high contrast mode, which could lead to insufficient contrast between the rail and the thumb or even make them invisible if their color matched the high contrast mode background.<br>
-          Note: The SVG element needs to have the CSS <code>forced-color-adjust</code> property set to <code>auto</code> for the <code>currentColor</code> value to be updated in high contrast mode.
+          Note: The SVG element needs to have the CSS <code>forced-color-adjust</code> property set to <code>auto</code> for the <code>currentcolor</code> value to be updated in high contrast mode.
           Some browsers do not use <code>auto</code> for the default value.
         </li>
       </ul>

--- a/examples/slider/slider-temperature.html
+++ b/examples/slider/slider-temperature.html
@@ -87,10 +87,10 @@
         <li>The display of the slider's current value remains adjacent to the thumb as the thumb is moved, so people with a small field of view (e.g., due to magnification) can easily see the value while focusing on the thumb as they move it.</li>
         <li>
           To ensure the borders of the slider rail, thumb and focus ring have sufficient contrast with the background when high contrast settings invert colors, the color of the borders are synchronized with the color of the text content.
-          For example, the color of the focus ring border is set to match the foreground color of  high contrast mode text by specifying the CSS <code>currentColor</code> value for the <code>stroke</code> property of the inline SVG <code>rect</code> element used to draw the focus ring border.
+          For example, the color of the focus ring border is set to match the foreground color of  high contrast mode text by specifying the CSS <code>currentcolor</code> value for the <code>stroke</code> property of the inline SVG <code>rect</code> element used to draw the focus ring border.
           To make the background of the <code>rect</code> match the high contrast background color, the <code>fill-opacity</code> attribute of the <code>rect</code> is set to zero.
           If specific colors were instead used to specify the <code>stroke</code> and <code>fill</code> properties, those colors would remain the same in high contrast mode, which could lead to insufficient contrast between the rail and the thumb or even make them invisible if their color matched the high contrast mode background.<br>
-          Note: The SVG element needs to have the CSS <code>forced-color-adjust</code> property set to <code>auto</code> for the <code>currentColor</code> value to be updated in high contrast mode.
+          Note: The SVG element needs to have the CSS <code>forced-color-adjust</code> property set to <code>auto</code> for the <code>currentcolor</code> value to be updated in high contrast mode.
           Some browsers do not use <code>auto</code> for the default value.
         </li>
       </ul>

--- a/examples/switch/css/switch-button.css
+++ b/examples/switch/css/switch-button.css
@@ -28,13 +28,13 @@ button[role="switch"] svg {
 button[role="switch"] svg rect {
   fill-opacity: 0;
   stroke-width: 2;
-  stroke: currentColor;
+  stroke: currentcolor;
 }
 
 button[role="switch"] svg rect.off {
   display: block;
-  stroke: currentColor;
-  fill: currentColor;
+  stroke: currentcolor;
+  fill: currentcolor;
   fill-opacity: 1;
 }
 
@@ -49,8 +49,8 @@ button[role="switch"] svg rect.on {
 button[role="switch"][aria-checked="true"] svg rect.on {
   color: green;
   display: block;
-  stroke-color: currentColor;
-  fill: currentColor;
+  stroke-color: currentcolor;
+  fill: currentcolor;
   fill-opacity: 1;
 }
 

--- a/examples/switch/switch-button.html
+++ b/examples/switch/switch-button.html
@@ -99,10 +99,10 @@
           </ul>
         </li>
         <li>
-          To ensure the SVG graphics have sufficient contrast with the background when high contrast settings invert colors, the CSS <code>currentColor</code> value for the <code>stroke</code> and <code>fill</code> properties is used to synchronize the colors with text content.
+          To ensure the SVG graphics have sufficient contrast with the background when high contrast settings invert colors, the CSS <code>currentcolor</code> value for the <code>stroke</code> and <code>fill</code> properties is used to synchronize the colors with text content.
           If specific colors were used to specify the <code>stroke</code> and <code>fill</code> properties, the color of these elements would remain the same in high contrast mode, which could lead to insufficient contrast between them and their background or even make them invisible if their color were to match the high contrast mode background.
           The <code>fill-opacity</code> of the container <code>rect</code> is set to zero for the background color of the page to provide the contrasting color to the <code>stroke</code> and <code>fill</code> colors.
-          <br>NOTE: The SVG elements need to set the CSS <code>forced-color-adjust</code> property to <code>auto</code> for some browsers to support the <code>currentColor</code> value.
+          <br>NOTE: The SVG elements need to set the CSS <code>forced-color-adjust</code> property to <code>auto</code> for some browsers to support the <code>currentcolor</code> value.
         </li>
       </ul>
     </section>

--- a/examples/table/css/sortable-table.css
+++ b/examples/table/css/sortable-table.css
@@ -49,21 +49,21 @@ table.sortable th button span {
 
 table.sortable th[aria-sort="descending"] span::after {
   content: "▼";
-  color: currentColor;
+  color: currentcolor;
   font-size: 100%;
   top: 0;
 }
 
 table.sortable th[aria-sort="ascending"] span::after {
   content: "▲";
-  color: currentColor;
+  color: currentcolor;
   font-size: 100%;
   top: 0;
 }
 
 table.show-unsorted-icon th:not([aria-sort]) button span::after {
   content: "♢";
-  color: currentColor;
+  color: currentcolor;
   font-size: 100%;
   position: relative;
   top: -3px;
@@ -83,7 +83,7 @@ table.sortable tbody tr:nth-child(odd) {
 table.sortable th button:focus,
 table.sortable th button:hover {
   padding: 2px;
-  border: 2px solid currentColor;
+  border: 2px solid currentcolor;
   background-color: #e5f4ff;
 }
 
@@ -95,7 +95,7 @@ table.sortable th button:hover span {
 table.sortable th:not([aria-sort]) button:focus span::after,
 table.sortable th:not([aria-sort]) button:hover span::after {
   content: "▼";
-  color: currentColor;
+  color: currentcolor;
   font-size: 100%;
   top: 0;
 }

--- a/examples/treeview/css/treeview-navigation.css
+++ b/examples/treeview/css/treeview-navigation.css
@@ -125,7 +125,7 @@
 
 .treeview-navigation a[role="treeitem"] span.icon svg polygon {
   stroke-width: 2px;
-  fill: currentColor;
+  fill: currentcolor;
   stroke: transparent;
 }
 
@@ -156,5 +156,5 @@
 }
 
 .treeview-navigation a[role="treeitem"] span.icon svg polygon:hover {
-  stroke: currentColor;
+  stroke: currentcolor;
 }

--- a/examples/treeview/treeview-navigation.html
+++ b/examples/treeview/treeview-navigation.html
@@ -388,7 +388,7 @@
                 When an element loses focus, its border changes from 3 pixels to 1 and padding is increased by 2 pixels.
               </li>
               <li>
-                To ensure the arrow icons used to indicate the expanded or collapsed state have sufficient contrast with the background when high contrast settings invert colors, the CSS <code>currentColor</code> value for the <code>fill</code> and <code>stroke</code> properties of the SVG <code>polygon</code> element is used to synchronize the color with text content.
+                To ensure the arrow icons used to indicate the expanded or collapsed state have sufficient contrast with the background when high contrast settings invert colors, the CSS <code>currentcolor</code> value for the <code>fill</code> and <code>stroke</code> properties of the SVG <code>polygon</code> element is used to synchronize the color with text content.
                 If specific colors are used to specify the <code>fill</code> and <code>stroke</code> properties, these colors will remain the same in high contrast mode, which could lead to insufficient contrast between the icon and the background or even make the icon invisible if its color matches the high contrast mode background.
               </li>
             </ul>

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "lint-staged": "^12.3.4",
         "prettier": "^2.5.1",
         "selenium-webdriver": "^4.1.1",
-        "stylelint": "^14.1.0",
+        "stylelint": "^14.5.3",
         "stylelint-config-prettier": "^9.0.3",
         "stylelint-config-standard": "^24.0.0",
         "stylelint-prettier": "^2.0.0",
@@ -2121,6 +2121,12 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "node_modules/colord": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/colord/-/colord-2.9.2.tgz",
+      "integrity": "sha512-Uqbg+J445nc1TKn4FoDPS6ZZqAvEDnwrH42yo8B40JSOgSLxMZ/gt3h4nmCtPLQeXhjJJkqBx7SCY35WnIixaQ==",
+      "dev": true
+    },
     "node_modules/colorette": {
       "version": "2.0.16",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.16.tgz",
@@ -2576,6 +2582,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/css-functions-list": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/css-functions-list/-/css-functions-list-3.0.1.tgz",
+      "integrity": "sha512-PriDuifDt4u4rkDgnqRCLnjfMatufLmWNfQnGCq34xZwpY3oabwhB9SqRBmuvWUgndbemCFlKqg+nO7C2q0SBw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.22"
       }
     },
     "node_modules/cssesc": {
@@ -3416,9 +3431,9 @@
       "dev": true
     },
     "node_modules/fast-glob": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.7.tgz",
-      "integrity": "sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==",
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
+      "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
       "dev": true,
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -3428,7 +3443,7 @@
         "micromatch": "^4.0.4"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=8.6.0"
       }
     },
     "node_modules/fast-json-stable-stringify": {
@@ -3960,16 +3975,16 @@
       }
     },
     "node_modules/globby": {
-      "version": "11.0.4",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
-      "integrity": "sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
       "dev": true,
       "dependencies": {
         "array-union": "^2.1.0",
         "dir-glob": "^3.0.1",
-        "fast-glob": "^3.1.1",
-        "ignore": "^5.1.4",
-        "merge2": "^1.3.0",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
         "slash": "^3.0.0"
       },
       "engines": {
@@ -4181,9 +4196,9 @@
       }
     },
     "node_modules/ignore": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.9.tgz",
-      "integrity": "sha512-2zeMQpbKz5dhZ9IwL0gbxSW5w0NK/MSAMtNuhgIHEPmaU3vPdKPL0UdvUCXs5SS4JAwsBxysK5sFMW8ocFiVjQ==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+      "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
       "dev": true,
       "engines": {
         "node": ">= 4"
@@ -4604,9 +4619,9 @@
       }
     },
     "node_modules/known-css-properties": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.23.0.tgz",
-      "integrity": "sha512-h9ivI88e1lFNmTT4HovBN33Ysn0OIJG7IPG2mkpx2uniQXFWqo35QdiX7w0TovlUFXfW8aPFblP5/q0jlOr2sA==",
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.24.0.tgz",
+      "integrity": "sha512-RTSoaUAfLvpR357vWzAz/50Q/BmHfmE6ETSWfutT0AJiw10e6CmcdYRQJlLRd95B53D0Y2aD1jSxD3V3ySF+PA==",
       "dev": true
     },
     "node_modules/levn": {
@@ -5809,14 +5824,14 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.3.11",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.11.tgz",
-      "integrity": "sha512-hCmlUAIlUiav8Xdqw3Io4LcpA1DOt7h3LSTAC4G6JGHFFaWzI6qvFt9oilvl8BmkbBRX1IhM90ZAmpk68zccQA==",
+      "version": "8.4.7",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.7.tgz",
+      "integrity": "sha512-L9Ye3r6hkkCeOETQX6iOaWZgjp3LL6Lpqm6EtgbKrgqGGteRMNb9vzBfRL96YOSu8o7x3MfIH9Mo5cPJFGrW6A==",
       "dev": true,
       "dependencies": {
-        "nanoid": "^3.1.30",
+        "nanoid": "^3.3.1",
         "picocolors": "^1.0.0",
-        "source-map-js": "^0.6.2"
+        "source-map-js": "^1.0.2"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
@@ -5855,9 +5870,9 @@
       }
     },
     "node_modules/postcss-selector-parser": {
-      "version": "6.0.6",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.6.tgz",
-      "integrity": "sha512-9LXrvaaX3+mcv5xkg5kFwqSzSH1JIObIx51PrndZwlmznwXRfxMddDvo9gve3gVR8ZTKgoFDdWkbRFmEhT4PMg==",
+      "version": "6.0.9",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.9.tgz",
+      "integrity": "sha512-UO3SgnZOVTwu4kyLR22UQ1xZh086RyNZppb7lLAKBFK8a32ttG5i87Y/P3+2bRSjZNyJ1B7hfFNo273tKe9YxQ==",
       "dev": true,
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -5868,9 +5883,9 @@
       }
     },
     "node_modules/postcss-value-parser": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz",
-      "integrity": "sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true
     },
     "node_modules/prelude-ls": {
@@ -6302,9 +6317,9 @@
       }
     },
     "node_modules/signal-exit": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
     },
     "node_modules/slash": {
@@ -6331,9 +6346,9 @@
       }
     },
     "node_modules/source-map-js": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-0.6.2.tgz",
-      "integrity": "sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -6470,49 +6485,52 @@
       "dev": true
     },
     "node_modules/stylelint": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-14.1.0.tgz",
-      "integrity": "sha512-IedkssuNVA11+v++2PIV2OHOU5A3SfRcXVi56vZVSsMhGrgtwmmit69jeM+08/Tun5DTBe7BuH1Zp1mMLmtKLA==",
+      "version": "14.5.3",
+      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-14.5.3.tgz",
+      "integrity": "sha512-omHETL+kGHR+fCXFK1SkZD/A+emCP9esggAdWEl8GPjTNeyRYj+H6uetRDcU+7E451zwWiUYGVAX+lApsAZgsQ==",
       "dev": true,
       "dependencies": {
         "balanced-match": "^2.0.0",
+        "colord": "^2.9.2",
         "cosmiconfig": "^7.0.1",
-        "debug": "^4.3.2",
+        "css-functions-list": "^3.0.1",
+        "debug": "^4.3.3",
         "execall": "^2.0.0",
-        "fast-glob": "^3.2.7",
+        "fast-glob": "^3.2.11",
         "fastest-levenshtein": "^1.0.12",
         "file-entry-cache": "^6.0.1",
         "get-stdin": "^8.0.0",
         "global-modules": "^2.0.0",
-        "globby": "^11.0.4",
+        "globby": "^11.1.0",
         "globjoin": "^0.1.4",
         "html-tags": "^3.1.0",
-        "ignore": "^5.1.9",
+        "ignore": "^5.2.0",
         "import-lazy": "^4.0.0",
         "imurmurhash": "^0.1.4",
         "is-plain-object": "^5.0.0",
-        "known-css-properties": "^0.23.0",
+        "known-css-properties": "^0.24.0",
         "mathml-tag-names": "^2.1.3",
         "meow": "^9.0.0",
         "micromatch": "^4.0.4",
         "normalize-path": "^3.0.0",
         "normalize-selector": "^0.2.0",
         "picocolors": "^1.0.0",
-        "postcss": "^8.3.11",
+        "postcss": "^8.4.6",
         "postcss-media-query-parser": "^0.2.3",
         "postcss-resolve-nested-selector": "^0.1.1",
         "postcss-safe-parser": "^6.0.0",
-        "postcss-selector-parser": "^6.0.6",
-        "postcss-value-parser": "^4.1.0",
+        "postcss-selector-parser": "^6.0.9",
+        "postcss-value-parser": "^4.2.0",
         "resolve-from": "^5.0.0",
         "specificity": "^0.4.1",
         "string-width": "^4.2.3",
         "strip-ansi": "^6.0.1",
         "style-search": "^0.1.0",
+        "supports-hyperlinks": "^2.2.0",
         "svg-tags": "^1.0.0",
-        "table": "^6.7.3",
+        "table": "^6.8.0",
         "v8-compile-cache": "^2.3.0",
-        "write-file-atomic": "^3.0.3"
+        "write-file-atomic": "^4.0.1"
       },
       "bin": {
         "stylelint": "bin/stylelint.js"
@@ -6593,6 +6611,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/stylelint/node_modules/write-file-atomic": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.1.tgz",
+      "integrity": "sha512-nSKUxgAbyioruk6hU87QzVbY279oYT6uiwgDoujth2ju4mJ+TZau7SQBhtbTmUyuNYTuXnSyRn66FV0+eCgcrQ==",
+      "dev": true,
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^3.0.7"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16"
+      }
+    },
     "node_modules/supertap": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/supertap/-/supertap-2.0.0.tgz",
@@ -6621,6 +6652,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/supports-hyperlinks": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.2.0.tgz",
+      "integrity": "sha512-6sXEzV5+I5j8Bmq9/vUphGRM/RJNT9SCURJLjwfOg51heRtguGWDzcaBlgAzKhQa0EVNpPEKzQuBwZ8S8WaCeQ==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0",
+        "supports-color": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/svg-tags": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/svg-tags/-/svg-tags-1.0.0.tgz",
@@ -6628,9 +6672,9 @@
       "dev": true
     },
     "node_modules/table": {
-      "version": "6.7.3",
-      "resolved": "https://registry.npmjs.org/table/-/table-6.7.3.tgz",
-      "integrity": "sha512-5DkIxeA7XERBqMwJq0aHZOdMadBx4e6eDoFRuyT5VR82J0Ycg2DwM6GfA/EQAhJ+toRTaS1lIdSQCqgrmhPnlw==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/table/-/table-6.8.0.tgz",
+      "integrity": "sha512-s/fitrbVeEyHKFa7mFdkuQMWlH1Wgw/yEXMt5xACT4ZpzWFluehAxRtUUQKPuWhaLAWhFcVx6w3oC8VKaUfPGA==",
       "dev": true,
       "dependencies": {
         "ajv": "^8.0.1",
@@ -6644,9 +6688,9 @@
       }
     },
     "node_modules/table/node_modules/ajv": {
-      "version": "8.7.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.7.1.tgz",
-      "integrity": "sha512-gPpOObTO1QjbnN1sVMjJcp1TF9nggMfO4MBR5uQl6ZVTOaEPq5i4oq/6R9q2alMMPB3eg53wFv1RuJBLuxf3Hw==",
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.10.0.tgz",
+      "integrity": "sha512-bzqAEZOjkrUMl2afH8dknrq5KEk2SrwdBROR+vH1EKVQTqaUbJVPdc/gEdggTMM0Se+s+Ja4ju4TlNcStKl2Hw==",
       "dev": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -8702,6 +8746,12 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "colord": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/colord/-/colord-2.9.2.tgz",
+      "integrity": "sha512-Uqbg+J445nc1TKn4FoDPS6ZZqAvEDnwrH42yo8B40JSOgSLxMZ/gt3h4nmCtPLQeXhjJJkqBx7SCY35WnIixaQ==",
+      "dev": true
+    },
     "colorette": {
       "version": "2.0.16",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.16.tgz",
@@ -9041,6 +9091,12 @@
         "fs-extra": "^10.0.0",
         "gensequence": "^3.1.1"
       }
+    },
+    "css-functions-list": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/css-functions-list/-/css-functions-list-3.0.1.tgz",
+      "integrity": "sha512-PriDuifDt4u4rkDgnqRCLnjfMatufLmWNfQnGCq34xZwpY3oabwhB9SqRBmuvWUgndbemCFlKqg+nO7C2q0SBw==",
+      "dev": true
     },
     "cssesc": {
       "version": "3.0.0",
@@ -9646,9 +9702,9 @@
       "dev": true
     },
     "fast-glob": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.7.tgz",
-      "integrity": "sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==",
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
+      "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
       "dev": true,
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -10049,16 +10105,16 @@
       }
     },
     "globby": {
-      "version": "11.0.4",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
-      "integrity": "sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
       "dev": true,
       "requires": {
         "array-union": "^2.1.0",
         "dir-glob": "^3.0.1",
-        "fast-glob": "^3.1.1",
-        "ignore": "^5.1.4",
-        "merge2": "^1.3.0",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
         "slash": "^3.0.0"
       }
     },
@@ -10209,9 +10265,9 @@
       "dev": true
     },
     "ignore": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.9.tgz",
-      "integrity": "sha512-2zeMQpbKz5dhZ9IwL0gbxSW5w0NK/MSAMtNuhgIHEPmaU3vPdKPL0UdvUCXs5SS4JAwsBxysK5sFMW8ocFiVjQ==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+      "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
       "dev": true
     },
     "ignore-by-default": {
@@ -10534,10 +10590,19 @@
       "dev": true
     },
     "known-css-properties": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.23.0.tgz",
-      "integrity": "sha512-h9ivI88e1lFNmTT4HovBN33Ysn0OIJG7IPG2mkpx2uniQXFWqo35QdiX7w0TovlUFXfW8aPFblP5/q0jlOr2sA==",
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.24.0.tgz",
+      "integrity": "sha512-RTSoaUAfLvpR357vWzAz/50Q/BmHfmE6ETSWfutT0AJiw10e6CmcdYRQJlLRd95B53D0Y2aD1jSxD3V3ySF+PA==",
       "dev": true
+    },
+    "latest-version": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-5.1.0.tgz",
+      "integrity": "sha512-weT+r0kTkRQdCdYCNtkMwWXQTMEswKrFBkm4ckQOMVhhqhIMI1UT2hMj+1iigIhgSZm5gTmrRXBNoGUgaTY1xA==",
+      "dev": true,
+      "requires": {
+        "package-json": "^6.3.0"
+      }
     },
     "levn": {
       "version": "0.4.1",
@@ -11388,14 +11453,14 @@
       }
     },
     "postcss": {
-      "version": "8.3.11",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.11.tgz",
-      "integrity": "sha512-hCmlUAIlUiav8Xdqw3Io4LcpA1DOt7h3LSTAC4G6JGHFFaWzI6qvFt9oilvl8BmkbBRX1IhM90ZAmpk68zccQA==",
+      "version": "8.4.7",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.7.tgz",
+      "integrity": "sha512-L9Ye3r6hkkCeOETQX6iOaWZgjp3LL6Lpqm6EtgbKrgqGGteRMNb9vzBfRL96YOSu8o7x3MfIH9Mo5cPJFGrW6A==",
       "dev": true,
       "requires": {
-        "nanoid": "^3.1.30",
+        "nanoid": "^3.3.1",
         "picocolors": "^1.0.0",
-        "source-map-js": "^0.6.2"
+        "source-map-js": "^1.0.2"
       }
     },
     "postcss-media-query-parser": {
@@ -11418,9 +11483,9 @@
       "requires": {}
     },
     "postcss-selector-parser": {
-      "version": "6.0.6",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.6.tgz",
-      "integrity": "sha512-9LXrvaaX3+mcv5xkg5kFwqSzSH1JIObIx51PrndZwlmznwXRfxMddDvo9gve3gVR8ZTKgoFDdWkbRFmEhT4PMg==",
+      "version": "6.0.9",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.9.tgz",
+      "integrity": "sha512-UO3SgnZOVTwu4kyLR22UQ1xZh086RyNZppb7lLAKBFK8a32ttG5i87Y/P3+2bRSjZNyJ1B7hfFNo273tKe9YxQ==",
       "dev": true,
       "requires": {
         "cssesc": "^3.0.0",
@@ -11428,9 +11493,9 @@
       }
     },
     "postcss-value-parser": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz",
-      "integrity": "sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true
     },
     "prelude-ls": {
@@ -11749,9 +11814,9 @@
       "dev": true
     },
     "signal-exit": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
     },
     "slash": {
@@ -11772,9 +11837,9 @@
       }
     },
     "source-map-js": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-0.6.2.tgz",
-      "integrity": "sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
       "dev": true
     },
     "spdx-correct": {
@@ -11886,49 +11951,52 @@
       "dev": true
     },
     "stylelint": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-14.1.0.tgz",
-      "integrity": "sha512-IedkssuNVA11+v++2PIV2OHOU5A3SfRcXVi56vZVSsMhGrgtwmmit69jeM+08/Tun5DTBe7BuH1Zp1mMLmtKLA==",
+      "version": "14.5.3",
+      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-14.5.3.tgz",
+      "integrity": "sha512-omHETL+kGHR+fCXFK1SkZD/A+emCP9esggAdWEl8GPjTNeyRYj+H6uetRDcU+7E451zwWiUYGVAX+lApsAZgsQ==",
       "dev": true,
       "requires": {
         "balanced-match": "^2.0.0",
+        "colord": "^2.9.2",
         "cosmiconfig": "^7.0.1",
-        "debug": "^4.3.2",
+        "css-functions-list": "^3.0.1",
+        "debug": "^4.3.3",
         "execall": "^2.0.0",
-        "fast-glob": "^3.2.7",
+        "fast-glob": "^3.2.11",
         "fastest-levenshtein": "^1.0.12",
         "file-entry-cache": "^6.0.1",
         "get-stdin": "^8.0.0",
         "global-modules": "^2.0.0",
-        "globby": "^11.0.4",
+        "globby": "^11.1.0",
         "globjoin": "^0.1.4",
         "html-tags": "^3.1.0",
-        "ignore": "^5.1.9",
+        "ignore": "^5.2.0",
         "import-lazy": "^4.0.0",
         "imurmurhash": "^0.1.4",
         "is-plain-object": "^5.0.0",
-        "known-css-properties": "^0.23.0",
+        "known-css-properties": "^0.24.0",
         "mathml-tag-names": "^2.1.3",
         "meow": "^9.0.0",
         "micromatch": "^4.0.4",
         "normalize-path": "^3.0.0",
         "normalize-selector": "^0.2.0",
         "picocolors": "^1.0.0",
-        "postcss": "^8.3.11",
+        "postcss": "^8.4.6",
         "postcss-media-query-parser": "^0.2.3",
         "postcss-resolve-nested-selector": "^0.1.1",
         "postcss-safe-parser": "^6.0.0",
-        "postcss-selector-parser": "^6.0.6",
-        "postcss-value-parser": "^4.1.0",
+        "postcss-selector-parser": "^6.0.9",
+        "postcss-value-parser": "^4.2.0",
         "resolve-from": "^5.0.0",
         "specificity": "^0.4.1",
         "string-width": "^4.2.3",
         "strip-ansi": "^6.0.1",
         "style-search": "^0.1.0",
+        "supports-hyperlinks": "^2.2.0",
         "svg-tags": "^1.0.0",
-        "table": "^6.7.3",
+        "table": "^6.8.0",
         "v8-compile-cache": "^2.3.0",
-        "write-file-atomic": "^3.0.3"
+        "write-file-atomic": "^4.0.1"
       },
       "dependencies": {
         "balanced-match": {
@@ -11942,6 +12010,16 @@
           "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-4.0.0.tgz",
           "integrity": "sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==",
           "dev": true
+        },
+        "write-file-atomic": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.1.tgz",
+          "integrity": "sha512-nSKUxgAbyioruk6hU87QzVbY279oYT6uiwgDoujth2ju4mJ+TZau7SQBhtbTmUyuNYTuXnSyRn66FV0+eCgcrQ==",
+          "dev": true,
+          "requires": {
+            "imurmurhash": "^0.1.4",
+            "signal-exit": "^3.0.7"
+          }
         }
       }
     },
@@ -11999,6 +12077,16 @@
         "has-flag": "^4.0.0"
       }
     },
+    "supports-hyperlinks": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.2.0.tgz",
+      "integrity": "sha512-6sXEzV5+I5j8Bmq9/vUphGRM/RJNT9SCURJLjwfOg51heRtguGWDzcaBlgAzKhQa0EVNpPEKzQuBwZ8S8WaCeQ==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^4.0.0",
+        "supports-color": "^7.0.0"
+      }
+    },
     "svg-tags": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/svg-tags/-/svg-tags-1.0.0.tgz",
@@ -12006,9 +12094,9 @@
       "dev": true
     },
     "table": {
-      "version": "6.7.3",
-      "resolved": "https://registry.npmjs.org/table/-/table-6.7.3.tgz",
-      "integrity": "sha512-5DkIxeA7XERBqMwJq0aHZOdMadBx4e6eDoFRuyT5VR82J0Ycg2DwM6GfA/EQAhJ+toRTaS1lIdSQCqgrmhPnlw==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/table/-/table-6.8.0.tgz",
+      "integrity": "sha512-s/fitrbVeEyHKFa7mFdkuQMWlH1Wgw/yEXMt5xACT4ZpzWFluehAxRtUUQKPuWhaLAWhFcVx6w3oC8VKaUfPGA==",
       "dev": true,
       "requires": {
         "ajv": "^8.0.1",
@@ -12019,9 +12107,9 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "8.7.1",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.7.1.tgz",
-          "integrity": "sha512-gPpOObTO1QjbnN1sVMjJcp1TF9nggMfO4MBR5uQl6ZVTOaEPq5i4oq/6R9q2alMMPB3eg53wFv1RuJBLuxf3Hw==",
+          "version": "8.10.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.10.0.tgz",
+          "integrity": "sha512-bzqAEZOjkrUMl2afH8dknrq5KEk2SrwdBROR+vH1EKVQTqaUbJVPdc/gEdggTMM0Se+s+Ja4ju4TlNcStKl2Hw==",
           "dev": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "lint-staged": "^12.3.4",
     "prettier": "^2.5.1",
     "selenium-webdriver": "^4.1.1",
-    "stylelint": "^14.1.0",
+    "stylelint": "^14.5.3",
     "stylelint-config-prettier": "^9.0.3",
     "stylelint-config-standard": "^24.0.0",
     "stylelint-prettier": "^2.0.0",


### PR DESCRIPTION
Resolve #2239 

Changes all instances of `currentColor` to `currentcolor`. This is due to changes in stylelint@14.3.0. [CSS Color level 3](https://www.w3.org/TR/css-color-3/#currentcolor) lists it as `currentColor` (camel case) but [CSS Color level 4](https://www.w3.org/TR/css-color-4/#currentcolor-color) changes that to `currentColor`.

Browsers don’t care how you capitalise CSS keywords. This is (mostly) a stylistic thing.