### PR TITLE
Remove self reference from first sentence of combobox section

### DIFF
--- a/aria-practices.html
+++ b/aria-practices.html
@@ -729,7 +729,7 @@ Some JavaScript and CSS may not function correctly in Internet Explorer.
     <section class="widget" id="combobox">
       <h3>Combobox</h3>
       <p>
-        A <a href="#combobox" class="role-reference">combobox</a> is an input widget with an associated popup that enables users to select a value for the combobox from a collection of possible values.
+        A <a href="#combobox" class="role-reference">combobox</a> is an input widget with an associated popup that enables users to select a value from a collection of possible values.
         In some implementations, the popup presents allowed values, while in other implementations, the popup presents suggested values, and users may either select one of the suggestions or type a value.
         The popup may be a <a href="#Listbox">listbox</a>,
         <a href="#grid">grid</a>,


### PR DESCRIPTION
The additional clause "for the combobox" does not add any useful meaning to the firs sentence of this section. It does not help the understanding of what a combobox is because it is self-referential. If could also confuse people because it isn't clear what "for" means.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 504 Gateway Timeout :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jun 5, 2022, 11:18 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Fraw.githubusercontent.com%2Ftinynow%2Faria-practices%2F390caab865f3e906c44f3c915dbe7dd6b2b09344%2Faria-practices.html%3FisPreview%3Dtrue)

```
<html><body><h1>504 Gateway Time-out</h1>
The server didn't respond in time.
</body></html>

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/aria-practices%232375.)._
</details>
