### PR TITLE
Accessible Names Practice: Recommend association via 'for' attribute when using 'label' element

### DIFF
--- a/content/practices/names-and-descriptions/names-and-descriptions-practice.html
+++ b/content/practices/names-and-descriptions/names-and-descriptions-practice.html
@@ -307,8 +307,8 @@
             However, unless the text is programmatically associated with the checkbox, assistive technology users will experience a checkbox without a label.
           </p>
           <p>
-            HTML provides two syntaxes for associating a label with a form control.
-            The syntax with the broadest browser and assistive technology support is to set the <code>for</code> attribute on the <code>label</code> element to the <code>id</code> of the control.
+            HTML provides two ways of associating a label with a form control.
+            The one that provides the broadest browser and assistive technology support is to set the <code>for</code> attribute on the <code>label</code> element to the <code>id</code> of the control.
             This way of associating the label with the control is often called explicit association.
           </p>
 
@@ -316,7 +316,7 @@
 &lt;label for="subscribe_checkbox"&gt;subscribe to our newsletter&lt;/label&gt;</code></pre>
 
           <p>
-            The other syntax, which is known as implicit association,  is to wrap the checkbox and the labeling text in a <code>label</code> element.
+            The other way, which is known as implicit association,  is to wrap the checkbox and the labeling text in a <code>label</code> element.
             Some combinations of assistive technologies and browsers fail to treat the element as having an accessible name that is specified by using implicit association.
           </p>
 

--- a/content/practices/names-and-descriptions/names-and-descriptions-practice.html
+++ b/content/practices/names-and-descriptions/names-and-descriptions-practice.html
@@ -301,25 +301,28 @@
         <section id="naming_with_labels">
           <h3>Naming Form Controls with the Label Element</h3>
           <p>
-            The HTML <code>label</code> element enables authors to identify content that serves as a label and associate it with a form control.
+             The HTML <code>label</code> element enables authors to identify content that serves as a label and associate it with a form control.
             When a <code>label</code> element is associated with a form control, browsers calculate an accessible name for the form control from the <code>label</code> content.
           </p>
           <p>
             For example, text displayed adjacent to a checkbox may be visually associated with the checkbox, so it is understood as the checkbox label by users who can perceive that visual association.
             However, unless the text is programmatically associated with the checkbox, assistive technology users will experience a checkbox without a label.
-            Wrapping the checkbox and the labeling text in a <code>label</code> element as follows gives the checkbox an accessible name.
+            HTML provides two syntaxes for specifying this relationship.
+            The syntax with the broadest browser and assistive technology support is to set the <code>for</code> attribute on the <code>label</code> element to the <code>ID</code></code> of the control.
           </p>
-          <pre><code>&lt;label&gt;
-  &lt;input type="checkbox" name="subscribe"&gt;
-  subscribe to our newsletter
-&lt;/label&gt;</code></pre>
-          <p>
-            A form control can also be associated with a label by using the <code>for</code> attribute on the <code>label</code> element.
-            This allows the label and the form control to be siblings or have different parents in the DOM, but requires adding an <code>id</code> attribute to the form control, which can be error-prone.
-            When possible, use the above encapsulation technique for association instead of the following <code>for</code> attribute technique.
-          </p>
+
           <pre><code>&lt;input type="checkbox" name="subscribe" id="subscribe_checkbox"&gt;
 &lt;label for="subscribe_checkbox"&gt;subscribe to our newsletter&lt;/label&gt;</code></pre>
+
+          <p>
+            The other syntax, which doesn't return the correct accessible name in as many combinations of assistive technologies and browsers, is to wrap the checkbox and the labeling text in a <code>label</code> element.
+          </p>
+
+<pre><code>&lt;label&gt;
+&lt;input type="checkbox" name="subscribe"&gt;
+subscribe to our newsletter
+&lt;/label&gt;</code></pre>
+
           <p>
             Using the <code>label</code> element is an effective technique for satisfying <a href="#naming_rule_visible_text">Rule 2: Prefer Visible Text</a>.
             It also satisfies <a href="#naming_rule_native_techniques">Rule 3: Prefer Native Techniques</a>.

