### PR TITLE
Fix links to practices and patterns

### DIFF
--- a/content/patterns/alert/alert-pattern.html
+++ b/content/patterns/alert/alert-pattern.html
@@ -18,7 +18,7 @@
     <p>
       Because alerts are intended to provide important and potentially time-sensitive information without interfering with the user's ability to continue working,
       it is crucial they do not affect keyboard focus.
-      The <a href="../alert-dialog/pattern-alert-dialog.html">alert dialog</a> is designed for situations where interrupting work flow is necessary.
+      The <a href="../alert-dialog/alert-dialog-pattern.html">Alert Dialog Pattern</a> is designed for situations where interrupting work flow is necessary.
     </p>
     <p>
       It is also important to avoid designing alerts that disappear automatically.

--- a/content/patterns/button/button-pattern.html
+++ b/content/patterns/button/button-pattern.html
@@ -39,7 +39,11 @@
     <h2>Examples</h2>
     <ul>
       <li><a href="examples/button.html">Button Examples</a>: Examples of clickable HTML <code>div</code> and <code>span</code> elements made into accessible command and toggle buttons.</li>
-      <li><a href="examples/button_idl.html">Button Examples (IDL)</a>: Examples of clickable HTML <code>div</code> and <code>span</code> elements made into accessible command and toggle buttons. This example uses the <a class="specref" href="#idl-interface">IDL Interface</a>.</li>
+      <li>
+        <a href="examples/button_idl.html">Button Examples (IDL)</a>:
+        Examples of clickable HTML <code>div</code> and <code>span</code> elements made into accessible command and toggle buttons.
+        This example uses the <a class="specref" href="#idl-interface">IDL Interface</a>.
+      </li>
     </ul>
   </section>
 

--- a/content/patterns/button/examples/button_idl.html
+++ b/content/patterns/button/examples/button_idl.html
@@ -6,10 +6,10 @@
 
   <!-- Core JS and CSS shared by all examples. Do not modify when using this template. -->
   <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/base.css">
-  <link rel="stylesheet" href="../css/core.css">
-  <script src="../js/examples.js"></script>
-  <script src="../js/highlight.pack.js"></script>
-  <script src="../js/app.js"></script>
+  <link rel="stylesheet" href="../../../shared/css/core.css">
+  <script src="../../../shared/js/examples.js"></script>
+  <script src="../../../shared/js/highlight.pack.js"></script>
+  <script src="../../../shared/js/app.js"></script>
 
   <!-- CSS and JS for this example. -->
   <link rel="stylesheet" href="css/button.css">
@@ -18,24 +18,25 @@
 <body>
   <nav aria-label="Related Links" class="feedback">
     <ul>
-      <li><a href="../../#browser_and_AT_support">Browser and Assistive Technology Support</a></li>
-      <li><a href="https://github.com/w3c/aria-practices/issues/new">Report Issue</a></li>
       <li><a href="https://github.com/w3c/aria-practices/projects/14">Related Issues</a></li>
-      <li><a href="../../#button">Design Pattern</a></li>
+      <li><a href="../button-pattern.html">Design Pattern</a></li>
     </ul>
   </nav>
 
   <main>
     <h1>Button Examples (IDL Version)</h1>
-    <p>
-      The following examples of the <a href="../../#button">button design pattern</a> demonstrate a new JavaScript syntax for coding ARIA attributes.
-    </p>
-    <p>
-      The JavaScript for the example buttons on this page uses the <a href="https://www.w3.org/TR/wai-aria-1.2/#idl-interface">IDL Interface defined in ARIA 1.2</a>.
-      The purpose of these examples is to illustrate how to use ARIA Attribute Reflection and provide a test case for browser and assistive technology interoperability.
-      Specifically, the <code>role</code> and <code>ariaPressed</code> attributes are accessed using dot notation instead of <code>setAttribute()</code> and <code>getAttribute()</code>.
-      In all other respects, these examples are identical to the <a href="button.html">Button Examples</a>.
-    </p>
+    <section>
+      <h2>About This example</h2>
+      <p>
+        The following examples of the <a href="../.button-pattern.html">button design pattern</a> demonstrate a new JavaScript syntax for coding ARIA attributes.
+      </p>
+      <p>
+        The JavaScript for the example buttons on this page uses the <a href="https://www.w3.org/TR/wai-aria-1.2/#idl-interface">IDL Interface defined in ARIA 1.2</a>.
+        The purpose of these examples is to illustrate how to use ARIA Attribute Reflection and provide a test case for browser and assistive technology interoperability.
+        Specifically, the <code>role</code> and <code>ariaPressed</code> attributes are accessed using dot notation instead of <code>setAttribute()</code> and <code>getAttribute()</code>.
+        In all other respects, these examples are identical to the <a href="button.html">Button Examples</a>.
+      </p>
+    </section>
 
     <section>
       <div class="example-header">
@@ -224,8 +225,5 @@
     </section>
   </main>
 
-  <nav>
-    <a href="../../#button">Button Design Pattern in WAI-ARIA Authoring Practices 1.1</a>
-  </nav>
 </body>
 </html>

--- a/content/patterns/button/examples/button_idl.html
+++ b/content/patterns/button/examples/button_idl.html
@@ -31,7 +31,7 @@
         The following examples of the <a href="../.button-pattern.html">button design pattern</a> demonstrate a new JavaScript syntax for coding ARIA attributes.
       </p>
       <p>
