### PR TITLE
Infrastructure: Exclude `skipto.js` in `coverage-report.js` and report accurate values in Coverage and Quality Reports

### DIFF
--- a/content/about/coverage-and-quality/coverage-and-quality-report.html
+++ b/content/about/coverage-and-quality/coverage-and-quality-report.html
@@ -1292,7 +1292,7 @@
           </tr>
           <tr>
             <th scope="row">Uses <code>event.which</code></th>
-            <td id="example_summary_which">60</td>
+            <td id="example_summary_which">8</td>
           </tr>
           <tr>
             <th scope="row">Use Class</th>
@@ -1300,7 +1300,7 @@
           </tr>
           <tr>
             <th scope="row">Use Prototype</th>
-            <td id="example_summary_prototype">60</td>
+            <td id="example_summary_prototype">22</td>
           </tr>
           <tr>
             <th scope="row">Mouse Events</th>
@@ -1308,7 +1308,7 @@
           </tr>
           <tr>
             <th scope="row">Pointer Events</th>
-            <td id="example_summary_pointer">59</td>
+            <td id="example_summary_pointer">11</td>
           </tr>
         </tbody>
       </table>
@@ -1333,29 +1333,29 @@
         <tbody id="example_coding_practices_tbody">
           <tr>
             <td><a href="../../../content/patterns/accordion/examples/accordion.html">Accordion</a></td>
-            <td>class, prototype</td>
+            <td>class</td>
             <td></td>
-            <td>Yes</td>
+            <td></td>
             <td></td>
             <td>ex1</td>
-            <td>2</td>
             <td>1</td>
-            <td>10</td>
+            <td>1</td>
+            <td>5</td>
             <td>3</td>
-            <td>heading,aria-busy,aria-describedby,aria-errormessage,aria-hidden,aria-label,aria-required,aria-roledescription</td>
+            <td>aria-hidden,aria-required</td>
           </tr>
           <tr>
             <td><a href="../../../content/patterns/alert/examples/alert.html">Alert</a></td>
-            <td>prototype</td>
             <td></td>
-            <td>Yes</td>
+            <td></td>
+            <td></td>
             <td></td>
             <td>ex1</td>
-            <td>2</td>
             <td>1</td>
-            <td>8</td>
+            <td>1</td>
+            <td>0</td>
             <td>2</td>
-            <td>heading,aria-busy,aria-describedby,aria-errormessage,aria-expanded,aria-hidden,aria-label,aria-labelledby,aria-roledescription,aria-live,aria-atomic</td>
+            <td>aria-live,aria-atomic</td>
           </tr>
           <tr>
             <td><a href="../../../content/patterns/alertdialog/examples/alertdialog.html">Alert Dialog</a></td>
@@ -1364,167 +1364,167 @@
             <td>Yes</td>
             <td></td>
             <td>ex_alertdialog</td>
-            <td>3</td>
             <td>2</td>
-            <td>10</td>
+            <td>2</td>
+            <td>5</td>
             <td>4</td>
-            <td>heading,aria-busy,aria-errormessage,aria-expanded,aria-hidden,aria-label,aria-roledescription</td>
+            <td>aria-hidden</td>
           </tr>
           <tr>
             <td><a href="../../../content/patterns/breadcrumb/examples/breadcrumb.html">Breadcrumb</a></td>
-            <td>prototype</td>
             <td></td>
-            <td>Yes</td>
+            <td></td>
+            <td></td>
             <td></td>
             <td>ex1</td>
-            <td>2</td>
+            <td>1</td>
             <td>0</td>
-            <td>9</td>
             <td>2</td>
-            <td>heading,navigation,aria-busy,aria-describedby,aria-errormessage,aria-expanded,aria-hidden,aria-labelledby,aria-roledescription</td>
+            <td>2</td>
+            <td>navigation</td>
           </tr>
           <tr>
             <td><a href="../../../content/patterns/button/examples/button_idl.html">Button  (IDL Version)</a></td>
-            <td>prototype</td>
-            <td>Yes</td>
+            <td></td>
             <td>Yes</td>
             <td></td>
+            <td></td>
             <td>example</td>
-            <td>2</td>
             <td>1</td>
-            <td>9</td>
+            <td>1</td>
             <td>2</td>
-            <td>heading,aria-busy,aria-describedby,aria-errormessage,aria-expanded,aria-label,aria-labelledby,aria-roledescription</td>
+            <td>2</td>
+            <td></td>
           </tr>
           <tr>
             <td><a href="../../../content/patterns/button/examples/button.html">Button</a></td>
-            <td>prototype</td>
-            <td>Yes</td>
+            <td></td>
             <td>Yes</td>
             <td></td>
+            <td></td>
             <td>example</td>
+            <td>1</td>
+            <td>1</td>
             <td>2</td>
             <td>1</td>
-            <td>9</td>
-            <td>1</td>
-            <td>heading,aria-busy,aria-describedby,aria-errormessage,aria-expanded,aria-hidden,aria-label,aria-labelledby,aria-roledescription</td>
+            <td>aria-hidden</td>
           </tr>
           <tr>
             <td><a href="../../../content/patterns/carousel/examples/carousel-1-prev-next.html">Auto-Rotating Image Carousel  with Buttons for Slide Control</a></td>
             <td>prototype</td>
             <td></td>
-            <td>Yes</td>
+            <td></td>
             <td></td>
             <td>ex1</td>
-            <td>3</td>
             <td>2</td>
-            <td>10</td>
+            <td>2</td>
             <td>4</td>
-            <td>heading,aria-busy,aria-describedby,aria-errormessage,aria-expanded,aria-hidden,aria-labelledby</td>
+            <td>4</td>
+            <td></td>
           </tr>
           <tr>
             <td><a href="../../../content/patterns/carousel/examples/carousel-2-tablist.html">Auto-Rotating Image Carousel with Tabs for Slide Control</a></td>
             <td>prototype</td>
             <td></td>
-            <td>Yes</td>
+            <td></td>
             <td>Yes</td>
             <td>ex1</td>
-            <td>5</td>
             <td>4</td>
-            <td>11</td>
+            <td>4</td>
             <td>5</td>
-            <td>heading,aria-busy,aria-describedby,aria-errormessage,aria-expanded,aria-hidden,aria-labelledby</td>
+            <td>5</td>
+            <td></td>
           </tr>
           <tr>
             <td><a href="../../../content/patterns/checkbox/examples/checkbox-mixed.html">Checkbox  (Mixed-State)</a></td>
-            <td>class, prototype</td>
+            <td>class</td>
+            <td></td>
             <td></td>
             <td>Yes</td>
