### PR TITLE
Infrastructure: fix link checker by spoofing user-agent (issue 2907)

### DIFF
--- a/scripts/link-checker.js
+++ b/scripts/link-checker.js
@@ -135,7 +135,14 @@ async function checkLinks() {
 
         const getPageData = async () => {
           try {
-            const response = await fetch(externalPageLink);
+            const response = await fetch(externalPageLink, {
+              headers: {
+                // Spoof a normal looking User-Agent to keep the servers happy
+                // See https://github.com/JustinBeckwith/linkinator/blob/main/src/index.ts
+                'User-Agent':
+                  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.117 Safari/537.36',
+              },
+            });
             const text = await response.text();
             const html = HTMLParser.parse(text);
             const ids = html


### PR DESCRIPTION
For more information see https://github.com/w3c/aria-practices/issues/2907#issuecomment-1942226078.

Fixes the link checker in cases where servers behave strangely in the absence of a user-agent header.

Shout out to the Linkinator package where I found the fix for this issue.
___
[WAI Preview Link](https://deploy-preview-298--aria-practices.netlify.app/ARIA/apg) _(Last built on Tue, 13 Feb 2024 22:05:36 GMT)._