### PR TITLE
Developing a Keyboard Interface Practice: Add missing `kbd` element to macOS re-do command in 'Key Assignment Conventions for Common Functions'

### DIFF
--- a/content/practices/keyboard-interface/keyboard-interface-practice.html
+++ b/content/practices/keyboard-interface/keyboard-interface-practice.html
@@ -480,7 +480,7 @@
             <tr>
               <th scope="row">Redo action</th>
               <td><kbd>Control + Y</kbd></td>
-              <td>Command + Shift + Z</td>
+              <td><kbd>Command + Shift + Z</kbd></td>
             </tr>
           </tbody>
         </table>


### PR DESCRIPTION
For consistency with rest of keyboard combinations. 

Conflicts with #1611 style of keyboard combinations (though this one isn't changed there yet)
___
[WAI Preview Link](https://deploy-preview-258--aria-practices.netlify.app/ARIA/apg) _(Last built on Tue, 19 Sep 2023 09:49:47 GMT)._