### PR TITLE
Add guidance for mark role

### DIFF
--- a/content/practices/names-and-descriptions/names-and-descriptions-practice.html
+++ b/content/practices/names-and-descriptions/names-and-descriptions-practice.html
@@ -931,6 +931,13 @@
             </tr>
             <tr>
               <td>
+                <a href="#mark" class="role-reference"><code>mark</code></a>
+              </td>
+              <td>Prohibited</td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>
                 <a href="#main" class="role-reference"><code>main</code></a>
               </td>
               <td>Discretionary</td>

--- a/content/practices/structural-roles/structural-roles-practice.html
+++ b/content/practices/structural-roles/structural-roles-practice.html
@@ -150,6 +150,10 @@
               <td>li</td>
             </tr>
             <tr>
+              <th>mark</th>
+              <td>mark</td>
+            </tr>
+            <tr>
               <th>math</th>
               <td>No equivalent element</td>
             </tr>


### PR DESCRIPTION
Updates two practice pages to add information about mark role:
1. On page "Structural Roles", adds mark role to table in section "All Structural Roles and Their HTML Equivalents".
2. On page "Providing Accessible Names and Descriptions", adds mark role to table in section"Accessible Name Guidance by Role".

Fixes #1821.
Replaces PR #1826.

### Review checklist

*Reviewers:* To learn what needs to be covered by each review, Follow the link for the type of review to which you are assigned.

* [ ] [Editorial review](https://github.com/w3c/aria-practices/wiki/Pull-Request-Review-Process#editorial_review) by reviewer_id
* N/A: [Functional review](https://github.com/w3c/aria-practices/wiki/Pull-Request-Review-Process#functional_review) by reviewer_id
* N/A: [Visual design review](https://github.com/w3c/aria-practices/wiki/Pull-Request-Review-Process#design_review) by reviewer_id
* N/A: [Accessibility review](https://github.com/w3c/aria-practices/wiki/Pull-Request-Review-Process#accessibility_review) by reviewer_id
* N/A: [Code review](https://github.com/w3c/aria-practices/wiki/Pull-Request-Review-Process#code_review) by reviewer_id (
* N/A: [Test review](https://github.com/w3c/aria-practices/wiki/Pull-Request-Review-Process#test_review) by reviewer_id

___
[WAI Preview Link](https://deploy-preview-246--aria-practices.netlify.app/ARIA/apg) _(Last built on Mon, 31 Jul 2023 23:03:58 GMT)._