### PR TITLE
Landmark Practice: Add note to prevent dialog content wrapped in a landmark

### DIFF
--- a/content/patterns/landmarks/examples/general-principles.html
+++ b/content/patterns/landmarks/examples/general-principles.html
@@ -80,6 +80,11 @@
               <li>
                 Landmark roles can be nested to identify parent/child relationships of the information being presented.
               </li>
+              <li>
+                Note that wrapping  the content  of a modal dialog in a landmark region is unnecessary.
+                A landmark that wraps modal content cannot provide any benefit to users because it is not perceivable unless the modal is open.
+                However, when a modal is open, a landmark containing its content would be superfluous because the modal itself is a container that provides both a name and boundaries.
+              </li>
             </ul>
 
             <p style="font-weight: bold">Step 3: Label each area</p>

--- a/content/patterns/landmarks/examples/general-principles.html
+++ b/content/patterns/landmarks/examples/general-principles.html
@@ -83,7 +83,7 @@
               <li>
                 Note that wrapping  the content  of a modal dialog in a landmark region is unnecessary.
                 A landmark that wraps modal content cannot provide any benefit to users because it is not perceivable unless the modal is open.
-                However, when a modal is open, a landmark containing its content would be superfluous because the modal itself is a container that provides both a name and boundaries.
+                In addition, when a modal is open, a landmark containing its content is   superfluous because the modal itself is a container that provides both a name and boundaries.
               </li>
             </ul>
 

--- a/content/practices/landmark-regions/landmark-regions-practice.html
+++ b/content/practices/landmark-regions/landmark-regions-practice.html
@@ -103,10 +103,13 @@
 
         <ul>
           <li>Assign landmark roles based on the type of content in the area.</li>
-
           <li><code>banner</code>, <code>main</code>, <code>complementary</code> and <code>contentinfo</code> landmarks should be top level landmarks.</li>
-
           <li>Landmark roles can be nested to identify parent/child relationships of the information being presented.</li>
+          <li>
+            Note that wrapping  the content  of a modal dialog in a landmark region is unnecessary.
+            A landmark wrapping modal content cannot provide any benefit to users because it is not perceivable unless the modal is open.
+            However, when a modal is open, a landmark wrapping its content would be superfluous because the modal itself is a container that provides both a name and boundaries.
+          </li>
         </ul>
 
         <p id="aria_lh_step3"><strong>Step 3: Label areas</strong></p>

--- a/content/practices/landmark-regions/landmark-regions-practice.html
+++ b/content/practices/landmark-regions/landmark-regions-practice.html
@@ -108,7 +108,7 @@
           <li>
             Note that wrapping  the content  of a modal dialog in a landmark region is unnecessary.
             A landmark that wraps modal content cannot provide any benefit to users because it is not perceivable unless the modal is open.
-            However, when a modal is open, a landmark containing its content would be superfluous because the modal itself is a container that provides both a name and boundaries.
+            In addition, when a modal is open, a landmark containing its content is superfluous because the modal itself is a container that provides both a name and boundaries.
           </li>
         </ul>
 

--- a/content/practices/landmark-regions/landmark-regions-practice.html
+++ b/content/practices/landmark-regions/landmark-regions-practice.html
@@ -107,8 +107,8 @@
           <li>Landmark roles can be nested to identify parent/child relationships of the information being presented.</li>
           <li>
             Note that wrapping  the content  of a modal dialog in a landmark region is unnecessary.
-            A landmark wrapping modal content cannot provide any benefit to users because it is not perceivable unless the modal is open.
-            However, when a modal is open, a landmark wrapping its content would be superfluous because the modal itself is a container that provides both a name and boundaries.
+            A landmark that wraps modal content cannot provide any benefit to users because it is not perceivable unless the modal is open.
+            However, when a modal is open, a landmark containing its content would be superfluous because the modal itself is a container that provides both a name and boundaries.
           </li>
         </ul>
 


### PR DESCRIPTION
This PR replaces #2512 by @jnurthen, which was delayed due to the back-end refactor after the redesign launch.

The wording is different from that originally proposed by James; the intent is equivalent.

#### Preview Links

On both of the following pages, the changes is under the heading "General Principles of Landmark Design". The new content is the 4th bullet under step 2. None of the other content is changed by this PR.

* Practice page: [Landmark Regions | APG | WAI | W3C](https://deploy-preview-265--aria-practices.netlify.app/aria/apg/practices/landmark-regions/#generalprinciplesoflandmarkdesign)
* Example page: [General Principles: Principles: ARIA Landmarks Example](https://deploy-preview-265--aria-practices.netlify.app/aria/apg/patterns/landmarks/examples/general-principles)

### Review checklist

*Reviewers:* To learn what needs to be covered by each review, Follow the link for the type of review to which you are assigned.

* [x] [Editorial review](https://github.com/w3c/aria-practices/wiki/Pull-Request-Review-Process#editorial_review) by @a11ydoer
* N/A: [Functional review](https://github.com/w3c/aria-practices/wiki/Pull-Request-Review-Process#functional_review) by reviewer_id
* N/A: [Visual design review](https://github.com/w3c/aria-practices/wiki/Pull-Request-Review-Process#design_review) by reviewer_id
* N/A: [Accessibility review](https://github.com/w3c/aria-practices/wiki/Pull-Request-Review-Process#accessibility_review) by reviewer_id
* N/A: [Code review](https://github.com/w3c/aria-practices/wiki/Pull-Request-Review-Process#code_review) by reviewer_id (
* N/A: [Test review](https://github.com/w3c/aria-practices/wiki/Pull-Request-Review-Process#test_review) by reviewer_id

___
[WAI Preview Link](https://deploy-preview-265--aria-practices.netlify.app/ARIA/apg) _(Last built on Sun, 01 Oct 2023 04:42:40 GMT)._