### PR TITLE
Add note on APG vs. browser multiselect listbox keyboard pattern

### DIFF
--- a/content/patterns/listbox/examples/listbox-rearrangeable.html
+++ b/content/patterns/listbox/examples/listbox-rearrangeable.html
@@ -264,9 +264,13 @@ while in the second example, they may select multiple options before activating 
         </tr>
       </tbody>
     </table>
-    <h4 id="kbd_label_multiselect">Multiple selection keys supported in example 2</h4>
+    <h3 id="kbd_label_multiselect">Multiple selection keys supported in example 2</h3>
     <p class="note">
-      The selection behavior demonstrated differs from the behavior provided by browsers for native HTML <code>&lt;select multiple&gt;</code> elements. The select element behavior is to alter selection with unmodified up/down arrow keys, requiring the use of modifier keys to select multiple options. This example demonstrates a multiple selection pattern that does not require the use of modifier keys.
+      The selection behavior demonstrated differs from the behavior provided by browsers for native HTML <code>&lt;select multiple&gt;</code> elements.
+      The HTML select element behavior is to alter selection with unmodified up/down arrow keys, requiring the use of modifier keys to select multiple options.
+      This example demonstrates  the multiple selection interaction model recommended in the
+      <a href="../listbox-pattern.html#keyboard_interaction">Keyboard Interaction section of the Listbox Pattern</a>,
+      which  does not require the use of modifier keys.
     </p>
     <table aria-labelledby="kbd_label_multiselect" class="def">
       <thead>

--- a/content/patterns/listbox/examples/listbox-rearrangeable.html
+++ b/content/patterns/listbox/examples/listbox-rearrangeable.html
@@ -265,6 +265,9 @@ while in the second example, they may select multiple options before activating 
       </tbody>
     </table>
     <h4 id="kbd_label_multiselect">Multiple selection keys supported in example 2</h4>
+    <p class="note">
+      The selection behavior demonstrated differs from the behavior provided by browsers for native HTML <code>&lt;select multiple&gt;</code> elements. The select element behavior is to alter selection with unmodified up/down arrow keys, requiring the use of modifier keys to select multiple options. This example demonstrates a multiple selection pattern that does not require the use of modifier keys.
+    </p>
     <table aria-labelledby="kbd_label_multiselect" class="def">
       <thead>
         <tr>


### PR DESCRIPTION
Fixes #2193

Adds a note with the wording we discussed in a meeting on the Rearrangeable Listbox multiselect example.