### PR TITLE
Fix aria-level in treegrid example 1

### DIFF
--- a/content/patterns/treegrid/examples/treegrid-1.html
+++ b/content/patterns/treegrid/examples/treegrid-1.html
@@ -121,32 +121,32 @@
                 <td role="gridcell">I agree with you, they are the shizzle</td>
                 <td role="gridcell"><a href="mailto:joe@blahblahblah.blahblah">joe@blahblahblah.blahblah</a></td>
               </tr>
-              <tr role="row" aria-level="2" aria-posinset="2" aria-setsize="3" aria-expanded="false">
+              <tr role="row" aria-level="1" aria-posinset="2" aria-setsize="3" aria-expanded="false">
                 <td role="gridcell">re: Treegrids are awesome</td>
                 <td role="gridcell">They are great for showing a lot of data, like a grid</td>
                 <td role="gridcell"><a href="mailto:billy@dangerous.fish">billy@dangerous.fish</a></td>
               </tr>
-              <tr role="row" aria-level="3" aria-posinset="1" aria-setsize="1" class="hidden">
+              <tr role="row" aria-level="2" aria-posinset="1" aria-setsize="1" class="hidden">
                 <td role="gridcell">re: Treegrids are awesome</td>
                 <td role="gridcell">Cool, we've been needing an example and documentation</td>
                 <td role="gridcell"><a href="mailto:doris@rufflazydogs.sleep">doris@rufflazydogs.sleep</a></td>
               </tr>
-              <tr role="row" aria-level="2" aria-posinset="3" aria-setsize="3" aria-expanded="false">
+              <tr role="row" aria-level="1" aria-posinset="3" aria-setsize="3" aria-expanded="false">
                 <td role="gridcell">re: Treegrids are awesome</td>
                 <td role="gridcell">I hear the Fancytree library is going to align with this example!</td>
                 <td role="gridcell"><a href="mailto:someone@please-do-it.company">someone@please-do-it.company</a></td>
               </tr>
-              <tr role="row" aria-level="3" aria-posinset="1" aria-setsize="1" aria-expanded="false" class="hidden">
+              <tr role="row" aria-level="2" aria-posinset="1" aria-setsize="1" aria-expanded="false" class="hidden">
                 <td role="gridcell">re: Treegrids are awesome</td>
                 <td role="gridcell">Sometimes they are more like trees, others are more like grids</td>
                 <td role="gridcell"><a href="mailto:mari@beingpractical.com">mari@beingpractical.com</a></td>
               </tr>
-              <tr role="row" aria-level="4" aria-posinset="1" aria-setsize="2" class="hidden">
+              <tr role="row" aria-level="3" aria-posinset="1" aria-setsize="2" class="hidden">
                 <td role="gridcell">re: Treegrids are awesome</td>
                 <td role="gridcell">Cool, when it's a tree, let's keep left/right to collapse/expand</td>
                 <td role="gridcell"><a href="mailto:issie@imadeadcatsadly.wascute">issie@imadeadcatsadly.wascute</a></td>
               </tr>
-              <tr role="row" aria-level="4" aria-posinset="2" aria-setsize="2" class="hidden">
+              <tr role="row" aria-level="3" aria-posinset="2" aria-setsize="2" class="hidden">
                 <td role="gridcell">re: Treegrids are awesome</td>
                 <td role="gridcell">I see, sometimes right arrow moves by column</td>
                 <td role="gridcell"><a href="mailto:kitten@kittenseason.future">kitten@kittenseason.future</a></td>


### PR DESCRIPTION
`aria-level` is defined as follows in the example page https://www.w3.org/WAI/ARIA/apg/patterns/treegrid/examples/treegrid-1/

aria-level="number" | tr | Defines the level of the row in the hierarchical treegrid structure. Counting is one-based. Root rows have aria-level=“1”.
-- | -- | --

If I understand the treegrids correctly, `aria-level` should indicate which level in the tree hierarchy the row is in. In this example, only the first row has `aria-level="1"` even though there are three top-level rows. This PR fixes this issue

Here is how the treegrid looks.
<img width="1025" alt="image" src="https://github.com/w3c/aria-practices/assets/2373958/10f1c3f3-44ab-42cb-a820-59dbde395927">

___
[WAI Preview Link](https://deploy-preview-229--aria-practices.netlify.app/ARIA/apg) _(Last built on Tue, 13 Jun 2023 18:37:59 GMT)._