### PR TITLE
Move-Examples: Fix notes and warnings

### DIFF
--- a/content/patterns/button/button-pattern.html
+++ b/content/patterns/button/button-pattern.html
@@ -34,13 +34,16 @@
           </li>
           <li>Menu button: as described in the <a href="../menu-button/menu-button-pattern.html">menu button pattern</a>, a button is revealed to assistive technologies as a menu button if it has the property <a href="#aria-haspopup" class="property-reference">aria-haspopup</a> set to either <code>menu</code> or <code>true</code>.</li>
         </ul>
-        <p class="note">
-          The types of actions performed by buttons are distinctly different from the function of a link (see <a href="../link/link-pattern.html">link pattern</a>).
-          It is important that both the appearance and role of a widget match the function it provides.
-          Nevertheless, elements occasionally have the visual style of a link but perform the action of a button.
-          In such cases, giving the element role <code>button</code> helps assistive technology users understand the function of the element.
-          However, a better solution is to adjust the visual design so it matches the function and ARIA role.
-        </p>
+        <div class="note">
+          <h3>Note</h3>
+          <p>
+            The types of actions performed by buttons are distinctly different from the function of a link (see <a href="../link/link-pattern.html">link pattern</a>).
+            It is important that both the appearance and role of a widget match the function it provides.
+            Nevertheless, elements occasionally have the visual style of a link but perform the action of a button.
+            In such cases, giving the element role <code>button</code> helps assistive technology users understand the function of the element.
+            However, a better solution is to adjust the visual design so it matches the function and ARIA role.
+          </p>
+        </div>
       </section>
 
       <section id="examples">

--- a/content/patterns/combobox/combobox-pattern.html
+++ b/content/patterns/combobox/combobox-pattern.html
@@ -154,6 +154,7 @@
           </li>
         </ul>
         <div class="note">
+          <h4>Note</h4>
           <p>Standard single line text editing keys appropriate for the device platform:</p>
           <ol>
             <li>include keys for input, cursor movement, selection, and text manipulation.</li>
@@ -198,13 +199,16 @@
           <li><kbd>Backspace</kbd> (Optional): If the combobox is editable, returns focus to the combobox and deletes the character prior to the cursor.</li>
           <li><kbd>Delete</kbd> (Optional): If the combobox is editable, returns focus to the combobox, removes the selected state if a suggestion was selected, and removes the inline autocomplete string if present.</li>
         </ul>
-        <ol class="note">
-          <li>
-            DOM Focus is maintained on the combobox and the assistive technology focus is moved within the listbox using <code>aria-activedescendant</code> as described in
-            <a href="../../practices/keyboard-interface/keyboard-interface-practice.html#kbd_focus_activedescendant">Managing Focus in Composites Using aria-activedescendant</a>.
-          </li>
-          <li>Selection follows focus in the listbox; the listbox allows only one suggested value to be selected at a time for the combobox value.</li>
-        </ol>
+        <div class="note">
+          <h4>Note</h4>
+          <ol>
+            <li>
+              DOM Focus is maintained on the combobox and the assistive technology focus is moved within the listbox using <code>aria-activedescendant</code> as described in
+              <a href="../../practices/keyboard-interface/keyboard-interface-practice.html#kbd_focus_activedescendant">Managing Focus in Composites Using aria-activedescendant</a>.
+            </li>
+            <li>Selection follows focus in the listbox; the listbox allows only one suggested value to be selected at a time for the combobox value.</li>
+          </ol>
+        </div>
         <h3>Grid Popup Keyboard Interaction</h3>
         <p>
           In a grid popup, each suggested value may be represented by either a single cell or an entire row.
@@ -268,35 +272,38 @@
           <li><kbd>Backspace</kbd> (Optional): If the combobox is editable, returns focus to the combobox and deletes the character prior to the cursor.</li>
           <li><kbd>Delete</kbd> (Optional): If the combobox is editable, returns focus to the combobox, removes the selected state if a suggestion was selected, and removes the inline autocomplete string if present.</li>
         </ul>
-        <ol class="note">
-          <li>
-            DOM Focus is maintained on the combobox and the assistive technology focus is moved within the grid using <code>aria-activedescendant</code> as described in
-            <a href="../../practices/keyboard-interface/keyboard-interface-practice.html#kbd_focus_activedescendant">Managing Focus in Composites Using aria-activedescendant</a>.
-          </li>
-          <li>The grid allows only one suggested value to be selected at a time for the combobox value.</li>
-          <li>
-            In a grid popup, each suggested value may be represented by either a single cell or an entire row.
-            This aspect of design effects focus and selection movement:
-            <ol>
-              <li>
-                If every cell contains a different suggested value:
-                <ul>
-                  <li>Selection follows focus so that the cell containing focus is selected.</li>
-                  <li>Horizontal arrow key navigation typically wraps from one row to another.</li>
-                  <li>Vertical arrow key navigation typically wraps from one column to another.</li>
-                </ul>
-              </li>
-              <li>
-                If all cells in a row contain information about the same suggested value:
-                <ul>
-                  <li>Either the row containing focus is selected or a cell containing a suggested value is selected when any cell in the same row contains focus.</li>
-                  <li>Horizontal key navigation may wrap from one row to another.</li>
-                  <li>Vertical arrow key navigation <strong>does not</strong> wrap from one column to another.</li>
-                </ul>
-              </li>
-            </ol>
-          </li>
-        </ol>
+        <div class="note">
+          <h4>Note</h4>
+          <ol>
+            <li>
+              DOM Focus is maintained on the combobox and the assistive technology focus is moved within the grid using <code>aria-activedescendant</code> as described in
+              <a href="../../practices/keyboard-interface/keyboard-interface-practice.html#kbd_focus_activedescendant">Managing Focus in Composites Using aria-activedescendant</a>.
+            </li>
+            <li>The grid allows only one suggested value to be selected at a time for the combobox value.</li>
+            <li>
+              In a grid popup, each suggested value may be represented by either a single cell or an entire row.
+              This aspect of design effects focus and selection movement:
+              <ol>
+                <li>
+                  If every cell contains a different suggested value:
+                  <ul>
+                    <li>Selection follows focus so that the cell containing focus is selected.</li>
+                    <li>Horizontal arrow key navigation typically wraps from one row to another.</li>
+                    <li>Vertical arrow key navigation typically wraps from one column to another.</li>
+                  </ul>
+                </li>
+                <li>
+                  If all cells in a row contain information about the same suggested value:
+                  <ul>
+                    <li>Either the row containing focus is selected or a cell containing a suggested value is selected when any cell in the same row contains focus.</li>
+                    <li>Horizontal key navigation may wrap from one row to another.</li>
+                    <li>Vertical arrow key navigation <strong>does not</strong> wrap from one column to another.</li>
+                  </ul>
+                </li>
+              </ol>
+            </li>
+          </ol>
+        </div>
         <h3>Tree Popup Keyboard Interaction</h3>
         <p>
           In some implementations of tree popups, some or all parent nodes may serve as suggestion category labels so may not be selectable values.
@@ -337,29 +344,32 @@
             </ul>
           </li>
         </ul>
-        <ol class="note">
-          <li>
-            DOM Focus is maintained on the combobox and the assistive technology focus is moved within the tree using <code>aria-activedescendant</code> as described in
-            <a href="../../practices/keyboard-interface/keyboard-interface-practice.html#kbd_focus_activedescendant">Managing Focus in Composites Using aria-activedescendant</a>.
-          </li>
-          <li>The tree allows only one suggested value to be selected at a time for the combobox value.</li>
-          <li>
-            In a tree popup, some or all parent nodes may not be selectable values; they may serve as category labels for suggested values.
-            If focus moves to a node that is not a selectable value, either:
-            <ul>
-              <li>The previously selected node, if any, remains selected until focus moves to a node that is selectable.</li>
-              <li>There is no selected value.</li>
-              <li>In either case, focus is visually distinct from selection so users can readily see if a value is selected or not.</li>
-            </ul>
-          </li>
-          <li>
-            If nodes in the tree are arranged horizontally (<a href="#aria-orientation" class="property-reference">aria-orientation</a> is set to <code>horizontal</code>):
-            <ol>
-              <li><kbd>Down Arrow</kbd> performs as <kbd>Right Arrow</kbd> is described above, and vice versa.</li>
-              <li><kbd>Up Arrow</kbd> performs as <kbd>Left Arrow</kbd> is described above, and vice versa.</li>
-            </ol>
-          </li>
-        </ol>
+        <div  class="note">
+          <h4>Note</h4>
+          <ol>
+            <li>
+              DOM Focus is maintained on the combobox and the assistive technology focus is moved within the tree using <code>aria-activedescendant</code> as described in
+              <a href="../../practices/keyboard-interface/keyboard-interface-practice.html#kbd_focus_activedescendant">Managing Focus in Composites Using aria-activedescendant</a>.
+            </li>
+            <li>The tree allows only one suggested value to be selected at a time for the combobox value.</li>
+            <li>
+              In a tree popup, some or all parent nodes may not be selectable values; they may serve as category labels for suggested values.
+              If focus moves to a node that is not a selectable value, either:
+              <ul>
+                <li>The previously selected node, if any, remains selected until focus moves to a node that is selectable.</li>
+                <li>There is no selected value.</li>
+                <li>In either case, focus is visually distinct from selection so users can readily see if a value is selected or not.</li>
+              </ul>
+            </li>
+            <li>
+              If nodes in the tree are arranged horizontally (<a href="#aria-orientation" class="property-reference">aria-orientation</a> is set to <code>horizontal</code>):
+              <ol>
+                <li><kbd>Down Arrow</kbd> performs as <kbd>Right Arrow</kbd> is described above, and vice versa.</li>
+                <li><kbd>Up Arrow</kbd> performs as <kbd>Left Arrow</kbd> is described above, and vice versa.</li>
+              </ol>
+            </li>
+          </ol>
+        </div>
         <h3>Dialog Popup Keyboard Interaction</h3>
         <p>When focus is in a dialog popup:</p>
         <ul>
@@ -375,7 +385,10 @@
           </li>
           <li>The dialog implements the keyboard interaction defined in the <a href="../dialog-modal/dialog-modal-pattern.html">modal dialog pattern.</a></li>
         </ul>
