### PR TITLE
Button Example Page: Fix CSS that caused focus indicator to disappear

### DIFF
--- a/content/patterns/button/examples/css/button.css
+++ b/content/patterns/button/examples/css/button.css
@@ -8,21 +8,23 @@
   color: #fff;
   text-shadow: 0 -1px 1px hsl(216deg 27% 25%);
   background-color: hsl(216deg 82% 51%);
-  background-image: linear-gradient(
-    to bottom,
-    hsl(216deg 82% 53%),
-    hsl(216deg 82% 47%)
-  );
+  background-image:
+    linear-gradient(
+      to bottom,
+      hsl(216deg 82% 53%),
+      hsl(216deg 82% 47%)
+    );
 }
 
 [role="button"]:hover {
   border-color: hsl(213deg 71% 29%);
   background-color: hsl(216deg 82% 31%);
-  background-image: linear-gradient(
-    to bottom,
-    hsl(216deg 82% 33%),
-    hsl(216deg 82% 27%)
-  );
+  background-image:
+    linear-gradient(
+      to bottom,
+      hsl(216deg 82% 33%),
+      hsl(216deg 82% 27%)
+    );
   cursor: default;
 }
 
@@ -32,7 +34,6 @@
 
 [role="button"]:focus::before {
   position: absolute;
-  z-index: -1;
 
   /* button border width - outline width - offset */
   top: calc(-1px - 3px - 3px);
@@ -49,11 +50,12 @@
 [role="button"]:active {
   border-color: hsl(213deg 71% 49%);
   background-color: hsl(216deg 82% 31%);
-  background-image: linear-gradient(
-    to bottom,
-    hsl(216deg 82% 53%),
-    hsl(216deg 82% 47%)
-  );
+  background-image:
+    linear-gradient(
+      to bottom,
+      hsl(216deg 82% 53%),
+      hsl(216deg 82% 47%)
+    );
   box-shadow: inset 0 3px 5px 1px hsl(216deg 82% 30%);
 }
 
@@ -62,21 +64,23 @@
   box-shadow: 0 1px 2px hsl(261deg 27% 55%);
   text-shadow: 0 -1px 1px hsl(261deg 27% 25%);
   background-color: hsl(261deg 82% 51%);
-  background-image: linear-gradient(
-    to bottom,
-    hsl(261deg 82% 53%),
-    hsl(261deg 82% 47%)
-  );
+  background-image:
+    linear-gradient(
+      to bottom,
+      hsl(261deg 82% 53%),
+      hsl(261deg 82% 47%)
+    );
 }
 
 [role="button"][aria-pressed]:hover {
   border-color: hsl(261deg 71% 29%);
   background-color: hsl(261deg 82% 31%);
-  background-image: linear-gradient(
-    to bottom,
-    hsl(261deg 82% 33%),
-    hsl(261deg 82% 27%)
-  );
+  background-image:
+    linear-gradient(
+      to bottom,
+      hsl(261deg 82% 33%),
+      hsl(261deg 82% 27%)
+    );
 }
 
 [role="button"][aria-pressed="true"] {
@@ -84,22 +88,24 @@
   padding-bottom: 0.3em;
   border-color: hsl(261deg 71% 49%);
   background-color: hsl(261deg 82% 31%);
-  background-image: linear-gradient(
-    to bottom,
-    hsl(261deg 82% 63%),
-    hsl(261deg 82% 57%)
-  );
+  background-image:
+    linear-gradient(
+      to bottom,
+      hsl(261deg 82% 63%),
+      hsl(261deg 82% 57%)
+    );
   box-shadow: inset 0 3px 5px 1px hsl(261deg 82% 30%);
 }
 
 [role="button"][aria-pressed="true"]:hover {
   border-color: hsl(261deg 71% 49%);
   background-color: hsl(261deg 82% 31%);
-  background-image: linear-gradient(
-    to bottom,
-    hsl(261deg 82% 43%),
-    hsl(261deg 82% 37%)
-  );
+  background-image:
+    linear-gradient(
+      to bottom,
+      hsl(261deg 82% 43%),
+      hsl(261deg 82% 37%)
+    );
   box-shadow: inset 0 3px 5px 1px hsl(261deg 82% 20%);
 }
 

--- a/content/patterns/button/examples/css/button.css
+++ b/content/patterns/button/examples/css/button.css
@@ -8,23 +8,21 @@
   color: #fff;
   text-shadow: 0 -1px 1px hsl(216deg 27% 25%);
   background-color: hsl(216deg 82% 51%);