-            <td>Yes</td>
             <td>ex1</td>
-            <td>2</td>
             <td>1</td>
-            <td>10</td>
+            <td>1</td>
             <td>2</td>
-            <td>heading,aria-busy,aria-describedby,aria-errormessage,aria-expanded,aria-hidden,aria-label,aria-labelledby,aria-roledescription</td>
+            <td>2</td>
+            <td></td>
           </tr>
           <tr>
             <td><a href="../../../content/patterns/checkbox/examples/checkbox.html">Checkbox  (Two State)</a></td>
-            <td>class, prototype</td>
+            <td>class</td>
+            <td></td>
             <td></td>
             <td>Yes</td>
-            <td>Yes</td>
             <td>ex1</td>
-            <td>3</td>
             <td>2</td>
-            <td>9</td>
             <td>2</td>
-            <td>heading,aria-busy,aria-describedby,aria-errormessage,aria-expanded,aria-hidden,aria-label,aria-roledescription</td>
+            <td>2</td>
+            <td>2</td>
+            <td></td>
           </tr>
           <tr>
             <td><a href="../../../content/patterns/combobox/examples/combobox-autocomplete-both.html">Editable Combobox With Both List and Inline Autocomplete</a></td>
-            <td>class, prototype</td>
+            <td>class</td>
+            <td></td>
             <td></td>
             <td>Yes</td>
-            <td>Yes</td>
             <td>ex1</td>
-            <td>4</td>
             <td>3</td>
-            <td>12</td>
+            <td>3</td>
+            <td>7</td>
             <td>6</td>
-            <td>heading,aria-busy,aria-describedby,aria-errormessage,aria-hidden,aria-labelledby,aria-roledescription</td>
+            <td>aria-hidden</td>
           </tr>
           <tr>
             <td><a href="../../../content/patterns/combobox/examples/combobox-autocomplete-list.html">Editable Combobox With List Autocomplete</a></td>
-            <td>class, prototype</td>
+            <td>class</td>
+            <td></td>
             <td></td>
             <td>Yes</td>
-            <td>Yes</td>
             <td>ex1</td>
-            <td>4</td>
             <td>3</td>
-            <td>12</td>
+            <td>3</td>
+            <td>7</td>
             <td>6</td>
-            <td>heading,aria-busy,aria-describedby,aria-errormessage,aria-hidden,aria-labelledby,aria-roledescription</td>
+            <td>aria-hidden</td>
           </tr>
           <tr>
             <td><a href="../../../content/patterns/combobox/examples/combobox-autocomplete-none.html">Editable Combobox without Autocomplete</a></td>
-            <td>class, prototype</td>
+            <td>class</td>
+            <td></td>
             <td></td>
             <td>Yes</td>
+            <td>ex1</td>
+            <td>3</td>
+            <td>3</td>
+            <td>7</td>
+            <td>6</td>
+            <td>aria-hidden</td>
+          </tr>
+          <tr>
+            <td><a href="../../../content/patterns/combobox/examples/combobox-datepicker.html">Date Picker Combobox</a></td>
+            <td>class</td>
+            <td></td>
+            <td></td>
             <td>Yes</td>
             <td>ex1</td>
             <td>4</td>
             <td>3</td>
-            <td>12</td>
-            <td>6</td>
-            <td>heading,aria-busy,aria-describedby,aria-errormessage,aria-hidden,aria-labelledby,aria-roledescription</td>
-          </tr>
-          <tr>
-            <td><a href="../../../content/patterns/combobox/examples/combobox-datepicker.html">Date Picker Combobox</a></td>
-            <td>class, prototype</td>
-            <td></td>
-            <td>Yes</td>
-            <td>Yes</td>
-            <td>ex1</td>
-            <td>5</td>
-            <td>3</td>
-            <td>14</td>
+            <td>11</td>
             <td>10</td>
-            <td>gridcell,heading,aria-busy,aria-errormessage,aria-hidden,aria-roledescription</td>
+            <td>gridcell,aria-hidden</td>
           </tr>
           <tr>
             <td><a href="../../../content/patterns/combobox/examples/combobox-select-only.html">Select-Only Combobox</a></td>
             <td>prototype</td>
             <td></td>
-            <td>Yes</td>
+            <td></td>
             <td></td>
             <td>ex1</td>
+            <td>2</td>
             <td>3</td>
-            <td>3</td>
-            <td>12</td>
+            <td>6</td>
             <td>5</td>
-            <td>heading,option,aria-busy,aria-describedby,aria-errormessage,aria-haspopup,aria-hidden,aria-label,aria-roledescription</td>
+            <td>option,aria-haspopup</td>
           </tr>
           <tr>
             <td><a href="../../../content/patterns/combobox/examples/grid-combo.html">Editable Combobox with Grid Popup</a></td>
@@ -1533,24 +1533,24 @@
             <td>Yes</td>
             <td></td>
             <td>ex1</td>
-            <td>3</td>
+            <td>2</td>
             <td>4</td>
-            <td>13</td>
             <td>7</td>
-            <td>heading,row,gridcell,aria-busy,aria-describedby,aria-errormessage,aria-hidden,aria-label,aria-roledescription</td>
+            <td>7</td>
+            <td>row,gridcell</td>
           </tr>
           <tr>
             <td><a href="../../../content/patterns/dialog-modal/examples/datepicker-dialog.html">Date Picker Dialog</a></td>
-            <td>class, prototype</td>
+            <td>class</td>
             <td></td>
             <td>Yes</td>
             <td>Yes</td>
             <td>example</td>
-            <td>4</td>
+            <td>3</td>
             <td>2</td>
-            <td>11</td>
             <td>6</td>
-            <td>gridcell,heading,aria-busy,aria-errormessage,aria-expanded,aria-hidden,aria-roledescription</td>
+            <td>6</td>
+            <td>gridcell</td>
           </tr>
           <tr>
             <td><a href="../../../content/patterns/dialog-modal/examples/dialog.html">Modal Dialog</a></td>
@@ -1559,63 +1559,63 @@
             <td>Yes</td>
             <td></td>
             <td>ex1</td>
-            <td>2</td>
             <td>1</td>
-            <td>9</td>
+            <td>1</td>
             <td>3</td>
-            <td>heading,aria-busy,aria-errormessage,aria-expanded,aria-hidden,aria-label,aria-roledescription</td>
+            <td>3</td>
+            <td></td>
           </tr>
           <tr>
             <td><a href="../../../content/patterns/disclosure/examples/disclosure-faq.html">Disclosure (Show/Hide) for Answers to Frequently Asked Questions</a></td>
