### PR TITLE
Menu Button Pattern: Change to specify aria-expanded="false" when menu is not visible

### DIFF
--- a/content/patterns/menu-button/menu-button-pattern.html
+++ b/content/patterns/menu-button/menu-button-pattern.html
@@ -56,8 +56,7 @@
           <li>The element with role <code>button</code> has <a href="#aria-haspopup" class="property-reference">aria-haspopup</a> set to either <code>menu</code> or <code>true</code>.</li>
           <li>
             When the menu is displayed, the element with role <code>button</code> has <a href="#aria-expanded" class="state-reference">aria-expanded</a> set to <code>true</code>.
-            When the menu is hidden, it is recommended that <code>aria-expanded</code> is not present.
-            If <code>aria-expanded</code> is specified when the menu is hidden, it is set to <code>false</code>.
+            When the menu is hidden, <code>aria-expanded</code> is set to <code>false</code>.
           </li>
           <li>
             The element that contains the menu items displayed by activating the button has role <a href="#menu" class="role-reference">menu</a>.


### PR DESCRIPTION
To resolve #697, remove the recommendation that aria-expanded be removed when the controlled menu is hidden. Instead, specify that aria-expanded should be set to false. See also #2808.

#### Preview Link

[Preview revised roles, states, and properties section of menu button pattern](https://deploy-preview-267--aria-practices.netlify.app/aria/apg/patterns/menu-button/#wai-ariaroles,states,andproperties)

### Review checklist

*Reviewers:* To learn what needs to be covered by each review, Follow the link for the type of review to which you are assigned.

* [x] [Editorial review](https://github.com/w3c/aria-practices/wiki/Pull-Request-Review-Process#editorial_review) by @a11ydoer
* N/A: [Functional review](https://github.com/w3c/aria-practices/wiki/Pull-Request-Review-Process#functional_review) by reviewer_id
* N/A: [Visual design review](https://github.com/w3c/aria-practices/wiki/Pull-Request-Review-Process#design_review) by reviewer_id
* N/A: [Accessibility review](https://github.com/w3c/aria-practices/wiki/Pull-Request-Review-Process#accessibility_review) by reviewer_id
* N/A: [Code review](https://github.com/w3c/aria-practices/wiki/Pull-Request-Review-Process#code_review) by reviewer_id (
* [ ] [Test review](https://github.com/w3c/aria-practices/wiki/Pull-Request-Review-Process#test_review) by @a11ydoer

___
[WAI Preview Link](https://deploy-preview-267--aria-practices.netlify.app/ARIA/apg) _(Last built on Mon, 02 Oct 2023 01:42:57 GMT)._