### PR TITLE
Checkbox Example (Two State): Activate checkbox only on keyup

### DIFF
--- a/examples/checkbox/js/checkbox.js
+++ b/examples/checkbox/js/checkbox.js
@@ -33,7 +33,7 @@ class Checkbox {
 
   /* EVENT HANDLERS */
 
-  // Make sure to prevent page scrolling on spacebar down
+  // Make sure to prevent page scrolling on space down
   onKeydown(event) {
     if (event.key === ' ') {
       event.preventDefault();

--- a/examples/checkbox/js/checkbox.js
+++ b/examples/checkbox/js/checkbox.js
@@ -55,7 +55,6 @@ class Checkbox {
 
     if (flag) {
       event.stopPropagation();
-      event.preventDefault();
     }
   }
 

--- a/examples/checkbox/js/checkbox.js
+++ b/examples/checkbox/js/checkbox.js
@@ -19,6 +19,7 @@ class Checkbox {
     }
 
     this.domNode.addEventListener('keydown', this.onKeydown.bind(this));
+    this.domNode.addEventListener('keyup', this.onKeyup.bind(this));
     this.domNode.addEventListener('click', this.onClick.bind(this));
   }
 
@@ -32,7 +33,14 @@ class Checkbox {
 
   /* EVENT HANDLERS */
 
+  // Make sure to prevent page scrolling on spacebar down
   onKeydown(event) {
+    if (event.key === ' ') {
+      event.preventDefault();
+    }
+  }
+
+  onKeyup(event) {
     var flag = false;
 
     switch (event.key) {


### PR DESCRIPTION
Fixes #2425.

I chose to move this logic to a `keyup` handler to maintain consistency with HTML checkboxes. If this fix is okay, we should probably make a similar fix to the [Mixed Checkbox example](https://www.w3.org/WAI/ARIA/apg/example-index/checkbox/checkbox-mixed.html).