### PR TITLE
Modal Dialog example: Correct JSDoc warning

### DIFF
--- a/content/patterns/dialog-modal/examples/js/dialog.js
+++ b/content/patterns/dialog-modal/examples/js/dialog.js
@@ -85,7 +85,7 @@ aria.Utils = aria.Utils || {};
   aria.OpenDialogList = aria.OpenDialogList || new Array(0);
 
   /**
-   * @returns {object} the last opened dialog (the current dialog)
+   * @returns {object|void} the last opened dialog (the current dialog)
    */
   aria.getCurrentDialog = function () {
     if (aria.OpenDialogList && aria.OpenDialogList.length) {


### PR DESCRIPTION
Noticed this on another PR, so made the updated according to the rule https://github.com/gajus/eslint-plugin-jsdoc/blob/main/docs/rules/require-returns-check.md#user-content-require-returns-check-passing-examples
___
[WAI Preview Link](https://deploy-preview-341--aria-practices.netlify.app/ARIA/apg) _(Last built on Wed, 31 Jul 2024 19:29:54 GMT)._