### PR TITLE
Regression Tests: Enable `disclosure_navigation.js` test to scroll to element and click in `executeScript` context

### DIFF
--- a/test/tests/disclosure_navigation.js
+++ b/test/tests/disclosure_navigation.js
@@ -75,7 +75,7 @@ ariaTest(
         await buttons[b].click();
         await t.context.session.executeScript(function () {
           const link = arguments[0];
-          link.scrollIntoView({ block: 'center' });
+          link.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
         }, links[l]);
         await links[l].click();
 

--- a/test/tests/disclosure_navigation.js
+++ b/test/tests/disclosure_navigation.js
@@ -76,8 +76,9 @@ ariaTest(
         await t.context.session.executeScript(function () {
           const link = arguments[0];
           link.scrollIntoView({ behavior: 'instant', block: 'nearest' });
+          link.click();
         }, links[l]);
-        await links[l].click();
+        // await links[l].click();
 
         t.is(
           await links[l].getAttribute('aria-current'),

--- a/test/tests/disclosure_navigation.js
+++ b/test/tests/disclosure_navigation.js
@@ -69,6 +69,10 @@ ariaTest(
     const menus = await t.context.queryElements(t, ex.menuSelector);
 
     for (let b = 0; b < buttons.length; b++) {
+      await t.context.session.executeScript(function () {
+        const menu = arguments[0];
+        menu.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+      }, menus[b]);
       const links = await t.context.queryElements(t, 'a', menus[b]);
 
       for (let l = 0; l < links.length; l++) {

--- a/test/tests/disclosure_navigation.js
+++ b/test/tests/disclosure_navigation.js
@@ -75,10 +75,9 @@ ariaTest(
         await buttons[b].click();
         await t.context.session.executeScript(function () {
           const link = arguments[0];
-          link.scrollIntoView({ behavior: 'instant', block: 'nearest' });
+          link.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
           link.click();
         }, links[l]);
-        // await links[l].click();
 
         t.is(
           await links[l].getAttribute('aria-current'),

--- a/test/tests/disclosure_navigation.js
+++ b/test/tests/disclosure_navigation.js
@@ -69,17 +69,13 @@ ariaTest(
     const menus = await t.context.queryElements(t, ex.menuSelector);
 
     for (let b = 0; b < buttons.length; b++) {
-      await t.context.session.executeScript(function () {
-        const menu = arguments[0];
-        menu.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
-      }, menus[b]);
       const links = await t.context.queryElements(t, 'a', menus[b]);
 
       for (let l = 0; l < links.length; l++) {
         await buttons[b].click();
         await t.context.session.executeScript(function () {
           const link = arguments[0];
-          link.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+          link.scrollIntoView({ behavior: 'instant', block: 'nearest' });
         }, links[l]);
         await links[l].click();
 


### PR DESCRIPTION
Fixes #2996. The previous fix, #2997 didn't fully resolve the issue described in https://github.com/w3c/aria-practices/issues/2996#issuecomment-2200912116.

Update `../tests/disclosure_navigation.js test > "aria-current" attribute on links` to scroll to link before click event and do click inside `executeScript`.
___
[WAI Preview Link](https://deploy-preview-331--aria-practices.netlify.app/ARIA/apg) _(Last built on Mon, 01 Jul 2024 20:50:58 GMT)._

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207778172716588