-        The JavaScript for the example buttons on this page uses the <a href="https://www.w3.org/TR/wai-aria-1.2/#idl-interface">IDL Interface defined in ARIA 1.2</a>.
+        The JavaScript for the example buttons on this page uses the <a class="specref" href="#idl-interface">IDL Interface defined in ARIA 1.2</a>.
         The purpose of these examples is to illustrate how to use ARIA Attribute Reflection and provide a test case for browser and assistive technology interoperability.
         Specifically, the <code>role</code> and <code>ariaPressed</code> attributes are accessed using dot notation instead of <code>setAttribute()</code> and <code>getAttribute()</code>.
         In all other respects, these examples are identical to the <a href="button.html">Button Examples</a>.

--- a/content/patterns/carousel/carousel-pattern.html
+++ b/content/patterns/carousel/carousel-pattern.html
@@ -92,7 +92,7 @@
         has either role <a href="#region" class="role-reference">region</a>
         or role <a href="#group" class="role-reference">group.</a>
         The most appropriate role for the carousel container depends on the information architecture of the page.
-        See the <a href="#aria_landmark">landmark regions guidance</a> to determine whether the carousel warrants being designated as a landmark region.
+        See the <a href="../../practices/landmark-regions/landmark-regions-practice.html">Landmark Regions Practice</a> to determine whether the carousel warrants being designated as a landmark region.
       </li>
       <li>The carousel container has the <a href="#aria-roledescription" class="property-reference">aria-roledescription</a> property set to <code>carousel</code>.</li>
       <li>

--- a/content/patterns/carousel/examples/carousel-2-tablist.html
+++ b/content/patterns/carousel/examples/carousel-2-tablist.html
@@ -31,7 +31,7 @@
         <a href="../carousel-pattern.html">carousel design pattern</a>
         demonstrates features of the pattern that are essential to accessibility for carousels that automatically start rotating when the page loads.
         This example also illustrates how to use the
-        <a href="../tabs-pattern.html">tabs pattern</a>
+        <a href="../../tabs/tabs-pattern.html">tabs pattern</a>
         to provide users with a way to skip slides in the sequence by directly choosing which one to view.
          Navigation among slides is provided by a series of circular buttons that function as tabs and are rendered over the rotating slides.
         Automatic rotation stops when users move focus to any control or link in the carousel or hover the mouse over carousel content.
@@ -704,7 +704,7 @@
                     <li>Removes the element from the page <kbd>Tab</kbd> sequence.</li>
                     <li>Set when a tab is not selected so that only the selected tab is in the page <kbd>Tab</kbd> sequence.</li>
                     <li>Since the tab element is an HTML <code>button</code>, the tabindex attribute is removed when a tab is selected (activated) rather than setting <code>tabindex="0"</code>.</li>
-                    <li>This approach to managing focus is described in the section on <a href="../../#kbd_roving_tabindex">roving tabindex</a>.</li>
+                    <li>This approach to managing focus is described in the section on <a href="../../../practices/keyboard-interface/keyboard-interface-practice.html#kbd_roving_tabindex">Managing Focus Within Components Using a Roving tabindex</a>.</li>
                   </ul>
                 </td>
               </tr>

--- a/content/patterns/checkbox/examples/checkbox-mixed.html
+++ b/content/patterns/checkbox/examples/checkbox-mixed.html
@@ -18,7 +18,7 @@
     <nav aria-label="Related Links" class="feedback">
       <ul>
         <li><a href="https://github.com/w3c/aria-practices/projects/9">Related Issues</a></li>
-        <li><a href="../../#checkbox">Design Pattern</a></li>
+        <li><a href="../checkbox-pattern.html">Design Pattern</a></li>
       </ul>
     </nav>
     <main>

--- a/content/patterns/combobox/combobox-pattern.html
+++ b/content/patterns/combobox/combobox-pattern.html
@@ -8,7 +8,7 @@
 <body>
   <h1>Combobox Pattern</h1>
   
-  <section>
+  <section id="about">
     <h2>About This Pattern</h2>
     <p>
       A <a href="#combobox" class="role-reference">combobox</a> is an input widget with an associated popup that enables users to select a value for the combobox from a collection of possible values.
@@ -87,7 +87,7 @@
     </p>
   </section>
 
-  <section>
+  <section id="examples">
     <h2>Examples</h2>
     <ul>
       <li><a href="examples/combobox-select-only.html">Select-Only Combobox</a>: A single-select combobox with no text input that is functionally similar to an HTML <code>select</code> element.</li>
@@ -99,7 +99,7 @@
     </ul>
   </section>
 
-  <section>
+  <section id="keyboard_interaction">
     <h2>Keyboard Interaction</h2>
     <ul>
       <li><kbd>Tab</kbd>: The combobox is in the page <kbd>Tab</kbd> sequence.</li>
@@ -171,7 +171,7 @@
       <li><kbd>Delete</kbd> (Optional): If the combobox is editable, returns focus to the combobox, removes the selected state if a suggestion was selected, and removes the inline autocomplete string if present.</li>
     </ul>
     <ol class="note">