-            <td>class, prototype</td>
+            <td>class</td>
+            <td></td>
             <td></td>
             <td>Yes</td>
-            <td>Yes</td>
             <td>ex1</td>
-            <td>1</td>
             <td>0</td>
-            <td>9</td>
+            <td>0</td>
             <td>2</td>
-            <td>heading,aria-busy,aria-describedby,aria-errormessage,aria-hidden,aria-label,aria-labelledby,aria-roledescription</td>
+            <td>2</td>
+            <td></td>
           </tr>
           <tr>
             <td><a href="../../../content/patterns/disclosure/examples/disclosure-image-description.html">Disclosure (Show/Hide) for Image Description</a></td>
-            <td>class, prototype</td>
+            <td>class</td>
+            <td></td>
             <td></td>
             <td>Yes</td>
-            <td>Yes</td>
             <td>ex1</td>
-            <td>1</td>
             <td>0</td>
-            <td>9</td>
+            <td>0</td>
+            <td>3</td>
             <td>2</td>
-            <td>heading,aria-busy,aria-describedby,aria-errormessage,aria-hidden,aria-label,aria-labelledby,aria-roledescription</td>
+            <td>aria-labelledby</td>
           </tr>
           <tr>
             <td><a href="../../../content/patterns/disclosure/examples/disclosure-navigation-hybrid.html">Disclosure Navigation Menu with Top-Level Links</a></td>
             <td>class, prototype</td>
             <td></td>
-            <td>Yes</td>
+            <td></td>
             <td></td>
             <td>ex1</td>
-            <td>5</td>
+            <td>4</td>
             <td>0</td>
-            <td>10</td>
+            <td>5</td>
             <td>3</td>
-            <td>banner,contentinfo,heading,navigation,region,aria-busy,aria-describedby,aria-errormessage,aria-hidden,aria-label,aria-labelledby,aria-roledescription</td>
+            <td>banner,contentinfo,navigation,region,aria-label,aria-labelledby</td>
           </tr>
           <tr>
             <td><a href="../../../content/patterns/disclosure/examples/disclosure-navigation.html">Disclosure Navigation Menu</a></td>
             <td>class, prototype</td>
             <td></td>
-            <td>Yes</td>
+            <td></td>
             <td>Yes</td>
             <td>ex1</td>
-            <td>3</td>
+            <td>2</td>
             <td>0</td>
-            <td>10</td>
+            <td>4</td>
             <td>3</td>
-            <td>heading,navigation,region,aria-busy,aria-describedby,aria-errormessage,aria-hidden,aria-label,aria-labelledby,aria-roledescription</td>
+            <td>navigation,region,aria-label</td>
           </tr>
           <tr>
             <td><a href="../../../content/patterns/feed/examples/feed-display.html">Feed Display</a></td>
@@ -1632,16 +1632,16 @@
           </tr>
           <tr>
             <td><a href="../../../content/patterns/feed/examples/feed.html">Infinite Scrolling Feed</a></td>
-            <td>prototype</td>
             <td></td>
-            <td>Yes</td>
+            <td></td>
+            <td></td>
             <td></td>
             <td>ex1</td>
-            <td>1</td>
+            <td>0</td>
             <td>2</td>
-            <td>8</td>
+            <td>0</td>
             <td>5</td>
-            <td>heading,feed,article,aria-errormessage,aria-expanded,aria-hidden,aria-label,aria-roledescription,aria-posinset,aria-setsize</td>
+            <td>feed,article,aria-labelledby,aria-busy,aria-describedby,aria-posinset,aria-setsize</td>
           </tr>
           <tr>
             <td><a href="../../../content/patterns/grid/examples/advanced-data-grid.html">Advanced Data Grid</a></td>
@@ -1650,11 +1650,11 @@
             <td>Yes</td>
             <td></td>
             <td>ex1</td>
-            <td>1</td>
             <td>0</td>
-            <td>13</td>
             <td>0</td>
-            <td>heading,aria-busy,aria-colindex,aria-controls,aria-describedby,aria-errormessage,aria-expanded,aria-haspopup,aria-hidden,aria-label,aria-labelledby,aria-roledescription,aria-rowindex,aria-sort</td>
+            <td>5</td>
+            <td>0</td>
+            <td>aria-colindex,aria-controls,aria-haspopup,aria-rowindex,aria-sort</td>
           </tr>
           <tr>
             <td><a href="../../../content/patterns/grid/examples/data-grids.html">Data Grid</a></td>
@@ -1663,11 +1663,11 @@
             <td>Yes</td>
             <td></td>
             <td>ex1</td>
-            <td>5</td>
+            <td>4</td>
             <td>1</td>
-            <td>15</td>
+            <td>8</td>
             <td>6</td>
-            <td>button,heading,menu,menuitem,aria-busy,aria-controls,aria-describedby,aria-errormessage,aria-expanded,aria-haspopup,aria-hidden,aria-label,aria-roledescription</td>
+            <td>button,menu,menuitem,aria-controls,aria-haspopup</td>
           </tr>
           <tr>
             <td><a href="../../../content/patterns/grid/examples/layout-grids.html">Layout Grid</a></td>
@@ -1676,440 +1676,440 @@
             <td>Yes</td>
             <td></td>
             <td>ex1</td>
-            <td>6</td>
+            <td>5</td>
             <td>3</td>
-            <td>15</td>
+            <td>9</td>
             <td>3</td>
-            <td>button,heading,region,aria-busy,aria-colindex,aria-describedby,aria-errormessage,aria-expanded,aria-haspopup,aria-hidden,aria-label,aria-live,aria-relevant,aria-roledescription,aria-sort</td>
+            <td>button,region,aria-colindex,aria-haspopup,aria-label,aria-live,aria-relevant,aria-sort</td>
           </tr>
           <tr>
             <td><a href="../../../content/patterns/link/examples/link.html">Link</a></td>
-            <td>prototype</td>
-            <td>Yes</td>
+            <td></td>
             <td>Yes</td>
             <td></td>
+            <td></td>
             <td>not found</td>
-            <td>2</td>
             <td>1</td>
-            <td>8</td>
             <td>1</td>
-            <td>heading,aria-busy,aria-describedby,aria-errormessage,aria-expanded,aria-hidden,aria-labelledby,aria-roledescription</td>
+            <td>1</td>
+            <td>1</td>
+            <td></td>
           </tr>
           <tr>
             <td><a href="../../../content/patterns/listbox/examples/listbox-collapsible.html">(Deprecated) Collapsible Dropdown Listbox</a></td>
             <td>class, prototype</td>
             <td></td>
