### PR TITLE
Infinite Scrolling Feed Example: Add fallback foreground color

### DIFF
--- a/content/patterns/feed/examples/css/feedDisplay.css
+++ b/content/patterns/feed/examples/css/feedDisplay.css
@@ -1,6 +1,7 @@
 body {
   background: #fafafa;
   font-family: Helvetica, Arial, sans-serif;
+  color: #000;
 }
 
 #side-panel {


### PR DESCRIPTION
Closes: #3149

Description: Added a fallback foreground color of `#000` to the body element in the Infinite Scrolling Feed Example iframe to address the 1.4.3 contrast failure.
___
[WAI Preview Link](https://deploy-preview-367--aria-practices.netlify.app/ARIA/apg) _(Last built on Tue, 22 Oct 2024 13:55:25 GMT)._