### PR TITLE
Sortable Table Example: Improve CSS so it works when all columns are sortable

### DIFF
--- a/content/patterns/table/examples/css/sortable-table.css
+++ b/content/patterns/table/examples/css/sortable-table.css
@@ -24,7 +24,6 @@ table.sortable th:nth-child(5) {
 }
 
 table.sortable th button {
-  position: absolute;
   padding: 4px;
   margin: 1px;
   font-size: 100%;


### PR DESCRIPTION
When all the columns are sortable, none of the header buttons create space in the layout, causing the th row's height to collapse. Fixes #2904.
___
[WAI Preview Link](https://deploy-preview-294--aria-practices.netlify.app/ARIA/apg) _(Last built on Thu, 25 Jan 2024 23:33:33 GMT)._