### PR TITLE
Example Pages: Change Javascript to JavaScript in h2 elements

### DIFF
--- a/content/patterns/accordion/examples/accordion.html
+++ b/content/patterns/accordion/examples/accordion.html
@@ -247,7 +247,7 @@
       </section>
 
       <section>
-        <h2>Javascript and CSS Source Code</h2>
+        <h2>JavaScript and CSS Source Code</h2>
         <ul id="css_js_files">
           <li>CSS: <a href="css/accordion.css" type="tex/css">accordion.css</a></li>
           <li>JavaScript: <a href="js/accordion.js" type="text/javascript">accordion.js</a></li>

--- a/content/patterns/alert/examples/alert.html
+++ b/content/patterns/alert/examples/alert.html
@@ -120,7 +120,7 @@
       </section>
 
       <section>
-        <h2>Javascript and CSS Source Code</h2>
+        <h2>JavaScript and CSS Source Code</h2>
         <ul id="css_js_files">
           <li>
             CSS:

--- a/content/patterns/breadcrumb/examples/breadcrumb.html
+++ b/content/patterns/breadcrumb/examples/breadcrumb.html
@@ -117,7 +117,7 @@
       </section>
 
       <section>
-        <h2>Javascript and CSS Source Code</h2>
+        <h2>JavaScript and CSS Source Code</h2>
         <ul id="css_js_files">
           <li>
             CSS:

--- a/content/patterns/button/examples/button.html
+++ b/content/patterns/button/examples/button.html
@@ -171,7 +171,7 @@
       </section>
 
       <section>
-        <h2>Javascript and CSS Source Code</h2>
+        <h2>JavaScript and CSS Source Code</h2>
 
         <ul id="css_js_files">
           <li>

--- a/content/patterns/button/examples/button_idl.html
+++ b/content/patterns/button/examples/button_idl.html
@@ -184,7 +184,7 @@
       </section>
 
       <section>
-        <h2>Javascript and CSS Source Code</h2>
+        <h2>JavaScript and CSS Source Code</h2>
 
         <ul id="css_js_files">
           <li>

--- a/content/patterns/carousel/examples/carousel-1-prev-next.html
+++ b/content/patterns/carousel/examples/carousel-1-prev-next.html
@@ -516,7 +516,7 @@
       </section>
 
       <section>
-        <h2>Javascript and CSS Source Code</h2>
+        <h2>JavaScript and CSS Source Code</h2>
         <ul id="css_js_files">
           <li>CSS: <a href="css/carousel-prev-next.css" type="text/css">carousel-prev-next.css</a></li>
           <li>Javascript: <a href="js/carousel-prev-next.js" type="text/javascript">carousel-prev-next.js</a></li>

--- a/content/patterns/carousel/examples/carousel-2-tablist.html
+++ b/content/patterns/carousel/examples/carousel-2-tablist.html
@@ -702,7 +702,7 @@
       </section>
 
       <section>
-        <h2>Javascript and CSS Source Code</h2>
+        <h2>JavaScript and CSS Source Code</h2>
         <ul id="css_js_files">
           <li>CSS: <a href="css/carousel-tablist.css" type="text/css">carousel-tablist.css</a></li>
           <li>Javascript: <a href="js/carousel-tablist.js" type="text/javascript">carousel-tablist.js</a></li>

--- a/content/patterns/checkbox/examples/checkbox-mixed.html
+++ b/content/patterns/checkbox/examples/checkbox-mixed.html
@@ -200,7 +200,7 @@
       </section>
 
       <section>
-        <h2>Javascript and CSS Source Code</h2>
+        <h2>JavaScript and CSS Source Code</h2>
         <ul id="css_js_files">
           <li>CSS: <a href="css/checkbox-mixed.css" type="text/css">checkbox-mixed.css</a></li>
           <li>Javascript: <a href="js/checkbox-mixed.js" type="text/javascript">checkbox-mixed.js</a></li>

