### PR TITLE
Update GitHub workflows to use new content tree (Issue 2418 task 10)

### DIFF
--- a/.github/workflows/coverage-report.yml
+++ b/.github/workflows/coverage-report.yml
@@ -3,9 +3,9 @@ name: Regression Tests Coverage Report
 on:
   pull_request_target:
     paths:
-    - "examples/**"
+    - "content/**/examples/**"
     - "test/**"
-    - "!examples/landmarks/**"
+    - "!content/landmarks/examples/**"
 
 permissions:
   contents: read

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -7,13 +7,13 @@ on:
     paths:
       - "package*.json"
       - ".github/workflows/examples.yml"
-      - "examples/**"
+      - "content/**/examples/**"
       - "scripts/reference-tables.*"
   pull_request:
     paths:
       - "package*.json"
       - ".github/workflows/examples.yml"
-      - "examples/**"
+      - "content/**/examples/**"
       - "scripts/reference-tables.*"
 
 jobs:

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -6,9 +6,8 @@ on:
       - ".github/workflows/regression.yml"
       - "package*.json"
       - "test/**"
-      - "examples/**"
-      - "!examples/landmarks/**"
-      - "!examples/coding-template/**"
+      - "content/**/examples/**"
+      - "!content/landmarks/examples/**"
   push:
     branches-ignore:
       - main
@@ -17,9 +16,8 @@ on:
       - ".github/workflows/regression.yml"
       - "package*.json"
       - "test/**"
-      - "examples/**"
-      - "!examples/landmarks/**"
-      - "!examples/coding-template/**"
+      - "content/**/examples/**"
+      - "!content/landmarks/examples/**"
 
 jobs:
   regression:

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -9,8 +9,7 @@ on:
       - "!**/*.min.js"
       - "!**/*.pack.js"
       - "!**/*.paint"
-      - "!aria-practices-DeletedSectionsArchive.html"
-      - "!examples/landmarks/css/bootstrap.css"
+      - "!content/landmarks/examples/css/bootstrap.css"
       - "!common/**"
       - "!respec-config.js"
 
@@ -20,8 +19,7 @@ on:
       - "!**/*.min.js"
       - "!**/*.pack.js"
       - "!**/*.paint"
-      - "!aria-practices-DeletedSectionsArchive.html"
-      - "!examples/landmarks/css/bootstrap.css"
+      - "!content/landmarks/examples/css/bootstrap.css"
       - "!common/**"
       - "!respec-config.js"
 

--- a/.github/workflows/wai-trigger-deploy.yml
+++ b/.github/workflows/wai-trigger-deploy.yml
@@ -7,7 +7,7 @@ on:
     paths:
       - ".github/workflows/wai-trigger-deploy.yml"
       - "common/**"
-      - "examples/**"
+      - "content/**/examples/**"
       - "img/**"
       - "aria-practices.html"
       - "index.html"

--- a/.github/workflows/wai-trigger-pr.yml
+++ b/.github/workflows/wai-trigger-pr.yml
@@ -11,11 +11,11 @@ on:
       - "scripts/reference-tables.*"
       - "**/*.js"
       - "test/**"
-      - "examples/**"
+      - "content/**/examples/**"
       - "aria-practices.html"
       - "index.html"
-      - "!examples/landmarks/**"
-      - "!examples/coding-template/**"
+      - "!content/landmarks/examples/**"
+      - "!coding-template/**"
       - "!common/**"
 
 jobs:


### PR DESCRIPTION
See https://github.com/w3c/aria-practices/issues/2418 for more information about the task. Note that the build will fail until the changes on the move-examples-6 branch (https://github.com/w3c/aria-practices/pull/2441) are approved and merged.