### PR TITLE
Accessibility: update aria labels for coverage-report

### DIFF
--- a/scripts/coverage-report.template
+++ b/scripts/coverage-report.template
@@ -120,7 +120,7 @@
     <section id="props_with_one_example">
       <h2 id="props_with_one_example_label">Properties and States with at Least One Guidance or Example (<span class="props_with_one_example_count"></span>)</h2>
       <div><strong>NOTE:</strong> The HC abbreviation means example has High Contrast support.</div>
-      <table aria-labelledby="props_with_one_example_label" class="data attributes">
+      <table aria-labelledby="properties_with_one_example_label" class="data attributes">
         <thead>
           <tr>
             <th>Property or State</th>
@@ -136,7 +136,7 @@
     <section id="props_with_more_than_one_example">
       <h2 id="props_with_more_than_one_label">Properties and States with More than One Guidance or Example (<span class="props_with_more_than_one_examples_count"></span>)</h2>
       <div><strong>NOTE:</strong> The HC abbreviation means example has High Contrast support.</div>
-      <table aria-labelledby="props_with_more_than_one_label" class="data attributes">
+      <table aria-labelledby="properties_with_more_than_one_label" class="data attributes">
         <thead>
           <tr>
             <th>Property or State</th>


### PR DESCRIPTION
Use clearer and more descriptive IDs for screen reader users. 