### PR TITLE
Landmark Example Pages: Remove link to FAE and update link to ainspector

### DIFF
--- a/content/patterns/landmarks/examples/resources.html
+++ b/content/patterns/landmarks/examples/resources.html
@@ -68,8 +68,7 @@
                             <li><a href="http://matatk.agrip.org.uk/landmarks/">Landmarks Browser Extension</a></li>
                             <li><a href="https://accessibility-bookmarklets.org/">Accessibility Bookmarklets: Landmark Bookmarklet</a></li>
                             <li><a href="http://whatsock.com/training/matrices/visual-aria.htm">The Visual ARIA Bookmarklet</a></li>
-                            <li><a href="https://addons.mozilla.org/en-US/firefox/addon/ainspector-wcag/">AInspector for Firefox</a> (Landmark Rule Category)</li>
-                            <li><a href="https://fae.disability.illinois.edu/">Functional Accessibility Evaluator 2.2</a> (Landmark Rule Category)</li>
+                            <li><a href="https://ainspector.disability.illinois.edu">AInspector for Firefox</a> (Landmark Rule Category)</li>
                           </ul>
 
                         </section>


### PR DESCRIPTION
Update the list of landmark resources to remove FAE and update link to AInspector for Firefox
___
[WAI Preview Link](https://deploy-preview-306--aria-practices.netlify.app/ARIA/apg) _(Last built on Sun, 07 Apr 2024 17:40:56 GMT)._