### PR TITLE
Treegrid Pattern keyboard section: Correct text for Control + Home/End

### DIFF
--- a/content/patterns/treegrid/treegrid-pattern.html
+++ b/content/patterns/treegrid/treegrid-pattern.html
@@ -165,7 +165,7 @@
                 If focus is in the first row, focus does not move.
               </li>
               <li>
-                If focus is on a cell, moves focus to the first cell in the column.
+                If focus is on a cell, moves focus to the cell in the first row in the same column as the cell that had focus.
                 If focus is in the first row, focus does not move.
               </li>
             </ul>
@@ -178,7 +178,7 @@
                 If focus is in the last row, focus does not move.
               </li>
               <li>
-                If focus is on a cell, moves focus to the last cell in the column.
+                If focus is on a cell, moves focus to the cell in the last row in the same column as the cell that had focus.
                 If focus is in the last row, focus does not move.
               </li>
             </ul>


### PR DESCRIPTION
The text in the treegrid pattern differed to the text in the treegrid example. The content of the treegrid pattern was nonsensical as a column only contains one cell so moving focus to the first cell in a column is meaningless.

The behaviour and text of the example are consistent and make logical sense.

Inaccurate text:
Control + Home: If focus is on a cell, moves focus to the first cell in the column.
Control + End: If focus is on a cell, moves focus to the last cell in the column.

Corrected text:
Control + Home: If focus is on a cell, moves focus to the cell in the first row in the same column as the cell that had focus.
Control + End: If focus is on a cell, moves focus to the cell in the last row in the same column as the cell that had focus.
___
[WAI Preview Link](https://deploy-preview-251--aria-practices.netlify.app/ARIA/apg) _(Last built on Wed, 30 Aug 2023 08:03:27 GMT)._