### PR TITLE
Infrastructure: Remove .pr-preview.json

### DIFF
--- a/.pr-preview.json
+++ b/.pr-preview.json
@@ -1,4 +1,0 @@
-{
-    "src_file": "aria-practices.html",
-    "type": "respec"
-}


### PR DESCRIPTION
Address #2416

This removes `.pr-preview.json` which seems to allow `pr-preview[bot]` to add a link to the editor's draft (which is no longer being used) onto the parent comment of some PRs.

It also seems to be [overwriting the generated APG redesign link](https://github.com/w3c/aria-practices/issues/2416#issuecomment-1194267587) which is attached to PRs by the `michael-n-cooper-bot` bot. An example exists in the edit history for #2415 parent comment.