### PR TITLE
Providing Accessible Names Practice: Change heading levels to make page TOC more informative

### DIFF
--- a/aria-practices.html
+++ b/aria-practices.html
@@ -4030,13 +4030,11 @@ However, most authors do not need such detailed understanding of the algorithms 
       </p>
     </section>
 
-    <section id="accessible_names">
-      <h3>Accessible Names</h3>
       <section id="naming_cardinal_rules">
-        <h4>Cardinal Rules of Naming</h4>
+        <h3>Cardinal Rules of Naming</h3>
 
         <section id="naming_rule_heed_warnings">
-          <h5>Rule 1: Heed Warnings and Test Thoroughly</h5>
+          <h4>Rule 1: Heed Warnings and Test Thoroughly</h4>
           <p>
             Several of the <a href="#naming_techniques">naming techniques</a> below include notes that warn against specific coding patterns that are either prohibited by the ARIA specification or fall into gray space that is not yet fully specified.
             Some of these prohibited or ambiguous patterns may appear logical and even yield desired names in some browsers.
@@ -4048,7 +4046,7 @@ However, most authors do not need such detailed understanding of the algorithms 
         </section>
 
         <section id="naming_rule_visible_text">
-          <h5>Rule 2: Prefer Visible Text</h5>
+          <h4>Rule 2: Prefer Visible Text</h4>
           <p>
             When a user interface includes visible text that could be used to provide an appropriate accessible name, using the visible text for the accessible name simplifies maintenance, prevents bugs, and reduces language translation requirements.
             When names are generated from text that exists only in markup and is never displayed visually, there is a greater likelihood that accessible names will not be updated when the user interface design or content are changed.
@@ -4061,7 +4059,7 @@ However, most authors do not need such detailed understanding of the algorithms 
         </section>
 
         <section id="naming_rule_native_techniques">
-          <h5>Rule 3: Prefer Native Techniques</h5>
+          <h4>Rule 3: Prefer Native Techniques</h4>
           <p>
             In HTML documents, whenever possible, rely on HTML naming techniques, such as the HTML <code>label</code> element for form elements  and <code>caption</code> element for tables.
             While less flexible, their simplicity and reliance on visible text help ensure robust accessible experiences.
@@ -4070,7 +4068,7 @@ However, most authors do not need such detailed understanding of the algorithms 
         </section>
 
         <section id="naming_rule_avoid_fallback">
-          <h5>Rule 4: Avoid Browser Fallback</h5>
+          <h4>Rule 4: Avoid Browser Fallback</h4>
           <p>
             When authors do not specify an accessible name using an element or attribute that is intended for naming, browsers attempt to help assistive technology users by resorting to fallback methods for generating a name.
             For example, the HTML <code>title</code> and <code>placeholder</code> attributes are used as last resort sources of content for accessible names.
@@ -4079,7 +4077,7 @@ However, most authors do not need such detailed understanding of the algorithms 
         </section>
 
         <section id="naming_rule_brief_names">
-        <h5>Rule 5: Compose Brief, Useful Names</h5>
+        <h4>Rule 5: Compose Brief, Useful Names</h4>
           <p>
             Similar to how visually crowded screens and ambiguous icons reduce usability, excessively long, insufficiently distinct, or unclear  accessible names can make a user interface very difficult, or even impossible, to use for someone who relies on a non-visual form of the user interface.
             In other words, for a web experience to be accessible, its accessible names must be effective.
@@ -4089,10 +4087,10 @@ However, most authors do not need such detailed understanding of the algorithms 
       </section>
 
       <section id="naming_techniques">
-        <h4>Naming Techniques</h4>
+        <h3>Naming Techniques</h3>
 
         <section id="naming_with_child_content">
-          <h5>Naming with Child Content</h5>
+          <h4>Naming with Child Content</h4>
           <p>
             Certain elements get their name from the content they contain.
             For example, the following link is named &quot;Home&quot;.
@@ -4148,7 +4146,7 @@ However, most authors do not need such detailed understanding of the algorithms 
         </section>
 
         <section id="naming_with_aria-label">
-          <h5>Naming with a String Attribute Via <code>aria-label</code></h5>
+          <h4>Naming with a String Attribute Via <code>aria-label</code></h4>
           <p>
             The <a href="#aria-label" class="property-reference">aria-label</a> property enables authors to name an element with a string that is not visually rendered.
             For example, the name of the following button is &quot;Close&quot;.
@@ -4181,7 +4179,7 @@ However, most authors do not need such detailed understanding of the algorithms 
         </section>
 
         <section id="naming_with_aria-labelledby">
-          <h5>Naming with Referenced Content Via <code>aria-labelledby</code></h5>
+          <h4>Naming with Referenced Content Via <code>aria-labelledby</code></h4>
           <p>
             The <a href="#aria-labelledby" class="property-reference">aria-labelledby property</a> enables authors to reference other elements on the page to define an accessible name.
             For example, the following switch is named by the text content of a previous sibling element.