--- a/content/patterns/checkbox/examples/checkbox.html
+++ b/content/patterns/checkbox/examples/checkbox.html
@@ -187,7 +187,7 @@
       </section>
 
       <section>
-        <h2>Javascript and CSS Source Code</h2>
+        <h2>JavaScript and CSS Source Code</h2>
         <ul id="css_js_files">
           <li>CSS: <a href="css/checkbox.css" type="text/css">checkbox.css</a></li>
           <li>Javascript: <a href="js/checkbox.js" type="text/javascript">checkbox.js</a></li>

--- a/content/patterns/combobox/examples/combobox-autocomplete-both.html
+++ b/content/patterns/combobox/examples/combobox-autocomplete-both.html
@@ -517,7 +517,7 @@
       </section>
 
       <section>
-        <h2>Javascript and CSS Source Code</h2>
+        <h2>JavaScript and CSS Source Code</h2>
         <ul id="css_js_files">
           <li>
             CSS:

--- a/content/patterns/combobox/examples/combobox-autocomplete-list.html
+++ b/content/patterns/combobox/examples/combobox-autocomplete-list.html
@@ -511,7 +511,7 @@
       </section>
 
       <section>
-        <h2>Javascript and CSS Source Code</h2>
+        <h2>JavaScript and CSS Source Code</h2>
         <ul id="css_js_files">
           <li>
             CSS:

--- a/content/patterns/combobox/examples/combobox-autocomplete-none.html
+++ b/content/patterns/combobox/examples/combobox-autocomplete-none.html
@@ -453,7 +453,7 @@
       </section>
 
       <section>
-        <h2>Javascript and CSS Source Code</h2>
+        <h2>JavaScript and CSS Source Code</h2>
         <ul id="css_js_files">
           <li>
             CSS:

--- a/content/patterns/combobox/examples/combobox-datepicker.html
+++ b/content/patterns/combobox/examples/combobox-datepicker.html
@@ -696,7 +696,7 @@ Moves focus to the day of the month that has the same number.
       </section>
 
       <section>
-        <h2>Javascript and CSS Source Code</h2>
+        <h2>JavaScript and CSS Source Code</h2>
         <ul id="css_js_files">
           <li>
             CSS:

--- a/content/patterns/combobox/examples/combobox-select-only.html
+++ b/content/patterns/combobox/examples/combobox-select-only.html
@@ -393,7 +393,7 @@
       </section>
 
       <section>
-        <h2>Javascript and CSS Source Code</h2>
+        <h2>JavaScript and CSS Source Code</h2>
         <ul id="css_js_files">
           <li>
             CSS:

--- a/content/patterns/combobox/examples/grid-combo.html
+++ b/content/patterns/combobox/examples/grid-combo.html
@@ -378,7 +378,7 @@
       </section>
 
       <section>
-        <h2>Javascript and CSS Source Code</h2>
+        <h2>JavaScript and CSS Source Code</h2>
         <ul id="css_js_files">
           <li>CSS: <a href="css/grid-combo.css" type="tex/css">grid-combo.css</a></li>
           <li>Javascript: <a href="js/grid-combo.js">grid-combo.js</a>, <a href="js/grid-combo-example.js">grid-combo-example.js</a>, <a href="../../../shared/js/utils.js">utils.js</a></li>

--- a/content/patterns/dialog-modal/examples/datepicker-dialog.html
+++ b/content/patterns/dialog-modal/examples/datepicker-dialog.html
@@ -630,7 +630,7 @@
       </section>
 
       <section>
-        <h2>Javascript and CSS Source Code</h2>
+        <h2>JavaScript and CSS Source Code</h2>
         <ul id="css_js_files">
           <li>
             CSS:

--- a/content/patterns/dialog-modal/examples/dialog.html
+++ b/content/patterns/dialog-modal/examples/dialog.html
@@ -329,7 +329,7 @@
       </section>
 
       <section>