-  background-image:
-    linear-gradient(
-      to bottom,
-      hsl(216deg 82% 53%),
-      hsl(216deg 82% 47%)
-    );
+  background-image: linear-gradient(
+    to bottom,
+    hsl(216deg 82% 53%),
+    hsl(216deg 82% 47%)
+  );
 }
 
 [role="button"]:hover {
   border-color: hsl(213deg 71% 29%);
   background-color: hsl(216deg 82% 31%);
-  background-image:
-    linear-gradient(
-      to bottom,
-      hsl(216deg 82% 33%),
-      hsl(216deg 82% 27%)
-    );
+  background-image: linear-gradient(
+    to bottom,
+    hsl(216deg 82% 33%),
+    hsl(216deg 82% 27%)
+  );
   cursor: default;
 }
 
@@ -50,12 +48,11 @@
 [role="button"]:active {
   border-color: hsl(213deg 71% 49%);
   background-color: hsl(216deg 82% 31%);
-  background-image:
-    linear-gradient(
-      to bottom,
-      hsl(216deg 82% 53%),
-      hsl(216deg 82% 47%)
-    );
+  background-image: linear-gradient(
+    to bottom,
+    hsl(216deg 82% 53%),
+    hsl(216deg 82% 47%)
+  );
   box-shadow: inset 0 3px 5px 1px hsl(216deg 82% 30%);
 }
 
@@ -64,23 +61,21 @@
   box-shadow: 0 1px 2px hsl(261deg 27% 55%);
   text-shadow: 0 -1px 1px hsl(261deg 27% 25%);
   background-color: hsl(261deg 82% 51%);
-  background-image:
-    linear-gradient(
-      to bottom,
-      hsl(261deg 82% 53%),
-      hsl(261deg 82% 47%)
-    );
+  background-image: linear-gradient(
+    to bottom,
+    hsl(261deg 82% 53%),
+    hsl(261deg 82% 47%)
+  );
 }
 
 [role="button"][aria-pressed]:hover {
   border-color: hsl(261deg 71% 29%);
   background-color: hsl(261deg 82% 31%);
-  background-image:
-    linear-gradient(
-      to bottom,
-      hsl(261deg 82% 33%),
-      hsl(261deg 82% 27%)
-    );
+  background-image: linear-gradient(
+    to bottom,
+    hsl(261deg 82% 33%),
+    hsl(261deg 82% 27%)
+  );
 }
 
 [role="button"][aria-pressed="true"] {
@@ -88,24 +83,22 @@
   padding-bottom: 0.3em;
   border-color: hsl(261deg 71% 49%);
   background-color: hsl(261deg 82% 31%);
-  background-image:
-    linear-gradient(
-      to bottom,
-      hsl(261deg 82% 63%),
-      hsl(261deg 82% 57%)
-    );
+  background-image: linear-gradient(
+    to bottom,
+    hsl(261deg 82% 63%),
+    hsl(261deg 82% 57%)
+  );
   box-shadow: inset 0 3px 5px 1px hsl(261deg 82% 30%);
 }
 
 [role="button"][aria-pressed="true"]:hover {
   border-color: hsl(261deg 71% 49%);
   background-color: hsl(261deg 82% 31%);
-  background-image:
-    linear-gradient(
-      to bottom,
-      hsl(261deg 82% 43%),
-      hsl(261deg 82% 37%)
-    );
+  background-image: linear-gradient(
+    to bottom,
+    hsl(261deg 82% 43%),
+    hsl(261deg 82% 37%)
+  );
   box-shadow: inset 0 3px 5px 1px hsl(261deg 82% 20%);
 }
 


### PR DESCRIPTION
For more information see https://github.com/w3c/aria-practices/issues/2650. 

On the button example there was an interaction between the website template's focus indication implementation and the example's focus indication that resulted in no indicator showing. There was some rightful concern from Howard that naively removing  z-index of -1 might result in a regression that the original author had intended to fix, so I tested the button as thoroughly as I can to cover our bases:

Following the change I tested both the final version as it appears on the website as well as the raw HTML version as it appears in the APG source code, on Mac with Chrome, Firefox and Safari, including with VoiceOver, and on Windows with Chrome, Firefox and Edge, including with NVDA. In all cases the buttons were focusable and interactable with visible focus indication.

cc @mcking65 
___
[WAI Preview Link](https://deploy-preview-214--aria-practices.netlify.app/ARIA/apg) _(Last built on Wed, 12 Apr 2023 18:18:56 GMT)._