### PR TITLE
Checkbox Example (Mixed-State): Toggle on keyup to prevent continuous toggling

### DIFF
--- a/content/patterns/checkbox/examples/js/checkbox-mixed.js
+++ b/content/patterns/checkbox/examples/js/checkbox-mixed.js
@@ -16,6 +16,7 @@ class CheckboxMixed {
     this.checkboxNodes = domNode.querySelectorAll('input[type="checkbox"]');
 
     this.mixedNode.addEventListener('keydown', this.onMixedKeydown.bind(this));
+    this.mixedNode.addEventListener('keyup', this.onMixedKeyup.bind(this));
     this.mixedNode.addEventListener('click', this.onMixedClick.bind(this));
     this.mixedNode.addEventListener('focus', this.onMixedFocus.bind(this));
     this.mixedNode.addEventListener('blur', this.onMixedBlur.bind(this));
@@ -116,22 +117,22 @@ class CheckboxMixed {
 
   /* EVENT HANDLERS */
 
+  // Prevent page scrolling on space down
   onMixedKeydown(event) {
-    var flag = false;
+    if (event.key === ' ') {
+      event.preventDefault();
+    }
+  }
 
+  onMixedKeyup(event) {
     switch (event.key) {
       case ' ':
         this.toggleMixed();
-        flag = true;
+        event.stopPropagation();
         break;
 
       default:
         break;
-    }
-
-    if (flag) {
-      event.stopPropagation();
-      event.preventDefault();
     }
   }
 


### PR DESCRIPTION
This is a follow-up PR to https://github.com/w3c/aria-practices/pull/2518 where [Checkbox Example (Two State)](https://www.w3.org/WAI/ARIA/apg/example-index/checkbox/checkbox.html) was changed to only toggle on keyup. I think it makes sense to make the same change to [Checkbox Example (Mixed-State)](https://www.w3.org/WAI/ARIA/apg/example-index/checkbox/checkbox-mixed.html) for consistency.

(Just a head's up, this is a resubmitting of #2541)
___
[WAI Preview Link](https://deploy-preview-231--aria-practices.netlify.app/ARIA/apg) _(Last built on Tue, 13 Jun 2023 18:40:15 GMT)._