-        <p class="note">Unlike other combobox popups, dialogs do not support <code>aria-activedescendant</code> so DOM focus moves into the dialog from the combobox.</p>
+        <div class="note">
+          <h4>Note</h4>
+          <p>Unlike other combobox popups, dialogs do not support <code>aria-activedescendant</code> so DOM focus moves into the dialog from the combobox.</p>
+        </div>
       </section>
 
       <section id="roles_states_properties">
@@ -423,6 +436,7 @@
           </li>
         </ul>
         <div class="note">
+          <h3>Note</h3>
           <ol>
             <li>
               In ARIA 1.0, the combobox referenced its popup with <a href="#aria-owns" class="property-reference">aria-owns</a> instead of <a href="#aria-controls" class="property-reference">aria-controls</a>.

--- a/content/patterns/dialog-modal/dialog-modal-pattern.html
+++ b/content/patterns/dialog-modal/dialog-modal-pattern.html
@@ -70,46 +70,49 @@
           </li>
           <li><kbd>Escape</kbd>: Closes the dialog.</li>
         </ul>
-        <ol class="note">
-          <li>
-            When a dialog opens, focus moves to an element contained in the dialog.
-            Generally, focus is initially set on the first focusable element.
-            However, the most appropriate focus placement will depend on the nature and size of the content.
-            Examples include:
-            <ul>
-              <li>
-                If the dialog content includes semantic structures, such as lists, tables, or multiple paragraphs, that need to be perceived in order to easily understand the content, i.e., if the content would be difficult to understand when announced as a single unbroken string, then it is advisable to add <code>tabindex="-1"</code> to a static element at the start of the content and initially focus that element.
-                This makes it easier for assistive technology users to read the content by navigating the semantic structures.
-                Additionally, it is advisable to omit applying <code>aria-describedby</code> to the dialog container in this scenario.
-              </li>
-              <li>If content is large enough that focusing the first interactive element could cause the beginning of content to scroll out of view, it is advisable to add <code>tabindex="-1"</code> to a static element at the top of the dialog, such as the dialog title or first paragraph, and initially focus that element.</li>
-              <li>
-                If a dialog contains the final step in a process that is not easily reversible, such as deleting data or completing a financial transaction, it may be advisable to set focus on the least destructive action, especially if undoing the action is difficult or impossible.
-                The <a href="../alertdialog/alertdialog-pattern.html">Alert Dialog Pattern</a> is often employed in such circumstances.</li>
-              <li>If a dialog is limited to interactions that either provide additional information or continue processing, it may be advisable to set focus to the element that is likely to be most frequently used, such as an <q>OK</q> or <q>Continue</q> button.</li>
-            </ul>
-          </li>
-          <li>
-            When a dialog closes, focus returns to the element that invoked the dialog unless either:
-            <ul>
-              <li>
-                The invoking element no longer exists.
-                Then, focus is set on another element that provides logical work flow.
-              </li>
-              <li>
-                The work flow design includes the following conditions that can occasionally make focusing a different element a more logical choice:
-                <ol>
-                  <li>It is very unlikely users need to immediately re-invoke the dialog.</li>
-                  <li>The task completed in the dialog is directly related to a subsequent step in the work flow.</li>
-                </ol>
-                For example, a grid has an associated toolbar with a button for adding rows.
-                The Add Rows button opens a dialog that prompts for the number of rows.
-                After the dialog closes, focus is placed in the first cell of the first new row.
-              </li>
-            </ul>
-          </li>
-          <li>It is strongly recommended that the tab sequence of all dialogs include a visible element with role <code>button</code> that closes the dialog, such as a close icon or cancel button.</li>
-        </ol>
+        <div class="note">
+          <h3>Note</h3>
+          <ol>
+            <li>
+              When a dialog opens, focus moves to an element contained in the dialog.
+              Generally, focus is initially set on the first focusable element.
+              However, the most appropriate focus placement will depend on the nature and size of the content.
+              Examples include:
+              <ul>
+                <li>
+                  If the dialog content includes semantic structures, such as lists, tables, or multiple paragraphs, that need to be perceived in order to easily understand the content, i.e., if the content would be difficult to understand when announced as a single unbroken string, then it is advisable to add <code>tabindex="-1"</code> to a static element at the start of the content and initially focus that element.
+                  This makes it easier for assistive technology users to read the content by navigating the semantic structures.
+                  Additionally, it is advisable to omit applying <code>aria-describedby</code> to the dialog container in this scenario.
+                </li>
+                <li>If content is large enough that focusing the first interactive element could cause the beginning of content to scroll out of view, it is advisable to add <code>tabindex="-1"</code> to a static element at the top of the dialog, such as the dialog title or first paragraph, and initially focus that element.</li>
+                <li>
+                  If a dialog contains the final step in a process that is not easily reversible, such as deleting data or completing a financial transaction, it may be advisable to set focus on the least destructive action, especially if undoing the action is difficult or impossible.
+                  The <a href="../alertdialog/alertdialog-pattern.html">Alert Dialog Pattern</a> is often employed in such circumstances.</li>
+                <li>If a dialog is limited to interactions that either provide additional information or continue processing, it may be advisable to set focus to the element that is likely to be most frequently used, such as an <q>OK</q> or <q>Continue</q> button.</li>
+              </ul>
+            </li>
+            <li>
+              When a dialog closes, focus returns to the element that invoked the dialog unless either:
+              <ul>
+                <li>
+                  The invoking element no longer exists.
+                  Then, focus is set on another element that provides logical work flow.
+                </li>
+                <li>
+                  The work flow design includes the following conditions that can occasionally make focusing a different element a more logical choice:
+                  <ol>
+                    <li>It is very unlikely users need to immediately re-invoke the dialog.</li>
+                    <li>The task completed in the dialog is directly related to a subsequent step in the work flow.</li>
+                  </ol>
+                  For example, a grid has an associated toolbar with a button for adding rows.
+                  The Add Rows button opens a dialog that prompts for the number of rows.
+                  After the dialog closes, focus is placed in the first cell of the first new row.
+                </li>
+              </ul>
+            </li>
+            <li>It is strongly recommended that the tab sequence of all dialogs include a visible element with role <code>button</code> that closes the dialog, such as a close icon or cancel button.</li>
+          </ol>
+        </div>
       </section>
 
       <section id="roles_states_properties">
@@ -133,24 +136,27 @@
             It is advisable to omit specifying <code>aria-describedby</code> if the dialog content includes semantic structures, such as lists, tables, or multiple paragraphs, that need to be perceived in order to easily understand the content, i.e., if the content would be difficult to understand when announced as a single unbroken string.
           </li>
         </ul>
-        <ul class="note">
-          <li>
-            Because marking a dialog modal by setting <a href="#aria-modal" class="property-reference">aria-modal</a> to <code>true</code> can prevent users of some assistive technologies from perceiving content outside the dialog, users of those technologies will experience severe negative ramifications if a dialog is marked modal but does not behave as a modal for other users.
-            So, mark a dialog modal <strong>only when both:</strong>
-            <ol>
-              <li>Application code prevents all users from interacting in any way with content outside of it.</li>
-              <li>Visual styling obscures the content outside of it.</li>
-            </ol>
-          </li>
-          <li>
-            The <code>aria-modal</code> property introduced by ARIA 1.1 replaces <a href="#aria-hidden" class="state-reference">aria-hidden</a> for informing assistive technologies that content outside a dialog is inert.
-            However, in legacy dialog implementations where <code>aria-hidden</code> is used to make content outside a dialog inert for assistive technology users, it is important that:
-            <ol>
-              <li><code>aria-hidden</code> is set to <code>true</code> on each element containing a portion of the inert layer.</li>
-              <li>The dialog element is not a descendant of any element that has <code>aria-hidden</code> set to <code>true</code>.</li>
-            </ol>
-          </li>
-        </ul>
+        <div class="note">
+          <h3>Note</h3>
+          <ul>
+            <li>
+              Because marking a dialog modal by setting <a href="#aria-modal" class="property-reference">aria-modal</a> to <code>true</code> can prevent users of some assistive technologies from perceiving content outside the dialog, users of those technologies will experience severe negative ramifications if a dialog is marked modal but does not behave as a modal for other users.
+              So, mark a dialog modal <strong>only when both:</strong>
+              <ol>
+                <li>Application code prevents all users from interacting in any way with content outside of it.</li>
+                <li>Visual styling obscures the content outside of it.</li>
+              </ol>
+            </li>
+            <li>
+              The <code>aria-modal</code> property introduced by ARIA 1.1 replaces <a href="#aria-hidden" class="state-reference">aria-hidden</a> for informing assistive technologies that content outside a dialog is inert.
+              However, in legacy dialog implementations where <code>aria-hidden</code> is used to make content outside a dialog inert for assistive technology users, it is important that:
+              <ol>
+                <li><code>aria-hidden</code> is set to <code>true</code> on each element containing a portion of the inert layer.</li>
+                <li>The dialog element is not a descendant of any element that has <code>aria-hidden</code> set to <code>true</code>.</li>
+              </ol>
+            </li>
+          </ul>
+        </div>
       </section>
     </main>
   </body>

--- a/content/patterns/feed/feed-pattern.html
+++ b/content/patterns/feed/feed-pattern.html
@@ -81,24 +81,27 @@
           <li><kbd>Control + End</kbd>: Move focus to the first focusable element after the feed.</li>
           <li><kbd>Control + Home</kbd>: Move focus to the first focusable element before the feed.</li>
         </ul>
