### PR TITLE
Fix path to ratings star images

### DIFF
--- a/content/patterns/feed/examples/js/feedDisplay.js
+++ b/content/patterns/feed/examples/js/feedDisplay.js
@@ -216,7 +216,7 @@ aria.FeedDisplay.prototype.renderItemData = function (itemData) {
       'alt="' +
       itemData.rating +
       ' stars" ' +
-      'src="imgs/rating-' +
+      'src="../../../../../content-assets/wai-aria-practices/patterns/feed/examples/imgs/rating-' +
       itemData.rating +
       '.png">' +
       '</div>';


### PR DESCRIPTION
This has not been tested in any way by myself, and it's possible there's a problem with "backing up" the directory tree that much, but as best as I can tell, this should fix these paths.
___
[WAI Preview Link](https://deploy-preview-223--aria-practices.netlify.app/ARIA/apg) _(Last built on Wed, 24 May 2023 08:33:37 GMT)._