-        <h2>Javascript and CSS Source Code</h2>
+        <h2>JavaScript and CSS Source Code</h2>
         <ul id="css_js_files">
           <li>
             CSS:

--- a/content/patterns/disclosure/examples/disclosure-faq.html
+++ b/content/patterns/disclosure/examples/disclosure-faq.html
@@ -209,7 +209,7 @@
       </section>
 
       <section>
-        <h2>Javascript and CSS Source Code</h2>
+        <h2>JavaScript and CSS Source Code</h2>
         <!--  After the js and css files are named with the name of this example, change the href and text of the following 2 links to refer to the appropriate js and css files.  -->
         <ul id="css_js_files">
           <li>

--- a/content/patterns/disclosure/examples/disclosure-image-description.html
+++ b/content/patterns/disclosure/examples/disclosure-image-description.html
@@ -352,7 +352,7 @@
       </section>
 
       <section>
-        <h2>Javascript and CSS Source Code</h2>
+        <h2>JavaScript and CSS Source Code</h2>
         <ul id="css_js_files">
           <li>
             CSS:

--- a/content/patterns/disclosure/examples/disclosure-navigation-hybrid.html
+++ b/content/patterns/disclosure/examples/disclosure-navigation-hybrid.html
@@ -352,7 +352,7 @@
       </section>
 
       <section>
-        <h2>Javascript and CSS Source Code</h2>
+        <h2>JavaScript and CSS Source Code</h2>
         <!--  After the js and css files are named with the name of this example, change the href and text of the following 2 links to refer to the appropriate js and css files.  -->
         <ul id="css_js_files">
           <li>

--- a/content/patterns/disclosure/examples/disclosure-navigation.html
+++ b/content/patterns/disclosure/examples/disclosure-navigation.html
@@ -346,7 +346,7 @@
       </section>
 
       <section>
-        <h2>Javascript and CSS Source Code</h2>
+        <h2>JavaScript and CSS Source Code</h2>
         <!--  After the js and css files are named with the name of this example, change the href and text of the following 2 links to refer to the appropriate js and css files.  -->
         <ul id="css_js_files">
           <li>

--- a/content/patterns/feed/examples/feed.html
+++ b/content/patterns/feed/examples/feed.html
@@ -189,7 +189,7 @@
       </section>
 
       <section>
-        <h2>Javascript and CSS Source Code</h2>
+        <h2>JavaScript and CSS Source Code</h2>
         <p>The following Javascript and CSS is used by the feed-display.html page:</p>
         <ul>
           <li><a href="css/feedDisplay.css" type="tex/css">feedDisplay.css</a></li>

--- a/content/patterns/grid/examples/advanced-data-grid.html
+++ b/content/patterns/grid/examples/advanced-data-grid.html
@@ -126,7 +126,7 @@
       </section>
 
       <section>
-        <h2>Javascript and CSS Source Code</h2>
+        <h2>JavaScript and CSS Source Code</h2>
         <!--  After the js and css files are named with the name of this example, change the href and text of the following 2 links to refer to the appropriate js and css files.  -->
         <ul>
           <li>

--- a/content/patterns/grid/examples/data-grids.html
+++ b/content/patterns/grid/examples/data-grids.html
@@ -747,7 +747,7 @@
       <div id="arrow-keys-indicator" class="hidden"></div>
 
       <section>
-        <h2>Javascript and CSS Source Code</h2>
+        <h2>JavaScript and CSS Source Code</h2>
         <ul id="css_js_files">
           <li>
             CSS:

--- a/content/patterns/grid/examples/layout-grids.html
+++ b/content/patterns/grid/examples/layout-grids.html
@@ -651,7 +651,7 @@
       </section>
 
       <section>
-        <h2>Javascript and CSS Source Code</h2>
+        <h2>JavaScript and CSS Source Code</h2>
         <ul id="css_js_files">
           <li>
             CSS:

