### PR TITLE
Add placeholder content for change history section of WAI-APG site

### DIFF
--- a/aria-practices.html
+++ b/aria-practices.html
@@ -7167,7 +7167,54 @@ So, As advised by <a href="#naming_rule_avoid_fallback">Rule 4: Avoid Browser Fa
 
   <section id="change_log" class="appendix">
     <h2>Change History</h2>
-    <p>Change history is maintained in a separate version-specific branch.</p>
+    
+    <p>
+      APG 1.1 supported ARIA 1.1, and this version, APG 1.2, includes changes to support version 1.2 of the ARIA specification.
+      It also includes nearly 200 significant updates to improve the quality and breadth of content.
+      A <a href="https://github.com/w3c/aria-practices/wiki/Change-Log-for-November-2021-APG-1.2-Note-Release-1">detailed log of all changes</a> is available on the wiki of the w3c/aria-practices GitHub repository.
+      Highlights of major changes to support ARIA 1.2 as well as some of the improvements include the following.
+    </p>
+    <ul>
+      <li>Added section to provide guidance related to 38 document structure roles, 18 of which are new in ARIA 1.2.</li>
+      <li>Revised guidance for roles where naming requirements changed in ARIA 1.2. ARIA 1.2 prohibits names on some roles. ARIA 1.2 removed naming requirements from some other roles.</li>
+      <li>Added naming guidance for 18 roles that are new in ARIA 1.2.</li>
+      <li>Revised the combobox pattern and 4 combobox examples to reflect the ARIA 1.2 revisions to combobox.</li>
+      <li>Added example illustrating changes in ARIA 1.2 that enable creation of custom select-only comboboxes, which are similar to HTML select elements. This replaces the Collapsible Listbox example, which is now deprecated.</li>
+      <li>Revised the listbox pattern to specify how to utilize the new ARIA 1.2 support for named groups of options and Added a new listbox example to demonstrate the named option group feature.</li>
+      <li>Revised the editor menubar example to illustrate new ARIA 1.2 support for named groups of items in a menu.</li>
+      <li>Updated the listbox and tree patterns to reflect current browser processing of aria-selected and provided guidance regarding the use of aria-checked to communicate selection.</li>
+      <li>Added section providing guidance about properties used with range widgets, such as aria-valuemin and aria-valuemax.</li>
+      <li>Added a design pattern and example implementation of the meter role, which is new in ARIA 1.2</li>
+      <li>Added two examples that demonstrate how to create rating inputs, one based on slider and one based on radio group.</li>
+      <li>Added two other slider examples: a vertical temperature slider and a media seek slider.</li>
+      <li>Added a switch design pattern and three example implementations: one made from a div element, one based on HTML button, and one that uses HTML checkbox input.</li>
+      <li>Added a button example that illustrates use of the new ARIA 1.2 IDL interface.</li>
+      <li>Added a date picker example that illustrates choosing a date with a combobox.</li>
+      <li>Added another example of a disclosure navigation menu that demonstrates how to include top-level links.</li>
+      <li>Added example of a sortable table.</li>
+      <li>Changed all example pages to include a <q>Jump to</q> menu, a button to  open the example in CodePen, and added a prominently placed warning with guidance about testing before re-using example code.</li>
+      <li>Improved support for high contrast settings and added detailed documentation of high contrast support in many examples.</li>
+      <li>Improved support for touch-based screen readers in several examples, most notably in sliders.</li>
+      <li>Due to change in ARIA 1.2, removed Math role from list of roles that have presentational children.</li>
+      <li>Developed a <a href="https://github.com/w3c/aria-practices/wiki/Code-Guide#apg-coding-standards">comprehensive set of coding standards for HTML, CSS, and Javascript</a> for the APG and updated a significant portion of content to conform with the standards.</li>
+      <li>In response to feedback, fixed many documentation errors and functional bugs in examples.</li>
+    </ul>
+    <p>Comprehensive lists of closed issues included in APG 1.2 release 1 are tracked in the following GitHub milestones.</p>
+    <ul>
+      <li>
+        <a href="https://github.com/w3c/aria-practices/milestone/2?closed=1">APG 1.2 Release 1 Milestone</a>:
+        Github issues closed in the first publication of APG 1.2 as a W3C Note in November 2021.
+      </li>
+      <li>
+        <a href="https://github.com/w3c/aria-practices/milestone/10">APG 1.2 Working Draft 3 Milestone</a>:
+        Github issues closed in the third working draft of APG 1.2 published in November 2019.
+      </li>
+      <li>
+        <a href="https://github.com/w3c/aria-practices/milestone/7">APG 1.2 Working Draft 1 milestone</a>:
+        GitHub issues closed in the first working draft of APG 1.2 published on July 17, 2018.
+      </li>
+    </ul>
+    
   </section>
 
   <section id="acknowledgements" class="appendix">


### PR DESCRIPTION
This commit pulls content from the APG 1.2 change history into the main branch so it can be rendered on the about page of the WAI-APG site.