### PR TITLE
Introduction page: Fix typo (change `plane` to `plain`

### DIFF
--- a/content/about/introduction/introduction.html
+++ b/content/about/introduction/introduction.html
@@ -89,7 +89,7 @@
           <li>Follow or mimic keyboard conventions in similar APG patterns or native operating system widgets.</li>
         </ul>
       </section>
-      
+
       <section id="not-design-system">
         <h2>APG is not a UI Design System</h2>
         <p>
@@ -106,7 +106,7 @@
       <section id="prerequisite-knowledge">
         <h2>Important Prerequisite Knowledge</h2>
         <p>
-          The APG Task Force strives to make the APG welcoming to a broad audience by using plane and simple language wherever possible.
+          The APG Task Force strives to make the APG welcoming to a broad audience by using plain and simple language wherever possible.
           Consequently, even readers with minimal understanding of web development or accessibility can benefit from a significant portion of the guidance, e.g., the keyboard interaction patterns.
           At the same time, many topics addressed by the APG are inherently complex and call for technically precise terminology.
           Additionally, some important aspects of creating accessible experiences fall outside the scope of the APG.
@@ -133,7 +133,7 @@
           These topics are covered by <a href="../aria-basics/aria-basics.html">ARIA Basics</a>.
         </p>
       </section>
-      
+
       <section id="organization">
         <h2>How the APG is Organized</h2>
         <p>
@@ -179,7 +179,7 @@
           </tbody>
         </table>
       </section>
-      
+
     </main>
   </body>
 </html>


### PR DESCRIPTION
Address a typo noticed at https://github.com/w3c/wai-aria-practices/pull/207#discussion_r1163284579.

* Change `plane and simple` to `plain and simple`.
___
[WAI Preview Link](https://deploy-preview-211--aria-practices.netlify.app/ARIA/apg) _(Last built on Tue, 11 Apr 2023 21:48:03 GMT)._