-        <ol class="note">
-          <li>Due to the lack of convention, providing easily discoverable keyboard interface documentation is especially important.</li>
-          <li>
-            In some cases, a feed may contain a nested feed.
-            For example, an article in a social media feed may contain a feed of comments on that article.
-            To navigate the nested feed, users first move focus inside the nested feed.
-            Options for supporting nested feed navigation include:
-            <ul>
-              <li>
-                Users move focus into the nested feed from the content of the containing article with <kbd>Tab</kbd>.
-                This may be slow if the article contains a significant number of links, buttons, or other widgets.
-              </li>
-              <li>Provide a key for moving focus from the elements in the containing article to the first item in the nested feed, e.g., <kbd>Alt + Page Down</kbd>.</li>
-              <li>To continue reading the outer feed, <kbd>Control + End</kbd> moves focus to the next article in the outer feed.</li>
-            </ul>
-          </li>
-          <li>In the rare circumstance that a feed article contains a widget that uses the above suggested keys, the feed navigation key will operate the contained widget, and the user needs to move focus to an element that does not utilize the feed navigation keys in order to navigate the feed.</li>
-        </ol>
+        <div class="note">
+          <h3>Note</h3>
+          <ol>
+            <li>Due to the lack of convention, providing easily discoverable keyboard interface documentation is especially important.</li>
+            <li>
+              In some cases, a feed may contain a nested feed.
+              For example, an article in a social media feed may contain a feed of comments on that article.
+              To navigate the nested feed, users first move focus inside the nested feed.
+              Options for supporting nested feed navigation include:
+              <ul>
+                <li>
+                  Users move focus into the nested feed from the content of the containing article with <kbd>Tab</kbd>.
+                  This may be slow if the article contains a significant number of links, buttons, or other widgets.
+                </li>
+                <li>Provide a key for moving focus from the elements in the containing article to the first item in the nested feed, e.g., <kbd>Alt + Page Down</kbd>.</li>
+                <li>To continue reading the outer feed, <kbd>Control + End</kbd> moves focus to the next article in the outer feed.</li>
+              </ul>
+            </li>
+            <li>In the rare circumstance that a feed article contains a widget that uses the above suggested keys, the feed navigation key will operate the contained widget, and the user needs to move focus to an element that does not utilize the feed navigation keys in order to navigate the feed.</li>
+          </ol>
+        </div>
       </section>
 
       <section id="roles_states_properties">

--- a/content/patterns/grid/grid-pattern.html
+++ b/content/patterns/grid/grid-pattern.html
@@ -111,17 +111,20 @@
             <li><kbd>Control + Home</kbd>: moves focus to the first cell in the first row.</li>
             <li><kbd>Control + End</kbd>: moves focus to the last cell in the last row.</li>
           </ul>
-          <ul class="note">
-            <li>
-              When the above grid navigation keys move focus, whether the focus is set on an element inside the cell or the grid cell depends on cell content.
-              See <a href="#gridNav_focus">Whether to Focus on a Cell or an Element Inside It</a>.
-            </li>
-            <li>
-              While navigation keys, such as arrow keys, are moving focus from cell to cell, they are not available to do something like operate a combobox or move an editing caret inside of a cell.
-              If this functionality is needed, see <a href="#gridNav_inside">Editing and Navigating Inside a Cell</a>.
-            </li>
-            <li>If navigation functions can dynamically add more rows or columns to the DOM, key events that move focus to the beginning or end of the grid, such as <kbd>control + End</kbd>, may move focus to the last row in the DOM rather than the last available row in the back-end data.</li>
-          </ul>
+          <div class="note">
+            <h4>Note</h4>
+            <ul>
+              <li>
+                When the above grid navigation keys move focus, whether the focus is set on an element inside the cell or the grid cell depends on cell content.
+                See <a href="#gridNav_focus">Whether to Focus on a Cell or an Element Inside It</a>.
+              </li>
+              <li>
+                While navigation keys, such as arrow keys, are moving focus from cell to cell, they are not available to do something like operate a combobox or move an editing caret inside of a cell.
+                If this functionality is needed, see <a href="#gridNav_inside">Editing and Navigating Inside a Cell</a>.
+              </li>
+              <li>If navigation functions can dynamically add more rows or columns to the DOM, key events that move focus to the beginning or end of the grid, such as <kbd>control + End</kbd>, may move focus to the last row in the DOM rather than the last available row in the back-end data.</li>
+            </ul>
+          </div>
           <p>If a grid supports selection of cells, rows, or columns, the following keys are commonly used for these functions.</p>
           <ul>
             <li><kbd>Control + Space</kbd>: selects the column that contains the focus.</li>
@@ -135,8 +138,10 @@
             <li><kbd>Shift + Down Arrow</kbd>: Extends selection one cell down.</li>
             <li><kbd>Shift + Up Arrow</kbd>: Extends selection one cell Up.</li>
           </ul>
-          <p class="note">
-            See <a href="../../practices/keyboard-interface/keyboard-interface-practice.html#kbd_common_conventions">Key Assignment Conventions for Common Functions</a> for cut, copy, and paste key assignments.</p>
+          <div class="note">
+            <h5>Note</h5>
+            <p>See <a href="../../practices/keyboard-interface/keyboard-interface-practice.html#kbd_common_conventions">Key Assignment Conventions for Common Functions</a> for cut, copy, and paste key assignments.</p>
+          </div>
         </section>
       </section>
 
@@ -212,18 +217,20 @@
             <li><kbd>Control + Home</kbd> (optional): moves focus to the first cell in the first row.</li>
             <li><kbd>Control + End</kbd> (Optional): moves focus to the last cell in the last row.</li>
           </ul>
-          <ul class="note">
-            <li>
-              When the above grid navigation keys move focus, whether the focus is set on an element inside the cell or the grid cell depends on cell content.
-              See <a href="#gridNav_focus">Whether to Focus on a Cell or an Element Inside It</a>.
-            </li>
-            <li>
-              While navigation keys, such as arrow keys, are moving focus from cell to cell, they are not available to do something like operate a combobox or move an editing caret inside of a cell.
-              If this functionality is needed, see <a href="#gridNav_inside">Editing and Navigating Inside a Cell</a>.
-            </li>
-            <li>If navigation functions can dynamically add more rows or columns to the DOM, key events that move focus to the beginning or end of the grid, such as <kbd>control + End</kbd>, may move focus to the last row in the DOM rather than the last available row in the back-end data.</li>
-          </ul>
-
+          <div class="note">
+            <h4>Note</h4>
+            <ul>
+              <li>
+                When the above grid navigation keys move focus, whether the focus is set on an element inside the cell or the grid cell depends on cell content.
+                See <a href="#gridNav_focus">Whether to Focus on a Cell or an Element Inside It</a>.
+              </li>
+              <li>
+                While navigation keys, such as arrow keys, are moving focus from cell to cell, they are not available to do something like operate a combobox or move an editing caret inside of a cell.
+                If this functionality is needed, see <a href="#gridNav_inside">Editing and Navigating Inside a Cell</a>.
+              </li>
+              <li>If navigation functions can dynamically add more rows or columns to the DOM, key events that move focus to the beginning or end of the grid, such as <kbd>control + End</kbd>, may move focus to the last row in the DOM rather than the last available row in the back-end data.</li>
+            </ul>
+          </div>
           <p>
             It would be unusual for a layout grid to provide functions that require cell selection.
             If it did, though, the following keys are commonly used for these functions.
@@ -241,10 +248,11 @@
             <li><kbd>Shift + Down Arrow</kbd>: Extends selection one cell down.</li>
             <li><kbd>Shift + Up Arrow</kbd>: Extends selection one cell Up.</li>
           </ul>
-          <p class="note">
-            See <a href="../../practices/keyboard-interface/keyboard-interface-practice.html#kbd_common_conventions">Key Assignment Conventions for Common Functions</a>
-            for cut, copy, and paste key assignments.
-          </p>
+          <div class="note">
+            <h4>Note</h4>
+            <p>See <a href="../../practices/keyboard-interface/keyboard-interface-practice.html#kbd_common_conventions">Key Assignment Conventions for Common Functions</a>
+            for cut, copy, and paste key assignments.</p>
+          </div>
         </section>
       </section>
 
@@ -397,14 +405,17 @@
           </li>
         </ul>
 
-        <ul class="note">
-          <li>
-            If the element with the <code>grid</code> role is an HTML <code>table</code> element, then it is not necessary to use ARIA roles for rows and cells because the HTML elements have implied ARIA semantics.
-            For example, an HTML <code>&lt;TR&gt;</code> has an implied ARIA role of <code>row</code>.
-            A <code>grid</code> built from an HTML <code>table</code> that includes cells that span multiple rows or columns must use HTML <code>rowspan</code> and <code>colspan</code> and must not use <code>aria-rowspan</code> or <code>aria-colspan</code>.
-          </li>
-          <li>If rows or cells are included in a grid via <a href="#aria-owns" class="property-reference">aria-owns</a>, they will be presented to assistive technologies after the DOM descendants of the <code>grid</code> element unless the DOM descendants are also included in the <code>aria-owns</code> attribute.</li>
-        </ul>
+        <div class="note">
+          <h3>Note</h3>
+          <ul>
+            <li>
+              If the element with the <code>grid</code> role is an HTML <code>table</code> element, then it is not necessary to use ARIA roles for rows and cells because the HTML elements have implied ARIA semantics.
+              For example, an HTML <code>&lt;TR&gt;</code> has an implied ARIA role of <code>row</code>.
+              A <code>grid</code> built from an HTML <code>table</code> that includes cells that span multiple rows or columns must use HTML <code>rowspan</code> and <code>colspan</code> and must not use <code>aria-rowspan</code> or <code>aria-colspan</code>.
+            </li>
+            <li>If rows or cells are included in a grid via <a href="#aria-owns" class="property-reference">aria-owns</a>, they will be presented to assistive technologies after the DOM descendants of the <code>grid</code> element unless the DOM descendants are also included in the <code>aria-owns</code> attribute.</li>
+          </ul>
+        </div>
       </section>
     </main>
   </body>

--- a/content/patterns/link/link-pattern.html
+++ b/content/patterns/link/link-pattern.html
@@ -22,11 +22,12 @@
           A <a href="#link" class="role-reference">link</a> widget provides an interactive reference to a resource.
           The target resource can be either external or local, i.e., either outside or within the current page or application.
         </p>
-        <p class="note">
-          Authors are strongly encouraged to use a native host language link element, such as an HTML <code>&lt;A&gt;</code> element with an <code>href</code> attribute.
+        <div class="note">
+          <h3>note</h3>
+          <p>Authors are strongly encouraged to use a native host language link element, such as an HTML <code>&lt;A&gt;</code> element with an <code>href</code> attribute.
           As with other WAI-ARIA widget roles, applying the link role to an element will not cause browsers to enhance the element with standard link behaviors, such as navigation to the link target or context menu actions.
-          When using the <code>link</code> role, providing these features of the element is the author's responsibility.
-        </p>
+          When using the <code>link</code> role, providing these features of the element is the author's responsibility.</p>
+        </div>
       </section>
 
       <section id="examples">

