### PR TITLE
fix(#2238): adds catch for when control number is 0

### DIFF
--- a/test/tests/spinbutton_datepicker.js
+++ b/test/tests/spinbutton_datepicker.js
@@ -357,6 +357,10 @@ ariaTest('up arrow on day', exampleFile, 'spinbutton-up-arrow', async (t) => {
   // Add 30 days to the control
   control = (control + 30) % daysInMonth;
 
+  if (control === 0) {
+    control = parseInt(ex.dayMax);
+  }
+
   t.is(
     parseInt(await daySpinner.getText()),
     control,


### PR DESCRIPTION
The example wraps. So in certain scenarios the control number will be 0. For example, 25th of February “minus” 31 days results in the code example to land on day 28. Due to the module on line 358 that would make the control number 0. This catches that and sets it to dayMax (same logic as in the code example itself).

Hotfix for #2238 (it’s preventing us from merging anything)