### PR TITLE
Home Page: Remove current work section and revise contribution section

### DIFF
--- a/index.html
+++ b/index.html
@@ -86,95 +86,25 @@
       </ul>
     </div>
 
-    <div id="work">
-      <h2>Current Work</h2>
-      <p>Check out  recent work of the APG Task Force</p>
-      <ul>
-        <li>
-          <h3>Release Plans</h3>
-          <p>
-            Take a look at the plan overview for WAI-ARIA Authoring Practices,
-            priorities and work in progress.
-          </p>
-          <a
-            rel="noopener noreferrer"
-            target="_blank"
-            href="https://github.com/w3c/aria-practices/wiki/Release-Plans"
-            aria-label="View release plans wiki"
-          >
-            Learn More
-          </a>
-        </li>
-        <li>
-          <h3>Patterns Progress Status</h3>
-          <p>
-            Status of work on design patterns and reference implementations of
-            those patterns for the first release of the ARIA 1.1 Authoring
-            Practices.
-          </p>
-          <a
-            rel="noopener noreferrer"
-            target="_blank"
-            href="https://github.com/w3c/aria-practices/wiki/Design-Patterns-Development-Status"
-            aria-label="View pattern status wiki"
-          >
-            Learn More
-          </a>
-        </li>
-        <li>
-          <h3>How to Write Regression Tests</h3>
-          <p>
-            Learn what the APG Regression Tests test, how to run them and
-            understand the results.
-          </p>
-          <a
-            rel="noopener noreferrer"
-            target="_blank"
-            href="https://github.com/w3c/aria-practices/wiki/Regression-Tests-for-APG-Example-Pages"
-            aria-label="View regression test documentation"
-          >
-            Learn More
-          </a>
-        </li>
-        <li>
-          <h3>Meetings</h3>
-          <p>
-            The APG Task Force meets on Tuesdays at 14:00 until 15:00 Eastern
-            Time. Minutes from previous meetings are available.
-          </p>
-          <a
-            rel="noopener noreferrer"
-            target="_blank"
-            href="https://github.com/w3c/aria-practices/wiki/Meetings"
-            aria-label="View meetings wiki"
-          >
-            Learn More
-          </a>
-        </li>
-      </ul>
-    </div>
-
     <div id="collaboration">
-      <h2 class="collaboration-h2">Collaboration</h2>
-      <h3>Get involved with our community and our work</h3>
+      <h2 class="collaboration-h2">Get Involved</h2>
       <p class="collaboration-p">
-        The APG Task Force conducts its work using a variety of synchronous and
-        asynchronous tools. And there are several ways to get involved.
+        The APG Task Force relies on broad community representation and participation to continuously improve the usefulness and quality of the APG.
+        There are a variety of ways you can get involved and help promote development of accessible experiences. 
       </p>
       <ul>
         <li>
-          <h3>Join Our Community</h3>
+          <h3>Join the Task Force</h3>
           <p>
-            To join the APG Task Force, individuals must be participants of the
-            ARIA Working Group. Participants are expected to actively contribute
-            to the work of the task force.
+            To join the APG Task Force, individuals need to first join the W3C ARIA Working Group.
+            Participants are expected to actively contribute to the work of the task force.
           </p>
           <a
             rel="noopener noreferrer"
             target="_blank"
             href="https://www.w3.org/WAI/ARIA/task-forces/practices/"
           >
-            Connect With Us
+            Learn more about the work of the task force and how to join
           </a>
           <img
             alt="An icon showing three nodes connecting."
@@ -182,19 +112,17 @@
          >
         </li>
         <li>
-          <h3>Contribute to Our Project</h3>
+          <h3>Contribute via GitHub</h3>
           <p>
-            To contribute without joining the task force, see the ARIA Working
-            Group contribute page for general instructions. To contribute to
-            documents under development, see how to contribute to the source
-            repository directly.
+            Many valueable contributions are made by people who find or raise issues of interest in our GitHub repository and then submit proposed changes via a GitHub pull request.
+            If you choose this path, it is tremendously helpful if you first study the APG's contribution guidelines.
           </p>
           <a
             rel="noopener noreferrer"
             target="_blank"
-            href="https://www.w3.org/WAI/ARIA/contribute"
+            href="https://github.com/w3c/aria-practices"
           >
-            Get Involved
+            View ReadMe in the GitHub repository
           </a>
           <img
             alt="An icon showing two human shapes carrying a burden."
@@ -212,8 +140,7 @@
               target="_blank"
               href="https://lists.w3.org/Archives/Public/public-aria-practices/"
               >view the mailing list archive</a>)</span>
-            for email discussion. Participants are automatically added to the
-            mailing list when they become a participant of the task force.
+            for email discussion. 
           </p>
           <p>
             Discussions of the task force prior to September 2017 are archived

