### PR TITLE
Read Me First: Close anchor tag in code example

### DIFF
--- a/content/practices/read-me-first/read-me-first-practice.html
+++ b/content/practices/read-me-first/read-me-first-practice.html
@@ -58,8 +58,8 @@
 &lt;/table&gt;
 &lt;ul role=&quot;navigation&quot;&gt;
   &lt;!-- This is a navigation region, not a list. --&gt;
-  &lt;li&gt;&lt;a href=&quot;uri1&quot;&gt;nav link 1&lt;/li&gt;
-  &lt;li&gt;&lt;a href=&quot;uri2&quot;&gt;nav link 2&lt;/li&gt;
+  &lt;li&gt;&lt;a href=&quot;uri1&quot;&gt;nav link 1&lt;/a&gt;&lt;/li&gt;
+  &lt;li&gt;&lt;a href=&quot;uri2&quot;&gt;nav link 2&lt;/a&gt;&lt;/li&gt;
   &lt;!-- ERROR! Previous list items are not in a list! --&gt;
 &lt;/ul&gt;</code></pre>
       </section>


### PR DESCRIPTION
In the [Read me first page](https://www.w3.org/WAI/ARIA/apg/practices/read-me-first/), section "Principle 2: ARIA Can Both Cloak and Enhance, Creating Both Power and Danger", the anchor tag is not closed in the third example.

Before:

```html
<li><a href="uri1">nav link 1</li>
<li><a href="uri2">nav link 2</li>
```

After:
```html
<li><a href="uri1">nav link 1</a></li>
<li><a href="uri2">nav link 2</a></li>
```


___
[WAI Preview Link](https://deploy-preview-340--aria-practices.netlify.app/ARIA/apg) _(Last built on Wed, 31 Jul 2024 08:17:27 GMT)._