@@ -4237,7 +4235,7 @@ However, most authors do not need such detailed understanding of the algorithms 
         </section>
 
         <section id="naming_with_labels">
-          <h5>Naming Form Controls with the Label Element</h5>
+          <h4>Naming Form Controls with the Label Element</h4>
           <p>
             The HTML <code>label</code> element enables authors to identify content that serves as a label and associate it with a form control.
             When a <code>label</code> element is associated with a form control, browsers calculate an accessible name for the form control from the <code>label</code> content.
@@ -4267,7 +4265,7 @@ However, most authors do not need such detailed understanding of the algorithms 
         </section>
 
         <section id="naming_with_legends">
-          <h5>Naming Fieldsets with the Legend Element</h5>
+          <h4>Naming Fieldsets with the Legend Element</h4>
           <p>
             The HTML <code>fieldset</code> element can be used to group form controls, and the <code>legend</code> element can be used to give the group a name.
             For example, a group of radio buttons can be grouped together in a <code>fieldset</code>, where the <code>legend</code> element labels the group for the radio buttons.
@@ -4301,7 +4299,7 @@ However, most authors do not need such detailed understanding of the algorithms 
         </section>
 
         <section id="naming_with_captions">
-          <h5>Naming Tables and Figures with Captions</h5>
+          <h4>Naming Tables and Figures with Captions</h4>
           <p>
             The accessible name for HTML <code>table</code> and <code>figure</code> elements can be derived from a child <code>caption</code> or <code>figcaption</code> element, respectively.
             Tables and figures often have a caption to explain what they are about, how to read them, and sometimes giving them numbers used to refer to them in surrounding prose.
@@ -4357,7 +4355,7 @@ However, most authors do not need such detailed understanding of the algorithms 
         </section>
 
         <section id="naming_with_fallback">
-          <h5>Fallback Names Derived from Titles and Placeholders</h5>
+          <h4>Fallback Names Derived from Titles and Placeholders</h4>
           <p>
             When an accessible name is not provided using one of the primary techniques (e.g., the <code>aria-label</code> or <code>aria-labelledby</code> attributes), or native markup techniques (e.g., the HTML <code>label</code> element, or the <code>alt</code> attribute of the HTML <code>img</code> element), browsers calculate an accessible name from other attributes as a fallback mechanism.
             Because the attributes used in fallback name calculation are not intended for naming, they typically yield low quality accessible names that are not effective.
@@ -4392,7 +4390,7 @@ So, As advised by <a href="#naming_rule_avoid_fallback">Rule 4: Avoid Browser Fa
       </section>
 
       <section id="naming_effectively">
-        <h4>Composing Effective and User-friendly Accessible Names</h4>
+        <h3>Composing Effective and User-friendly Accessible Names</h3>
         <p>
           For assistive technology users, especially screen reader users, the quality of accessible names is one of the most  significant contributors to usability.
           Names that do not provide enough information reduce users' effectiveness while names that are too long reduce efficiency.
@@ -4434,7 +4432,7 @@ So, As advised by <a href="#naming_rule_avoid_fallback">Rule 4: Avoid Browser Fa
       </section>
 
       <section id="naming_role_guidance">
-        <h4><span id="naming_role_guidance_heading">Accessible Name Guidance by Role</span></h4>
+        <h3><span id="naming_role_guidance_heading">Accessible Name Guidance by Role</span></h3>
         <p>
           Certain elements always require a name, others may usually or sometimes require a name, and still others should never be named.
           The table below lists all ARIA roles and provides the following information for each :
@@ -5237,7 +5235,7 @@ So, As advised by <a href="#naming_rule_avoid_fallback">Rule 4: Avoid Browser Fa
       </section>
 
       <section id="name_calculation">
-        <h4>Accessible name calculation</h4>
+        <h3>Accessible name calculation</h3>
         <p>
           User agents construct an accessible name string for an element by walking through a list of potential naming methods and using the first that generates a name.
           The algorithm they follow is defined in the <a href="" class="accname">accessible name specification</a>.
@@ -5332,7 +5330,7 @@ So, As advised by <a href="#naming_rule_avoid_fallback">Rule 4: Avoid Browser Fa
 &lt;/ul&gt;</code></pre>
 
         <section id="name_calculation_non-recursive_ex">
-          <h5>Examples of non-recursive accessible name calculation</h5>
+          <h4>Examples of non-recursive accessible name calculation</h4>
           <p>Consider an <code>input</code> element that has no associated <code>label</code> element and only a <code>name</code> attribute and so does not have an accessible name (do not do this):</p>
           <pre><code>&lt;input name="code"&gt;</code></pre>
           <p>If there is a <code>placeholder</code> attribute, then it serves as a naming fallback mechanism (avoid doing this):</p>