--- a/content/patterns/link/examples/link.html
+++ b/content/patterns/link/examples/link.html
@@ -147,7 +147,7 @@
       </section>
 
       <section>
-        <h2>Javascript and CSS Source Code</h2>
+        <h2>JavaScript and CSS Source Code</h2>
         <ul id="css_js_files">
           <li>
             CSS:

--- a/content/patterns/listbox/examples/listbox-collapsible.html
+++ b/content/patterns/listbox/examples/listbox-collapsible.html
@@ -292,7 +292,7 @@
       </section>
 
       <section>
-        <h2>Javascript and CSS Source Code</h2>
+        <h2>JavaScript and CSS Source Code</h2>
         <ul id="css_js_files">
           <li>
             CSS:

--- a/content/patterns/listbox/examples/listbox-grouped.html
+++ b/content/patterns/listbox/examples/listbox-grouped.html
@@ -216,7 +216,7 @@
       </section>
 
       <section>
-        <h2>Javascript and CSS Source Code</h2>
+        <h2>JavaScript and CSS Source Code</h2>
         <ul id="css_js_files">
           <li>
             CSS:

--- a/content/patterns/listbox/examples/listbox-rearrangeable.html
+++ b/content/patterns/listbox/examples/listbox-rearrangeable.html
@@ -404,7 +404,7 @@
       </section>
 
       <section>
-        <h2>Javascript and CSS Source Code</h2>
+        <h2>JavaScript and CSS Source Code</h2>
         <ul id="css_js_files">
           <li>
             CSS:

--- a/content/patterns/listbox/examples/listbox-scrollable.html
+++ b/content/patterns/listbox/examples/listbox-scrollable.html
@@ -211,7 +211,7 @@
       </section>
 
       <section>
-        <h2>Javascript and CSS Source Code</h2>
+        <h2>JavaScript and CSS Source Code</h2>
         <ul id="css_js_files">
           <li>
             CSS:

--- a/content/patterns/menu-button/examples/menu-button-actions-active-descendant.html
+++ b/content/patterns/menu-button/examples/menu-button-actions-active-descendant.html
@@ -333,7 +333,7 @@
       </section>
 
       <section>
-        <h2>Javascript and CSS Source Code</h2>
+        <h2>JavaScript and CSS Source Code</h2>
 
         <ul id="css_js_files">
           <li>CSS: <a href="css/menu-button-actions.css" type="text/css">menu-button-actions.css</a></li>

--- a/content/patterns/menu-button/examples/menu-button-actions.html
+++ b/content/patterns/menu-button/examples/menu-button-actions.html
@@ -312,7 +312,7 @@
       </section>
 
       <section>
-        <h2>Javascript and CSS Source Code</h2>
+        <h2>JavaScript and CSS Source Code</h2>
 
         <ul id="css_js_files">
           <li>CSS: <a href="css/menu-button-actions.css" type="text/css">menu-button-actions.css</a></li>

--- a/content/patterns/menu-button/examples/menu-button-links.html
+++ b/content/patterns/menu-button/examples/menu-button-links.html
@@ -336,7 +336,7 @@
       </section>
 
       <section>
-        <h2>Javascript and CSS Source Code</h2>
+        <h2>JavaScript and CSS Source Code</h2>
 
         <ul id="cssJsFiles">
           <li>CSS: <a href="css/menu-button-links.css" type="text/css">menu-button-links.css</a></li>

--- a/content/patterns/menubar/examples/menubar-editor.html
+++ b/content/patterns/menubar/examples/menubar-editor.html
@@ -768,7 +768,7 @@
       </section>
 
       <section>
-        <h2>Javascript and CSS Source Code</h2>
+        <h2>JavaScript and CSS Source Code</h2>
         <ul id="css_js_files">
           <li>
             CSS:

--- a/content/patterns/menubar/examples/menubar-navigation.html
+++ b/content/patterns/menubar/examples/menubar-navigation.html
@@ -806,7 +806,7 @@
       </section>
 
       <section>