-            <td>Yes</td>
+            <td></td>
             <td></td>
             <td>ex</td>
-            <td>3</td>
             <td>2</td>
-            <td>14</td>
+            <td>2</td>
+            <td>8</td>
             <td>5</td>
-            <td>heading,aria-busy,aria-describedby,aria-disabled,aria-errormessage,aria-hidden,aria-keyshortcuts,aria-label,aria-multiselectable,aria-roledescription</td>
+            <td>aria-disabled,aria-keyshortcuts,aria-multiselectable</td>
           </tr>
           <tr>
             <td><a href="../../../content/patterns/listbox/examples/listbox-grouped.html">Listbox  with Grouped Options</a></td>
             <td>class, prototype</td>
             <td></td>
-            <td>Yes</td>
+            <td></td>
             <td></td>
             <td>ex</td>
-            <td>5</td>
-            <td>3</td>
-            <td>13</td>
             <td>4</td>
-            <td>heading,presentation,aria-busy,aria-describedby,aria-disabled,aria-errormessage,aria-expanded,aria-keyshortcuts,aria-label,aria-multiselectable,aria-roledescription</td>
+            <td>3</td>
+            <td>7</td>
+            <td>4</td>
+            <td>presentation,aria-disabled,aria-keyshortcuts,aria-multiselectable</td>
           </tr>
           <tr>
             <td><a href="../../../content/patterns/listbox/examples/listbox-rearrangeable.html">Listboxes with Rearrangeable Options</a></td>
             <td>class, prototype</td>
             <td></td>
-            <td>Yes</td>
+            <td></td>
             <td></td>
             <td>ex1</td>
-            <td>4</td>
+            <td>3</td>
             <td>2</td>
-            <td>14</td>
+            <td>9</td>
             <td>5</td>
-            <td>heading,toolbar,aria-busy,aria-describedby,aria-disabled,aria-errormessage,aria-expanded,aria-keyshortcuts,aria-label,aria-live,aria-roledescription</td>
+            <td>toolbar,aria-disabled,aria-keyshortcuts,aria-label,aria-live</td>
           </tr>
           <tr>
             <td><a href="../../../content/patterns/listbox/examples/listbox-scrollable.html">Scrollable Listbox</a></td>
             <td>class, prototype</td>
             <td></td>
-            <td>Yes</td>
+            <td></td>
             <td></td>
             <td>ex</td>
-            <td>3</td>
             <td>2</td>
-            <td>13</td>
+            <td>2</td>
+            <td>7</td>
             <td>4</td>
-            <td>heading,aria-busy,aria-describedby,aria-disabled,aria-errormessage,aria-expanded,aria-keyshortcuts,aria-label,aria-multiselectable,aria-roledescription</td>
+            <td>aria-disabled,aria-keyshortcuts,aria-multiselectable</td>
           </tr>
           <tr>
             <td><a href="../../../content/patterns/menu-button/examples/menu-button-actions-active-descendant.html">Actions Menu Button  Using aria-activedescendant</a></td>
-            <td>class, prototype</td>
+            <td>class</td>
+            <td></td>
             <td></td>
             <td>Yes</td>
-            <td>Yes</td>
             <td>ex1</td>
-            <td>3</td>
             <td>2</td>
-            <td>11</td>
+            <td>2</td>
             <td>5</td>
-            <td>heading,aria-busy,aria-describedby,aria-errormessage,aria-hidden,aria-label,aria-roledescription</td>
+            <td>5</td>
+            <td></td>
           </tr>
           <tr>
             <td><a href="../../../content/patterns/menu-button/examples/menu-button-actions.html">Actions Menu Button  Using element.focus()</a></td>
-            <td>class, prototype</td>
+            <td>class</td>
+            <td></td>
             <td></td>
             <td>Yes</td>
-            <td>Yes</td>
             <td>ex1</td>
-            <td>3</td>
             <td>2</td>
-            <td>10</td>
+            <td>2</td>
             <td>4</td>
-            <td>heading,aria-busy,aria-describedby,aria-errormessage,aria-hidden,aria-label,aria-roledescription</td>
+            <td>4</td>
+            <td></td>
           </tr>
           <tr>
             <td><a href="../../../content/patterns/menu-button/examples/menu-button-links.html">Navigation Menu Button</a></td>
-            <td>class, prototype</td>
+            <td>class</td>
+            <td></td>
             <td></td>
             <td>Yes</td>
-            <td>Yes</td>
             <td>ex1</td>
-            <td>4</td>
             <td>3</td>
-            <td>10</td>
+            <td>3</td>
             <td>4</td>
-            <td>heading,aria-busy,aria-describedby,aria-errormessage,aria-hidden,aria-label,aria-roledescription</td>
+            <td>4</td>
+            <td></td>
           </tr>
           <tr>
             <td><a href="../../../content/patterns/menubar/examples/menubar-editor.html">Editor Menubar</a></td>
-            <td>class, prototype</td>
+            <td>class</td>
+            <td></td>
             <td></td>
             <td>Yes</td>
-            <td>Yes</td>
             <td>ex1</td>
-            <td>9</td>
+            <td>8</td>
             <td>7</td>
-            <td>12</td>
+            <td>7</td>
             <td>6</td>
-            <td>heading,none,aria-busy,aria-describedby,aria-errormessage,aria-labelledby,aria-orientation,aria-roledescription</td>
+            <td>none,aria-orientation</td>
           </tr>
           <tr>
             <td><a href="../../../content/patterns/menubar/examples/menubar-navigation.html">Navigation Menubar</a></td>
-            <td>class, prototype</td>
+            <td>class</td>
+            <td></td>
             <td></td>
             <td>Yes</td>
-            <td>Yes</td>
             <td>ex1</td>
-            <td>10</td>
+            <td>9</td>
             <td>8</td>
-            <td>11</td>
+            <td>6</td>
             <td>5</td>
-            <td>heading,separator,aria-busy,aria-describedby,aria-errormessage,aria-hidden,aria-orientation,aria-roledescription</td>
+            <td>separator,aria-orientation</td>
           </tr>
           <tr>
             <td><a href="../../../content/patterns/meter/examples/meter.html">Meter</a></td>
             <td>prototype</td>
             <td></td>
-            <td>Yes</td>
+            <td></td>
             <td></td>
             <td>example</td>
-            <td>2</td>
             <td>1</td>
-            <td>11</td>
+            <td>1</td>
+            <td>5</td>
             <td>4</td>