-      <li>DOM Focus is maintained on the combobox and the assistive technology focus is moved within the listbox using <code>aria-activedescendant</code> as described in <a href="#kbd_focus_activedescendant">Managing Focus in Composites Using aria-activedescendant.</a></li>
+      <li>DOM Focus is maintained on the combobox and the assistive technology focus is moved within the listbox using <code>aria-activedescendant</code> as described in <a href="../../practices/keyboard-interface/keyboard-interface-practice.html#kbd_focus_activedescendant">Managing Focus in Composites Using aria-activedescendant</a>.</li>
       <li>Selection follows focus in the listbox; the listbox allows only one suggested value to be selected at a time for the combobox value.</li>
     </ol>
     <h3>Grid Popup Keyboard Interaction</h3>
@@ -227,7 +227,7 @@
       <li><kbd>Delete</kbd> (Optional): If the combobox is editable, returns focus to the combobox, removes the selected state if a suggestion was selected, and removes the inline autocomplete string if present.</li>
     </ul>
     <ol class="note">
-      <li>DOM Focus is maintained on the combobox and the assistive technology focus is moved within the grid using <code>aria-activedescendant</code> as described in <a href="#kbd_focus_activedescendant">Managing Focus in Composites Using aria-activedescendant.</a></li>
+      <li>DOM Focus is maintained on the combobox and the assistive technology focus is moved within the grid using <code>aria-activedescendant</code> as described in <a href="../../practices/keyboard-interface/keyboard-interface-practice.html#kbd_focus_activedescendant">Managing Focus in Composites Using aria-activedescendant</a>.</li>
       <li>The grid allows only one suggested value to be selected at a time for the combobox value.</li>
       <li>In a grid popup, each suggested value may be represented by either a single cell or an entire row. This aspect of design effects focus and selection movement:
         <ol>
@@ -283,7 +283,7 @@
       </li>
     </ul>
     <ol class="note">
-    <li>DOM Focus is maintained on the combobox and the assistive technology focus is moved within the tree using <code>aria-activedescendant</code> as described in <a href="#kbd_focus_activedescendant">Managing Focus in Composites Using aria-activedescendant.</a></li>
+    <li>DOM Focus is maintained on the combobox and the assistive technology focus is moved within the tree using <code>aria-activedescendant</code> as described in <a href="../../practices/keyboard-interface/keyboard-interface-practice.html#kbd_focus_activedescendant">Managing Focus in Composites Using aria-activedescendant</a>.</li>
     <li>The tree allows only one suggested value to be selected at a time for the combobox value.</li>
       <li>
         In a tree popup, some or all parent nodes may not be selectable values; they may serve as category labels for suggested values.
@@ -320,7 +320,7 @@
     </p>
   </section>
 
-  <section>
+  <section id="roles_states_properties">
     <h2>WAI-ARIA Roles, States, and Properties</h2>
     <ul>
       <li>The element that serves as an input and displays the combobox value has role <a href="#combobox" class="role-reference">combobox</a>.</li>

--- a/content/patterns/combobox/examples/combobox-autocomplete-both.html
+++ b/content/patterns/combobox/examples/combobox-autocomplete-both.html
@@ -164,7 +164,7 @@
       <p>
       The example combobox on this page implements the following keyboard interface.
         Other variations and options for the keyboard interface are described in the
-        <a href="../../#keyboard-interaction-6">Keyboard Interaction section of the combobox design pattern.</a>
+        <a href="../combobox-pattern.html#keyboard_interaction">Keyboard Interaction section of the combobox design pattern.</a>
       </p>
       <h3 id="kbd_label_textbox">Textbox</h3>
       <table aria-labelledby="kbd_label_textbox kbd_label" class="def">
@@ -235,7 +235,7 @@
         <strong>NOTE:</strong> When visual focus is in the listbox, DOM focus remains on the textbox and the value of <code>aria-activedescendant</code> on the textbox is set to a value that refers to the listbox option that is visually indicated as focused.
         Where the following descriptions of keyboard commands mention focus, they are referring to the visual focus indicator.
         For more information about this focus management technique, see
-        <a href="../../#kbd_focus_activedescendant">Using aria-activedescendant to Manage Focus.</a>
+        <a href="../../../practices/keyboard-interface/keyboard-interface-practice.html#kbd_focus_activedescendant">Managing Focus in Composites Using aria-activedescendant</a>.
       </p>
       <table aria-labelledby="kbd_label_listbox kbd_label" class="def">
         <thead>
@@ -324,7 +324,7 @@
       <p>
         The example combobox on this page implements the following ARIA roles, states, and properties.
         Information about other ways of applying ARIA roles, states, and properties is available in the
-        <a href="../../#wai-aria-roles-states-and-properties-6">Roles, States, and Properties section of the combobox design pattern.</a>
+        <a href="../combobox-pattern.html#roles_states_properties">Roles, States, and Properties section of the combobox design pattern.</a>
       </p>
       <h3 id="rps_label_textbox">Textbox</h3>
       <table aria-labelledby="rps_label_textbox rps_label" class="data attributes">
@@ -403,7 +403,7 @@
                 <li>Enables assistive technologies to know which element the application regards as focused while DOM focus remains on the <code>input</code> element.</li>
                 <li>
                   For more information about this focus management technique, see
