### PR TITLE
Infrastructure: Update `localhost` references for regression tests

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -35,7 +35,6 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16
           cache: npm
 
       - name: Install npm dependencies

--- a/test/index.js
+++ b/test/index.js
@@ -17,7 +17,7 @@ if (!coverageReportRun) {
   test.before(async () => {
     geckodriver = await startGeckodriver(1022, 12 * 1000);
     session = new webdriver.Builder()
-      .usingServer('http://localhost:' + geckodriver.port)
+      .usingServer('http://127.0.0.1:' + geckodriver.port)
       .withCapabilities({
         'moz:firefoxOptions': {
           args: firefoxArgs,

--- a/test/util/start-geckodriver.js
+++ b/test/util/start-geckodriver.js
@@ -35,7 +35,7 @@ const startOnPort = (port, timeout) => {
         return;
       }
 
-      getJSON('http://localhost:' + port + '/status')
+      getJSON('http://127.0.0.1:' + port + '/status')
         .then((data) => {
           assert(data.value.ready);
 


### PR DESCRIPTION
See #2636 

Node v17+ deprioritised IPv4 addresses in favour of IPv6 with a change to [dns.setDefaultResultOrder](https://nodejs.org/api/dns.html#dnssetdefaultresultorderorder). This [was done](https://github.com/nodejs/node/issues/40702) without a [happy-eyeballs](https://en.wikipedia.org/wiki/Happy_Eyeballs) implementation which meant the loopback address used when running the regression tests resolved to `::1` rather than the IPv4 loopback, `127.0.0.1` which geckodriver expected. So this PR now explicitly uses `127.0.0.1`.

Alternatively, we could have added `--dns-result-order=ipv4first` to the running script, or added `dns.setDefaultResultOrder('ipv4first');`, but would eventually remove it as the happy-eyeballs implementation is now [included in v20](https://github.com/nodejs/node/pull/44731).

Note the current environment details for the regression tests when running the node setup:
```
Environment details
  node: v18.16.1
  npm: 9.5.1
```
___
[WAI Preview Link](https://deploy-preview-242--aria-practices.netlify.app/ARIA/apg) _(Last built on Tue, 11 Jul 2023 21:24:38 GMT)._