-            <td>heading,aria-busy,aria-describedby,aria-errormessage,aria-expanded,aria-hidden,aria-label,aria-roledescription</td>
+            <td>aria-hidden</td>
           </tr>
           <tr>
             <td><a href="../../../content/patterns/radio/examples/radio-activedescendant.html">Radio Group  Using aria-activedescendant</a></td>
-            <td>class, prototype</td>
+            <td>class</td>
+            <td></td>
             <td></td>
             <td>Yes</td>
-            <td>Yes</td>
             <td>ex1</td>
-            <td>3</td>
             <td>2</td>
-            <td>10</td>
+            <td>2</td>
             <td>3</td>
-            <td>heading,aria-busy,aria-describedby,aria-errormessage,aria-expanded,aria-hidden,aria-label,aria-roledescription</td>
+            <td>3</td>
+            <td></td>
           </tr>
           <tr>
             <td><a href="../../../content/patterns/radio/examples/radio-rating.html">Rating Radio Group</a></td>
-            <td>class, prototype</td>
+            <td>class</td>
+            <td></td>
             <td></td>
             <td>Yes</td>
-            <td>Yes</td>
             <td>ex1</td>
-            <td>4</td>
             <td>3</td>
-            <td>9</td>
             <td>3</td>
-            <td>heading,aria-busy,aria-describedby,aria-errormessage,aria-expanded,aria-hidden,aria-roledescription</td>
+            <td>3</td>
+            <td>3</td>
+            <td></td>
           </tr>
           <tr>
             <td><a href="../../../content/patterns/radio/examples/radio.html">Radio Group  Using Roving tabindex</a></td>
-            <td>class, prototype</td>
+            <td>class</td>
+            <td></td>
             <td></td>
             <td>Yes</td>
-            <td>Yes</td>
             <td>ex1</td>
-            <td>3</td>
             <td>2</td>
-            <td>9</td>
             <td>2</td>
-            <td>heading,aria-busy,aria-describedby,aria-errormessage,aria-expanded,aria-hidden,aria-label,aria-roledescription</td>
+            <td>2</td>
+            <td>2</td>
+            <td></td>
           </tr>
           <tr>
             <td><a href="../../../content/patterns/slider-multithumb/examples/slider-multithumb.html">Horizontal Multi-Thumb Slider</a></td>
-            <td>class, prototype</td>
+            <td>class</td>
+            <td></td>
             <td></td>
             <td>Yes</td>
-            <td>Yes</td>
             <td>ex1</td>
-            <td>3</td>
             <td>2</td>
-            <td>11</td>
+            <td>2</td>
             <td>5</td>
-            <td>heading,aria-busy,aria-describedby,aria-errormessage,aria-expanded,aria-labelledby,aria-roledescription</td>
+            <td>5</td>
+            <td></td>
           </tr>
           <tr>
             <td><a href="../../../content/patterns/slider/examples/slider-color-viewer.html">Color Viewer Slider</a></td>
-            <td>class, prototype</td>
+            <td>class</td>
+            <td></td>
             <td></td>
             <td>Yes</td>
-            <td>Yes</td>
             <td>ex1</td>
-            <td>3</td>
             <td>2</td>
-            <td>11</td>
+            <td>2</td>
             <td>5</td>
-            <td>heading,aria-busy,aria-describedby,aria-errormessage,aria-expanded,aria-label,aria-roledescription</td>
+            <td>5</td>
+            <td></td>
           </tr>
           <tr>
             <td><a href="../../../content/patterns/slider/examples/slider-rating.html">Rating Slider</a></td>
-            <td>class, prototype</td>
+            <td>class</td>
+            <td></td>
             <td></td>
             <td>Yes</td>
-            <td>Yes</td>
             <td>ex1</td>
-            <td>2</td>
             <td>1</td>
-            <td>12</td>
+            <td>1</td>
             <td>6</td>
-            <td>heading,aria-busy,aria-describedby,aria-errormessage,aria-expanded,aria-label,aria-roledescription</td>
+            <td>6</td>
+            <td></td>
           </tr>
           <tr>
             <td><a href="../../../content/patterns/slider/examples/slider-seek.html">Media Seek Slider</a></td>
-            <td>class, prototype</td>
+            <td>class</td>
+            <td></td>
             <td></td>
             <td>Yes</td>
-            <td>Yes</td>
             <td>ex1</td>
-            <td>3</td>
             <td>2</td>
-            <td>12</td>
+            <td>2</td>
             <td>6</td>
-            <td>heading,aria-busy,aria-describedby,aria-errormessage,aria-expanded,aria-label,aria-roledescription</td>
+            <td>6</td>
+            <td></td>
           </tr>
           <tr>
             <td><a href="../../../content/patterns/slider/examples/slider-temperature.html">Vertical Temperature Slider</a></td>
-            <td>class, prototype</td>
+            <td>class</td>
+            <td></td>
             <td></td>
             <td>Yes</td>
-            <td>Yes</td>
             <td>ex1</td>
-            <td>3</td>
             <td>2</td>
-            <td>13</td>
+            <td>2</td>
             <td>7</td>
-            <td>heading,aria-busy,aria-describedby,aria-errormessage,aria-expanded,aria-label,aria-roledescription</td>
+            <td>7</td>
+            <td></td>
           </tr>
           <tr>
             <td><a href="../../../content/patterns/spinbutton/examples/datepicker-spinbuttons.html">Date Picker Spin Button</a></td>
             <td>prototype</td>
             <td>Yes</td>
-            <td>Yes</td>
+            <td></td>
             <td></td>
             <td>example</td>
-            <td>3</td>
             <td>2</td>
-            <td>12</td>
+            <td>2</td>
             <td>7</td>
-            <td>heading,aria-busy,aria-describedby,aria-errormessage,aria-expanded,aria-roledescription</td>
+            <td>7</td>
+            <td></td>
           </tr>
           <tr>
             <td><a href="../../../content/patterns/switch/examples/switch-button.html">Switch  Using HTML Button</a></td>
-            <td>class, prototype</td>
+            <td>class</td>
+            <td></td>
             <td></td>
             <td>Yes</td>
-            <td>Yes</td>
             <td>ex1</td>
-            <td>3</td>
             <td>2</td>
-            <td>9</td>
+            <td>2</td>
             <td>3</td>
-            <td>heading,aria-busy,aria-describedby,aria-errormessage,aria-expanded,aria-label,aria-roledescription</td>
+            <td>3</td>
+            <td></td>
           </tr>
           <tr>
             <td><a href="../../../content/patterns/switch/examples/switch-checkbox.html">Switch  Using HTML Checkbox Input</a></td>
-            <td>class, prototype</td>
+            <td>class</td>
+            <td></td>
             <td></td>
             <td>Yes</td>
