### PR TITLE
Infrastructure: link-checker.js: Check if any of the known `pageIds` include the hash being checked for

### DIFF
--- a/.link-checker.js
+++ b/.link-checker.js
@@ -11,9 +11,16 @@ module.exports = {
       '.carousel-image a',
     ],
   },
+  hashCheckHandlers: [
+    {
+      name: 'github',
+      pattern: /^https:\/\/github\.com\/.*/,
+      matchHash: (ids, hash) =>
+        ids.includes(hash) || ids.includes(`user-content-${hash}`),
+    },
+  ],
   ignoreHashesOnExternalPagesMatchingRegex: [
     // Some hash links are resolved with JS and are therefore difficult to check algorithmically
-    /^https:\/\/github\.com\/.*\/wiki\//,
     /^https:\/\/html\.spec\.whatwg\.org\/multipage\//,
   ],
 };

--- a/scripts/link-checker.js
+++ b/scripts/link-checker.js
@@ -227,7 +227,7 @@ async function checkLinks() {
 
         let matchesHash = true;
         if (hash) {
-          matchesHash = !!matchingPage?.ids.includes(hash);
+          matchesHash = !!matchingPage?.ids.some((id) => id.includes(hash));
         }
 
         const isLinkBroken = !(
@@ -274,7 +274,11 @@ async function checkLinks() {
             hrefOrSrc.match(pattern)
           );
 
-        if (!isHashCheckingDisabled && hash && !pageData.ids.includes(hash)) {
+        if (
+          !isHashCheckingDisabled &&
+          hash &&
+          !pageData.ids.some((id) => id.includes(hash))
+        ) {
           consoleError(
             `Found broken external link on ${htmlPath}:${lineNumber}:${columnNumber}, ` +
               'hash not found on page'

--- a/scripts/link-checker.js
+++ b/scripts/link-checker.js
@@ -227,6 +227,15 @@ async function checkLinks() {
 
         let matchesHash = true;
         if (hash) {
+          // On some websites, the ids may not exactly match the hash included
+          // in the link.
+          // For e.g. GitHub will prepend client facing ids with their own
+          // calculated value. A heading in a README for example could be
+          // Foo bar, navigated to with https://github.com/foo/bar#foo-bar,
+          // but GitHub calculates the actual markup id included in the document
+          // as being user-content-foo-bar for its own page processing purposes.
+          //
+          // See https://github.com/w3c/aria-practices/issues/2809
           matchesHash = !!matchingPage?.ids.some((id) => id.includes(hash));
         }
 


### PR DESCRIPTION
Closes #2809. Follow up on my thoughts in https://github.com/w3c/aria-practices/issues/2809#issuecomment-1733823225.

Should this explicitly check for `user-content-` when checking GitHub links instead?
___
[WAI Preview Link](https://deploy-preview-261--aria-practices.netlify.app/ARIA/apg) _(Last built on Mon, 02 Oct 2023 13:59:20 GMT)._