--- a/content/patterns/listbox/examples/listbox-rearrangeable.html
+++ b/content/patterns/listbox/examples/listbox-rearrangeable.html
@@ -261,11 +261,12 @@
           </tbody>
         </table>
         <h3 id="kbd_label_multiselect">Multiple selection keys supported in example 2</h3>
-        <p class="note">
-          The selection behavior demonstrated differs from the behavior provided by browsers for native HTML <code>&lt;select multiple&gt;</code> elements.
+        <div class="note">
+          <h4>Note</h4>
+          <p>The selection behavior demonstrated differs from the behavior provided by browsers for native HTML <code>&lt;select multiple&gt;</code> elements.
           The HTML select element behavior is to alter selection with unmodified up/down arrow keys, requiring the use of modifier keys to select multiple options.
-          This example demonstrates the multiple selection interaction model recommended in the <a href="../listbox-pattern.html#keyboard_interaction">Keyboard Interaction section of the Listbox Pattern</a>, which does not require the use of modifier keys.
-        </p>
+          This example demonstrates the multiple selection interaction model recommended in the <a href="../listbox-pattern.html#keyboard_interaction">Keyboard Interaction section of the Listbox Pattern</a>, which does not require the use of modifier keys.</p>
+        </div>
         <table aria-labelledby="kbd_label_multiselect" class="def">
           <thead>
             <tr>

--- a/content/patterns/listbox/listbox-pattern.html
+++ b/content/patterns/listbox/listbox-pattern.html
@@ -151,30 +151,33 @@
             </ul>
           </li>
         </ul>
-        <ol class="note">
-          <li>
-            DOM focus (the active element) is functionally distinct from the selected state.
-            For more details, see <a href="../../practices/keyboard-interface/keyboard-interface-practice.html#kbd_focus_vs_selection">this description of differences between focus and selection</a>.
-          </li>
-          <li>
-            The <code>listbox</code> role supports the <a class="property-reference" href="#aria-activedescendant">aria-activedescendant</a> property, which provides an alternative to moving DOM focus among <code>option</code> elements when implementing keyboard navigation. For details, see
-            <a href="../../practices/keyboard-interface/keyboard-interface-practice.html#kbd_focus_activedescendant">Managing Focus in Composites Using aria-activedescendant</a>.
-          </li>
-          <li>
-            In a single-select listbox, moving focus may optionally unselect the previously selected option and select the newly focused option.
-            This model of selection is known as &quot;selection follows focus&quot;.
-            Having selection follow focus can be very helpful in some circumstances and can severely degrade accessibility in others.
-            For additional guidance, see <a href="../../practices/keyboard-interface/keyboard-interface-practice.html#kbd_selection_follows_focus">Deciding When to Make Selection Automatically Follow Focus</a>.
-          </li>
-          <li>If selecting or unselecting all options is an important function, implementing separate controls for these actions, such as buttons for &quot;Select All&quot; and &quot;Unselect All&quot;, significantly improves accessibility.</li>
-          <li>
-            If the options in a listbox are arranged horizontally:
-            <ol>
-              <li><kbd>Down Arrow</kbd> performs as <kbd>Right Arrow</kbd> is described above, and vice versa.</li>
-              <li><kbd>Up Arrow</kbd> performs as <kbd>Left Arrow</kbd> is described above, and vice versa.</li>
-            </ol>
-          </li>
-        </ol>
+        <div class="note">
+          <h3>Note</h3>
+          <ol>
+            <li>
+              DOM focus (the active element) is functionally distinct from the selected state.
+              For more details, see <a href="../../practices/keyboard-interface/keyboard-interface-practice.html#kbd_focus_vs_selection">this description of differences between focus and selection</a>.
+            </li>
+            <li>
+              The <code>listbox</code> role supports the <a class="property-reference" href="#aria-activedescendant">aria-activedescendant</a> property, which provides an alternative to moving DOM focus among <code>option</code> elements when implementing keyboard navigation. For details, see
+              <a href="../../practices/keyboard-interface/keyboard-interface-practice.html#kbd_focus_activedescendant">Managing Focus in Composites Using aria-activedescendant</a>.
+            </li>
+            <li>
+              In a single-select listbox, moving focus may optionally unselect the previously selected option and select the newly focused option.
+              This model of selection is known as &quot;selection follows focus&quot;.
+              Having selection follow focus can be very helpful in some circumstances and can severely degrade accessibility in others.
+              For additional guidance, see <a href="../../practices/keyboard-interface/keyboard-interface-practice.html#kbd_selection_follows_focus">Deciding When to Make Selection Automatically Follow Focus</a>.
+            </li>
+            <li>If selecting or unselecting all options is an important function, implementing separate controls for these actions, such as buttons for &quot;Select All&quot; and &quot;Unselect All&quot;, significantly improves accessibility.</li>
+            <li>
+              If the options in a listbox are arranged horizontally:
+              <ol>
+                <li><kbd>Down Arrow</kbd> performs as <kbd>Right Arrow</kbd> is described above, and vice versa.</li>
+                <li><kbd>Up Arrow</kbd> performs as <kbd>Left Arrow</kbd> is described above, and vice versa.</li>
+              </ol>
+            </li>
+          </ol>
+        </div>
       </section>
 
       <section id="roles_states_properties">
@@ -227,37 +230,40 @@
             The default value of <code>aria-orientation</code> for <code>listbox</code> is <code>vertical</code>.
           </li>
         </ul>
-        <ol class="note">
-          <li>
-            Some factors to consider when choosing whether to indicate selection with <code>aria-selected</code> or <code>aria-checked</code> are:
-            <ul>
-              <li>
-                Some design systems use <code>aria-selected</code> for single-select widgets and <code>aria-checked</code> for multi-select widgets.
-                In the absence of factors that would make an alternative convention more appropriate, this is a recommended convention.
-              </li>
-              <li>
-                The language of instructions and the appearance of the interface might suggest one attribute is more appropriate than the other.
-                For instance, do instructions say to <q>select</q> items?
-                Or, is the visual indicator of selection a check mark?
-              </li>
-              <li>It is important to adopt a consistent convention for selection models across a site or app.</li>
-            </ul>
-          </li>
-          <li>
-            Conditions that would permit a listbox to include both <code>aria-selected</code> and <code>aria-checked</code> are extremely rare.
-            It is strongly recommended to avoid designing a listbox widget that would have the need for more than one type of state.
-            If both states were to be used within a listbox, all the following conditions need to be satisfied:
-            <ul>
-              <li>The meaning and purpose of <code>aria-selected</code> is different from the meaning and purpose of <code>aria-checked</code> in the user interface.</li>
-              <li>The user interface makes the meaning and purpose of each state apparent.</li>
-              <li>The user interface provides a separate method for controlling each state.</li>
-            </ul>
-          </li>
-          <li>
-            If <a href="#aria-owns" class="property-reference">aria-owns</a> is set on the listbox element to include elements that are not DOM children of the container, those elements will appear in the reading order in the sequence they are referenced and after any items that are DOM children.
-            Scripts that manage focus need to ensure the visual focus order matches this assistive technology reading order.
-          </li>
-        </ol>
+        <div class="note">
+          <h3>Note</h3>
+          <ol>
+            <li>
+              Some factors to consider when choosing whether to indicate selection with <code>aria-selected</code> or <code>aria-checked</code> are:
+              <ul>
+                <li>
+                  Some design systems use <code>aria-selected</code> for single-select widgets and <code>aria-checked</code> for multi-select widgets.
+                  In the absence of factors that would make an alternative convention more appropriate, this is a recommended convention.
+                </li>
+                <li>
+                  The language of instructions and the appearance of the interface might suggest one attribute is more appropriate than the other.
+                  For instance, do instructions say to <q>select</q> items?
+                  Or, is the visual indicator of selection a check mark?
+                </li>
+                <li>It is important to adopt a consistent convention for selection models across a site or app.</li>
+              </ul>
+            </li>
+            <li>
+              Conditions that would permit a listbox to include both <code>aria-selected</code> and <code>aria-checked</code> are extremely rare.
+              It is strongly recommended to avoid designing a listbox widget that would have the need for more than one type of state.
+              If both states were to be used within a listbox, all the following conditions need to be satisfied:
+              <ul>
+                <li>The meaning and purpose of <code>aria-selected</code> is different from the meaning and purpose of <code>aria-checked</code> in the user interface.</li>
+                <li>The user interface makes the meaning and purpose of each state apparent.</li>
+                <li>The user interface provides a separate method for controlling each state.</li>
+              </ul>
+            </li>
+            <li>
+              If <a href="#aria-owns" class="property-reference">aria-owns</a> is set on the listbox element to include elements that are not DOM children of the container, those elements will appear in the reading order in the sequence they are referenced and after any items that are DOM children.
+              Scripts that manage focus need to ensure the visual focus order matches this assistive technology reading order.
+            </li>
+          </ol>
+        </div>
       </section>
     </main>
   </body>

--- a/content/patterns/menubar/menu-and-menubar-pattern.html
+++ b/content/patterns/menubar/menu-and-menubar-pattern.html
@@ -150,26 +150,29 @@
           <li>Any key that corresponds to a printable character (Optional): Move focus to the next item in the current menu whose label begins with that printable character.</li>
           <li><kbd>Escape</kbd>: Close the menu that contains focus and return focus to the element or context, e.g., menu button or parent <code>menuitem</code>, from which the menu was opened.</li>
         </ul>