-            <td>Yes</td>
             <td>ex1</td>
-            <td>2</td>
             <td>1</td>
-            <td>8</td>
             <td>1</td>
-            <td>heading,aria-busy,aria-describedby,aria-errormessage,aria-expanded,aria-label,aria-labelledby,aria-roledescription</td>
+            <td>1</td>
+            <td>1</td>
+            <td></td>
           </tr>
           <tr>
             <td><a href="../../../content/patterns/switch/examples/switch.html">Switch</a></td>
-            <td>class, prototype</td>
+            <td>class</td>
+            <td></td>
             <td></td>
             <td>Yes</td>
-            <td>Yes</td>
             <td>ex1</td>
-            <td>2</td>
             <td>1</td>
-            <td>9</td>
+            <td>1</td>
             <td>2</td>
-            <td>heading,aria-busy,aria-describedby,aria-errormessage,aria-expanded,aria-label,aria-labelledby,aria-roledescription</td>
+            <td>2</td>
+            <td></td>
           </tr>
           <tr>
             <td><a href="../../../content/patterns/table/examples/sortable-table.html">Sortable Table</a></td>
-            <td>class, prototype</td>
+            <td>class</td>
+            <td></td>
             <td></td>
             <td>Yes</td>
-            <td>Yes</td>
             <td>ex1</td>
-            <td>1</td>
             <td>0</td>
-            <td>9</td>
+            <td>0</td>
             <td>2</td>
-            <td>heading,aria-busy,aria-describedby,aria-errormessage,aria-expanded,aria-label,aria-labelledby,aria-roledescription</td>
+            <td>2</td>
+            <td></td>
           </tr>
           <tr>
             <td><a href="../../../content/patterns/table/examples/table.html">Table</a></td>
-            <td>prototype</td>
             <td></td>
-            <td>Yes</td>
+            <td></td>
+            <td></td>
             <td></td>
             <td>ex1</td>
-            <td>6</td>
             <td>5</td>
-            <td>8</td>
+            <td>5</td>
             <td>2</td>
-            <td>heading,aria-busy,aria-errormessage,aria-expanded,aria-hidden,aria-labelledby,aria-roledescription</td>
+            <td>2</td>
+            <td></td>
           </tr>
           <tr>
             <td><a href="../../../content/patterns/tabs/examples/tabs-automatic.html">Tabs with Automatic Activation</a></td>
-            <td>class, prototype</td>
+            <td>class</td>
+            <td></td>
             <td></td>
             <td>Yes</td>
-            <td>Yes</td>
             <td>ex1</td>
-            <td>4</td>
             <td>3</td>
-            <td>10</td>
             <td>3</td>
-            <td>heading,aria-busy,aria-describedby,aria-errormessage,aria-expanded,aria-hidden,aria-label,aria-roledescription</td>
+            <td>3</td>
+            <td>3</td>
+            <td></td>
           </tr>
           <tr>
             <td><a href="../../../content/patterns/tabs/examples/tabs-manual.html">Tabs with Manual Activation</a></td>
-            <td>class, prototype</td>
+            <td>class</td>
+            <td></td>
             <td></td>
             <td>Yes</td>
-            <td>Yes</td>
             <td>ex1</td>
-            <td>4</td>
             <td>3</td>
-            <td>10</td>
             <td>3</td>
-            <td>heading,aria-busy,aria-describedby,aria-errormessage,aria-expanded,aria-hidden,aria-label,aria-roledescription</td>
+            <td>3</td>
+            <td>3</td>
+            <td></td>
           </tr>
           <tr>
             <td><a href="../../../content/patterns/toolbar/examples/help.html">Toolbar</a></td>
-            <td>prototype</td>
             <td></td>
-            <td>Yes</td>
+            <td></td>
+            <td></td>
             <td></td>
             <td>not found</td>
-            <td>1</td>
             <td>0</td>
-            <td>8</td>
             <td>0</td>
-            <td>heading,aria-busy,aria-describedby,aria-errormessage,aria-expanded,aria-hidden,aria-label,aria-labelledby,aria-roledescription</td>
+            <td>0</td>
+            <td>0</td>
+            <td></td>
           </tr>
           <tr>
             <td><a href="../../../content/patterns/toolbar/examples/toolbar.html">Toolbar</a></td>
             <td>prototype</td>
             <td>Yes</td>
-            <td>Yes</td>
+            <td></td>
             <td></td>
             <td>ex1</td>
-            <td>7</td>
             <td>6</td>
-            <td>17</td>
+            <td>6</td>
             <td>12</td>
-            <td>heading,aria-busy,aria-describedby,aria-errormessage,aria-labelledby,aria-roledescription</td>
+            <td>12</td>
+            <td></td>
           </tr>
           <tr>
             <td><a href="../../../content/patterns/treegrid/examples/treegrid-1.html">Treegrid Email Inbox</a></td>
             <td>prototype</td>
             <td>Yes</td>
-            <td>Yes</td>
+            <td></td>
             <td></td>
             <td>ex1</td>
-            <td>4</td>
             <td>3</td>
-            <td>13</td>
+            <td>3</td>
+            <td>7</td>
             <td>5</td>
-            <td>heading,aria-activedescendant,aria-busy,aria-current,aria-describedby,aria-errormessage,aria-hidden,aria-labelledby,aria-roledescription</td>
+            <td>aria-activedescendant,aria-current</td>
           </tr>
           <tr>
             <td><a href="../../../content/patterns/treeview/examples/treeview-1a.html">File Directory Treeview  Using Computed Properties</a></td>
             <td>prototype</td>
             <td>Yes</td>
-            <td>Yes</td>
+            <td></td>
             <td></td>
             <td>ex1</td>
+            <td>3</td>
+            <td>3</td>
             <td>4</td>
             <td>3</td>
-            <td>9</td>
-            <td>3</td>
-            <td>heading,aria-busy,aria-describedby,aria-errormessage,aria-hidden,aria-label,aria-roledescription</td>
+            <td>aria-label</td>
           </tr>
           <tr>
             <td><a href="../../../content/patterns/treeview/examples/treeview-1b.html">File Directory Treeview  Using Declared Properties</a></td>
             <td>prototype</td>
             <td>Yes</td>
-            <td>Yes</td>
+            <td></td>
             <td></td>
             <td>ex1</td>
-            <td>4</td>
             <td>3</td>
-            <td>12</td>
+            <td>3</td>
+            <td>7</td>
             <td>6</td>