--- a/index.html
+++ b/index.html
@@ -114,7 +114,7 @@
         <li>
           <h3>Contribute via GitHub</h3>
           <p>
-            Many valueable contributions are made by people who find or raise issues of interest in our GitHub repository and then submit proposed changes via a GitHub pull request.
+            Many valuable contributions are made by people who find or raise issues of interest in our GitHub repository and then submit proposed changes via a GitHub pull request.
             If you choose this path, it is tremendously helpful if you first study the APG's contribution guidelines.
           </p>
           <a

--- a/index.html
+++ b/index.html
@@ -61,7 +61,7 @@
           <h3>Providing Accessible Names and Descriptions</h3>
           <p>
             Providing elements with accessible names and, where appropriate,
-            accessible descriptions, is one of the most important
+            accessible descriptions is one of the most important
             responsibilities authors have when developing accessible web
             experiences.
           </p>

--- a/index.html
+++ b/index.html
@@ -187,7 +187,7 @@
           <h3>Contribute via GitHub</h3>
           <p>
             Many valuable contributions are made by people who find or raise issues of interest in our GitHub repository and then submit proposed changes via a GitHub pull request.
-            If you choose this path, it is tremendously helpful if you first study the APG's contribution guidelines.
+            If you choose this path, please start by studying our guidelines for contributing to the repository and maintaining code quality.
           </p>
           <a
             rel="noopener noreferrer"

--- a/index.html
+++ b/index.html
@@ -85,6 +85,78 @@
         </li>
       </ul>
     </div>
+    
+    <div id="work">
+      <!--
+        This section will be hidden by the builder for the launch on May 19, 2022.
+        A plan for what to do with this section will be developed post-launch.
+      -->
+      <h2>Current Work</h2>
+      <p>Check out  recent work of the APG Task Force</p>
+      <ul>
+        <li>
+          <h3>Release Plans</h3>
+          <p>
+            Take a look at the plan overview for WAI-ARIA Authoring Practices,
+            priorities and work in progress.
+          </p>
+          <a
+            rel="noopener noreferrer"
+            target="_blank"
+            href="https://github.com/w3c/aria-practices/wiki/Release-Plans"
+            aria-label="View release plans wiki"
+          >
+            Learn More
+          </a>
+        </li>
+        <li>
+          <h3>Patterns Progress Status</h3>
+          <p>
+            Status of work on design patterns and reference implementations of
+            those patterns for the first release of the ARIA 1.1 Authoring
+            Practices.
+          </p>
+          <a
+            rel="noopener noreferrer"
+            target="_blank"
+            href="https://github.com/w3c/aria-practices/wiki/Design-Patterns-Development-Status"
+            aria-label="View pattern status wiki"
+          >
+            Learn More
+          </a>
+        </li>
+        <li>
+          <h3>How to Write Regression Tests</h3>
+          <p>
+            Learn what the APG Regression Tests test, how to run them and
+            understand the results.
+          </p>
+          <a
+            rel="noopener noreferrer"
+            target="_blank"
+            href="https://github.com/w3c/aria-practices/wiki/Regression-Tests-for-APG-Example-Pages"
+            aria-label="View regression test documentation"
+          >
+            Learn More
+          </a>
+        </li>
+        <li>
+          <h3>Meetings</h3>
+          <p>
+            The APG Task Force meets on Tuesdays at 14:00 until 15:00 Eastern
+            Time. Minutes from previous meetings are available.
+          </p>
+          <a
+            rel="noopener noreferrer"
+            target="_blank"
+            href="https://github.com/w3c/aria-practices/wiki/Meetings"
+            aria-label="View meetings wiki"
+          >
+            Learn More
+          </a>
+        </li>
+      </ul>
+    </div>
 
     <div id="collaboration">
       <h2 class="collaboration-h2">Get Involved</h2>

--- a/index.html
+++ b/index.html
@@ -213,10 +213,8 @@
               href="https://lists.w3.org/Archives/Public/public-aria-practices/"
               >view the mailing list archive</a>)</span>
             for email discussion. 
-          </p>
-          <p>
-            Discussions of the task force prior to September 2017 are archived
-            on the public-aria mailing list.
+            Meeting announcements, agendas, and links to minutes are sent to the mailing list.
+            While GitHub issues are the preferred place to discuss APG content, the mailing list is available to anyone who would prefer to communicate with the APG Task Force via email.
           </p>
           <img
             alt="A notification bell icon appears over an email icon."


### PR DESCRIPTION
Several of the resources referenced in the current work section are out-of-date and not ready to be featured on the home page.

This revision is intended to reduce, clarify, and simplify the home page.
___
[WAI Preview Link](https://deploy-preview-95--wai-aria-practices2.netlify.app)