### PR TITLE
Regression Tests: Enable `disclosure_navigation.js` test to scroll to element

### DIFF
--- a/test/tests/disclosure_navigation.js
+++ b/test/tests/disclosure_navigation.js
@@ -73,6 +73,10 @@ ariaTest(
 
       for (let l = 0; l < links.length; l++) {
         await buttons[b].click();
+        await t.context.session.executeScript(function () {
+          const link = arguments[0];
+          link.scrollIntoView({ block: 'center' });
+        }, links[l]);
         await links[l].click();
 
         t.is(


### PR DESCRIPTION
Fixes #2996.

Update `../tests/disclosure_navigation.js test > "aria-current" attribute on links` to scroll to link before click event.
___
[WAI Preview Link](https://deploy-preview-316--aria-practices.netlify.app/ARIA/apg) _(Last built on Thu, 25 Apr 2024 19:28:54 GMT)._