### PR TITLE
Infrastructure: Modify GitHub workflow to add Netlify preview links to PRs from forks

### DIFF
--- a/.github/workflows/wai-trigger-cleanup.yml
+++ b/.github/workflows/wai-trigger-cleanup.yml
@@ -33,7 +33,7 @@ jobs:
           APG_BRANCH: ${{ github.event.ref }}
 
   cleanup-pr-wai:
-    if: ${{ github.event_name == 'pull_request' }}
+    if: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_target' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/wai-trigger-pr.yml
+++ b/.github/workflows/wai-trigger-pr.yml
@@ -33,6 +33,7 @@ jobs:
           APG_BRANCH: ${{ github.head_ref }}
           APG_SHA: ${{ github.event.pull_request.head.sha }}
           APG_PR_NUMBER: ${{ github.event.pull_request.number }}
+          FORK_PATH: ${{ github.event.pull_request.head.repo.fork && github.event.pull_request.head.repo.full_name }}
         with:
           github-token: ${{ secrets.GH_TOKEN }}
           script: |
@@ -45,5 +46,6 @@ jobs:
                 apg_branch: process.env.APG_BRANCH,
                 apg_sha: process.env.APG_SHA,
                 apg_pr_number: process.env.APG_PR_NUMBER,
+                fork_path: process.env.FORK_PATH,
               }
             });


### PR DESCRIPTION
This adds support to provide preview links being appended to PRs which have been submitted from forked repositories such as https://github.com/w3c/aria-practices/pull/2437.

This also depends on https://github.com/w3c/wai-aria-practices/pull/162 being approved and merged.
___
[WAI Preview Link](https://deploy-preview-163--wai-aria-practices2.netlify.app)