-                  <a href="../../#kbd_focus_activedescendant">Using aria-activedescendant to Manage Focus.</a>
+                  <a href="../../../practices/keyboard-interface/keyboard-interface-practice.html#kbd_focus_activedescendant">Managing Focus in Composites Using aria-activedescendant</a>.
                 </li>
               </ul>
             </td>

--- a/content/patterns/combobox/examples/combobox-autocomplete-list.html
+++ b/content/patterns/combobox/examples/combobox-autocomplete-list.html
@@ -164,7 +164,7 @@
       <p>
       The example combobox on this page implements the following keyboard interface.
         Other variations and options for the keyboard interface are described in the
-        <a href="../../#keyboard-interaction-6">Keyboard Interaction section of the combobox design pattern.</a>
+        <a href="../combobox-pattern.html#keyboard_interaction">Keyboard Interaction section of the combobox design pattern.</a>
       </p>
       <h3 id="kbd_label_textbox">Textbox</h3>
       <table aria-labelledby="kbd_label_textbox kbd_label" class="def">
@@ -230,7 +230,7 @@
         <strong>NOTE:</strong> When visual focus is in the listbox, DOM focus remains on the textbox and the value of <code>aria-activedescendant</code> on the textbox is set to a value that refers to the listbox option that is visually indicated as focused.
         Where the following descriptions of keyboard commands mention focus, they are referring to the visual focus indicator.
         For more information about this focus management technique, see
-        <a href="../../#kbd_focus_activedescendant">Using aria-activedescendant to Manage Focus.</a>
+        <a href="../../../practices/keyboard-interface/keyboard-interface-practice.html#kbd_focus_activedescendant">Managing Focus in Composites Using aria-activedescendant</a>.
       </p>
       <table aria-labelledby="kbd_label_listbox kbd_label" class="def">
         <thead>
@@ -318,7 +318,7 @@
       <p>
         The example combobox on this page implements the following ARIA roles, states, and properties.
         Information about other ways of applying ARIA roles, states, and properties is available in the
-        <a href="../../#wai-aria-roles-states-and-properties-6">Roles, States, and Properties section of the combobox design pattern.</a>
+        <a href="../combobox-pattern.html#roles_states_properties">Roles, States, and Properties section of the combobox design pattern.</a>
       </p>
       <h3 id="rps_label_textbox">Textbox</h3>
       <table aria-labelledby="rps_label_textbox rps_label" class="data attributes">
@@ -397,7 +397,7 @@
                 <li>Enables assistive technologies to know which element the application regards as focused while DOM focus remains on the <code>input</code> element.</li>
                 <li>
                   For more information about this focus management technique, see
-                  <a href="../../#kbd_focus_activedescendant">Using aria-activedescendant to Manage Focus.</a>
+                  <a href="../../../practices/keyboard-interface/keyboard-interface-practice.html#kbd_focus_activedescendant">Managing Focus in Composites Using aria-activedescendant</a>.
                 </li>
               </ul>
             </td>

--- a/content/patterns/combobox/examples/combobox-autocomplete-none.html
+++ b/content/patterns/combobox/examples/combobox-autocomplete-none.html
@@ -19,7 +19,7 @@
   <nav aria-label="Related Links" class="feedback">
     <ul>
       <li><a href="https://github.com/w3c/aria-practices/projects/7">Related Issues</a></li>
-      <li><a href="../../#combobox">Design Pattern</a></li>
+      <li><a href="../combobox-pattern.html">Design Pattern</a></li>
     </ul>
   </nav>
   <main>
@@ -28,7 +28,7 @@
       <h2>About This Example</h2>
     <p>
       The below combobox that enables users to choose a term from a hypothetical list of previously searched terms demonstrates the
-      <a href="../../#combobox">ARIA design pattern for combobox.</a>
+      <a href="../combobox-pattern.html">ARIA design pattern for combobox.</a>
       The design pattern describes four types of autocomplete behavior.
       This example illustrates the autocomplete behavior known as <q>no autocomplete</q>.
       The terms that appear in the listbox popup are not related to the string that is present in the textbox.
@@ -119,7 +119,7 @@
       <p>
       The example combobox on this page implements the following keyboard interface.
         Other variations and options for the keyboard interface are described in the
-        <a href="../../#keyboard-interaction-6">Keyboard Interaction section of the combobox design pattern.</a>
+        <a href="../combobox-pattern.html#keyboard_interaction">Keyboard Interaction section of the combobox design pattern.</a>
       </p>
       <h3 id="kbd_label_textbox">Textbox</h3>
       <table aria-labelledby="kbd_label_textbox kbd_label" class="def">
@@ -174,7 +174,7 @@
         <strong>NOTE:</strong> When visual focus is in the listbox, DOM focus remains on the textbox and the value of <code>aria-activedescendant</code> on the textbox is set to a value that refers to the listbox option that is visually indicated as focused.
         Where the following descriptions of keyboard commands mention focus, they are referring to the visual focus indicator.
         For more information about this focus management technique, see
-        <a href="../../#kbd_focus_activedescendant">Using aria-activedescendant to Manage Focus.</a>
+        <a href="../../../practices/keyboard-interface/keyboard-interface-practice.html#kbd_focus_activedescendant">Managing Focus in Composites Using aria-activedescendant</a>.
       </p>
       <table aria-labelledby="kbd_label_listbox kbd_label" class="def">
         <thead>