-        <h2>Javascript and CSS Source Code</h2>
+        <h2>JavaScript and CSS Source Code</h2>
         <ul id="css_js_files">
           <li>CSS: <a href="css/menubar-navigation.css" type="tex/css">menubar-navigation.css</a></li>
           <li>Javascript: <a href="js/menubar-navigation.js" type="text/javascript">menubar-navigation.js</a></li>

--- a/content/patterns/meter/examples/meter.html
+++ b/content/patterns/meter/examples/meter.html
@@ -115,7 +115,7 @@
       </section>
 
       <section>
-        <h2>Javascript and CSS Source Code</h2>
+        <h2>JavaScript and CSS Source Code</h2>
 
         <ul id="css_js_files">
           <li>

--- a/content/patterns/radio/examples/radio-activedescendant.html
+++ b/content/patterns/radio/examples/radio-activedescendant.html
@@ -245,7 +245,7 @@
       </section>
 
       <section>
-        <h2>Javascript and CSS Source Code</h2>
+        <h2>JavaScript and CSS Source Code</h2>
         <ul id="css_js_files">
           <li>CSS: <a href="css/radio.css" type="tex/css">radio.css</a></li>
           <li>Javascript: <a href="js/radio-activedescendant.js" type="text/javascript">radio-activedescendant.js</a></li>

--- a/content/patterns/radio/examples/radio-rating.html
+++ b/content/patterns/radio/examples/radio-rating.html
@@ -275,7 +275,7 @@
       </section>
 
       <section>
-        <h2>Javascript and CSS Source Code</h2>
+        <h2>JavaScript and CSS Source Code</h2>
         <ul id="css_js_files">
           <li>CSS: <a href="css/radio-rating.css" type="text/css">radio-rating.css</a></li>
           <li>Javascript: <a href="js/radio-rating.js" type="text/javascript">radio-rating.js</a></li>

--- a/content/patterns/radio/examples/radio.html
+++ b/content/patterns/radio/examples/radio.html
@@ -246,7 +246,7 @@
       </section>
 
       <section>
-        <h2>Javascript and CSS Source Code</h2>
+        <h2>JavaScript and CSS Source Code</h2>
         <ul id="css_js_files">
           <li>CSS: <a href="css/radio.css">radio.css</a></li>
           <li>Javascript: <a href="js/radio.js">radio.js</a></li>

--- a/content/patterns/slider-multithumb/examples/slider-multithumb.html
+++ b/content/patterns/slider-multithumb/examples/slider-multithumb.html
@@ -252,7 +252,7 @@
       </section>
 
       <section>
-        <h2>Javascript and CSS Source Code</h2>
+        <h2>JavaScript and CSS Source Code</h2>
         <ul id="css_js_files">
           <li>CSS: <a href="css/slider-multithumb.css" type="tex/css">slider-multithumb.css</a></li>
           <li>Javascript: <a href="js/slider-multithumb.js" type="text/javascript">slider-multithumb.js</a></li>

--- a/content/patterns/slider/examples/slider-color-viewer.html
+++ b/content/patterns/slider/examples/slider-color-viewer.html
@@ -292,7 +292,7 @@
       </section>
 
       <section>
-        <h2>Javascript and CSS Source Code</h2>
+        <h2>JavaScript and CSS Source Code</h2>
         <ul id="css_js_files">
           <li>CSS: <a href="css/slider-color-viewer.css" type="text/css">slider-color-viewer.css</a></li>
           <li>Javascript: <a href="js/slider-color-viewer.js" type="text/javascript">slider-color-viewer.js</a></li>

--- a/content/patterns/slider/examples/slider-rating.html
+++ b/content/patterns/slider/examples/slider-rating.html
@@ -274,7 +274,7 @@
       </section>
 
       <section>