-        <ol class="note">
-          <li>Disabled menu items are focusable but cannot be activated.</li>
-          <li>A <a href="#separator" class="role-reference">separator</a> in a menu is not focusable or interactive.</li>
-          <li>
-            If a menu is opened or a menubar receives focus as a result of a context action, <kbd>Escape</kbd> or <kbd>Enter</kbd> may return focus to the invoking context.
-            For example, a rich text editor may have a menubar that receives focus when a shortcut key, e.g., <kbd>alt + F10</kbd>, is pressed while editing.
-            In this case, pressing <kbd>Escape</kbd> or activating a command from the menu may return focus to the editor.
-          </li>
-          <li>
-            Although it is recommended that authors avoid doing so, some implementations of navigation menubars may have <code>menuitem</code> elements that both perform a function and open a submenu.
-            In such implementations, <kbd>Enter</kbd> and <kbd>Space</kbd> perform a navigation function, e.g., load new content, while <kbd>Down Arrow</kbd>, in a horizontal menubar, opens the submenu associated with that same <code>menuitem</code>.
-          </li>
-          <li>
-            When items in a <code>menubar</code> are arranged vertically and items in <code>menu</code> containers are arranged horizontally:
-            <ol>
-              <li><kbd>Down Arrow</kbd> performs as <kbd>Right Arrow</kbd> is described above, and vice versa.</li>
-              <li><kbd>Up Arrow</kbd> performs as <kbd>Left Arrow</kbd> is described above, and vice versa.</li>
-            </ol>
-          </li>
-        </ol>
+        <div class="note">
+          <h3>Note</h3>
+          <ol>
+            <li>Disabled menu items are focusable but cannot be activated.</li>
+            <li>A <a href="#separator" class="role-reference">separator</a> in a menu is not focusable or interactive.</li>
+            <li>
+              If a menu is opened or a menubar receives focus as a result of a context action, <kbd>Escape</kbd> or <kbd>Enter</kbd> may return focus to the invoking context.
+              For example, a rich text editor may have a menubar that receives focus when a shortcut key, e.g., <kbd>alt + F10</kbd>, is pressed while editing.
+              In this case, pressing <kbd>Escape</kbd> or activating a command from the menu may return focus to the editor.
+            </li>
+            <li>
+              Although it is recommended that authors avoid doing so, some implementations of navigation menubars may have <code>menuitem</code> elements that both perform a function and open a submenu.
+              In such implementations, <kbd>Enter</kbd> and <kbd>Space</kbd> perform a navigation function, e.g., load new content, while <kbd>Down Arrow</kbd>, in a horizontal menubar, opens the submenu associated with that same <code>menuitem</code>.
+            </li>
+            <li>
+              When items in a <code>menubar</code> are arranged vertically and items in <code>menu</code> containers are arranged horizontally:
+              <ol>
+                <li><kbd>Down Arrow</kbd> performs as <kbd>Right Arrow</kbd> is described above, and vice versa.</li>
+                <li><kbd>Up Arrow</kbd> performs as <kbd>Left Arrow</kbd> is described above, and vice versa.</li>
+              </ol>
+            </li>
+          </ol>
+        </div>
       </section>
 
       <section id="roles_states_properties">
@@ -232,10 +235,11 @@
             The default value of <code>aria-orientation</code> for a menu is <code>vertical</code>.
           </li>
         </ul>
-        <p class="note">
-          If <a href="#aria-owns" class="property-reference">aria-owns</a> is set on the menu container to include elements that are not DOM children of the container, those elements will appear in the reading order in the sequence they are referenced and after any items that are DOM children.
-          Scripts that manage focus need to ensure the visual focus order matches this assistive technology reading order.
-        </p>
+        <div class="note">
+          <h3>Note</h3>
+          <p>If <a href="#aria-owns" class="property-reference">aria-owns</a> is set on the menu container to include elements that are not DOM children of the container, those elements will appear in the reading order in the sequence they are referenced and after any items that are DOM children.
+          Scripts that manage focus need to ensure the visual focus order matches this assistive technology reading order.</p>
+        </div>
       </section>
     </main>
   </body>

--- a/content/patterns/meter/meter-pattern.html
+++ b/content/patterns/meter/meter-pattern.html
@@ -22,13 +22,16 @@
           A <a class="role-reference" href="#meter">meter</a> is a graphical display of a numeric value that varies within a defined range.
           For example, a meter could be used to depict a device's current battery percentage or a car's fuel level.
         </p>
-        <ul class="note">
-          <li>A <code>meter</code> should not be used to represent a value like the current world population since it does not have a meaningful maximum limit.</li>
-          <li>
-            The <code>meter</code> should not be used to indicate progress, such as loading or percent completion of a task.
-            To communicate progress, use the <a href="#progressbar" class="role-reference">progressbar</a> role instead.
-          </li>
-        </ul>
+        <div class="note">
+          <h3>Note</h3>
+          <ul>
+            <li>A <code>meter</code> should not be used to represent a value like the current world population since it does not have a meaningful maximum limit.</li>
+            <li>
+              The <code>meter</code> should not be used to indicate progress, such as loading or percent completion of a task.
+              To communicate progress, use the <a href="#progressbar" class="role-reference">progressbar</a> role instead.
+            </li>
+          </ul>
+        </div>
       </section>
 
       <section id="examples">

--- a/content/patterns/radio/radio-group-pattern.html
+++ b/content/patterns/radio/radio-group-pattern.html
@@ -60,10 +60,11 @@
               If focus is on the first button, focus moves to the last button.
             </li>
           </ul>
-          <p class="note">
-            The initial focus behavior described above differs slightly from the behavior provided by some browsers for native HTML radio groups.
-            In some browsers, if none of the radio buttons are selected, moving focus into the radio group with <kbd>Shift+Tab</kbd> will place focus on the last radio button instead of the first radio button.
-          </p>
+          <div class="note">
+            <h3>Note</h3>
+            <p>The initial focus behavior described above differs slightly from the behavior provided by some browsers for native HTML radio groups.
+            In some browsers, if none of the radio buttons are selected, moving focus into the radio group with <kbd>Shift+Tab</kbd> will place focus on the last radio button instead of the first radio button.</p>
+          </div>
         </section>
         <section>
           <h3>For Radio Group Contained in a Toolbar</h3>
@@ -107,10 +108,11 @@
               If focus is on the first radio button in the radio group, moves focus to the last radio button in the group.
             </li>
           </ul>
-          <p class="note">
-            Radio buttons in a toolbar are frequently styled in a manner that appears more like toggle buttons.
-            For an example, See the <a href="../toolbar/examples/toolbar.html">Simple Editor Toolbar Example</a>.
-          </p>
+          <div class="note">
+            <h4>Note</h4>
+            <p>Radio buttons in a toolbar are frequently styled in a manner that appears more like toggle buttons.
+            For an example, See the <a href="../toolbar/examples/toolbar.html">Simple Editor Toolbar Example</a>.</p>
+          </div>
         </section>
       </section>
 

--- a/content/patterns/slider-multithumb/slider-multithumb-pattern.html
+++ b/content/patterns/slider-multithumb/slider-multithumb-pattern.html
@@ -27,12 +27,15 @@
           Conversely, the minimum value of the upper end thumb is limited by the current value of the lower end thumb.
           However, in some multi-thumb sliders, each thumb sets a value that does not depend on the other thumb values.
         </p>
-        <p class="warning">
-          Some users of touch-based assistive technologies may experience difficulty utilizing widgets that implement this slider pattern because the gestures their assistive technology provides for operating sliders may not yet generate the necessary output.
-          To change the slider value, touch-based assistive technologies need to respond to user gestures for increasing and decreasing the value by synthesizing key events.
-          This is a new convention that may not be fully implemented by some assistive technologies.
-          Authors should fully test slider widgets using assistive technologies on devices where touch is a primary input mechanism before considering incorporation into production systems.
-        </p>
+        <div class="warning">
+          <h3>Warning</h3>
+          <p>
+            Some users of touch-based assistive technologies may experience difficulty utilizing widgets that implement this slider pattern because the gestures their assistive technology provides for operating sliders may not yet generate the necessary output.
+            To change the slider value, touch-based assistive technologies need to respond to user gestures for increasing and decreasing the value by synthesizing key events.
+            This is a new convention that may not be fully implemented by some assistive technologies.
+            Authors should fully test slider widgets using assistive technologies on devices where touch is a primary input mechanism before considering incorporation into production systems.
+          </p>
+        </div>
       </section>
 
       <section id="examples">

--- a/content/patterns/slider/slider-pattern.html
+++ b/content/patterns/slider/slider-pattern.html
@@ -22,12 +22,15 @@
           A slider is an input where the user selects a value from within a given range.
           Sliders typically have a slider thumb that can be moved along a bar, rail, or track to change the value of the slider.
         </p>
-        <p class="warning">
-          Some users of touch-based assistive technologies may experience difficulty utilizing widgets that implement this slider pattern because the gestures their assistive technology provides for operating sliders may not yet generate the necessary output.
-          To change the slider value, touch-based assistive technologies need to respond to user gestures for increasing and decreasing the value by synthesizing key events.
-          This is a new convention that may not be fully implemented by some assistive technologies.
-          Authors should fully test slider widgets using assistive technologies on devices where touch is a primary input mechanism before considering incorporation into production systems.
-        </p>
+        <div class="warning">
+          <h3>Warning</h3>
+          <p>
+            Some users of touch-based assistive technologies may experience difficulty utilizing widgets that implement this slider pattern because the gestures their assistive technology provides for operating sliders may not yet generate the necessary output.
+            To change the slider value, touch-based assistive technologies need to respond to user gestures for increasing and decreasing the value by synthesizing key events.
+            This is a new convention that may not be fully implemented by some assistive technologies.
+            Authors should fully test slider widgets using assistive technologies on devices where touch is a primary input mechanism before considering incorporation into production systems.
+          </p>
+        </div>
       </section>
 
       <section id="examples">

--- a/content/patterns/slider/slider-pattern.html
+++ b/content/patterns/slider/slider-pattern.html
@@ -55,10 +55,13 @@
           <li><kbd>Page Up</kbd> (Optional): Increase the slider value by an amount larger than the step change made by <kbd>Up Arrow</kbd>.</li>
           <li><kbd>Page Down</kbd> (Optional): Decrease the slider value by an amount larger than the step change made by <kbd>Down Arrow</kbd>.</li>
         </ul>
