### PR TITLE
Menu button pattern and 4 examples: Set aria-expanded to false when menus are closed

### DIFF
--- a/content/patterns/menu-button/examples/js/menu-button-actions-active-descendant.js
+++ b/content/patterns/menu-button/examples/js/menu-button-actions-active-descendant.js
@@ -162,7 +162,7 @@ class MenuButtonActionsActiveDescendant {
 
   closePopup() {
     if (this.isOpen()) {
-      this.buttonNode.removeAttribute('aria-expanded');
+      this.buttonNode.setAttribute('aria-expanded', 'false');
       this.menuNode.setAttribute('aria-activedescendant', '');
       for (var i = 0; i < this.menuitemNodes.length; i++) {
         this.menuitemNodes[i].classList.remove('focus');

--- a/content/patterns/menu-button/examples/js/menu-button-actions-active-descendant.js
+++ b/content/patterns/menu-button/examples/js/menu-button-actions-active-descendant.js
@@ -164,7 +164,7 @@ class MenuButtonActionsActiveDescendant {
     if (this.isOpen()) {
       this.buttonNode.setAttribute('aria-expanded', 'false');
       this.menuNode.setAttribute('aria-activedescendant', '');
-      for (var i = 0; i < this.menuitemNodes.length; i++) {
+      for (let i = 0; i < this.menuitemNodes.length; i++) {
         this.menuitemNodes[i].classList.remove('focus');
       }
       this.menuNode.style.display = 'none';

--- a/content/patterns/menu-button/examples/js/menu-button-actions.js
+++ b/content/patterns/menu-button/examples/js/menu-button-actions.js
@@ -156,7 +156,7 @@ class MenuButtonActions {
 
   closePopup() {
     if (this.isOpen()) {
-      this.buttonNode.removeAttribute('aria-expanded');
+      this.buttonNode.setAttribute('aria-expanded', 'false');
       this.menuNode.style.display = 'none';
     }
   }

--- a/content/patterns/menu-button/examples/js/menu-button-links.js
+++ b/content/patterns/menu-button/examples/js/menu-button-links.js
@@ -153,7 +153,7 @@ class MenuButtonLinks {
 
   closePopup() {
     if (this.isOpen()) {
-      this.buttonNode.removeAttribute('aria-expanded');
+      this.buttonNode.setAttribute('aria-expanded', 'false');
       this.menuNode.style.display = 'none';
     }
   }

--- a/content/patterns/menu-button/examples/menu-button-actions-active-descendant.html
+++ b/content/patterns/menu-button/examples/menu-button-actions-active-descendant.html
@@ -51,7 +51,7 @@
         <div role="separator" id="ex_start_sep" aria-labelledby="ex_start_sep ex_label" aria-label="Start of"></div>
         <div id="ex1">
           <div class="menu-button-actions">
-            <button type="button" id="menubutton1" aria-haspopup="true" aria-controls="menu1">
+            <button type="button" id="menubutton1" aria-haspopup="true" aria-expanded="false" aria-controls="menu1">
               Actions
               <svg xmlns="http://www.w3.org/2000/svg" class="down" width="12" height="9" viewBox="0 0 12 9">
                 <polygon points="1 0, 11 0, 6 8" />

--- a/content/patterns/menu-button/examples/menu-button-actions-active-descendant.html
+++ b/content/patterns/menu-button/examples/menu-button-actions-active-descendant.html
@@ -197,7 +197,7 @@
           <tbody>
             <tr data-test-id="button-aria-haspopup">
               <td></td>
-              <th scope="row"><code>aria-haspopup=&quot;true&quot;</code></th>
+              <th scope="row"><code>aria-haspopup="true"</code></th>
               <td>
                 <code>button</code>
               </td>
@@ -213,7 +213,7 @@
             </tr>
             <tr data-test-id="button-aria-controls">
               <td></td>
-              <th scope="row"><code>aria-controls=&quot;ID_REFERENCE&quot;</code></th>
+              <th scope="row"><code>aria-controls="ID_REFERENCE"</code></th>
               <td>
                 <code>button</code>
               </td>
@@ -226,13 +226,13 @@
             </tr>
             <tr data-test-id="button-aria-expanded-false">
               <td></td>
-              <th scope="row"><code>aria-expanded=&quot;false&quot;</code></th>
+              <th scope="row"><code>aria-expanded="false"</code></th>
               <td><code>button</code></td>
               <td>Indicates the menu is not displayed and that activating the menu button opens the menu.</td>
             </tr>
             <tr data-test-id="button-aria-expanded">
               <td></td>
-              <th scope="row"><code>aria-expanded=&quot;true&quot;</code></th>
+              <th scope="row"><code>aria-expanded="true"</code></th>
               <td><code>button</code></td>
               <td>Indicates the menu is displayed and that activating the menu button closes the menu.</td>
             </tr>
@@ -263,7 +263,7 @@
               <td>
                 <code></code>
               </td>
-              <th scope="row"><code>aria-labelledby=&quot;ID_REFERENCE&quot;</code></th>
+              <th scope="row"><code>aria-labelledby="ID_REFERENCE"</code></th>
               <td>
                 <code>ul</code>
               </td>
@@ -276,7 +276,7 @@
             </tr>
             <tr data-test-id="menu-tabindex">
               <td></td>
-              <th scope="row"><code>tabindex=&quot;-1&quot;</code></th>
+              <th scope="row"><code>tabindex="-1"</code></th>
               <td>
                 <code>ul</code>
               </td>
@@ -293,7 +293,7 @@
             </tr>
             <tr data-test-id="menu-aria-activedescendant">
               <td></td>
-              <th scope="row"><code>aria-activedescendant=&quot;ID_REFERENCE&quot;</code></th>
+              <th scope="row"><code>aria-activedescendant="ID_REFERENCE"</code></th>
               <td>
                 <code>ul</code>
               </td>

--- a/content/patterns/menu-button/examples/menu-button-actions-active-descendant.html
+++ b/content/patterns/menu-button/examples/menu-button-actions-active-descendant.html
@@ -240,6 +240,17 @@
                 </ul>
               </td>
             </tr>
+            <tr data-test-id="button-aria-expanded-false">
+              <td></td>
+              <th scope="row"><code>aria-expanded=&quot;false&quot;</code></th>
+              <td><code>button</code></td>
+              <td>
+                <ul>
+                  <li>Added when the menu is closed.</li>
+                  <li>The <code>aria-expanded</code> attribute is set to false when the menu is closed.</li>
+                </ul>
+              </td>
+            </tr>
           </tbody>
         </table>
         <h3 id="rps2_label">Menu</h3>

--- a/content/patterns/menu-button/examples/menu-button-actions-active-descendant.html
+++ b/content/patterns/menu-button/examples/menu-button-actions-active-descendant.html
@@ -213,7 +213,7 @@
             </tr>
             <tr data-test-id="button-aria-controls">
               <td></td>
-              <th scope="row"><code>aria-controls=&quot;IDREF&quot;</code></th>
+              <th scope="row"><code>aria-controls=&quot;ID_REFERENCE&quot;</code></th>
               <td>
                 <code>button</code>
               </td>
@@ -263,7 +263,7 @@
               <td>
                 <code></code>
               </td>
-              <th scope="row"><code>aria-labelledby=&quot;IDREF&quot;</code></th>
+              <th scope="row"><code>aria-labelledby=&quot;ID_REFERENCE&quot;</code></th>
               <td>
                 <code>ul</code>
               </td>
@@ -293,14 +293,14 @@
             </tr>
             <tr data-test-id="menu-aria-activedescendant">
               <td></td>
-              <th scope="row"><code>aria-activedescendant=&quot;IDREF&quot;</code></th>
+              <th scope="row"><code>aria-activedescendant=&quot;ID_REFERENCE&quot;</code></th>
               <td>
                 <code>ul</code>
               </td>
               <td>
                 <ul>
                   <li>Refers to the descendant <code>menuitem</code> element that is visually indicated as focused.</li>
-                  <li>The <code>IDREF</code> value is updated when keys that move the focus indicator among menu items are pressed.</li>
+                  <li>The <code>ID_REFERENCE</code> value is updated when keys that move the focus indicator among menu items are pressed.</li>
                   <li>Enables assistive technologies to know which element the application regards as focused while DOM focus remains on the <code>ul</code> element with role <code>menu</code>.</li>
                   <li>
                     For more information about this focus management technique, see

--- a/content/patterns/menu-button/examples/menu-button-actions-active-descendant.html
+++ b/content/patterns/menu-button/examples/menu-button-actions-active-descendant.html
@@ -224,32 +224,17 @@
                 </ul>
               </td>
             </tr>
-            <tr data-test-id="button-aria-expanded">
-              <td></td>
-              <th scope="row"><code>aria-expanded=&quot;true&quot;</code></th>
-              <td><code>button</code></td>
-              <td>
-                <ul>
-                  <li>Added when the menu is open.</li>
-                  <li>Indicates that the menu is displayed and that activating the menu button closes the menu.</li>
-                  <li>The <code>aria-expanded</code> attribute is removed when the menu is closed.</li>
-                  <li>
-                    Included to support touch devices where screen reader users can touch the menu button when the menu is displayed.
-                    Keyboard users cannot focus the menu button when the menu is open.
-                  </li>
-                </ul>
-              </td>
-            </tr>
             <tr data-test-id="button-aria-expanded-false">
               <td></td>
               <th scope="row"><code>aria-expanded=&quot;false&quot;</code></th>
               <td><code>button</code></td>
-              <td>
-                <ul>
-                  <li>Added when the menu is closed.</li>
-                  <li>The <code>aria-expanded</code> attribute is set to false when the menu is closed.</li>
-                </ul>
-              </td>
+              <td>Indicates the menu is not displayed and that activating the menu button opens the menu.</td>
+            </tr>
+            <tr data-test-id="button-aria-expanded">
+              <td></td>
+              <th scope="row"><code>aria-expanded=&quot;true&quot;</code></th>
+              <td><code>button</code></td>
+              <td>Indicates the menu is displayed and that activating the menu button closes the menu.</td>
             </tr>
           </tbody>
         </table>

--- a/content/patterns/menu-button/examples/menu-button-actions.html
+++ b/content/patterns/menu-button/examples/menu-button-actions.html
@@ -214,7 +214,7 @@
             </tr>
             <tr data-test-id="menu-button-aria-controls">
               <td></td>
-              <th scope="row"><code>aria-controls=&quot;IDREF&quot;</code></th>
+              <th scope="row"><code>aria-controls=&quot;ID_REFERENCE&quot;</code></th>
               <td>
                 <code>button</code>
               </td>
@@ -264,7 +264,7 @@
               <td>
                 <code></code>
               </td>
-              <th scope="row"><code>aria-labelledby=&quot;IDREF&quot;</code></th>
+              <th scope="row"><code>aria-labelledby=&quot;ID_REFERENCE&quot;</code></th>
               <td>
                 <code>ul</code>
               </td>

--- a/content/patterns/menu-button/examples/menu-button-actions.html
+++ b/content/patterns/menu-button/examples/menu-button-actions.html
@@ -51,7 +51,7 @@
         <div role="separator" id="ex_start_sep" aria-labelledby="ex_start_sep ex_label" aria-label="Start of"></div>
         <div id="ex1">
           <div class="menu-button-actions">
-            <button type="button" id="menubutton1" aria-haspopup="true" aria-controls="menu1">
+            <button type="button" id="menubutton1" aria-haspopup="true" aria-expanded="false" aria-controls="menu1">
               Actions
               <svg xmlns="http://www.w3.org/2000/svg" class="down" width="12" height="9" viewBox="0 0 12 9">
                 <polygon points="1 0, 11 0, 6 8" />

--- a/content/patterns/menu-button/examples/menu-button-actions.html
+++ b/content/patterns/menu-button/examples/menu-button-actions.html
@@ -225,32 +225,17 @@
                 </ul>
               </td>
             </tr>
-            <tr data-test-id="menu-button-aria-expanded">
-              <td></td>
-              <th scope="row"><code>aria-expanded=&quot;true&quot;</code></th>
-              <td><code>button</code></td>
-              <td>
-                <ul>
-                  <li>Added when the menu is open.</li>
-                  <li>Indicates that the menu is displayed and that activating the menu button closes the menu.</li>
-                  <li>The <code>aria-expanded</code> attribute is removed when the menu is closed.</li>
-                  <li>
-                    Included to support touch devices where screen reader users can touch the menu button when the menu is displayed.
-                    Keyboard users cannot focus the menu button when the menu is open.
-                  </li>
-                </ul>
-              </td>
-            </tr>
             <tr data-test-id="button-aria-expanded-false">
               <td></td>
               <th scope="row"><code>aria-expanded=&quot;false&quot;</code></th>
               <td><code>button</code></td>
-              <td>
-                <ul>
-                  <li>Added when the menu is closed.</li>
-                  <li>The <code>aria-expanded</code> attribute is set to false when the menu is closed.</li>
-                </ul>
-              </td>
+              <td>Indicates the menu is not displayed and that activating the menu button opens the menu.</td>
+            </tr>
+            <tr data-test-id="menu-button-aria-expanded">
+              <td></td>
+              <th scope="row"><code>aria-expanded=&quot;true&quot;</code></th>
+              <td><code>button</code></td>
+              <td>Indicates the menu is displayed and that activating the menu button closes the menu.</td>
             </tr>
           </tbody>
         </table>

--- a/content/patterns/menu-button/examples/menu-button-actions.html
+++ b/content/patterns/menu-button/examples/menu-button-actions.html
@@ -241,6 +241,17 @@
                 </ul>
               </td>
             </tr>
+            <tr data-test-id="button-aria-expanded-false">
+              <td></td>
+              <th scope="row"><code>aria-expanded=&quot;false&quot;</code></th>
+              <td><code>button</code></td>
+              <td>
+                <ul>
+                  <li>Added when the menu is closed.</li>
+                  <li>The <code>aria-expanded</code> attribute is set to false when the menu is closed.</li>
+                </ul>
+              </td>
+            </tr>
           </tbody>
         </table>
         <h3 id="rps2_label">Menu</h3>

--- a/content/patterns/menu-button/examples/menu-button-actions.html
+++ b/content/patterns/menu-button/examples/menu-button-actions.html
@@ -34,7 +34,7 @@
           In this example, choosing an action from the menu will cause the chosen action to be displayed in the <q>Last Action</q> edit box.
         </p>
         <p>
-          In this implementation, each item in the menu is made focusable by setting <code>tabindex=&quot;-1&quot;</code> so the JavaScript can use <code>element.focus()</code> to set focus in response to events that trigger focus movement inside the menu.
+          In this implementation, each item in the menu is made focusable by setting <code>tabindex="-1"</code> so the JavaScript can use <code>element.focus()</code> to set focus in response to events that trigger focus movement inside the menu.
           An alternative technique for managing focus movement among menu items is demonstrated in <a href="menu-button-actions-active-descendant.html">the action menu button example that uses aria-activedescendant.</a>
         </p>
         <p>Similar examples include:</p>
@@ -198,7 +198,7 @@
           <tbody>
             <tr data-test-id="menu-button-aria-haspopup">
               <td></td>
-              <th scope="row"><code>aria-haspopup=&quot;true&quot;</code></th>
+              <th scope="row"><code>aria-haspopup="true"</code></th>
               <td>
                 <code>button</code>
               </td>
@@ -214,7 +214,7 @@
             </tr>
             <tr data-test-id="menu-button-aria-controls">
               <td></td>
-              <th scope="row"><code>aria-controls=&quot;ID_REFERENCE&quot;</code></th>
+              <th scope="row"><code>aria-controls="ID_REFERENCE"</code></th>
               <td>
                 <code>button</code>
               </td>
@@ -227,13 +227,13 @@
             </tr>
             <tr data-test-id="button-aria-expanded-false">
               <td></td>
-              <th scope="row"><code>aria-expanded=&quot;false&quot;</code></th>
+              <th scope="row"><code>aria-expanded="false"</code></th>
               <td><code>button</code></td>
               <td>Indicates the menu is not displayed and that activating the menu button opens the menu.</td>
             </tr>
             <tr data-test-id="menu-button-aria-expanded">
               <td></td>
-              <th scope="row"><code>aria-expanded=&quot;true&quot;</code></th>
+              <th scope="row"><code>aria-expanded="true"</code></th>
               <td><code>button</code></td>
               <td>Indicates the menu is displayed and that activating the menu button closes the menu.</td>
             </tr>
@@ -264,7 +264,7 @@
               <td>
                 <code></code>
               </td>
-              <th scope="row"><code>aria-labelledby=&quot;ID_REFERENCE&quot;</code></th>
+              <th scope="row"><code>aria-labelledby="ID_REFERENCE"</code></th>
               <td>
                 <code>ul</code>
               </td>
@@ -292,7 +292,7 @@
             </tr>
             <tr data-test-id="menuitem-tabindex">
               <td></td>
-              <th scope="row"><code>tabindex=&quot;-1&quot;</code></th>
+              <th scope="row"><code>tabindex="-1"</code></th>
               <td>
                 <code>li</code>
               </td>

--- a/content/patterns/menu-button/examples/menu-button-links.html
+++ b/content/patterns/menu-button/examples/menu-button-links.html
@@ -235,32 +235,17 @@
                 </ul>
               </td>
             </tr>
-            <tr data-test-id="button-aria-expanded">
-              <td></td>
-              <th scope="row"><code>aria-expanded=&quot;true&quot;</code></th>
-              <td><code>button</code></td>
-              <td>
-                <ul>
-                  <li>Added when the menu is open.</li>
-                  <li>Indicates that the menu is displayed and that activating the menu button closes the menu.</li>
-                  <li>The <code>aria-expanded</code> attribute is removed when the menu is closed.</li>
-                  <li>
-                    Included to support touch devices where screen reader users can touch the menu button when the menu is displayed.
-                    Keyboard users cannot focus the menu button when the menu is open.
-                  </li>
-                </ul>
-              </td>
-            </tr>
             <tr data-test-id="button-aria-expanded-false">
               <td></td>
               <th scope="row"><code>aria-expanded=&quot;false&quot;</code></th>
               <td><code>button</code></td>
-              <td>
-                <ul>
-                  <li>Added when the menu is closed.</li>
-                  <li>The <code>aria-expanded</code> attribute is set to false when the menu is closed.</li>
-                </ul>
-              </td>
+              <td>Indicates the menu is not displayed and that activating the menu button opens the menu.</td>
+            </tr>
+            <tr data-test-id="button-aria-expanded">
+              <td></td>
+              <th scope="row"><code>aria-expanded=&quot;true&quot;</code></th>
+              <td><code>button</code></td>
+              <td>Indicates the menu is displayed and that activating the menu button closes the menu.</td>
             </tr>
           </tbody>
         </table>

--- a/content/patterns/menu-button/examples/menu-button-links.html
+++ b/content/patterns/menu-button/examples/menu-button-links.html
@@ -208,7 +208,7 @@
           <tbody>
             <tr data-test-id="button-aria-haspopup">
               <td></td>
-              <th scope="row"><code>aria-haspopup=&quot;true&quot;</code></th>
+              <th scope="row"><code>aria-haspopup="true"</code></th>
               <td>
                 <code>button</code>
               </td>
@@ -224,7 +224,7 @@
             </tr>
             <tr data-test-id="button-aria-controls">
               <td></td>
-              <th scope="row"><code>aria-controls=&quot;ID_REFERENCE&quot;</code></th>
+              <th scope="row"><code>aria-controls="ID_REFERENCE"</code></th>
               <td>
                 <code>button</code>
               </td>
@@ -237,13 +237,13 @@
             </tr>
             <tr data-test-id="button-aria-expanded-false">
               <td></td>
-              <th scope="row"><code>aria-expanded=&quot;false&quot;</code></th>
+              <th scope="row"><code>aria-expanded="false"</code></th>
               <td><code>button</code></td>
               <td>Indicates the menu is not displayed and that activating the menu button opens the menu.</td>
             </tr>
             <tr data-test-id="button-aria-expanded">
               <td></td>
-              <th scope="row"><code>aria-expanded=&quot;true&quot;</code></th>
+              <th scope="row"><code>aria-expanded="true"</code></th>
               <td><code>button</code></td>
               <td>Indicates the menu is displayed and that activating the menu button closes the menu.</td>
             </tr>
@@ -276,7 +276,7 @@
               <td>
                 <code></code>
               </td>
-              <th scope="row"><code>aria-labelledby=&quot;ID_REFERENCE&quot;</code></th>
+              <th scope="row"><code>aria-labelledby="ID_REFERENCE"</code></th>
               <td>
                 <code>ul</code>
               </td>
@@ -321,7 +321,7 @@
             </tr>
             <tr data-test-id="menuitem-tabindex">
               <td></td>
-              <th scope="row"><code>tabindex=&quot;-1&quot;</code></th>
+              <th scope="row"><code>tabindex="-1"</code></th>
               <td>
                 <code>a</code>
               </td>

--- a/content/patterns/menu-button/examples/menu-button-links.html
+++ b/content/patterns/menu-button/examples/menu-button-links.html
@@ -224,7 +224,7 @@
             </tr>
             <tr data-test-id="button-aria-controls">
               <td></td>
-              <th scope="row"><code>aria-controls=&quot;IDREF&quot;</code></th>
+              <th scope="row"><code>aria-controls=&quot;ID_REFERENCE&quot;</code></th>
               <td>
                 <code>button</code>
               </td>
@@ -276,7 +276,7 @@
               <td>
                 <code></code>
               </td>
-              <th scope="row"><code>aria-labelledby=&quot;IDREF&quot;</code></th>
+              <th scope="row"><code>aria-labelledby=&quot;ID_REFERENCE&quot;</code></th>
               <td>
                 <code>ul</code>
               </td>

--- a/content/patterns/menu-button/examples/menu-button-links.html
+++ b/content/patterns/menu-button/examples/menu-button-links.html
@@ -56,7 +56,7 @@
         <div role="separator" id="ex_start_sep" aria-labelledby="ex_start_sep ex_label" aria-label="Start of"></div>
         <div id="ex1">
           <div class="menu-button-links">
-            <button type="button" id="menubutton" aria-haspopup="true" aria-controls="menu2">
+            <button type="button" id="menubutton" aria-haspopup="true" aria-controls="menu2" aria-expanded="false">
               WAI-ARIA Quick Links
               <svg xmlns="http://www.w3.org/2000/svg" class="down" width="12" height="9" viewBox="0 0 12 9">
                 <polygon points="1 0, 11 0, 6 8" />
@@ -248,6 +248,17 @@
                     Included to support touch devices where screen reader users can touch the menu button when the menu is displayed.
                     Keyboard users cannot focus the menu button when the menu is open.
                   </li>
+                </ul>
+              </td>
+            </tr>
+            <tr data-test-id="button-aria-expanded-false">
+              <td></td>
+              <th scope="row"><code>aria-expanded=&quot;false&quot;</code></th>
+              <td><code>button</code></td>
+              <td>
+                <ul>
+                  <li>Added when the menu is closed.</li>
+                  <li>The <code>aria-expanded</code> attribute is set to false when the menu is closed.</li>
                 </ul>
               </td>
             </tr>

--- a/content/patterns/menu-button/menu-button-pattern.html
+++ b/content/patterns/menu-button/menu-button-pattern.html
@@ -57,7 +57,7 @@
           <li>
             When the menu is displayed, the element with role <code>button</code> has <a href="#aria-expanded" class="state-reference">aria-expanded</a> set to <code>true</code>.
             When the menu is hidden, it is recommended that <code>aria-expanded</code> is not present.
-            If <code>aria-expanded</code> is specified when the menu is hidden, it is set to <code>false</code>.
+            If <code>aria-expanded</code> is specified when the menu is closed, <code>button</code> has <a href="#aria-expanded" class="state-reference">aria-expanded</a> set to <code>false</code>.
           </li>
           <li>
             The element that contains the menu items displayed by activating the button has role <a href="#menu" class="role-reference">menu</a>.

--- a/content/patterns/menu-button/menu-button-pattern.html
+++ b/content/patterns/menu-button/menu-button-pattern.html
@@ -56,8 +56,7 @@
           <li>The element with role <code>button</code> has <a href="#aria-haspopup" class="property-reference">aria-haspopup</a> set to either <code>menu</code> or <code>true</code>.</li>
           <li>
             When the menu is displayed, the element with role <code>button</code> has <a href="#aria-expanded" class="state-reference">aria-expanded</a> set to <code>true</code>.
-            When the menu is hidden, it is recommended that <code>aria-expanded</code> is not present.
-            If <code>aria-expanded</code> is specified when the menu is closed, <code>button</code> has <a href="#aria-expanded" class="state-reference">aria-expanded</a> set to <code>false</code>.
+            When the menu is hidden, <code>aria-expanded</code> is set to <code>false</code>.
           </li>
           <li>
             The element that contains the menu items displayed by activating the button has role <a href="#menu" class="role-reference">menu</a>.

--- a/content/patterns/toolbar/examples/js/FontMenu.js
+++ b/content/patterns/toolbar/examples/js/FontMenu.js
@@ -242,6 +242,6 @@ FontMenu.prototype.close = function (force) {
     (!this.hasFocus && !this.hasHover && !this.controller.hasHover)
   ) {
     this.domNode.style.display = 'none';
-    this.controller.domNode.removeAttribute('aria-expanded');
+    this.controller.domNode.setAttribute('aria-expanded', 'false');
   }
 };

--- a/content/patterns/toolbar/examples/toolbar.html
+++ b/content/patterns/toolbar/examples/toolbar.html
@@ -88,7 +88,7 @@
               <button type="button" class="item cut" aria-disabled="true" tabindex="-1">Cut</button>
             </div>
             <div class="menu-popup group">
-              <button type="button" aria-haspopup="true" aria-controls="menu1" class="item menu-button" tabindex="-1" aria-label="Font: Sans-serif" style="text-align: left; width: 140px; font-family: sans-serif">
+              <button type="button" aria-haspopup="true" aria-expanded="false" aria-controls="menu1" class="item menu-button" tabindex="-1" aria-label="Font: Sans-serif" style="text-align: left; width: 140px; font-family: sans-serif">
                 SANS-SERIF
                 <span></span>
               </button>
@@ -772,32 +772,17 @@ But, in a larger sense, we can not dedicate, we can not consecrate, we can not h
                   </ul>
                 </td>
               </tr>
+              <tr data-test-id="toolbar-menubutton-aria-expanded-false">
+                <td></td>
+                <th scope="row"><code>aria-expanded="false"</code></th>
+                <td><code>button</code></td>
+                <td>Indicates the menu is not displayed and that activating the menu button opens the menu.</td>
+              </tr>
               <tr data-test-id="toolbar-menubutton-aria-expanded">
                 <td></td>
                 <th scope="row"><code>aria-expanded="true"</code></th>
                 <td><code>button</code></td>
-                <td>
-                  <ul>
-                    <li>Added when the menu is open.</li>
-                    <li>Indicates that the menu is displayed and that activating the menu button closes the menu.</li>
-                    <li>The <code>aria-expanded</code> attribute is removed when the menu is closed.</li>
-                    <li>
-                      Included to support touch devices where screen reader users can touch the menu button when the menu is displayed.
-                      Keyboard users cannot focus the menu button when the menu is open.
-                    </li>
-                  </ul>
-                </td>
-              </tr>
-              <tr data-test-id="toolbar-menubutton-aria-expanded-false">
-                <td></td>
-                <th scope="row"><code>aria-expanded=&quot;false&quot;</code></th>
-                <td><code>button</code></td>
-                <td>
-                  <ul>
-                    <li>Added when the menu is closed.</li>
-                    <li>The <code>aria-expanded</code> attribute is set to false when the menu is closed.</li>
-                  </ul>
-                </td>
+                <td>Indicates the menu is displayed and that activating the menu button closes the menu.</td>
               </tr>
             </tbody>
           </table>

--- a/content/patterns/toolbar/examples/toolbar.html
+++ b/content/patterns/toolbar/examples/toolbar.html
@@ -788,6 +788,17 @@ But, in a larger sense, we can not dedicate, we can not consecrate, we can not h
                   </ul>
                 </td>
               </tr>
+              <tr data-test-id="toolbar-menubutton-aria-expanded-false">
+                <td></td>
+                <th scope="row"><code>aria-expanded=&quot;false&quot;</code></th>
+                <td><code>button</code></td>
+                <td>
+                  <ul>
+                    <li>Added when the menu is closed.</li>
+                    <li>The <code>aria-expanded</code> attribute is set to false when the menu is closed.</li>
+                  </ul>
+                </td>
+              </tr>
             </tbody>
           </table>
         </section>

--- a/content/patterns/toolbar/examples/toolbar.html
+++ b/content/patterns/toolbar/examples/toolbar.html
@@ -778,7 +778,7 @@ But, in a larger sense, we can not dedicate, we can not consecrate, we can not h
                 <td><code>button</code></td>
                 <td>Indicates the menu is not displayed and that activating the menu button opens the menu.</td>
               </tr>
-              <tr data-test-id="toolbar-menubutton-aria-expanded">
+              <tr data-test-id="toolbar-menubutton-aria-expanded-true">
                 <td></td>
                 <th scope="row"><code>aria-expanded="true"</code></th>
                 <td><code>button</code></td>

--- a/test/tests/menu-button_actions-active-descendant.js
+++ b/test/tests/menu-button_actions-active-descendant.js
@@ -85,7 +85,7 @@ ariaTest(
       return document.querySelector(selector).hasAttribute('aria-expanded');
     }, ex.menubuttonSelector);
 
-    t.false(
+    t.true(
       hasAttribute,
       'The menuitem should have the "aria-expanded is false" attribute if the popup is closed'
     );

--- a/test/tests/menu-button_actions-active-descendant.js
+++ b/test/tests/menu-button_actions-active-descendant.js
@@ -87,7 +87,7 @@ ariaTest(
 
     t.false(
       hasAttribute,
-      'The menuitem should not have the "aria-expanded" attribute if the popup is closed'
+      'The menuitem should have the "aria-expanded is false" attribute if the popup is closed'
     );
 
     t.false(

--- a/test/tests/menu-button_actions.js
+++ b/test/tests/menu-button_actions.js
@@ -69,7 +69,7 @@ ariaTest(
       return document.querySelector(selector).hasAttribute('aria-expanded');
     }, ex.menubuttonSelector);
 
-    t.false(
+    t.true(
       hasAttribute,
       'The menuitem should have the "aria-expanded is false" attribute if the popup is closed'
     );

--- a/test/tests/menu-button_actions.js
+++ b/test/tests/menu-button_actions.js
@@ -71,7 +71,7 @@ ariaTest(
 
     t.false(
       hasAttribute,
-      'The menuitem should not have the "aria-expanded" attribute if the popup is closed'
+      'The menuitem should have the "aria-expanded is false" attribute if the popup is closed'
     );
 
     t.false(

--- a/test/tests/menu-button_links.js
+++ b/test/tests/menu-button_links.js
@@ -98,7 +98,7 @@ ariaTest(
       return document.querySelector(selector).hasAttribute('aria-expanded');
     }, ex.menubuttonSelector);
 
-    t.false(
+    t.true(
       hasAttribute,
       'The menuitem should have the "aria-expanded is false" attribute if the popup is closed'
     );

--- a/test/tests/menu-button_links.js
+++ b/test/tests/menu-button_links.js
@@ -100,7 +100,7 @@ ariaTest(
 
     t.false(
       hasAttribute,
-      'The menuitem should not have the "aria-expanded" attribute if the popup is closed'
+      'The menuitem should have the "aria-expanded is false" attribute if the popup is closed'
     );
 
     t.false(

--- a/test/tests/toolbar_toolbar.js
+++ b/test/tests/toolbar_toolbar.js
@@ -311,7 +311,7 @@ ariaTest(
       t,
       ex.fontFamilyButtonSelector,
       'aria-expanded',
-      'true'
+      'false'
     );
   }
 );

--- a/test/tests/toolbar_toolbar.js
+++ b/test/tests/toolbar_toolbar.js
@@ -3,7 +3,6 @@ const { By, Key } = require('selenium-webdriver');
 const assertAriaControls = require('../util/assertAriaControls');
 const assertAriaLabelExists = require('../util/assertAriaLabelExists');
 const assertAriaRoles = require('../util/assertAriaRoles');
-const assertAttributeDNE = require('../util/assertAttributeDNE');
 const assertAttributeValues = require('../util/assertAttributeValues');
 const assertRovingTabindex = require('../util/assertRovingTabindex');
 const assertHasFocus = require('../util/assertHasFocus');
@@ -297,12 +296,24 @@ ariaTest(
 );
 
 ariaTest(
-  'Font family button has aria-expanded',
+  'Font family button has aria-expanded=false',
   exampleFile,
-  'toolbar-menubutton-aria-expanded',
+  'toolbar-menubutton-aria-expanded-false',
   async (t) => {
-    await assertAttributeDNE(t, ex.fontFamilyButtonSelector, 'aria-expanded');
+    await assertAttributeValues(
+      t,
+      ex.fontFamilyButtonSelector,
+      'aria-expanded',
+      'false'
+    );
+  }
+);
 
+ariaTest(
+  'Font family button has aria-expanded=true',
+  exampleFile,
+  'toolbar-menubutton-aria-expanded-true',
+  async (t) => {
     await (
       await t.context.session.findElement(By.css(ex.fontFamilyButtonSelector))
     ).click();
@@ -311,7 +322,7 @@ ariaTest(
       t,
       ex.fontFamilyButtonSelector,
       'aria-expanded',
-      'false'
+      'true'
     );
   }
 );


### PR DESCRIPTION
Closes #697 and #2834 with the following changes:
* Revise menu button pattern to specify that aria-expanded is set to false when the menu is not displayed.
* Revise JS and documentation for 3 menu button examples and the toolbar example to set aria-expanded false when their menus are closed.
* Adjusts corresponding regression tests to ensure the state of expanded is true when the menus are open and false when the menus are closed.

#### Preview links

* [Menu Button Pattern](https://deploy-preview-272--aria-practices.netlify.app/aria/apg/patterns/menu-button/)
* [Actions Menu Button Example Using aria-activedescendant](https://deploy-preview-272--aria-practices.netlify.app/aria/apg/patterns/menu-button/examples/menu-button-actions-active-descendant/)
* [Actions Menu Button Example Using <code>element.focus()</code>](https://deploy-preview-272--aria-practices.netlify.app/aria/apg/patterns/menu-button/examples/menu-button-actions/)
* [Navigation Menu Button Example](https://deploy-preview-272--aria-practices.netlify.app/aria/apg/patterns/menu-button/examples/menu-button-links/)
* [Toolbar Example](https://deploy-preview-272--aria-practices.netlify.app/aria/apg/patterns/toolbar/examples/toolbar/)

### Review checklist

*Reviewers:* To learn what needs to be covered by each review, Follow the link for the type of review to which you are assigned.

* [x] [Editorial review](https://github.com/w3c/aria-practices/wiki/Pull-Request-Review-Process#editorial_review) by @mcking65
* [x] [Functional review](https://github.com/w3c/aria-practices/wiki/Pull-Request-Review-Process#functional_review) by @mcking65
* N/A: [Visual design review](https://github.com/w3c/aria-practices/wiki/Pull-Request-Review-Process#design_review) by reviewer_id
* N/A: [Accessibility review](https://github.com/w3c/aria-practices/wiki/Pull-Request-Review-Process#accessibility_review) by reviewer_id
* [x] [Code review](https://github.com/w3c/aria-practices/wiki/Pull-Request-Review-Process#code_review) by @jongund 
* [x] [Test review](https://github.com/w3c/aria-practices/wiki/Pull-Request-Review-Process#test_review) by @a11ydoer

___
[WAI Preview Link](https://deploy-preview-272--aria-practices.netlify.app/ARIA/apg) _(Last built on Mon, 11 Dec 2023 15:40:06 GMT)._