-        <h2>Javascript and CSS Source Code</h2>
+        <h2>JavaScript and CSS Source Code</h2>
         <ul id="css_js_files">
           <li>CSS: <a href="css/slider-rating.css" type="text/css">slider-rating.css</a></li>
           <li>Javascript: <a href="js/slider-rating.js" type="text/javascript">slider-rating.js</a></li>

--- a/content/patterns/slider/examples/slider-seek.html
+++ b/content/patterns/slider/examples/slider-seek.html
@@ -299,7 +299,7 @@
       </section>
 
       <section>
-        <h2>Javascript and CSS Source Code</h2>
+        <h2>JavaScript and CSS Source Code</h2>
         <ul id="css_js_files">
           <li>CSS: <a href="css/slider-seek.css" type="text/css">slider-seek.css</a></li>
           <li>Javascript: <a href="js/slider-seek.js" type="text/javascript">slider-seek.js</a></li>

--- a/content/patterns/slider/examples/slider-temperature.html
+++ b/content/patterns/slider/examples/slider-temperature.html
@@ -280,7 +280,7 @@
       </section>
 
       <section>
-        <h2>Javascript and CSS Source Code</h2>
+        <h2>JavaScript and CSS Source Code</h2>
         <ul id="css_js_files">
           <li>CSS: <a href="css/slider-temperature.css" type="text/css">slider-temperature.css</a></li>
           <li>Javascript: <a href="js/slider-temperature.js" type="text/javascript">slider-temperature.js</a></li>

--- a/content/patterns/spinbutton/examples/datepicker-spinbuttons.html
+++ b/content/patterns/spinbutton/examples/datepicker-spinbuttons.html
@@ -306,7 +306,7 @@
       </section>
 
       <section>
-        <h2>Javascript and CSS Source Code</h2>
+        <h2>JavaScript and CSS Source Code</h2>
         <ul id="css_js_files">
           <li>
             CSS:

--- a/content/patterns/switch/examples/switch-button.html
+++ b/content/patterns/switch/examples/switch-button.html
@@ -211,7 +211,7 @@
       </section>
 
       <section>
-        <h2>Javascript and CSS Source Code</h2>
+        <h2>JavaScript and CSS Source Code</h2>
         <!--  After the js and css files are named with the name of this example, change the href and text of the following 2 links to refer to the appropriate js and css files.  -->
         <ul id="css_js_files">
           <li>

--- a/content/patterns/switch/examples/switch-checkbox.html
+++ b/content/patterns/switch/examples/switch-checkbox.html
@@ -170,7 +170,7 @@
       </section>
 
       <section>
-        <h2>Javascript and CSS Source Code</h2>
+        <h2>JavaScript and CSS Source Code</h2>
         <ul id="css_js_files">
           <li>
             CSS:

--- a/content/patterns/switch/examples/switch.html
+++ b/content/patterns/switch/examples/switch.html
@@ -182,7 +182,7 @@
       </section>
 
       <section>
-        <h2>Javascript and CSS Source Code</h2>
+        <h2>JavaScript and CSS Source Code</h2>
         <ul id="css_js_files">
           <li>CSS: <a href="css/switch.css" type="tex/css">switch.css</a></li>
           <li>Javascript: <a href="js/switch.js" type="text/javascript">switch.js</a></li>

--- a/content/patterns/table/examples/sortable-table.html
+++ b/content/patterns/table/examples/sortable-table.html
@@ -193,7 +193,7 @@
       </section>
 
       <section>
-        <h2>Javascript and CSS Source Code</h2>
+        <h2>JavaScript and CSS Source Code</h2>
         <ul id="css_js_files">
           <li>
             CSS:

--- a/content/patterns/table/examples/table.html
+++ b/content/patterns/table/examples/table.html
@@ -159,7 +159,7 @@
       </section>
 
       <section>
-        <h2>Javascript and CSS Source Code</h2>
+        <h2>JavaScript and CSS Source Code</h2>
         <!--  After the js and css files are named with the name of this example, change the href and text of the following 2 links to refer to the appropriate js and css files.  -->
         <ul id="css_js_files">
           <li>

