### PR TITLE
Infrastructure: Fix inconsistencies in lists of CSS and JS files on 3 example pages (Related to wai-aria-practices issue 255)

### DIFF
--- a/content/patterns/feed/examples/feed.html
+++ b/content/patterns/feed/examples/feed.html
@@ -192,8 +192,8 @@
       <section>
         <h2>JavaScript and CSS Source Code</h2>
         <p>The following Javascript and CSS is used by the feed-display.html page:</p>
-        <ul>
-          <li><a href="css/feedDisplay.css" type="tex/css">feedDisplay.css</a></li>
+        <ul id="css_js_files">
+          <li>CSS: <a href="css/feedDisplay.css" type="tex/css">feedDisplay.css</a></li>
           <li>Javascript: <a href="js/feed.js" type="text/javascript">feed.js</a>, <a href="js/feedDisplay.js" type="text/javascript">feedDisplay.js</a>, <a href="js/main.js" type="text/javascript">main.js</a>, <a href="../../../shared/js/utils.js">utils.js</a></li>
         </ul>
       </section>

--- a/content/patterns/grid/examples/advanced-data-grid.html
+++ b/content/patterns/grid/examples/advanced-data-grid.html
@@ -129,7 +129,7 @@
       <section>
         <h2>JavaScript and CSS Source Code</h2>
         <!--  After the js and css files are named with the name of this example, change the href and text of the following 2 links to refer to the appropriate js and css files.  -->
-        <ul>
+        <ul id="css_js_files">
           <li>
             CSS:
             <!--a href="css/example_name.css" type="tex/css">example_name.css</a-->

--- a/content/patterns/menu-button/examples/menu-button-links.html
+++ b/content/patterns/menu-button/examples/menu-button-links.html
@@ -350,7 +350,7 @@
       <section>
         <h2>JavaScript and CSS Source Code</h2>
 
-        <ul id="cssJsFiles">
+        <ul id="css_js_files">
           <li>CSS: <a href="css/menu-button-links.css" type="text/css">menu-button-links.css</a></li>
           <li>Javascript: <a href="js/menu-button-links.js" type="text/javascript">menu-button-links.js</a></li>
         </ul>


### PR DESCRIPTION
This is a minor enhancement related to the PR https://github.com/w3c/wai-aria-practices/pull/281 over in wai-aria-practices, which fixes issue https://github.com/w3c/wai-aria-practices/issues/255. 

That PR addresses inaccuracies with the last modified date listed in the footer of example pages. However I noticed a few examples that did not follow the common convention CSS and JS files are listed. This PR fixes the inconsistencies.

This PR can be reviewed independently from the other PR, and can be merged when ready, before or after 281 is reviewed and merged.
___
[WAI Preview Link](https://deploy-preview-285--aria-practices.netlify.app/ARIA/apg) _(Last built on Tue, 12 Dec 2023 18:23:15 GMT)._