### PR TITLE
Modal Dialog Example: Increase z-index of dialog backdrop

### DIFF
--- a/content/patterns/dialog-modal/examples/css/dialog.css
+++ b/content/patterns/dialog-modal/examples/css/dialog.css
@@ -113,6 +113,7 @@
   right: 0;
   bottom: 0;
   left: 0;
+  z-index: 1;
 }
 
 @media screen and (min-width: 640px) {


### PR DESCRIPTION
Relates to #2842.

Initially considered a bottom-padding adjustment, but that would create visual inconsistencies.
This solution seemed best, since, in my opinion, the user would not need to use the "Back to Top" link when the modal is open.

### Preview link

[Modal Dialog Example in compare branch](https://deploy-preview-274--aria-practices.netlify.app/aria/apg/patterns/dialog-modal/examples/dialog/)

### Review checklist

*Reviewers:* To learn what needs to be covered by each review, Follow the link for the type of review to which you are assigned.

* N/A: [Editorial review](https://github.com/w3c/aria-practices/wiki/Pull-Request-Review-Process#editorial_review) by reviewer_id
* [x] [Functional review](https://github.com/w3c/aria-practices/wiki/Pull-Request-Review-Process#functional_review) by jongund
* [ ] [Visual design review](https://github.com/w3c/aria-practices/wiki/Pull-Request-Review-Process#design_review) by reviewer_id
* N/A: [Accessibility review](https://github.com/w3c/aria-practices/wiki/Pull-Request-Review-Process#accessibility_review) by reviewer_id
* [ ] [Code review](https://github.com/w3c/aria-practices/wiki/Pull-Request-Review-Process#code_review) by reviewer_id (
* N/A: [Test review](https://github.com/w3c/aria-practices/wiki/Pull-Request-Review-Process#test_review) by reviewer_id

___
[WAI Preview Link](https://deploy-preview-274--aria-practices.netlify.app/ARIA/apg) _(Last built on Thu, 26 Oct 2023 07:26:25 GMT)._