-        <ol class="note">
-          <li>Focus is placed on the slider (the visual object that the mouse user would move, also known as the thumb.</li>
-          <li>In some circumstances, reversing the direction of the value change for the keys specified above, e.g., having <kbd>Up Arrow</kbd> decrease the value, could create a more intuitive experience.</li>
-        </ol>
+        <div class="note">
+          <h3>Note</h3>
+          <ol>
+            <li>Focus is placed on the slider (the visual object that the mouse user would move, also known as the thumb.</li>
+            <li>In some circumstances, reversing the direction of the value change for the keys specified above, e.g., having <kbd>Up Arrow</kbd> decrease the value, could create a more intuitive experience.</li>
+          </ol>
+        </div>
       </section>
 
       <section id="roles_states_properties">

--- a/content/patterns/spinbutton/spinbutton-pattern.html
+++ b/content/patterns/spinbutton/spinbutton-pattern.html
@@ -59,18 +59,21 @@
             </ul>
           </li>
         </ul>
-        <ol class="note">
-          <li>Focus remains on the text field during operation.</li>
-          <li>
-            Standard single line text editing keys appropriate for the device platform:
-            <ol>
-              <li>include keys for input, cursor movement, selection, and text manipulation.</li>
-              <li>Standard key assignments for editing functions depend on the device operating system.</li>
-              <li>The most robust approach for providing text editing functions is to rely on browsers, which supply them for HTML inputs with type text and for elements with the <code>contenteditable</code> HTML attribute.</li>
-              <li><strong>IMPORTANT:</strong> Be sure that JavaScript does not interfere with browser-provided text editing functions by capturing key events for the keys used to perform them.</li>
-            </ol>
-          </li>
-        </ol>
+        <div class="note">
+          <h3>Note</h3>
+          <ol>
+            <li>Focus remains on the text field during operation.</li>
+            <li>
+              Standard single line text editing keys appropriate for the device platform:
+              <ol>
+                <li>include keys for input, cursor movement, selection, and text manipulation.</li>
+                <li>Standard key assignments for editing functions depend on the device operating system.</li>
+                <li>The most robust approach for providing text editing functions is to rely on browsers, which supply them for HTML inputs with type text and for elements with the <code>contenteditable</code> HTML attribute.</li>
+                <li><strong>IMPORTANT:</strong> Be sure that JavaScript does not interfere with browser-provided text editing functions by capturing key events for the keys used to perform them.</li>
+              </ol>
+            </li>
+          </ol>
+        </div>
       </section>
 
       <section id="roles_states_properties">

--- a/content/patterns/table/table-pattern.html
+++ b/content/patterns/table/table-pattern.html
@@ -28,11 +28,12 @@
           Since a table is not a widget, each widget contained in a table is a separate stop in the page tab sequence.
           If the number of widgets is large, replacing the table with a grid can dramatically reduce the length of the page tab sequence because a grid is a composite widget that can contain other widgets.
         </p>
-        <p class="note">
-          As with other WAI-ARIA roles that have a native host language equivalent, authors are strongly encouraged to use a native HTML <code>table</code> element whenever possible.
+        <div class="note">
+          <h3>Note</h3>
+          <p>As with other WAI-ARIA roles that have a native host language equivalent, authors are strongly encouraged to use a native HTML <code>table</code> element whenever possible.
           This is especially important with role <code>table</code> because it is a new feature of WAI-ARIA 1.1.
-          It is thus advisable to test implementations thoroughly with each browser and assistive technology combination that could be used by the target audience.
-        </p>
+          It is thus advisable to test implementations thoroughly with each browser and assistive technology combination that could be used by the target audience.</p>
+        </div>
       </section>
 
       <section id="examples">
@@ -83,7 +84,10 @@
             <a href="../../practices/grid-and-table-properties/grid-and-table-properties-practice.html#gridAndTableProperties_spans">Grid and Table Properties Practice</a>.
           </li>
         </ul>
-        <p class="note">If rows or cells are included in a table via <a href="#aria-owns" class="property-reference">aria-owns</a>, they will be presented to assistive technologies after the DOM descendants of the <code>table</code> element unless the DOM descendants are also included in the <code>aria-owns</code> attribute.</p>
+        <div class="note">
+          <h3>Note</h3>
+          <p>If rows or cells are included in a table via <a href="#aria-owns" class="property-reference">aria-owns</a>, they will be presented to assistive technologies after the DOM descendants of the <code>table</code> element unless the DOM descendants are also included in the <code>aria-owns</code> attribute.</p>
+        </div>
       </section>
     </main>
   </body>

--- a/content/patterns/tabs/tabs-pattern.html
+++ b/content/patterns/tabs/tabs-pattern.html
@@ -95,23 +95,26 @@
             </ul>
           </li>
         </ul>
-        <ol class="note">
-          <li>
-            It is recommended that tabs activate automatically when they receive focus as long as their associated tab panels are displayed without noticeable latency.
-            This typically requires tab panel content to be preloaded.
-            Otherwise, automatic activation slows focus movement, which significantly hampers users' ability to navigate efficiently across the tab list.
-            For additional guidance, see <a href="../../practices/keyboard-interface/keyboard-interface-practice.html#kbd_selection_follows_focus">Deciding When to Make Selection Automatically Follow Focus</a>.
-          </li>
-          <li>
-            When a tab list has its <a href="#aria-orientation" class="property-reference">aria-orientation</a> set to <code>vertical</code>:
-            <ol>
-              <li><kbd>Down Arrow</kbd> performs as <kbd>Right Arrow</kbd> is described above.</li>
-              <li><kbd>Up Arrow</kbd> performs as <kbd>Left Arrow</kbd> is described above.</li>
-            </ol>
-          </li>
-          <li>If the tab list is horizontal, it does not listen for <kbd>Down Arrow</kbd> or <kbd>Up Arrow</kbd> so those keys can provide their normal browser scrolling functions even when focus is inside the tab list.</li>
-          <li>When the tabpanel does not contain any focusable elements or the first element with content is not focusable, the tabpanel should set <code>tabindex="0"</code> to include it in the tab sequence of the page.</li>
-        </ol>
+        <div class="note">
+          <h3>Note</h3>
+          <ol>
+            <li>
+              It is recommended that tabs activate automatically when they receive focus as long as their associated tab panels are displayed without noticeable latency.
+              This typically requires tab panel content to be preloaded.
+              Otherwise, automatic activation slows focus movement, which significantly hampers users' ability to navigate efficiently across the tab list.
+              For additional guidance, see <a href="../../practices/keyboard-interface/keyboard-interface-practice.html#kbd_selection_follows_focus">Deciding When to Make Selection Automatically Follow Focus</a>.
+            </li>
+            <li>
+              When a tab list has its <a href="#aria-orientation" class="property-reference">aria-orientation</a> set to <code>vertical</code>:
+              <ol>
+                <li><kbd>Down Arrow</kbd> performs as <kbd>Right Arrow</kbd> is described above.</li>
+                <li><kbd>Up Arrow</kbd> performs as <kbd>Left Arrow</kbd> is described above.</li>
+              </ol>
+            </li>
+            <li>If the tab list is horizontal, it does not listen for <kbd>Down Arrow</kbd> or <kbd>Up Arrow</kbd> so those keys can provide their normal browser scrolling functions even when focus is inside the tab list.</li>
+            <li>When the tabpanel does not contain any focusable elements or the first element with content is not focusable, the tabpanel should set <code>tabindex="0"</code> to include it in the tab sequence of the page.</li>
+          </ol>
+        </div>
       </section>
 
       <section id="roles_states_properties">

--- a/content/patterns/toolbar/toolbar-pattern.html
+++ b/content/patterns/toolbar/toolbar-pattern.html
@@ -83,21 +83,24 @@
           <li><kbd>Home</kbd> (Optional): Moves focus to first element.</li>
           <li><kbd>End</kbd> (Optional): Moves focus to last element.</li>
         </ul>
-        <ol class="note">
-          <li>
-            If the items in a toolbar are arranged vertically:
-            <ol>
-              <li><kbd>Down Arrow</kbd> performs as <kbd>Right Arrow</kbd> is described above.</li>
-              <li><kbd>Up Arrow</kbd> performs as <kbd>Left Arrow</kbd> is described above.</li>
-            </ol>
-          </li>
-          <li>
-            Typically, disabled elements are not focusable when navigating with a keyboard.
-            However, in circumstances where discoverability of a function is crucial, it may be helpful if disabled controls are focusable so screen reader users are more likely to be aware of their presence.
-            For additional guidance, see <a href="../../practices/keyboard-interface/keyboard-interface-practice.html#kbd_disabled_controls">Focusability of disabled controls</a>.
-          </li>
-          <li>In applications where quick access to a toolbar is important, such as accessing an editor's toolbar from its text area, a documented shortcut key for moving focus from the relevant context to its corresponding toolbar is recommended.</li>
-        </ol>
+        <div class="note">
+          <h3>Note</h3>
+          <ol>
+            <li>
+              If the items in a toolbar are arranged vertically:
+              <ol>
+                <li><kbd>Down Arrow</kbd> performs as <kbd>Right Arrow</kbd> is described above.</li>
+                <li><kbd>Up Arrow</kbd> performs as <kbd>Left Arrow</kbd> is described above.</li>
+              </ol>
+            </li>
+            <li>
+              Typically, disabled elements are not focusable when navigating with a keyboard.
+              However, in circumstances where discoverability of a function is crucial, it may be helpful if disabled controls are focusable so screen reader users are more likely to be aware of their presence.
+              For additional guidance, see <a href="../../practices/keyboard-interface/keyboard-interface-practice.html#kbd_disabled_controls">Focusability of disabled controls</a>.
+            </li>
+            <li>In applications where quick access to a toolbar is important, such as accessing an editor's toolbar from its text area, a documented shortcut key for moving focus from the relevant context to its corresponding toolbar is recommended.</li>
+          </ol>
+        </div>
       </section>
 
       <section id="roles_states_properties">

--- a/content/patterns/tooltip/tooltip-pattern.html
+++ b/content/patterns/tooltip/tooltip-pattern.html
@@ -40,13 +40,16 @@
       <section id="keyboard_interaction">
         <h2>Keyboard Interaction</h2>
         <p><kbd>Escape</kbd>: Dismisses the Tooltip.</p>
-        <ol class="note">
-          <li>Focus stays on the triggering element while the tooltip is displayed.</li>
-          <li>
-            If the tooltip is invoked when the trigger element receives focus, then it is dismissed when it no longer has focus (onBlur).
-            If the tooltip is invoked with mouseIn, then it is dismissed with on mouseOut.
-          </li>
-        </ol>
+        <div class="note">
+          <h3>Note</h3>
+          <ol>
+            <li>Focus stays on the triggering element while the tooltip is displayed.</li>
+            <li>
+              If the tooltip is invoked when the trigger element receives focus, then it is dismissed when it no longer has focus (onBlur).
+              If the tooltip is invoked with mouseIn, then it is dismissed with on mouseOut.
+            </li>
+          </ol>
+        </div>
       </section>
 
       <section id="roles_states_properties">

--- a/content/patterns/treegrid/treegrid-pattern.html
+++ b/content/patterns/treegrid/treegrid-pattern.html
@@ -184,17 +184,20 @@
             </ul>
           </li>
         </ul>
-        <ul class="note">
-          <li>
-            When the above <code>treegrid</code> navigation keys move focus, whether the focus is set on an element inside the cell or on the cell depends on cell content.
-            See <a href="../grid/grid-pattern.html#gridNav_focus">Whether to Focus on a Cell or an Element Inside It</a>.
-          </li>
-          <li>
-            While navigation keys, such as arrow keys, are moving focus from cell to cell, they are not available to do something like operate a combobox or move an editing caret inside of a cell.
-            If this functionality is needed, see <a href="../grid/grid-pattern.html#gridNav_inside">Editing and Navigating Inside a Cell</a>.
-          </li>
-          <li>If navigation functions can dynamically add more rows or columns to the DOM, key events that move focus to the beginning or end of the grid, such as <kbd>control + End</kbd>, may move focus to the last row in the DOM rather than the last available row in the back-end data.</li>
-        </ul>
+        <div class="note">
+          <h3>Note</h3>
+          <ul>
+            <li>
+              When the above <code>treegrid</code> navigation keys move focus, whether the focus is set on an element inside the cell or on the cell depends on cell content.
+              See <a href="../grid/grid-pattern.html#gridNav_focus">Whether to Focus on a Cell or an Element Inside It</a>.
+            </li>
+            <li>
+              While navigation keys, such as arrow keys, are moving focus from cell to cell, they are not available to do something like operate a combobox or move an editing caret inside of a cell.
+              If this functionality is needed, see <a href="../grid/grid-pattern.html#gridNav_inside">Editing and Navigating Inside a Cell</a>.
+            </li>
+            <li>If navigation functions can dynamically add more rows or columns to the DOM, key events that move focus to the beginning or end of the grid, such as <kbd>control + End</kbd>, may move focus to the last row in the DOM rather than the last available row in the back-end data.</li>
+          </ul>
+        </div>
         <p>If a treegrid supports selection of cells, rows, or columns, the following keys are commonly used for these functions.</p>
         <ul>
           <li>
@@ -244,7 +247,10 @@
             </ul>
           </li>
         </ul>
-        <p class="note">See <a href="../../practices/keyboard-interface/keyboard-interface-practice.html#kbd_common_conventions">Key Assignment Conventions for Common Functions</a> for cut, copy, and paste key assignments.</p>
+        <div class="note">
+          <h3>Note</h3>
+          <p>See <a href="../../practices/keyboard-interface/keyboard-interface-practice.html#kbd_common_conventions">Key Assignment Conventions for Common Functions</a> for cut, copy, and paste key assignments.</p>
+        </div>
       </section>
 
       <section id="roles_states_properties">
@@ -305,10 +311,13 @@
             <a href="../../practices/grid-and-table-properties/grid-and-table-properties-practice.html#gridAndTableProperties_spans">Grid and Table Properties Practice</a>.
           </li>
         </ul>
-        <ul class="note">
-          <li>A <code>treegrid</code> built from an HTML <code>table</code> that includes cells that span multiple rows or columns must use HTML <code>rowspan</code> and <code>colspan</code> and must not use <code>aria-rowspan</code> or <code>aria-colspan</code>.</li>
-          <li>If rows or cells are included in a treegrid via <a href="#aria-owns" class="property-reference">aria-owns</a>, they will be presented to assistive technologies after the DOM descendants of the <code>treegrid</code> element unless the DOM descendants are also included in the <code>aria-owns</code> attribute.</li>
-        </ul>
+        <div class="note">
+          <h3>Note</h3>
+          <ul>
+            <li>A <code>treegrid</code> built from an HTML <code>table</code> that includes cells that span multiple rows or columns must use HTML <code>rowspan</code> and <code>colspan</code> and must not use <code>aria-rowspan</code> or <code>aria-colspan</code>.</li>
+            <li>If rows or cells are included in a treegrid via <a href="#aria-owns" class="property-reference">aria-owns</a>, they will be presented to assistive technologies after the DOM descendants of the <code>treegrid</code> element unless the DOM descendants are also included in the <code>aria-owns</code> attribute.</li>
+          </ul>
+        </div>
       </section>
     </main>
   </body>

--- a/content/patterns/treeview/treeview-pattern.html
+++ b/content/patterns/treeview/treeview-pattern.html
@@ -169,30 +169,33 @@
             </ul>
           </li>
         </ul>
-        <ol class="note">
-          <li>
-            DOM focus (the active element) is functionally distinct from the selected state.
-            For more details, see <a href="../../practices/keyboard-interface/keyboard-interface-practice.html#kbd_focus_vs_selection">this description of differences between focus and selection</a>.
-          </li>
-          <li>
-            The <code>tree</code> role supports the <a class="property-reference" href="#aria-activedescendant">aria-activedescendant</a> property, which provides an alternative to moving DOM focus among <code>treeitem</code> elements when implementing keyboard navigation.
-            For details, see <a href="../../practices/keyboard-interface/keyboard-interface-practice.html#kbd_focus_activedescendant">Managing Focus in Composites Using aria-activedescendant</a>.
-          </li>
-          <li>
-            In a single-select tree, moving focus may optionally unselect the previously selected node and select the newly focused node.
-            This model of selection is known as &quot;selection follows focus&quot;.
-            Having selection follow focus can be very helpful in some circumstances and can severely degrade accessibility in others.
-            For additional guidance, see <a href="../../practices/keyboard-interface/keyboard-interface-practice.html#kbd_selection_follows_focus">Deciding When to Make Selection Automatically Follow Focus</a>.
-          </li>
-          <li>If selecting or unselecting all nodes is an important function, implementing separate controls for these actions, such as buttons for &quot;Select All&quot; and &quot;Unselect All&quot;, significantly improves accessibility.</li>
-          <li>
-            If the nodes in a tree are arranged horizontally:
-            <ol>
-              <li><kbd>Down Arrow</kbd> performs as <kbd>Right Arrow</kbd> is described above, and vice versa.</li>
-              <li><kbd>Up Arrow</kbd> performs as <kbd>Left Arrow</kbd> is described above, and vice versa.</li>
-            </ol>
-          </li>
-        </ol>
+        <div class="note">
+          <h3>Note</h3>
+          <ol>
+            <li>
+              DOM focus (the active element) is functionally distinct from the selected state.
+              For more details, see <a href="../../practices/keyboard-interface/keyboard-interface-practice.html#kbd_focus_vs_selection">this description of differences between focus and selection</a>.
+            </li>
+            <li>
+              The <code>tree</code> role supports the <a class="property-reference" href="#aria-activedescendant">aria-activedescendant</a> property, which provides an alternative to moving DOM focus among <code>treeitem</code> elements when implementing keyboard navigation.
+              For details, see <a href="../../practices/keyboard-interface/keyboard-interface-practice.html#kbd_focus_activedescendant">Managing Focus in Composites Using aria-activedescendant</a>.
+            </li>
+            <li>
+              In a single-select tree, moving focus may optionally unselect the previously selected node and select the newly focused node.
+              This model of selection is known as &quot;selection follows focus&quot;.
+              Having selection follow focus can be very helpful in some circumstances and can severely degrade accessibility in others.
+              For additional guidance, see <a href="../../practices/keyboard-interface/keyboard-interface-practice.html#kbd_selection_follows_focus">Deciding When to Make Selection Automatically Follow Focus</a>.
+            </li>
+            <li>If selecting or unselecting all nodes is an important function, implementing separate controls for these actions, such as buttons for &quot;Select All&quot; and &quot;Unselect All&quot;, significantly improves accessibility.</li>
+            <li>
+              If the nodes in a tree are arranged horizontally:
+              <ol>
+                <li><kbd>Down Arrow</kbd> performs as <kbd>Right Arrow</kbd> is described above, and vice versa.</li>
+                <li><kbd>Up Arrow</kbd> performs as <kbd>Left Arrow</kbd> is described above, and vice versa.</li>
+              </ol>
+            </li>
+          </ol>
+        </div>
       </section>
 
       <section id="roles_states_properties">
@@ -239,36 +242,39 @@
             The default value of <code>aria-orientation</code> for a tree is <code>vertical</code>.
           </li>
         </ul>
-        <ol class="note">
-          <li>
-            Some factors to consider when choosing whether to indicate selection with <code>aria-selected</code> or <code>aria-checked</code> are:
-            <ul>
-              <li>
-                Some design systems use <code>aria-selected</code> for single-select widgets and <code>aria-checked</code> for multi-select widgets.
-                In the absence of factors that would make an alternative convention more appropriate, this is a recommended convention.
-              </li>
-              <li>
-                The language of instructions and the appearance of the interface might suggest one attribute is more appropriate than the other.
-                For instance, do instructions say to <q>select</q> items? Or, is the visual indicator of selection a check mark?
-              </li>
-              <li>It is important to adopt a consistent convention for selection models across a site or app.</li>
-            </ul>
-          </li>
-          <li>
-            Conditions that would permit a tree to include both <code>aria-selected</code> and <code>aria-checked</code> are extremely rare.
-            It is strongly recommended to avoid designing a tree widget that would have the need for more than one type of state.
-            If both states were to be used within a tree, all the following conditions need to be satisfied:
-            <ul>
-              <li>The meaning and purpose of <code>aria-selected</code> is different from the meaning and purpose of <code>aria-checked</code> in the user interface.</li>
-              <li>The user interface makes the meaning and purpose of each state apparent.</li>
-              <li>The user interface provides a separate method for controlling each state.</li>
-            </ul>
-          </li>
-          <li>
-            If <a href="#aria-owns" class="property-reference">aria-owns</a> is set on the tree container to include elements that are not DOM children of the container, those elements will appear in the reading order in the sequence they are referenced and after any items that are DOM children.
-            Scripts that manage focus need to ensure the visual focus order matches this assistive technology reading order.
-          </li>
-        </ol>
+        <div class="note">
+          <h3>Note</h3>
+          <ol>
+            <li>
+              Some factors to consider when choosing whether to indicate selection with <code>aria-selected</code> or <code>aria-checked</code> are:
+              <ul>
+                <li>
+                  Some design systems use <code>aria-selected</code> for single-select widgets and <code>aria-checked</code> for multi-select widgets.
+                  In the absence of factors that would make an alternative convention more appropriate, this is a recommended convention.
+                </li>
+                <li>
+                  The language of instructions and the appearance of the interface might suggest one attribute is more appropriate than the other.
+                  For instance, do instructions say to <q>select</q> items? Or, is the visual indicator of selection a check mark?
+                </li>
+                <li>It is important to adopt a consistent convention for selection models across a site or app.</li>
+              </ul>
+            </li>
+            <li>
+              Conditions that would permit a tree to include both <code>aria-selected</code> and <code>aria-checked</code> are extremely rare.
+              It is strongly recommended to avoid designing a tree widget that would have the need for more than one type of state.
+              If both states were to be used within a tree, all the following conditions need to be satisfied:
+              <ul>
+                <li>The meaning and purpose of <code>aria-selected</code> is different from the meaning and purpose of <code>aria-checked</code> in the user interface.</li>
+                <li>The user interface makes the meaning and purpose of each state apparent.</li>
+                <li>The user interface provides a separate method for controlling each state.</li>
+              </ul>
+            </li>
+            <li>
+              If <a href="#aria-owns" class="property-reference">aria-owns</a> is set on the tree container to include elements that are not DOM children of the container, those elements will appear in the reading order in the sequence they are referenced and after any items that are DOM children.
+              Scripts that manage focus need to ensure the visual focus order matches this assistive technology reading order.
+            </li>
+          </ol>
+        </div>
       </section>
     </main>
   </body>

--- a/content/patterns/windowsplitter/windowsplitter-pattern.html
+++ b/content/patterns/windowsplitter/windowsplitter-pattern.html
@@ -67,7 +67,10 @@
           </li>
           <li><kbd>F6</kbd> (Optional): Cycle through window panes.</li>
         </ul>
-        <p class="note">A fixed size splitter omits implementation of the arrow keys.</p>
+        <div class="note">
+          <h3>Note</h3>
+          <p>A fixed size splitter omits implementation of the arrow keys.</p>
+        </div>
       </section>
 
       <section id="roles_states_properties">

--- a/content/practices/keyboard-interface/keyboard-interface-practice.html
+++ b/content/practices/keyboard-interface/keyboard-interface-practice.html
@@ -609,7 +609,10 @@
             And, given the vast array of operating system, browser, and assistive technology keys, it is almost impossible to be certain conflicts do not exist.
             So it is also important to employ strategies that mitigate the impact of conflicts whether they are intentional or unknown.
           </p>
-          <p class="note">In the following sections, <kbd>meta</kbd> key refers to the <kbd>Windows</kbd> key on Windows-compatible keyboards and the <kbd>Command</kbd> key on MacOS-compatible keyboards.</p>
+          <div class="note">
+            <h4>Note</h4>
+            <p>In the following sections, <kbd>meta</kbd> key refers to the <kbd>Windows</kbd> key on Windows-compatible keyboards and the <kbd>Command</kbd> key on MacOS-compatible keyboards.</p>
+          </div>
           <section id="kbd_shortcuts_assignments_opsys_conflicts">
             <h4>Operating System Key Conflicts</h4>
 

--- a/content/practices/names-and-descriptions/names-and-descriptions-practice.html
+++ b/content/practices/names-and-descriptions/names-and-descriptions-practice.html
@@ -198,11 +198,12 @@
   &lt;/li&gt;
 &lt;/ul&gt;
           </code></pre>
-          <p class="warning">
-            If an element with one of the above roles that supports naming from child content is named by using <code>aria-label</code> or <code>aria-labelledby</code>, content contained in the element and its descendants is hidden from assistive technology users unless the descendant content is referenced by <code>aria-labelledby</code>.
+          <div class="warning">
+            <h3>Warning</h3>
+            <p>If an element with one of the above roles that supports naming from child content is named by using <code>aria-label</code> or <code>aria-labelledby</code>, content contained in the element and its descendants is hidden from assistive technology users unless the descendant content is referenced by <code>aria-labelledby</code>.
             It is strongly recommended to avoid using either of these attributes to override content of one of the above elements except in rare circumstances where hiding content from assistive technology users is beneficial.
-            In addition, in situations where visible content is hidden from assistive technology users by use of one of these attributes, thorough testing with assistive technologies is particularly important.
-          </p>
+            In addition, in situations where visible content is hidden from assistive technology users by use of one of these attributes, thorough testing with assistive technologies is particularly important.</p>
+          </div>
         </section>
 
         <section id="naming_with_aria-label">
@@ -224,18 +225,21 @@
   &lt;!-- list of navigation links to product pages --&gt;
 &lt;/nav&gt;</code></pre>
           <p>When encountering this navigation region, a screen reader user will hear the name and role of the element, e.g., &quot;Product navigation region&quot;, and then be able to read through the links contained in the region.</p>
-          <ol class="warning">
-            <li>
-              If <code>aria-label</code> is applied to an element with one of the roles that supports <a href="#naming_with_child_content">naming from child content</a>, content contained in the element and its descendants is hidden from assistive technology users.
-              It is strongly recommended to avoid using <code>aria-label</code> to override content of one of these elements except in rare circumstances where hiding content from assistive technology users is beneficial.
-            </li>
-            <li>
-              There are certain types of elements, such as paragraphs and list items, that should not be named with <code>aria-label</code>.
-              They are identified in the table in the <a href="#naming_role_guidance">Accessible Name Guidance by Role</a> section.
-            </li>
-            <li>Because the value of <code>aria-label</code> is not rendered visually, testing with assistive technologies to ensure the expected name is presented to users is particularly important.</li>
-            <li>When a user interface is translated into multiple languages, ensure that <code>aria-label</code> values are translated.</li>
-          </ol>
+          <div class="warning">
+            <h4>Warning</h4>
+            <ol>
+              <li>
+                If <code>aria-label</code> is applied to an element with one of the roles that supports <a href="#naming_with_child_content">naming from child content</a>, content contained in the element and its descendants is hidden from assistive technology users.
+                It is strongly recommended to avoid using <code>aria-label</code> to override content of one of these elements except in rare circumstances where hiding content from assistive technology users is beneficial.
+              </li>
+              <li>
+                There are certain types of elements, such as paragraphs and list items, that should not be named with <code>aria-label</code>.
+                They are identified in the table in the <a href="#naming_role_guidance">Accessible Name Guidance by Role</a> section.
+              </li>
+              <li>Because the value of <code>aria-label</code> is not rendered visually, testing with assistive technologies to ensure the expected name is presented to users is particularly important.</li>
+              <li>When a user interface is translated into multiple languages, ensure that <code>aria-label</code> values are translated.</li>
+            </ol>
+          </div>
         </section>
 
         <section id="naming_with_aria-labelledby">
@@ -284,19 +288,22 @@
 &lt;button id="download-button" aria-labelledby="download-button download-details"&gt;Download&lt;/button&gt;
 &lt;span id="download-details"&gt;PDF, 2.4 MB&lt;/span&gt;</code></pre>
           <p>In the above example, the accessible name of the button will be "Download PDF, 2.4 MB", with a space between "Download" and "PDF", and not "DownloadPDF, 2.4 MB".</p>
-          <ol class="warning">
-            <li>The <code>aria-labelledby</code> property cannot be chained, i.e., if an element with <code>aria-labelledby</code> references another element that also has <code>aria-labelledby</code>, the <code>aria-labelledby</code> attribute on the referenced element will be ignored.</li>
-            <li>If an element is referenced by <code>aria-labelledby</code> more than one time during a name calculation, the second and any subsequent references will be ignored.</li>
-            <li>
-              There are certain types of elements, such as paragraphs and list items, that should not be named with <code>aria-labelledby</code>.
-              They are identified in the table in the <a href="#naming_role_guidance">Accessible Name Guidance by Role</a> section.
-            </li>
-            <li>
-              If <code>aria-labelledby</code> is applied to an element with one of the roles that supports <a href="#naming_with_child_content">naming from child content</a>, content contained in the element and its descendants is hidden from assistive technology users unless it is also referenced by <code>aria-labelledby</code>.
-              It is strongly recommended to avoid using this attribute to override content of one of these elements except in rare circumstances where hiding content from assistive technology users is beneficial.
-            </li>
-            <li>Because calculating the name of an element with <code>aria-labelledby</code> can be complex and reference hidden content, testing with assistive technologies to ensure the expected name is presented to users is particularly important.</li>
-          </ol>
+          <div class="warning">
+            <h4>Warning</h4>
+            <ol>
+              <li>The <code>aria-labelledby</code> property cannot be chained, i.e., if an element with <code>aria-labelledby</code> references another element that also has <code>aria-labelledby</code>, the <code>aria-labelledby</code> attribute on the referenced element will be ignored.</li>
+              <li>If an element is referenced by <code>aria-labelledby</code> more than one time during a name calculation, the second and any subsequent references will be ignored.</li>
+              <li>
+                There are certain types of elements, such as paragraphs and list items, that should not be named with <code>aria-labelledby</code>.
+                They are identified in the table in the <a href="#naming_role_guidance">Accessible Name Guidance by Role</a> section.
+              </li>
+              <li>
+                If <code>aria-labelledby</code> is applied to an element with one of the roles that supports <a href="#naming_with_child_content">naming from child content</a>, content contained in the element and its descendants is hidden from assistive technology users unless it is also referenced by <code>aria-labelledby</code>.
+                It is strongly recommended to avoid using this attribute to override content of one of these elements except in rare circumstances where hiding content from assistive technology users is beneficial.
+              </li>
+              <li>Because calculating the name of an element with <code>aria-labelledby</code> can be complex and reference hidden content, testing with assistive technologies to ensure the expected name is presented to users is particularly important.</li>
+            </ol>
+          </div>
         </section>
 
         <section id="naming_with_labels">


### PR DESCRIPTION
Reformat instances of `class="note"` and `class="warning"`.

For each instance of either class:
* If the class is not on a `div`:
    * Wrap the element with the class in a `div`.
    * Increase indent of the wrapped element two spaces.
    * Delete the class from the wrapped element.
    * Add the class to the `div`.
* In the the `div` with the class, add a heading as the first child:
    * Make the heading level one deeper than the containing section.
    * If the class is "note", set heading text to "Note".
    * If the class is "warning", set heading text to "Warning".