### PR TITLE
Apply aria-hidden to the font icon for the calendar button in the Date Picker Dialog Example

### DIFF
--- a/examples/dialog-modal/datepicker-dialog.html
+++ b/examples/dialog-modal/datepicker-dialog.html
@@ -62,7 +62,7 @@
             <button type="button"
                     class="icon"
                     aria-label="Choose Date">
-              <span class="fa fa-calendar-alt fa-2x"></span>
+              <span class="fa fa-calendar-alt fa-2x" aria-hidden="true"></span>
             </button>
 
           </div>


### PR DESCRIPTION
Apply aria-hidden to the font icon for the calendar button in the Date Picker Dialog Example, to avoid the possibility that it gets announced by screen readers