### PR TITLE
Radio Group Pattern and Examples: Remove Enter key as a way of checking a radio

### DIFF
--- a/content/patterns/radio/examples/js/radio-activedescendant.js
+++ b/content/patterns/radio/examples/js/radio-activedescendant.js
@@ -120,7 +120,6 @@ class RadioGroupActiveDescendant {
     var currentItem = this.getCurrentRadioButton();
     switch (event.key) {
       case ' ':
-      case 'Enter':
         this.setChecked(currentItem);
         flag = true;
         break;

--- a/content/patterns/radio/examples/js/radio-rating.js
+++ b/content/patterns/radio/examples/js/radio-rating.js
@@ -94,7 +94,6 @@ class RatingRadioGroup {
 
     switch (event.key) {
       case ' ':
-      case 'Enter':
         this.setChecked(tgt);
         flag = true;
         break;

--- a/content/patterns/radio/examples/js/radio.js
+++ b/content/patterns/radio/examples/js/radio.js
@@ -82,7 +82,6 @@ class RadioGroup {
 
     switch (event.key) {
       case ' ':
-      case 'Enter':
         this.setChecked(tgt);
         flag = true;
         break;


### PR DESCRIPTION
* The documentation does not include information about the enter key, it was an undocumented behavior
* The regression tests for radio group examples do not include any tests for the enter key
___
[WAI Preview Link](https://deploy-preview-305--aria-practices.netlify.app/ARIA/apg) _(Last built on Sun, 07 Apr 2024 17:43:37 GMT)._