### PR TITLE
Infrastructure: Temporarily ignore specific link causing `link-checker` fail

### DIFF
--- a/.link-checker.js
+++ b/.link-checker.js
@@ -25,5 +25,6 @@ module.exports = {
   ignoreHashesOnExternalPagesMatchingRegex: [
     // Some hash links are resolved with JS and are therefore difficult to check algorithmically
     /^https:\/\/html\.spec\.whatwg\.org\/multipage\//,
+    'https://github.com/w3c/aria-practices#code-conformance', // TODO: Remove when #2907 is resolved
   ],
 };

--- a/scripts/link-checker.js
+++ b/scripts/link-checker.js
@@ -302,7 +302,7 @@ async function checkLinks() {
         ) {
           consoleError(
             `Found broken external link on ${htmlPath}:${lineNumber}:${columnNumber}, ` +
-              'hash not found on page'
+              `hash "#${hash}" not found on page`
           );
         }
       }


### PR DESCRIPTION
This PR will (temporarily) ignore the offending link when `npm run link-checker` is ran.

The failing link is https://github.com/w3c/aria-practices#code-conformance and this should be removed once #2907 is resolved.
___
[WAI Preview Link](https://deploy-preview-296--aria-practices.netlify.app/ARIA/apg) _(Last built on Tue, 06 Feb 2024 21:12:57 GMT)._