@@ -262,7 +262,7 @@
       <p>
         The example combobox on this page implements the following ARIA roles, states, and properties.
         Information about other ways of applying ARIA roles, states, and properties is available in the
-        <a href="../../#wai-aria-roles-states-and-properties-6">Roles, States, and Properties section of the combobox design pattern.</a>
+        <a href="../combobox-pattern.html#roles_states_properties">Roles, States, and Properties section of the combobox design pattern.</a>
       </p>
       <h3 id="rps_label_textbox">Textbox</h3>
       <table aria-labelledby="rps_label_textbox rps_label" class="data attributes">
@@ -341,7 +341,7 @@
                 <li>Enables assistive technologies to know which element the application regards as focused while DOM focus remains on the <code>input</code> element.</li>
                 <li>
                   For more information about this focus management technique, see
-                  <a href="../../#kbd_focus_activedescendant">Using aria-activedescendant to Manage Focus.</a>
+                  <a href="../../../practices/keyboard-interface/keyboard-interface-practice.html#kbd_focus_activedescendant">Managing Focus in Composites Using aria-activedescendant</a>.
                 </li>
               </ul>
             </td>

--- a/content/patterns/combobox/examples/combobox-datepicker.html
+++ b/content/patterns/combobox/examples/combobox-datepicker.html
@@ -28,14 +28,14 @@
   <section>
     <h2>About This Example</h2>
     <p>
-      The below date picker demonstrates an implementation of the <a href="../../#combobox">combobox design pattern</a> that opens a dialog.
+      The below date picker demonstrates an implementation of the <a href="../combobox-pattern.html">combobox design pattern</a> that opens a dialog.
       The date picker dialog is opened by activating the choose date button or by moving keyboard focus to the combobox and pressing <kbd>Down Arrow</kbd> or <kbd>Alt + Down Arrow</kbd>.
-      The  dialog contains an implementation of the <a href="../../#grid">grid pattern</a> for displaying a calendar and enabling selection of a date.
+      The  dialog contains an implementation of the <a href="../../grid/grid-pattern.html">grid pattern</a> for displaying a calendar and enabling selection of a date.
       Additional buttons in the dialog are available for changing the month and year shown in the grid.
     </p>
     <p>Similar examples include:</p>
     <ul>
-      <li><a href="../dialog-modal/datepicker-dialog.html">Date Picker Dialog example</a>: Demonstrates a dialog containing a calendar grid for choosing a date.</li>
+      <li><a href="../../dialog-modal/examples/datepicker-dialog.html">Date Picker Dialog example</a>: Demonstrates a dialog containing a calendar grid for choosing a date.</li>
       <li><a href="combobox-select-only.html">Select-Only Combobox</a>: A single-select combobox with no text input that is functionally similar to an HTML <code>select</code> element.</li>
       <li><a href="combobox-autocomplete-both.html">Editable Combobox with Both List and Inline Autocomplete</a>: An editable combobox that demonstrates the autocomplete behavior known as &quot;list with inline autocomplete&quot;.</li>
       <li><a href="combobox-autocomplete-list.html">Editable Combobox with List Autocomplete</a>: An editable combobox that demonstrates the autocomplete behavior known as &quot;list with manual selection&quot;.</li>
@@ -283,7 +283,7 @@
               <td>
                 <ul>
                   <li>Moves focus to next element in the dialog <kbd>Tab</kbd> sequence.</li>
-                  <li>Note that, as specified in the <a href="../../#grid">grid design pattern</a>, only one element in the calendar grid is in the <kbd>Tab</kbd> sequence.</li>
+                  <li>Note that, as specified in the <a href="../../grid/grid-pattern.html">grid design pattern</a>, only one element in the calendar grid is in the <kbd>Tab</kbd> sequence.</li>
                   <li>If focus is on the last button (i.e., &quot;OK&quot;), moves focus to the first button (i.e. &quot;Previous Year&quot;).</li>
                 </ul>
               </td>
@@ -293,7 +293,7 @@
               <td>
                 <ul>
                   <li>Moves focus to previous element in the dialog <kbd>Tab</kbd> sequence.</li>
-                  <li>Note that, as specified in the <a href="../../#grid">grid design pattern</a>, only one element in the calendar grid is in the <kbd>Tab</kbd> sequence.</li>
+                  <li>Note that, as specified in the <a href="../../grid/grid-pattern.html">grid design pattern</a>, only one element in the calendar grid is in the <kbd>Tab</kbd> sequence.</li>
                   <li>If focus is on the first button (i.e., &quot;Previous Year&quot;), moves focus to the last button (i.e. &quot;OK&quot;).</li>
                 </ul>
               </td>
@@ -674,7 +674,7 @@
                 <li>Makes the gridcell focusable and includes it in the dialog <kbd>Tab</kbd> sequence.</li>
                 <li>Set dynamically by the JavaScript when the element is to be included in the dialog <kbd>Tab</kbd> sequence.</li>
                 <li>At any given time, only one gridcell within the grid is in the dialog <kbd>Tab</kbd> sequence.</li>
-                <li>This approach to managing focus is described in the section on <a href="../../#kbd_roving_tabindex">roving tabindex</a>.</li>
+                <li>This approach to managing focus is described in the section on <a href="../../../practices/keyboard-interface/keyboard-interface-practice.html#kbd_roving_tabindex">Managing Focus Within Components Using a Roving tabindex</a>.</li>
               </ul>
             </td>
           </tr>