--- a/content/practices/names-and-descriptions/names-and-descriptions-practice.html
+++ b/content/practices/names-and-descriptions/names-and-descriptions-practice.html
@@ -308,7 +308,7 @@
             For example, text displayed adjacent to a checkbox may be visually associated with the checkbox, so it is understood as the checkbox label by users who can perceive that visual association.
             However, unless the text is programmatically associated with the checkbox, assistive technology users will experience a checkbox without a label.
             HTML provides two syntaxes for specifying this relationship.
-            The syntax with the broadest browser and assistive technology support is to set the <code>for</code> attribute on the <code>label</code> element to the <code>ID</code> of the control.
+            The syntax with the broadest browser and assistive technology support is to set the <code>for</code> attribute on the <code>label</code> element to the <code>id</code> of the control.
           </p>
 
           <pre><code>&lt;input type="checkbox" name="subscribe" id="subscribe_checkbox"&gt;

--- a/content/practices/names-and-descriptions/names-and-descriptions-practice.html
+++ b/content/practices/names-and-descriptions/names-and-descriptions-practice.html
@@ -301,7 +301,7 @@
         <section id="naming_with_labels">
           <h3>Naming Form Controls with the Label Element</h3>
           <p>
-             The HTML <code>label</code> element enables authors to identify content that serves as a label and associate it with a form control.
+            The HTML <code>label</code> element enables authors to identify content that serves as a label and associate it with a form control.
             When a <code>label</code> element is associated with a form control, browsers calculate an accessible name for the form control from the <code>label</code> content.
             For example, text displayed adjacent to a checkbox may be visually associated with the checkbox, so it is understood as the checkbox label by users who can perceive that visual association.
             However, unless the text is programmatically associated with the checkbox, assistive technology users will experience a checkbox without a label.
@@ -309,14 +309,15 @@
           <p>
             HTML provides two syntaxes for associating a label with a form control.
             The syntax with the broadest browser and assistive technology support is to set the <code>for</code> attribute on the <code>label</code> element to the <code>id</code> of the control.
+            This way of associating the label with the control is often called explicit association.
           </p>
 
           <pre><code>&lt;input type="checkbox" name="subscribe" id="subscribe_checkbox"&gt;
 &lt;label for="subscribe_checkbox"&gt;subscribe to our newsletter&lt;/label&gt;</code></pre>
 
           <p>
-            The other syntax is to wrap the checkbox and the labeling text in a <code>label</code> element.
-            However, some combinations of assistive technologies and browsers fail to treat the element as having the accessible name that is specified by using this syntax.
+            The other syntax, which is known as implicit association,  is to wrap the checkbox and the labeling text in a <code>label</code> element.
+            Some combinations of assistive technologies and browsers fail to treat the element as having an accessible name that is specified by using implicit association.
           </p>
 
 <pre><code>&lt;label&gt;

--- a/content/practices/names-and-descriptions/names-and-descriptions-practice.html
+++ b/content/practices/names-and-descriptions/names-and-descriptions-practice.html
@@ -308,7 +308,7 @@
             For example, text displayed adjacent to a checkbox may be visually associated with the checkbox, so it is understood as the checkbox label by users who can perceive that visual association.
             However, unless the text is programmatically associated with the checkbox, assistive technology users will experience a checkbox without a label.
             HTML provides two syntaxes for specifying this relationship.
-            The syntax with the broadest browser and assistive technology support is to set the <code>for</code> attribute on the <code>label</code> element to the <code>ID</code></code> of the control.
+            The syntax with the broadest browser and assistive technology support is to set the <code>for</code> attribute on the <code>label</code> element to the <code>ID</code> of the control.
           </p>
 
           <pre><code>&lt;input type="checkbox" name="subscribe" id="subscribe_checkbox"&gt;

