### PR TITLE
Infrastructure: cleanup lint-staged steps

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,12 +62,10 @@
   },
   "lint-staged": {
     "*.css": [
-      "stylelint --fix",
-      "git add"
+      "stylelint --fix"
     ],
     "*.js": [
-      "eslint --fix",
-      "git add"
+      "eslint --fix"
     ],
     "examples/**/*.html": [
       "npm run reference-tables",


### PR DESCRIPTION
* Removes `git add` steps from lint-staged instructions because `git add` is now [an automatic step](https://github.com/okonet/lint-staged#v10).

When committing, the following warning message is returned: _⚠ Some of your tasks use `git add` command. Please remove it from the config since all modifications made by tasks will be automatically added to the git commit index_

Related comments: https://github.com/w3c/aria-practices/pull/2166#issue-1069122296 & https://github.com/w3c/aria-practices/pull/2154#issuecomment-976093237.

cc @nschonni 