-            <td>heading,aria-busy,aria-describedby,aria-errormessage,aria-hidden,aria-label,aria-roledescription</td>
+            <td>aria-label</td>
           </tr>
           <tr>
             <td><a href="../../../content/patterns/treeview/examples/treeview-navigation.html">Navigation Treeview</a></td>
-            <td>class, prototype</td>
+            <td>class</td>
             <td>Yes</td>
-            <td>Yes</td>
+            <td></td>
             <td>Yes</td>
             <td>ex1</td>
-            <td>9</td>
             <td>8</td>
-            <td>10</td>
+            <td>8</td>
             <td>5</td>
-            <td>heading,aria-busy,aria-describedby,aria-errormessage,aria-hidden,aria-roledescription</td>
+            <td>5</td>
+            <td></td>
           </tr></tbody>
       </table>
 
@@ -2631,54 +2631,14 @@
         </thead>
         <tbody id="example_mouse_pointer_tbody">
           <tr>
-            <td><a href="../../../content/patterns/accordion/examples/accordion.html">Accordion</a></td>
-            <td></td>
-            <td>Yes</td>
-          </tr>
-          <tr>
-            <td><a href="../../../content/patterns/alert/examples/alert.html">Alert</a></td>
-            <td></td>
-            <td>Yes</td>
-          </tr>
-          <tr>
-            <td><a href="../../../content/patterns/alertdialog/examples/alertdialog.html">Alert Dialog</a></td>
-            <td></td>
-            <td>Yes</td>
-          </tr>
-          <tr>
-            <td><a href="../../../content/patterns/breadcrumb/examples/breadcrumb.html">Breadcrumb</a></td>
-            <td></td>
-            <td>Yes</td>
-          </tr>
-          <tr>
-            <td><a href="../../../content/patterns/button/examples/button_idl.html">Button  (IDL Version)</a></td>
-            <td></td>
-            <td>Yes</td>
-          </tr>
-          <tr>
-            <td><a href="../../../content/patterns/button/examples/button.html">Button</a></td>
-            <td></td>
-            <td>Yes</td>
-          </tr>
-          <tr>
             <td><a href="../../../content/patterns/carousel/examples/carousel-1-prev-next.html">Auto-Rotating Image Carousel  with Buttons for Slide Control</a></td>
             <td>Yes</td>
-            <td>Yes</td>
+            <td></td>
           </tr>
           <tr>
             <td><a href="../../../content/patterns/carousel/examples/carousel-2-tablist.html">Auto-Rotating Image Carousel with Tabs for Slide Control</a></td>
             <td>Yes</td>
-            <td>Yes</td>
-          </tr>
-          <tr>
-            <td><a href="../../../content/patterns/checkbox/examples/checkbox-mixed.html">Checkbox  (Mixed-State)</a></td>
             <td></td>
-            <td>Yes</td>
-          </tr>
-          <tr>
-            <td><a href="../../../content/patterns/checkbox/examples/checkbox.html">Checkbox  (Two State)</a></td>
-            <td></td>
-            <td>Yes</td>
           </tr>
           <tr>
             <td><a href="../../../content/patterns/combobox/examples/combobox-autocomplete-both.html">Editable Combobox With Both List and Inline Autocomplete</a></td>
@@ -2698,17 +2658,12 @@
           <tr>
             <td><a href="../../../content/patterns/combobox/examples/combobox-datepicker.html">Date Picker Combobox</a></td>
             <td>Yes</td>
-            <td>Yes</td>
+            <td></td>
           </tr>
           <tr>
             <td><a href="../../../content/patterns/combobox/examples/combobox-select-only.html">Select-Only Combobox</a></td>
             <td>Yes</td>
-            <td>Yes</td>
-          </tr>
-          <tr>
-            <td><a href="../../../content/patterns/combobox/examples/grid-combo.html">Editable Combobox with Grid Popup</a></td>
             <td></td>
-            <td>Yes</td>
           </tr>
           <tr>
             <td><a href="../../../content/patterns/dialog-modal/examples/datepicker-dialog.html">Date Picker Dialog</a></td>
@@ -2716,89 +2671,39 @@
             <td>Yes</td>
           </tr>
           <tr>
-            <td><a href="../../../content/patterns/dialog-modal/examples/dialog.html">Modal Dialog</a></td>
-            <td></td>
-            <td>Yes</td>
-          </tr>
-          <tr>
-            <td><a href="../../../content/patterns/disclosure/examples/disclosure-faq.html">Disclosure (Show/Hide) for Answers to Frequently Asked Questions</a></td>
-            <td></td>
-            <td>Yes</td>
-          </tr>
-          <tr>
-            <td><a href="../../../content/patterns/disclosure/examples/disclosure-image-description.html">Disclosure (Show/Hide) for Image Description</a></td>
-            <td></td>
-            <td>Yes</td>
-          </tr>
-          <tr>
-            <td><a href="../../../content/patterns/disclosure/examples/disclosure-navigation-hybrid.html">Disclosure Navigation Menu with Top-Level Links</a></td>
-            <td></td>
-            <td>Yes</td>
-          </tr>
-          <tr>
-            <td><a href="../../../content/patterns/disclosure/examples/disclosure-navigation.html">Disclosure Navigation Menu</a></td>
-            <td></td>
-            <td>Yes</td>
-          </tr>
-          <tr>
-            <td><a href="../../../content/patterns/feed/examples/feed.html">Infinite Scrolling Feed</a></td>
-            <td></td>
-            <td>Yes</td>
-          </tr>
-          <tr>
-            <td><a href="../../../content/patterns/grid/examples/advanced-data-grid.html">Advanced Data Grid</a></td>
-            <td></td>
-            <td>Yes</td>
-          </tr>
-          <tr>
-            <td><a href="../../../content/patterns/grid/examples/data-grids.html">Data Grid</a></td>
-            <td></td>
-            <td>Yes</td>
-          </tr>
-          <tr>
-            <td><a href="../../../content/patterns/grid/examples/layout-grids.html">Layout Grid</a></td>
-            <td></td>
-            <td>Yes</td>
-          </tr>
-          <tr>
-            <td><a href="../../../content/patterns/link/examples/link.html">Link</a></td>
-            <td></td>
-            <td>Yes</td>
-          </tr>
-          <tr>
             <td><a href="../../../content/patterns/listbox/examples/listbox-collapsible.html">(Deprecated) Collapsible Dropdown Listbox</a></td>
             <td>Yes</td>
-            <td>Yes</td>
+            <td></td>
           </tr>
           <tr>
             <td><a href="../../../content/patterns/listbox/examples/listbox-grouped.html">Listbox  with Grouped Options</a></td>
             <td>Yes</td>