--- a/content/practices/names-and-descriptions/names-and-descriptions-practice.html
+++ b/content/practices/names-and-descriptions/names-and-descriptions-practice.html
@@ -303,11 +303,11 @@
           <p>
              The HTML <code>label</code> element enables authors to identify content that serves as a label and associate it with a form control.
             When a <code>label</code> element is associated with a form control, browsers calculate an accessible name for the form control from the <code>label</code> content.
-          </p>
-          <p>
             For example, text displayed adjacent to a checkbox may be visually associated with the checkbox, so it is understood as the checkbox label by users who can perceive that visual association.
             However, unless the text is programmatically associated with the checkbox, assistive technology users will experience a checkbox without a label.
-            HTML provides two syntaxes for specifying this relationship.
+          </p>
+          <p>
+            HTML provides two syntaxes for associating a label with a form control.
             The syntax with the broadest browser and assistive technology support is to set the <code>for</code> attribute on the <code>label</code> element to the <code>id</code> of the control.
           </p>
 

--- a/content/practices/names-and-descriptions/names-and-descriptions-practice.html
+++ b/content/practices/names-and-descriptions/names-and-descriptions-practice.html
@@ -315,7 +315,8 @@
 &lt;label for="subscribe_checkbox"&gt;subscribe to our newsletter&lt;/label&gt;</code></pre>
 
           <p>
-            The other syntax, which doesn't return the correct accessible name in as many combinations of assistive technologies and browsers, is to wrap the checkbox and the labeling text in a <code>label</code> element.
+            The other syntax is to wrap the checkbox and the labeling text in a <code>label</code> element.
+            However, some combinations of assistive technologies and browsers fail to treat the element as having the accessible name that is specified by using this syntax.
           </p>
 
 <pre><code>&lt;label&gt;

--- a/content/practices/names-and-descriptions/names-and-descriptions-practice.html
+++ b/content/practices/names-and-descriptions/names-and-descriptions-practice.html
@@ -197,7 +197,7 @@
   &lt;/li&gt;
 &lt;/ul&gt;</code></pre>
           <div class="warning">
-            <h3>Warning</h3>
+            <h4>Warning</h4>
             <p>If an element with one of the above roles that supports naming from child content is named by using <code>aria-label</code> or <code>aria-labelledby</code>, content contained in the element and its descendants is hidden from assistive technology users unless the descendant content is referenced by <code>aria-labelledby</code>.
             It is strongly recommended to avoid using either of these attributes to override content of one of the above elements except in rare circumstances where hiding content from assistive technology users is beneficial.
             In addition, in situations where visible content is hidden from assistive technology users by use of one of these attributes, thorough testing with assistive technologies is particularly important.</p>


### PR DESCRIPTION
Inspired by #2871, this is an alternative proposal for resolving #2870.

@patrickhlauke, I originally was looking at writing this as a suggestion in #2871, but it became too complicated. I appreciate the time you took to make a PR; I do not intend to be dismissive of your work on the issue.

In addition to reducing word count, here are the notable editorial differences and my reasons for proposing them. Feedback is welcome on all of them.

1. It describes the preferred syntax first. It seems beneficial to present the most valuable and important information first and enable people to skip over information they may not use.
2. It uses more concrete language for explaining the reason for the preference. In particular, help people understand that it is due to specific AT/Browser combinations not calculating the correct name.
3. It emphasizes the preference by mentioning it two times.
#### Preview

[Preview of the proposed changes to the names and description practice](https://deploy-preview-283--aria-practices.netlify.app/aria/apg/practices/names-and-descriptions/#namingtechniques)

___
[WAI Preview Link](https://deploy-preview-283--aria-practices.netlify.app/ARIA/apg) _(Last built on Sun, 17 Dec 2023 08:02:10 GMT)._