### PR TITLE
Infrastructure: Use Stylelint GitHub Action matcher

### DIFF
--- a/.github/workflows/lint-css.yml
+++ b/.github/workflows/lint-css.yml
@@ -33,10 +33,11 @@ jobs:
         with:
           cache: npm
 
-      - uses: xt0rted/stylelint-problem-matcher@v1
-
       - name: Install npm dependencies
         run: npm ci
 
       - name: Stylelint
-        run: npm run lint:css
+        run: npx stylelint "**/*.css" -f github
+
+      - name: Prettier
+        run: npx prettier --check "**/*.css"


### PR DESCRIPTION
Saw on a different repo that they've added their own built-in formatter. Could't just add `npm run lint:css -f github` because it confused Prettier, so just split the tasks in the CI config.