### PR TITLE
Ratings Slider: Use buttontext instead of linktext system color in high contrast mode

### DIFF
--- a/content/patterns/slider/examples/css/slider-rating.css
+++ b/content/patterns/slider/examples/css/slider-rating.css
@@ -67,23 +67,23 @@
 
 @media (forced-colors: active) {
   .rating-slider svg .focus-ring {
-    fill: linktext;
+    fill: buttontext;
   }
 
   .rating-slider svg .target {
-    stroke: linktext;
+    stroke: buttontext;
   }
 
   .rating-slider svg .label {
-    fill: linktext;
+    fill: buttontext;
   }
 
   .rating-slider svg .description {
-    fill: linktext;
+    fill: buttontext;
   }
 
   .rating-slider svg .current .target {
-    fill: linktext;
+    fill: buttontext;
   }
 
   .rating-slider svg .current .label {

--- a/cspell.json
+++ b/cspell.json
@@ -25,6 +25,7 @@
     "Botr",
     "Brinza",
     "Bucketwheat",
+    "buttontext",
     "camelcase",
     "canvastext",
     "Capitan",


### PR DESCRIPTION
I think the use of `buttontext` system color is a better choice than `linktext` for styling the slider when in Windows 10/11 high contrast modes.   This change makes no difference on high contrast on macOS.

[Preview of updated rating slider](https://deploy-preview-325--aria-practices.netlify.app/aria/apg/patterns/slider/examples/slider-rating/)

___
[WAI Preview Link](https://deploy-preview-325--aria-practices.netlify.app/ARIA/apg) _(Last built on Tue, 04 Jun 2024 18:26:17 GMT)._