### PR TITLE
Infrastructure: Add workflows to support APG Redesign connection with w3c/wai-aria-practices

### DIFF
--- a/.github/workflows/wai-trigger-cleanup.yml
+++ b/.github/workflows/wai-trigger-cleanup.yml
@@ -1,0 +1,54 @@
+name: Trigger branch cleanup workflow for wai repository
+
+on:
+  delete:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  cleanup-branch-wai:
+    if: ${{ github.event_name == 'delete' && github.event.ref_type == 'branch' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
+        with:
+          cache: npm
+
+      - name: Install @octokit/rest
+        run: npm install @octokit/rest
+
+      - name: Run wai-trigger-cleanup script
+        run: |
+          node scripts/wai-trigger-cleanup.js
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+          # reference github.event.ref for branch deletion
+          APG_BRANCH: ${{ github.event.ref }}
+
+  cleanup-pr-wai:
+    if: ${{ github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
+        with:
+          cache: npm
+
+      - name: Install @octokit/rest
+        run: npm install @octokit/rest
+
+      - name: Run wai-trigger-cleanup script
+        run: |
+          node scripts/wai-trigger-cleanup.js
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+          # reference github.head_ref for pull request
+          APG_BRANCH: ${{ github.head_ref }}

--- a/.github/workflows/wai-trigger-deploy.yml
+++ b/.github/workflows/wai-trigger-deploy.yml
@@ -1,0 +1,31 @@
+name: Trigger deploy for wai repository
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/wai-trigger-deploy.yml"
+      - "common/**"
+      - "examples/**"
+      - "img/**"
+      - "aria-practices.html"
+      - "README.md"
+
+jobs:
+  deploy-wai:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Trigger wai-aria-practices update
+        uses: actions/github-script@v5
+        with:
+          github-token: ${{ secrets.GH_TOKEN }}
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: 'wai-aria-practices',
+              workflow_id: 'deploy.yml',
+              ref: 'main'
+            });

--- a/.github/workflows/wai-trigger-pr.yml
+++ b/.github/workflows/wai-trigger-pr.yml
@@ -1,0 +1,47 @@
+name: Trigger pull request creation for wai repository
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/wai-trigger-pr.yml"
+      - ".github/workflows/regression.yml"
+      - ".github/workflows/examples.yml"
+      - "scripts/reference-tables.*"
+      - "package*.json"
+      - "**/*.js"
+      - "test/**"
+      - "examples/**"
+      - "!examples/landmarks/**"
+      - "!examples/coding-template/**"
+      - "!common/**"
+      - "aria-practices.html"
+
+jobs:
+  create-pr-wai:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/head
+
+      - name: Trigger wai-aria-practices PR update
+        uses: actions/github-script@v5
+        env:
+          APG_BRANCH: ${{ github.head_ref }}
+          APG_SHA: ${{ github.event.pull_request.head.sha }}
+          APG_PR_NUMBER: ${{ github.event.pull_request.number }}
+        with:
+          github-token: ${{ secrets.GH_TOKEN }}
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: 'wai-aria-practices',
+              workflow_id: 'pr-create.yml',
+              ref: 'main',
+              inputs: {
+                apg_branch: process.env.APG_BRANCH,
+                apg_sha: process.env.APG_SHA,
+                apg_pr_number: process.env.APG_PR_NUMBER,
+              }
+            });

--- a/scripts/wai-trigger-cleanup.js
+++ b/scripts/wai-trigger-cleanup.js
@@ -1,0 +1,36 @@
+const { Octokit } = require('@octokit/rest');
+
+// octokit should be authenticated with GITHUB_TOKEN from GA
+const octokit = new Octokit({
+  auth: process.env.GH_TOKEN,
+});
+
+(async () => {
+  try {
+    // check if wai generated branch exists with branch name
+    await octokit.rest.repos.getBranch({
+      owner: process.env.OWNER,
+      repo: 'wai-aria-practices',
+      branch: 'apg/' + process.env.APG_BRANCH,
+    });
+  } catch (e) {
+    console.info(`'apg/${process.env.APG_BRANCH}' not found`);
+    process.exit();
+  }
+
+  try {
+    await octokit.rest.actions.createWorkflowDispatch({
+      owner: process.env.OWNER,
+      repo: 'wai-aria-practices',
+      workflow_id: 'remove-branch.yml',
+      ref: 'main',
+      inputs: {
+        apg_branch: process.env.APG_BRANCH,
+      },
+    });
+    console.info('remove-branch.workflow.dispatch.success');
+  } catch (e) {
+    console.error('workflow.dispatch.fail', e);
+    process.exit(1);
+  }
+})();


### PR DESCRIPTION
To facilitate the [APG Redesign](https://github.com/w3c/wai-aria-practices), this PR implements the workflows outlined in https://github.com/w3c/wai-aria-practices/issues/13.

Related PRs:
- https://github.com/w3c/wai-aria-practices/pull/15.

Workflows:
* wai-trigger-deploy.yml
  - Triggers w3c/wai-aria-practices `deploy.yml` workflow to update APG Redesign production URL with latest APG content.
* wai-trigger-pr.yml
  - Triggers w3c/wai-aria-practices `pr-create.yml` workflow to populate PR with preview from APG Redesign.
  - eg. Note `WAI Preview Link` in https://github.com/howard-e/aria-practices/pull/35.
* wai-trigger-cleanup.yml
  - Triggers w3c/wai-aria-practices `remove-branch.yml` workflow to remove branches which are no longer required when PRs have been merged/closed.

___

_This is a recreation of #2246 due to [rules around using secrets from forked repositories](https://docs.github.com/en/actions/security-guides/encrypted-secrets#using-encrypted-secrets-in-a-workflow)._

> ... secrets are not passed to the runner when a workflow is triggered from a forked repository.

_Also, [comment](https://github.com/w3c/aria-practices/pull/2246#pullrequestreview-895332639) from #2246._

___
[WAI Preview Link](https://deploy-preview-17--wai-aria-practices2.netlify.app)