@@ -692,7 +692,7 @@
                 <li>Makes the gridcell focusable and excludes it from the dialog <kbd>Tab</kbd> sequence.</li>
                 <li>Changed dynamically to <code>0</code> by the JavaScript when the gridcell is to be included in the dialog <kbd>Tab</kbd> sequence.</li>
                 <li>At any given time, only one gridcell within the grid is in the dialog <kbd>Tab</kbd> sequence.</li>
-                <li>This approach to managing focus is described in the section on <a href="../../#kbd_roving_tabindex">roving tabindex</a>.</li>
+                <li>This approach to managing focus is described in the section on <a href="../../../practices/keyboard-interface/keyboard-interface-practice.html#kbd_roving_tabindex">Managing Focus Within Components Using a Roving tabindex</a>.</li>
               </ul>
             </td>
           </tr>

--- a/content/patterns/combobox/examples/combobox-select-only.html
+++ b/content/patterns/combobox/examples/combobox-select-only.html
@@ -92,7 +92,7 @@
       <p>
       The example combobox on this page implements the following keyboard interface.
         Other variations and options for the keyboard interface are described in the
-        <a href="../../#keyboard-interaction-6">Keyboard Interaction section of the combobox design pattern.</a>
+        <a href="../combobox-pattern.html#keyboard_interaction">Keyboard Interaction section of the combobox pattern.</a>
       </p>
       <h3 id="kbd_label_combobox">Closed Combobox</h3>
       <table aria-labelledby="kbd_label_combobox kbd_label" class="def">
@@ -168,7 +168,7 @@
         <strong>NOTE:</strong> When visual focus is in the listbox, DOM focus remains on the combobox and the value of <code>aria-activedescendant</code> on the combobox is set to a value that refers to the listbox option that is visually indicated as focused.
         Where the following descriptions of keyboard commands mention focus, they are referring to the visual focus indicator.
         For more information about this focus management technique, see
-        <a href="../../#kbd_focus_activedescendant">Using aria-activedescendant to Manage Focus.</a>
+        <a href="../../../practices/keyboard-interface/keyboard-interface-practice.html#kbd_focus_activedescendant">Managing Focus in Composites Using aria-activedescendant</a>.
       </p>
       <table aria-labelledby="kbd_label_listbox kbd_label" class="def">
         <thead>
@@ -282,7 +282,7 @@
       <p>
         The example combobox on this page implements the following ARIA roles, states, and properties.
         Information about other ways of applying ARIA roles, states, and properties is available in the
-        <a href="../../#wai-aria-roles-states-and-properties-6">Roles, States, and Properties section of the combobox design pattern.</a>
+        <a href="../combobox-pattern.html#roles_states_properties">Roles, States, and Properties section of the combobox design pattern.</a>
       </p>
       <h3 id="rps_label_combobox">Combobox</h3>
       <table aria-labelledby="rps_label_combobox rps_label" class="data attributes">
@@ -348,7 +348,7 @@
                 <li>Enables assistive technologies to know which element the application regards as focused while DOM focus remains on the <code>input</code> element.</li>
                 <li>
                   For more information about this focus management technique, see
-                  <a href="../../#kbd_focus_activedescendant">Using aria-activedescendant to Manage Focus.</a>
+                  <a href="../../../practices/keyboard-interface/keyboard-interface-practice.html#kbd_focus_activedescendant">Managing Focus in Composites Using aria-activedescendant</a>.
                 </li>
               </ul>
             </td>

--- a/content/patterns/combobox/examples/grid-combo.html
+++ b/content/patterns/combobox/examples/grid-combo.html
@@ -30,7 +30,7 @@
       <h2>About This Example</h2>
     <p>
       The following example combobox implements the
-      <a href="../../#combobox">combobox design pattern</a>
+      <a href="../combobox-pattern.html">combobox pattern</a>
       using a grid for the suggested values popup.
     </p>
     <p>
@@ -92,7 +92,7 @@
       <p>
       The example combobox on this page implements the following keyboard interface.
         Other variations and options for the keyboard interface are described in the
-        <a href="../../#keyboard-interaction-6">Keyboard Interaction section of the combobox design pattern.</a>
+        <a href="../combobox-pattern.html#keyboard_interaction">Keyboard Interaction section of the combobox pattern.</a>
       </p>
       <h3 id="kbd_label_textbox">Textbox</h3>
       <table aria-labelledby="kbd_label_textbox kbd_label" class="def">
@@ -136,7 +136,7 @@
           <strong>NOTE:</strong> When visual focus is in the grid, DOM focus remains on the textbox and the value of <code>aria-activedescendant</code> on the textbox is set to a value that refers to an element in the grid that is visually indicated as focused.
           Where the following descriptions of keyboard commands mention focus, they are referring to the visual focus indicator.
           For more information about this focus management technique, see
-          <a href="../../#kbd_focus_activedescendant">Using aria-activedescendant to Manage Focus.</a>
+          <a href="../../../practices/keyboard-interface/keyboard-interface-practice.html#kbd_focus_activedescendant">Managing Focus in Composites Using aria-activedescendant</a>.
         </p>
       <table aria-labelledby="kbd_label_popup kbd_label" class="def">
         <thead>