-            <td>Yes</td>
+            <td></td>
           </tr>
           <tr>
             <td><a href="../../../content/patterns/listbox/examples/listbox-rearrangeable.html">Listboxes with Rearrangeable Options</a></td>
             <td>Yes</td>
-            <td>Yes</td>
+            <td></td>
           </tr>
           <tr>
             <td><a href="../../../content/patterns/listbox/examples/listbox-scrollable.html">Scrollable Listbox</a></td>
             <td>Yes</td>
-            <td>Yes</td>
+            <td></td>
           </tr>
           <tr>
             <td><a href="../../../content/patterns/menu-button/examples/menu-button-actions-active-descendant.html">Actions Menu Button  Using aria-activedescendant</a></td>
             <td>Yes</td>
-            <td>Yes</td>
+            <td></td>
           </tr>
           <tr>
             <td><a href="../../../content/patterns/menu-button/examples/menu-button-actions.html">Actions Menu Button  Using element.focus()</a></td>
             <td>Yes</td>
-            <td>Yes</td>
+            <td></td>
           </tr>
           <tr>
             <td><a href="../../../content/patterns/menu-button/examples/menu-button-links.html">Navigation Menu Button</a></td>
             <td>Yes</td>
-            <td>Yes</td>
+            <td></td>
           </tr>
           <tr>
             <td><a href="../../../content/patterns/menubar/examples/menubar-editor.html">Editor Menubar</a></td>
@@ -2807,26 +2712,6 @@
           </tr>
           <tr>
             <td><a href="../../../content/patterns/menubar/examples/menubar-navigation.html">Navigation Menubar</a></td>
-            <td></td>
-            <td>Yes</td>
-          </tr>
-          <tr>
-            <td><a href="../../../content/patterns/meter/examples/meter.html">Meter</a></td>
-            <td></td>
-            <td>Yes</td>
-          </tr>
-          <tr>
-            <td><a href="../../../content/patterns/radio/examples/radio-activedescendant.html">Radio Group  Using aria-activedescendant</a></td>
-            <td></td>
-            <td>Yes</td>
-          </tr>
-          <tr>
-            <td><a href="../../../content/patterns/radio/examples/radio-rating.html">Rating Radio Group</a></td>
-            <td></td>
-            <td>Yes</td>
-          </tr>
-          <tr>
-            <td><a href="../../../content/patterns/radio/examples/radio.html">Radio Group  Using Roving tabindex</a></td>
             <td></td>
             <td>Yes</td>
           </tr>
@@ -2856,74 +2741,24 @@
             <td>Yes</td>
           </tr>
           <tr>
-            <td><a href="../../../content/patterns/spinbutton/examples/datepicker-spinbuttons.html">Date Picker Spin Button</a></td>
-            <td></td>
-            <td>Yes</td>
-          </tr>
-          <tr>
-            <td><a href="../../../content/patterns/switch/examples/switch-button.html">Switch  Using HTML Button</a></td>
-            <td></td>
-            <td>Yes</td>
-          </tr>
-          <tr>
-            <td><a href="../../../content/patterns/switch/examples/switch-checkbox.html">Switch  Using HTML Checkbox Input</a></td>
-            <td></td>
-            <td>Yes</td>
-          </tr>
-          <tr>
-            <td><a href="../../../content/patterns/switch/examples/switch.html">Switch</a></td>
-            <td></td>
-            <td>Yes</td>
-          </tr>
-          <tr>
-            <td><a href="../../../content/patterns/table/examples/sortable-table.html">Sortable Table</a></td>
-            <td></td>
-            <td>Yes</td>
-          </tr>
-          <tr>
-            <td><a href="../../../content/patterns/table/examples/table.html">Table</a></td>
-            <td></td>
-            <td>Yes</td>
-          </tr>
-          <tr>
-            <td><a href="../../../content/patterns/tabs/examples/tabs-automatic.html">Tabs with Automatic Activation</a></td>
-            <td></td>
-            <td>Yes</td>
-          </tr>
-          <tr>
-            <td><a href="../../../content/patterns/tabs/examples/tabs-manual.html">Tabs with Manual Activation</a></td>
-            <td></td>
-            <td>Yes</td>
-          </tr>
-          <tr>
-            <td><a href="../../../content/patterns/toolbar/examples/help.html">Toolbar</a></td>
-            <td></td>
-            <td>Yes</td>
-          </tr>
-          <tr>
             <td><a href="../../../content/patterns/toolbar/examples/toolbar.html">Toolbar</a></td>
             <td>Yes</td>
-            <td>Yes</td>
-          </tr>
-          <tr>
-            <td><a href="../../../content/patterns/treegrid/examples/treegrid-1.html">Treegrid Email Inbox</a></td>
             <td></td>
-            <td>Yes</td>
           </tr>
           <tr>
             <td><a href="../../../content/patterns/treeview/examples/treeview-1a.html">File Directory Treeview  Using Computed Properties</a></td>
             <td>Yes</td>
-            <td>Yes</td>
+            <td></td>
           </tr>
           <tr>
             <td><a href="../../../content/patterns/treeview/examples/treeview-1b.html">File Directory Treeview  Using Declared Properties</a></td>
             <td>Yes</td>
-            <td>Yes</td>
+            <td></td>
           </tr>
           <tr>
             <td><a href="../../../content/patterns/treeview/examples/treeview-navigation.html">Navigation Treeview</a></td>
             <td>Yes</td>
-            <td>Yes</td>
+            <td></td>
           </tr></tbody>
       </table>
 

--- a/scripts/coverage-report.js
+++ b/scripts/coverage-report.js
@@ -474,7 +474,8 @@ glob
       if (
         src.indexOf('examples.js') < 0 &&
         src.indexOf('highlight.pack.js') < 0 &&
-        src.indexOf('app.js') < 0
+        src.indexOf('app.js') < 0 &&
+        src.indexOf('skipto.js') < 0
       ) {
         console.log('  [script]: ' + src);
         dataJS += fs.readFileSync(joinPaths(dir, src), 'utf8');


### PR DESCRIPTION
While investigating https://github.com/w3c/aria-practices/pull/3000#issuecomment-2125885984, found that values under the Coding Summary, Coding Practices and Mouse and Pointer Events of the Coverage and Quality Reports page were being significantly and inaccurately increased.

That's because of the `skipto.js` utility included in each pattern's html file was not being ignored in the `coverage-report.js` script and was adding to the metrics when the *.js files were being evaluated.
___
[WAI Preview Link](https://deploy-preview-326--aria-practices.netlify.app/ARIA/apg) _(Last built on Thu, 23 May 2024 12:59:46 GMT)._