### PR TITLE
Infrastructure: Include full link in message when external link errors in link-checker script

### DIFF
--- a/scripts/link-checker.js
+++ b/scripts/link-checker.js
@@ -314,8 +314,9 @@ async function checkLinks() {
 
         if (!pageData.ok) {
           consoleError(
-            `Found broken external link on ${htmlPath}:${lineNumber}:${columnNumber}, ` +
-              `status was ${pageData.status}`
+            `Found broken external link on ${htmlPath}:${lineNumber}:${columnNumber}. ` +
+              `Link is ${hrefOrSrc}, ` +
+              `status is ${pageData.status}`
           );
           continue;
         }


### PR DESCRIPTION
Modifies the error message to detail the actual link that has failed to easily relay the information instead of just providing the line and column number.

Example:
`Found broken external link on content/patterns/accordion/examples/accordion.html:22:13, status was 404` would now be `Found broken external link on content/patterns/accordion/examples/accordion.html:22:13. Link is https://github.com/w3c/aria-practices/projects/8, status is 404`
___
[WAI Preview Link](https://deploy-preview-351--aria-practices.netlify.app/ARIA/apg) _(Last built on Sun, 03 Nov 2024 03:54:35 GMT)._