### PR TITLE
Tabs Example: Update cursor style to default

### DIFF
--- a/content/patterns/tabs/examples/css/tabs.css
+++ b/content/patterns/tabs/examples/css/tabs.css
@@ -25,7 +25,7 @@
   max-width: 22%;
   overflow: hidden;
   text-align: left;
-  cursor: pointer;
+  cursor: default;
 }
 
 [role="tab"][aria-selected="true"] {


### PR DESCRIPTION
Update cursor style to default for tab elements.

Changed the cursor style from 'pointer' to 'default' for tabs to align with the [CSS2 specification](https://www.w3.org/TR/CSS2/ui.html#propdef-cursor), as tabs are not links and should not indicate such with a pointer cursor. 

Fixes #2951 

___
[WAI Preview Link](https://deploy-preview-302--aria-practices.netlify.app/ARIA/apg) _(Last built on Fri, 01 Mar 2024 17:10:48 GMT)._