### PR TITLE
Update Example-Template.html

### DIFF
--- a/content-templates/Example-Template.html
+++ b/content-templates/Example-Template.html
@@ -52,7 +52,7 @@
       <section>
         <h2>About This Example</h2>
         <p>
-          <!-- Provide an overview of the example where the first sentence provides a link to the section of aria-practices.html that describes the pattern this example implements. -->
+          <!-- Provide an overview of the example. The first sentence should link to the section of aria-practices.html that describes the pattern implemented by this example. -->
           Replace this paragraph with an overview of the example that is something like the following. The below example section demonstrates a simple checkbox that implements the
           <a href="../../#checkbox">design pattern for checkbox.</a>
           This example uses ... summarize salient techniques )
@@ -141,8 +141,8 @@
               <th><kbd>KeyName</kbd></th>
               <td>
                 <ul>
-                  <li>If condition 1, performs function 1.</li>
-                  <li>If condition 2, performs function 2.</li>
+                  <li>If condition 1, perform function 1.</li>
+                  <li>If condition 2, perform function 2.</li>
                   <li>Only use a list if multiple statements are needed.</li>
                 </ul>
               </td>


### PR DESCRIPTION
- The original sentence is long and convoluted. Breaking it into two sentences improves clarity.
- Remove unnecessary "s"