@@ -231,7 +231,7 @@
       <p>
         The example comboboxes on this page implement the following ARIA roles, states, and properties.
         Information about other ways of applying ARIA roles, states, and properties is available in the
-        <a href="../../#wai-aria-roles-states-and-properties-6">Roles, States, and Properties section of the combobox design pattern.</a>
+        <a href="../combobox-pattern.html#roles_states_properties">Roles, States, and Properties section of the combobox pattern.</a>
       </p>
       <h3 id="rps_label_textbox">Textbox</h3>
       <table aria-labelledby="rps_label_textbox rps_label" class="data attributes">
@@ -318,7 +318,7 @@
                 <li>Enables assistive technologies to know which element the application regards as focused while DOM focus remains on the <code>input</code> element.</li>
                 <li>
                   For more information about this focus management technique, see
-                  <a href="../../#kbd_focus_activedescendant">Using aria-activedescendant to Manage Focus.</a>
+                  <a href="../../../practices/keyboard-interface/keyboard-interface-practice.html#kbd_focus_activedescendant">Managing Focus in Composites Using aria-activedescendant</a>.
                 </li>
               </ul>
             </td>
@@ -389,7 +389,7 @@
       <h2>Javascript and CSS Source Code</h2>
       <ul id="css_js_files">
         <li> CSS: <a href="css/grid-combo.css" type="tex/css">grid-combo.css</a></li>
-        <li>Javascript: <a href="js/grid-combo.js">grid-combo.js</a>, <a href="js/grid-combo-example.js">grid-combo-example.js</a>, <a href="../js/utils.js">utils.js</a></li>
+        <li>Javascript: <a href="js/grid-combo.js">grid-combo.js</a>, <a href="js/grid-combo-example.js">grid-combo-example.js</a>, <a href="../../../shared/js/utils.js">utils.js</a></li>
       </ul>
     </section>
 

--- a/content/patterns/dialog-modal/examples/alertdialog.html
+++ b/content/patterns/dialog-modal/examples/alertdialog.html
@@ -9,10 +9,10 @@
     <script src="../../../shared/js/examples.js"></script>
     <script src="../../../shared/js/highlight.pack.js"></script>
     <script src="../../../shared/js/app.js"></script>
-    <!-- js from the dialog-modal example -->
-    <script src="../js/utils.js"></script>
-    <script src="js/dialog.js"></script>
+    <script src="../../../shared/js/utils.js"></script>
+
     <!--  js and css for this example. -->
+    <script src="js/dialog.js"></script>
     <link href="css/dialog.css" rel="stylesheet">
     <script src="js/alertdialog.js"></script>
   </head>
@@ -21,7 +21,7 @@
     <nav aria-label="Related Links" class="feedback">
       <ul>
         <li><a href="https://github.com/w3c/aria-practices/projects/20">Related Issues</a></li>
-        <li><a href="../dialog-modal-pattern.html">Design Pattern</a></li>
+        <li><a href="../../alert-dialog/alert-dialog-pattern.html">Design Pattern</a></li>
       </ul>
     </nav>
     <main>
@@ -30,8 +30,8 @@
         <h2>About This Example</h2>
 
       <p>
-        The below example of a confirmation prompt demonstrates the <a href="../../#alertdialog">design pattern for an alert dialog</a>.
-        It also includes an example of the <a href="../../#alert">design pattern for an alert</a> to make comparing the experiences provided by the two patterns easy.
+        The below example of a confirmation prompt demonstrates the <a href="../../alert-dialog/alert-dialog-pattern.html">design pattern for an alert dialog</a>.
+        It also includes an example of the <a href="../../alert/alert-pattern.html">design pattern for an alert</a> to make comparing the experiences provided by the two patterns easy.
       </p>
       <p>To use this example:</p>
       <ul>
@@ -56,7 +56,7 @@
         </p>
       <p>Similar examples include:</p>
       <ul>
-        <li><a href="../alertdialog.html">Alert</a>: a basic alert.</li>
+        <li><a href="../../alert/examples/alert.html">Alert</a>: a basic alert.</li>
         <li><a href="dialog.html">Modal Dialog Example</a>: An example demonstrating multiple layers of modal dialogs with both small and large amounts of content.</li>
         <li><a href="datepicker-dialog.html">Date Picker Dialog example</a>: Demonstrates a dialog containing a calendar grid for choosing a date.</li>
       </ul>
@@ -235,7 +235,7 @@
         <h2 id="src_label">Javascript and CSS Source Code</h2>
         <ul id="css_js_files">
           <li> CSS: <a href="css/dialog.css" type="text/css">dialog.css</a></li>
-          <li> Javascript: <a href="js/alertdialog.js" type="text/javascript">alertdialog.js</a>, <a href="js/dialog.js" type="text/javascript">dialog.js</a>, <a href="../js/utils.js">utils.js</a></li>
+          <li> Javascript: <a href="js/alertdialog.js" type="text/javascript">alertdialog.js</a>, <a href="js/dialog.js" type="text/javascript">dialog.js</a>, <a href="../../../shared/js/utils.js">utils.js</a></li>
         </ul>
       </section>
       <section>

