### PR TITLE
Infrastructure: bump cSpell config schema version

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.1",
+    "version": "0.2",
     "dictionaries": [
         "html",
         "css",


### PR DESCRIPTION
The 0.2 replaced the old schema awhile ago. I don't believe there is any keys used that are affected in the file.