### PR TITLE
Sortable Table Example: Separate off-screen portion of caption with parenthesis instead of comma

### DIFF
--- a/content/patterns/table/examples/sortable-table.html
+++ b/content/patterns/table/examples/sortable-table.html
@@ -65,7 +65,7 @@
           <table class="sortable">
             <caption>
               Students currently enrolled in WAI-ARIA 101
-              <span class="sr-only">, column headers with buttons are sortable.</span>
+              <span class="sr-only">(column headers with buttons are sortable).</span>
             </caption>
             <thead>
               <tr>

--- a/content/patterns/table/examples/sortable-table.html
+++ b/content/patterns/table/examples/sortable-table.html
@@ -65,7 +65,7 @@
           <table class="sortable">
             <caption>
               Students currently enrolled in WAI-ARIA 101
-              <span class="sr-only">(column headers with buttons are sortable).</span>
+              <span class="sr-only"> (column headers with buttons are sortable).</span>
             </caption>
             <thead>
               <tr>

--- a/content/patterns/table/examples/sortable-table.html
+++ b/content/patterns/table/examples/sortable-table.html
@@ -65,7 +65,7 @@
           <table class="sortable">
             <caption>
               Students currently enrolled in WAI-ARIA 101
-              <span class="sr-only"> (column headers with buttons are sortable).</span>
+              <span class="sr-only">&puncsp;(column headers with buttons are sortable).</span>
             </caption>
             <thead>
               <tr>


### PR DESCRIPTION
Fixes #3066

updating sr-only text to parenthesis instead of a comma


#### Preview

[Preview Sortable Table Example in compare branch](https://deploy-preview-339--aria-practices.netlify.app/aria/apg/patterns/table/examples/sortable-table/)

___
[WAI Preview Link](https://deploy-preview-339--aria-practices.netlify.app/ARIA/apg) _(Last built on Tue, 27 Aug 2024 02:57:06 GMT)._