--- a/content/patterns/tabs/examples/tabs-automatic.html
+++ b/content/patterns/tabs/examples/tabs-automatic.html
@@ -339,7 +339,7 @@
       </section>
 
       <section>
-        <h2>Javascript and CSS Source Code</h2>
+        <h2>JavaScript and CSS Source Code</h2>
         <ul id="css_js_files">
           <li>CSS: <a href="css/tabs.css" type="tex/css">tabs.css</a></li>
           <li>Javascript: <a href="js/tabs-automatic.js" type="text/javascript">tabs-automatic.js</a></li>

--- a/content/patterns/tabs/examples/tabs-manual.html
+++ b/content/patterns/tabs/examples/tabs-manual.html
@@ -333,7 +333,7 @@
       </section>
 
       <section>
-        <h2>Javascript and CSS Source Code</h2>
+        <h2>JavaScript and CSS Source Code</h2>
         <ul id="css_js_files">
           <li>CSS: <a href="css/tabs.css" type="tex/css">tabs.css</a></li>
           <li>Javascript: <a href="js/tabs-manual.js" type="text/javascript">tabs-manual.js</a></li>

--- a/content/patterns/toolbar/examples/toolbar.html
+++ b/content/patterns/toolbar/examples/toolbar.html
@@ -941,7 +941,7 @@ But, in a larger sense, we can not dedicate, we can not consecrate, we can not h
       </section>
 
       <section>
-        <h2>Javascript and CSS Source Code</h2>
+        <h2>JavaScript and CSS Source Code</h2>
         <ul id="css_js_files">
           <li>CSS: <a href="css/toolbar.css" type="text/css">toolbar.css</a></li>
           <li>CSS: <a href="css/menuButton.css" type="text/css">menuButton.css</a></li>

--- a/content/patterns/treegrid/examples/treegrid-1.html
+++ b/content/patterns/treegrid/examples/treegrid-1.html
@@ -440,7 +440,7 @@
       </section>
 
       <section>
-        <h2>Javascript and CSS Source Code</h2>
+        <h2>JavaScript and CSS Source Code</h2>
         <!--  After the js and css files are named with the name of this example, change the href and text of the following 2 links to refer to the appropriate js and css files.  -->
         <ul id="css_js_files">
           <li>

--- a/content/patterns/treeview/examples/treeview-1a.html
+++ b/content/patterns/treeview/examples/treeview-1a.html
@@ -395,7 +395,7 @@
       </section>
 
       <section>
-        <h2>Javascript and CSS Source Code</h2>
+        <h2>JavaScript and CSS Source Code</h2>
         <ul id="css_js_files">
           <li>
             CSS:

--- a/content/patterns/treeview/examples/treeview-1b.html
+++ b/content/patterns/treeview/examples/treeview-1b.html
@@ -421,7 +421,7 @@
       </section>
 
       <section>
-        <h2>Javascript and CSS Source Code</h2>
+        <h2>JavaScript and CSS Source Code</h2>
         <ul id="css_js_files">
           <li>
             CSS:

--- a/content/patterns/treeview/examples/treeview-navigation.html
+++ b/content/patterns/treeview/examples/treeview-navigation.html
@@ -674,7 +674,7 @@
       </section>
 
       <section>
-        <h2>Javascript and CSS Source Code</h2>
+        <h2>JavaScript and CSS Source Code</h2>
         <ul id="css_js_files">
           <li>
             CSS:


### PR DESCRIPTION
JavaScript was spelled with a lowercase 's' in the h2 for source files.
This PR corrects the case of the word JavaScript on 57 example pages.
This issue was raised by @coliff in #2382.
___
[WAI Preview Link](https://deploy-preview-230--aria-practices.netlify.app/ARIA/apg) _(Last built on Tue, 13 Jun 2023 18:38:06 GMT)._