### PR TITLE
suggestion: small update to WAI-ARIA Roles, States, and Properties

### DIFF
--- a/content/patterns/menu-button/menu-button-pattern.html
+++ b/content/patterns/menu-button/menu-button-pattern.html
@@ -53,7 +53,7 @@
         <h2>WAI-ARIA Roles, States, and Properties</h2>
         <ul>
           <li>The element that opens the menu has role <a href="#button" class="role-reference">button</a>.</li>
-          <li>The element with role <code>button</code> has <a href="#aria-haspopup" class="property-reference">aria-haspopup</a> set to either <code>menu</code> or <code>true</code>.</li>
+          <li>The element with role <code>button</code> has <a href="#aria-haspopup" class="property-reference">aria-haspopup</a> set to either <code>menu</code> or <code>true</code> (<code>true</code> is an alias for <code>menu</code>)</code>.</li>
           <li>
             When the menu is displayed, the element with role <code>button</code> has <a href="#aria-expanded" class="state-reference">aria-expanded</a> set to <code>true</code>.
             When the menu is hidden, it is recommended that <code>aria-expanded</code> is not present.


### PR DESCRIPTION
I added a small update suggestion for the second line under the heading, "WAI-ARIA Roles, States, and Properties". The line states that the author can use `menu` or `true`, but it might be good to highlight that that is because `true` is an alias for `menu`.

I would like to know your thoughts.
___
[WAI Preview Link](https://deploy-preview-274--aria-practices.netlify.app/ARIA/apg) _(Last built on Mon, 13 Nov 2023 16:38:50 GMT)._