### PR TITLE
Landmark Regions Practice: Update `search` landmark guidance to include new HTML `search` element

### DIFF
--- a/content/practices/landmark-regions/landmark-regions-practice.html
+++ b/content/practices/landmark-regions/landmark-regions-practice.html
@@ -82,6 +82,12 @@
 
               <td><code>region</code> when it has an accessible name using <code>aria-labelledby</code> or <code>aria-label</code></td>
             </tr>
+
+            <tr>
+              <td><code>search</code></td>
+
+              <td><code>search</code></td>
+            </tr>
           </tbody>
         </table>
       </section>

--- a/content/practices/landmark-regions/landmark-regions-practice.html
+++ b/content/practices/landmark-regions/landmark-regions-practice.html
@@ -414,11 +414,12 @@
 
           <section>
             <h4>HTML Technique</h4>
-            <p>There is no HTML element that defines a <code>search</code> landmark.</p>
+
+            <p>Use the HTML <code>search</code> element to define a <code>search</code> landmark.</p>
 
             <h4>ARIA Technique</h4>
 
-            <p>The <code>role=&quot;search&quot;</code> attribute defines a <code>search</code> landmark.</p>
+            <p>If the HTML <code>search</code> element technique is not being used, use a <code>role=&quot;search&quot;</code> attribute to define a <code>search</code> landmark.</p>
           </section>
 
           <section>


### PR DESCRIPTION
The HTML spec now support the `<search>` element. It maps to an implicit `role=search`.

Fix: https://github.com/w3c/aria-practices/issues/2652
___
[WAI Preview Link](https://deploy-preview-349--aria-practices.netlify.app/ARIA/apg) _(Last built on Wed, 04 Sep 2024 19:04:38 GMT)._