--- a/content/patterns/dialog-modal/examples/datepicker-dialog.html
+++ b/content/patterns/dialog-modal/examples/datepicker-dialog.html
@@ -28,8 +28,8 @@
     <section>
     <h2>About This Example</h2>
     <p>
-      The example below includes a date input field and a button that opens a date picker that implements the <a href="../dialog-modal-pattern.html">dialog design pattern</a>.
-      The dialog contains a calendar that uses the <a href="../../#grid">grid pattern</a> to present buttons that enable the user to choose a day from the calendar.
+      The example below includes a date input field and a button that opens a date picker that implements the <a href="../dialog-modal-pattern.html">Dialog (Modal) Pattern</a>.
+      The dialog contains a calendar that uses the <a href="../../grid/grid-pattern.html">grid pattern</a> to present buttons that enable the user to choose a day from the calendar.
       Choosing a date from the calendar closes the dialog and populates the date input field.
       When the dialog is opened, if the input field is empty, or does not contain a valid date, then the current date is focused in the calendar.
       Otherwise, the focus is placed on the day in the calendar that matches the value of the date input field.
@@ -38,7 +38,7 @@
     <ul>
       <li><a href="alertdialog.html">Alert Dialog Example</a>: A confirmation prompt that demonstrates an alert dialog.</li>
       <li><a href="dialog.html">Modal Dialog Example</a>: An example demonstrating multiple layers of modal dialogs with both small and large amounts of content.</li>
-      <li><a href="../combobox/combobox-datepicker.html">Date Picker Combobox</a>: An editable date input combobox that opens a dialog containing a calendar grid and buttons for navigating by month and year.</li>
+      <li><a href="../../combobox/examples/combobox-datepicker.html">Date Picker Combobox</a>: An editable date input combobox that opens a dialog containing a calendar grid and buttons for navigating by month and year.</li>
     </ul>
   </section>
   <section>
@@ -270,7 +270,7 @@
             <td>
               <ul>
                 <li>Moves focus to next element in the dialog <kbd>Tab</kbd> sequence.</li>
-                <li>Note that, as specified in the <a href="../../#grid">grid design pattern</a>, only one button in the calendar grid is in the <kbd>Tab</kbd> sequence.</li>
+                <li>Note that, as specified in the <a href="../../grid/grid-pattern.html">Grid Pattern</a>, only one button in the calendar grid is in the <kbd>Tab</kbd> sequence.</li>
                 <li>If focus is on the last button (i.e., &quot;OK&quot;), moves focus to the first button (i.e. &quot;Previous Year&quot;).</li>
               </ul>
             </td>
@@ -280,7 +280,7 @@
             <td>
               <ul>
                 <li>Moves focus to previous element in the dialog <kbd>Tab</kbd> sequence.</li>
-                <li>Note that, as specified in the <a href="../../#grid">grid design pattern</a>, only one button in the calendar grid is in the <kbd>Tab</kbd> sequence.</li>
+                <li>Note that, as specified in the <a href="../../grid/grid-pattern.html">Grid Pattern</a>, only one button in the calendar grid is in the <kbd>Tab</kbd> sequence.</li>
                 <li>If focus is on the first button (i.e., &quot;Previous Year&quot;), moves focus to the last button (i.e. &quot;OK&quot;).</li>
               </ul>
             </td>
@@ -600,7 +600,7 @@
                 <li>Makes the cell focusable and includes it in the dialog <kbd>Tab</kbd> sequence.</li>
                 <li>Set dynamically by the JavaScript when the element is to be included in the dialog <kbd>Tab</kbd> sequence.</li>
                 <li>At any given time, only one <code>gridcell</code> within the grid is in the dialog <kbd>Tab</kbd> sequence.</li>
-                <li>This approach to managing focus is described in the section on <a href="../../#kbd_roving_tabindex">roving tabindex</a>.</li>
+                <li>This approach to managing focus is described in the section on <a href="../../../practices/keyboard-interface/keyboard-interface-practice.html#kbd_roving_tabindex">Managing Focus Within Components Using a Roving tabindex</a>.</li>
               </ul>
             </td>
           </tr>
@@ -617,7 +617,7 @@
                 <li>Makes the cell focusable and excludes it from the dialog <kbd>Tab</kbd> sequence.</li>
                 <li>Changed dynamically to <code>0</code> by the JavaScript when the cell is to be included in the dialog <kbd>Tab</kbd> sequence.</li>
                 <li>At any given time, only one <code>gridcell</code> within the grid is in the dialog <kbd>Tab</kbd> sequence.</li>
-                <li>This approach to managing focus is described in the section on <a href="../../#kbd_roving_tabindex">roving tabindex</a>.</li>
+                <li>This approach to managing focus is described in the section on <a href="../../../practices/keyboard-interface/keyboard-interface-practice.html#kbd_roving_tabindex">Managing Focus Within Components Using a Roving tabindex</a>.</li>
               </ul>
             </td>
           </tr>


### PR DESCRIPTION
Link patterns and examples to new practices and fix other broken links as discovered.

Looking at all links that include a `#` and are not already a link to a new pattern location (do not include "-pattern.html") and do not link to the ARIA spec (do not have a class that ends with "-reference"). Using search pattern:

~~~
<a (?!.*-reference\")(?!.*-pattern.html).*href=".*\#.*"
~~~
