### PR TITLE
Select-only Combobox Example: Fix scroll event listener bug

### DIFF
--- a/content/patterns/combobox/examples/js/select-only.js
+++ b/content/patterns/combobox/examples/js/select-only.js
@@ -194,9 +194,13 @@ Select.prototype.init = function () {
   this.comboEl.innerHTML = this.options[0];
 
   // add event listeners
-  this.comboEl.addEventListener('blur', this.onComboBlur.bind(this));
   this.comboEl.addEventListener('click', this.onComboClick.bind(this));
   this.comboEl.addEventListener('keydown', this.onComboKeyDown.bind(this));
+  this.comboEl.addEventListener(
+    'pointerup',
+    this.onBackgroundPointerUp.bind(this),
+    true
+  );
 
   // create options
   this.options.map((option, index) => {
@@ -350,6 +354,17 @@ Select.prototype.onOptionMouseDown = function () {
   // Clicking an option will cause a blur event,
   // but we don't want to perform the default keyboard blur action
   this.ignoreBlur = true;
+};
+
+Select.prototype.onBackgroundPointerUp = function (event) {
+  if (
+    !this.comboEl.contains(event.target) &&
+    !this.listboxEl.contains(event.target)
+  ) {
+    if (this.open) {
+      this.updateMenuState(false, false);
+    }
+  }
 };
 
 Select.prototype.selectOption = function (index) {

--- a/content/patterns/combobox/examples/js/select-only.js
+++ b/content/patterns/combobox/examples/js/select-only.js
@@ -241,10 +241,8 @@ Select.prototype.getSearchString = function (char) {
 };
 
 Select.prototype.onComboBlur = function (event) {
-  // do not do blur action if ignoreBlur flag has been set
-  // also do not blur if focus is moving to the listbox
-  if (this.ignoreBlur || this.listboxEl.contains(event.relatedTarget)) {
-    this.ignoreBlur = false;
+  // do nothing if relatedTarget is contained within listboxEl
+  if (this.listboxEl.contains(event.relatedTarget)) {
     return;
   }
 

--- a/content/patterns/combobox/examples/js/select-only.js
+++ b/content/patterns/combobox/examples/js/select-only.js
@@ -194,12 +194,12 @@ Select.prototype.init = function () {
   this.comboEl.innerHTML = this.options[0];
 
   // add event listeners
+  this.comboEl.addEventListener('blur', this.onComboBlur.bind(this));
   this.comboEl.addEventListener('click', this.onComboClick.bind(this));
   this.comboEl.addEventListener('keydown', this.onComboKeyDown.bind(this));
-  this.comboEl.addEventListener(
-    'pointerup',
-    this.onBackgroundPointerUp.bind(this),
-    true
+  this.listboxEl.addEventListener(
+    'mousedown',
+    this.onListBoxMouseDown.bind(this)
   );
 
   // create options
@@ -356,15 +356,10 @@ Select.prototype.onOptionMouseDown = function () {
   this.ignoreBlur = true;
 };
 
-Select.prototype.onBackgroundPointerUp = function (event) {
-  if (
-    !this.comboEl.contains(event.target) &&
-    !this.listboxEl.contains(event.target)
-  ) {
-    if (this.open) {
-      this.updateMenuState(false, false);
-    }
-  }
+Select.prototype.onListBoxMouseDown = function () {
+  // Clicking on the listbox will cause a blur event,
+  // but we don't want to perform the default keyboard blur action when clicking the scrollbar
+  this.ignoreBlur = true;
 };
 
 Select.prototype.selectOption = function (index) {

--- a/content/patterns/combobox/examples/js/select-only.js
+++ b/content/patterns/combobox/examples/js/select-only.js
@@ -195,12 +195,9 @@ Select.prototype.init = function () {
 
   // add event listeners
   this.comboEl.addEventListener('blur', this.onComboBlur.bind(this));
+  this.listboxEl.addEventListener('focusout', this.onComboBlur.bind(this));
   this.comboEl.addEventListener('click', this.onComboClick.bind(this));
   this.comboEl.addEventListener('keydown', this.onComboKeyDown.bind(this));
-  this.listboxEl.addEventListener(
-    'mousedown',
-    this.onListBoxMouseDown.bind(this)
-  );
 
   // create options
   this.options.map((option, index) => {
@@ -243,9 +240,10 @@ Select.prototype.getSearchString = function (char) {
   return this.searchString;
 };
 
-Select.prototype.onComboBlur = function () {
+Select.prototype.onComboBlur = function (event) {
   // do not do blur action if ignoreBlur flag has been set
-  if (this.ignoreBlur) {
+  // also do not blur if focus is moving to the listbox
+  if (this.ignoreBlur || this.listboxEl.contains(event.relatedTarget)) {
     this.ignoreBlur = false;
     return;
   }
@@ -353,12 +351,6 @@ Select.prototype.onOptionClick = function (index) {
 Select.prototype.onOptionMouseDown = function () {
   // Clicking an option will cause a blur event,
   // but we don't want to perform the default keyboard blur action
-  this.ignoreBlur = true;
-};
-
-Select.prototype.onListBoxMouseDown = function () {
-  // Clicking on the listbox will cause a blur event,
-  // but we don't want to perform the default keyboard blur action when clicking the scrollbar
   this.ignoreBlur = true;
 };
 


### PR DESCRIPTION
Fixes #2719.
Select only scrollbar would close when user would try to click on it.
worked on with @andreancardona 🎉 

[Preview fixed Select-Only Combobox Example | APG | WAI | W3C](https://deploy-preview-228--aria-practices.netlify.app/aria/apg/patterns/combobox/examples/combobox-select-only/)

### Review checklist

*Reviewers:* To learn what needs to be covered by each review, Follow the link for the type of review to which you are assigned.

* N/A: [Editorial review](https://github.com/w3c/aria-practices/wiki/Pull-Request-Review-Process#editorial_review)
* [x] [Functional review](https://github.com/w3c/aria-practices/wiki/Pull-Request-Review-Process#functional_review) by @spectranaut
* N/A: [Visual design review](https://github.com/w3c/aria-practices/wiki/Pull-Request-Review-Process#design_review)
* N/A: [Accessibility review](https://github.com/w3c/aria-practices/wiki/Pull-Request-Review-Process#accessibility_review)
* [x] [Code review](https://github.com/w3c/aria-practices/wiki/Pull-Request-Review-Process#code_review) by @spectranaut
* [x] [Test review](https://github.com/w3c/aria-practices/wiki/Pull-Request-Review-Process#test_review) by @spectranaut

___
[WAI Preview Link](https://deploy-preview-228--aria-practices.netlify.app/ARIA/apg) _(Last built on Tue, 25 Jul 2023 22:54:47 GMT)._