### PR TITLE
Infrastructure: Change source of h2 for 'Read This First" section header on example pages

### DIFF
--- a/content/shared/templates/example-usage-warning.html
+++ b/content/shared/templates/example-usage-warning.html
@@ -3,6 +3,7 @@
   <meta charset="utf-8">
   <title>Support Notice (Template)</title>
   <body>
+    <h2 id="support-notice-header">Read This First</h2>
     <details id="support-notice">
       <summary>
         The code in this example is not intended for production environments.


### PR DESCRIPTION
See #2838 

Should be merged before https://github.com/w3c/wai-aria-practices/pull/278.

This pull request replaces all "Read This First" h2 headers that were implemented by the build scripts on the example pages for the APG. The build script headers were replaced with "Read This First" h2 headers authored in `example-usage-warning.html`.
___
[WAI Preview Link](https://deploy-preview-279--aria-practices.netlify.app/ARIA/apg) _(Last built on Wed, 22 Nov 2023 20:17:39 GMT)._