### PR TITLE
Landmark Examples: Underline links in main content

### DIFF
--- a/examples/landmarks/css/common.css
+++ b/examples/landmarks/css/common.css
@@ -82,7 +82,7 @@ aside a {
   text-decoration: underline;
 }
 
-main p a {
+main a {
   text-decoration: underline;
 }
 

--- a/examples/landmarks/main.html
+++ b/examples/landmarks/main.html
@@ -6,7 +6,6 @@
     <link href="css/bootstrap.css" rel="stylesheet" media="screen">
     <link href="css/bootstrap-theme.css" rel="stylesheet" media="screen">
     <link href="css/bootstrap-accessibility.css" rel="stylesheet" media="screen">
-    <link href="css/bootstrap-accessibility.css" rel="stylesheet" media="screen">
     <link href="css/visua11y.css" rel="stylesheet" media="screen">
     <link href="css/common.css" rel="stylesheet" media="screen">
   </head>

--- a/examples/landmarks/resources.html
+++ b/examples/landmarks/resources.html
@@ -66,7 +66,7 @@
                             <li><a href="http://matatk.agrip.org.uk/landmarks/">Landmarks Browser Extension</a></li>
                             <li><a href="http://accessibility-bookmarklets.org/">Accessibility Bookmarklets: Landmark Bookmarklet</a></li>
                             <li><a href="http://whatsock.com/training/matrices/visual-aria.htm">The Visual ARIA Bookmarklet</a></li>
-                            <li><a href="https://github.com/paypal/skipto#readme">SkipTo, version 4.1</a> (PayPal/Illinois)</li>
+                            <li><a href="https://github.com/paypal/skipto#readme">SkipTo Browser Extension and Page Scripts</a></li>
                             <li><a href="https://addons.mozilla.org/en-US/firefox/addon/ainspector-wcag/">AInspector WCAG for Firefox</a> (Landmark Rule Category)</li>
                             <li><a href="https://fae.disability.illinois.edu/">Functional Accessibility Evaluator 2.2</a> (Landmark Rule Category)</li>
                           </ul>

--- a/examples/landmarks/resources.html
+++ b/examples/landmarks/resources.html
@@ -64,9 +64,9 @@
 
                           <ul>
                             <li><a href="http://matatk.agrip.org.uk/landmarks/">Landmarks Browser Extension</a></li>
-                            <li><a href="http://accessibility-bookmarklets.org/">Accessibility Bookmarklets: Landmark Bookmarklet</a></li>
+                            <li><a href="https://accessibility-bookmarklets.org/">Accessibility Bookmarklets: Landmark Bookmarklet</a></li>
                             <li><a href="http://whatsock.com/training/matrices/visual-aria.htm">The Visual ARIA Bookmarklet</a></li>
-                            <li><a href="https://github.com/paypal/skipto#readme">SkipTo Browser Extension and Page Scripts</a></li>
+                            <li><a href="https://skipto-landmarks-headings.github.io">SkipTo Browser Extension and Page Scripts</a></li>
                             <li><a href="https://addons.mozilla.org/en-US/firefox/addon/ainspector-wcag/">AInspector WCAG for Firefox</a> (Landmark Rule Category)</li>
                             <li><a href="https://fae.disability.illinois.edu/">Functional Accessibility Evaluator 2.2</a> (Landmark Rule Category)</li>
                           </ul>


### PR DESCRIPTION
Updated `commons.css` stylesheet to include underlining all links in the MAIN content.

Edited a resource page to update a link to the latest information.

This pull request is related to issue #2505.  Since the links are now underlined in the main region, color is not the only way to distinguish link content from other content.