### PR TITLE
Infrastructure: Group Minor/Patch Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,13 @@ updates:
     open-pull-requests-limit: 99
     commit-message:
       prefix: "Infrastructure"
+    groups:
+      dependencies:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
   - package-ecosystem: github-actions
     directory: "/"
     schedule:


### PR DESCRIPTION
Not sure how the commit message/PR title will show up for this one. The idea is that all the minor patch updates will be in one PR, but the major version updates will continue to be opened as individual PRs