### PR TITLE
Infrastructure: Re-run `npm run reference-tables` and `npm run coverage-report` on source script update

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,14 @@
       "git add content/index/index.html",
       "npm run coverage-report",
       "git add content/about/coverage-and-quality/"
+    ],
+    "scripts/reference-tables.*": [
+      "npm run reference-tables",
+      "git add content/index/index.html"
+    ],
+    "scripts/coverage-report.*": [
+      "npm run coverage-report",
+      "git add content/about/coverage-and-quality/"
     ]
   },
   "ava": {


### PR DESCRIPTION
Related to https://github.com/w3c/aria-practices/pull/3024#issuecomment-2189085884.

Currently, using `lint-staged`, the `npm run reference-tables` and `npm run coverage-report` scripts are automatically ran when a git commit happens ONLY if files matching `content/patterns/**/examples/*.html` have been changed.

The generating scripts have been overlooked in that automatic process so this PR adds those (`scripts/coverage-report.*` and `scripts/reference-tables.*`). This should reduce any issues with the `Check examples/index.html / coverage` check if only those script files have been updated in a PR.