@@ -5378,7 +5376,7 @@ So, As advised by <a href="#naming_rule_avoid_fallback">Rule 4: Avoid Browser Fa
           </section>
 
           <section id="name_calculation_recursive_ex">
-            <h5>Examples of recursive accessible name calculation</h5>
+            <h4>Examples of recursive accessible name calculation</h4>
             <p>The accessible name calculation algorithm will be invoked recursively when necessary. An <code>aria-labelledby</code> reference causes the algorithm to be invoked recursively, and when computing an accessible name from content the algorithm is invoked recursively for each child node.</p>
 
             <p>In this example, the label for the button is computed by recursing into each child node, resulting in <q>Move to trash</q>.</p>
@@ -5395,14 +5393,11 @@ So, As advised by <a href="#naming_rule_avoid_fallback">Rule 4: Avoid Browser Fa
 &lt;/div&gt;</code></pre>
         </section>
       </section>
-    </section>
 
-    <section id="accessible_descriptions">
-      <h3>Accessible Descriptions</h3>
       <section id="describing_techniques">
-        <h4>Describing Techniques</h4>
+        <h3>Describing Techniques</h3>
         <section id="describing_with_aria-describedby">
-          <h5>Describing by referencing content with <code>aria-describedby</code></h5>
+          <h4>Describing by referencing content with <code>aria-describedby</code></h4>
           <p>
             The <code>aria-describedby</code> property works similarly to the <code>aria-labelledby</code> property.
             For example, a button could be described by a sibling paragraph.
@@ -5434,7 +5429,7 @@ So, As advised by <a href="#naming_rule_avoid_fallback">Rule 4: Avoid Browser Fa
         </section>
 
         <section id="describing_with_captions">
-          <h5>Describing Tables and Figures with Captions</h5>
+          <h4>Describing Tables and Figures with Captions</h4>
           <p>
             In HTML, if the <code>table</code> is named using <code>aria-label</code> or <code>aria-labelledby</code>, a child <code>caption</code> element becomes an accessible description.
             For example, a preceding heading might serve as an appropriate accessible name, and the <code>caption</code> element might contain a longer description.
@@ -5467,7 +5462,7 @@ So, As advised by <a href="#naming_rule_avoid_fallback">Rule 4: Avoid Browser Fa
          </section>
 
         <section id="describing_with_title">
-          <h5>Descriptions Derived from Titles</h5>
+          <h4>Descriptions Derived from Titles</h4>
           <p>If an accessible description was not provided using the <code>aria-describedby</code> attribute or one of the primary host-language-specific attributes or elements (e.g., the <code>caption</code> element for <code>table</code>), then, for HTML, if the element has a <code>title</code> attribute, that is used as the accessible description.</p>
           <p>A visible description together with <code>aria-describedby</code> is generally recommended. If a description that is not visible is desired, then the <code>title</code> attribute can be used, for any HTML element that can have an accessible description.</p>
           <p>Note that the <code>title</code> attribute might not be accessible to some users, in particular sighted users not using a screen reader and not using a pointing device that supports hover (e.g., a mouse).</p>
@@ -5487,7 +5482,7 @@ So, As advised by <a href="#naming_rule_avoid_fallback">Rule 4: Avoid Browser Fa
       </section>
 
       <section id="description_calculation">
-        <h4>Accessible description calculation</h4>
+        <h3>Accessible description calculation</h3>
         <p>
           Like the <a href="#name_calculation">accessible name calculation</a>, the accessible description calculation produces a text string.
         </p>
@@ -5520,7 +5515,6 @@ So, As advised by <a href="#naming_rule_avoid_fallback">Rule 4: Avoid Browser Fa
           </li>
         </ol>
       </section>
-    </section>
   </section>
 
   <section id="keyboard">


### PR DESCRIPTION
The current side bar containing the page TOC for the [naming and describing practice page](https://www.w3.org/WAI/aria/apg/practices/names-and-descriptions/) includes only the following:

1. Introduction
2. What ARE Accessible Names and Descriptions?
3. How Are Name and Description Strings Derived?
4. Accessible Names
5. Accessible Descriptions

Items 4 and 5 are large sections. It is difficult for users to know what is on the page with so many subsections tucked away under them.

This PR proposes removing the headings associated with items 4 and 5 to bump up their subsections and expose them in the page TOC.

### Preview new version

[View the new version with 10 items in the page contentes side bar](https://deploy-preview-94--wai-aria-practices2.netlify.app/aria/apg/practices/names-and-descriptions/)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 504 Gateway Timeout :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on May 17, 2022, 7:25 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Fraw.githubusercontent.com%2Fw3c%2Faria-practices%2F7a7935bf4f4f1260fd7298bb99b5e5c5eb80fe6b%2Faria-practices.html%3FisPreview%3Dtrue)

```
<html><body><h1>504 Gateway Time-out</h1>
The server didn't respond in time.
</body></html>

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/aria-practices%232324.)._
</details>
