### PR TITLE
Add `@csstools/stylelint-formatter-github` as Stylelint's GitHub formatter

### DIFF
--- a/.github/workflows/lint-css.yml
+++ b/.github/workflows/lint-css.yml
@@ -37,7 +37,7 @@ jobs:
         run: npm ci
 
       - name: Stylelint
-        run: npx stylelint "**/*.css" -f github
+        run: npx stylelint "**/*.css" --custom-formatter @csstools/stylelint-formatter-github
 
       - name: Prettier
         run: npx prettier --check "**/*.css"

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
       "devDependencies": {
         "@babel/core": "^7.25.2",
         "@babel/eslint-parser": "^7.25.1",
+        "@csstools/stylelint-formatter-github": "^1.0.0",
         "ava": "^6.1.3",
         "cheerio": "^1.0.0-rc.12",
         "cross-spawn": "^7.0.3",
@@ -995,6 +996,29 @@
       },
       "peerDependencies": {
         "postcss-selector-parser": "^6.0.13"
+      }
+    },
+    "node_modules/@csstools/stylelint-formatter-github": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/stylelint-formatter-github/-/stylelint-formatter-github-1.0.0.tgz",
+      "integrity": "sha512-YBKb4lNRXEpqrO6oJY0ql+D7lQGZcIwj/bs2bf3t95CU3NZFLrrZoJrKxVeyp5mCPo5iNopsp+wkksrjI7FI/Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "stylelint": "^16.6.0"
       }
     },
     "node_modules/@dual-bundle/import-meta-resolve": {
@@ -8502,6 +8526,13 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-3.1.1.tgz",
       "integrity": "sha512-a7cxGcJ2wIlMFLlh8z2ONm+715QkPHiyJcxwQlKOz/03GPw1COpfhcmC9wm4xlZfp//jWHNNMwzjtqHXVWU9KA==",
+      "dev": true,
+      "requires": {}
+    },
+    "@csstools/stylelint-formatter-github": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/stylelint-formatter-github/-/stylelint-formatter-github-1.0.0.tgz",
+      "integrity": "sha512-YBKb4lNRXEpqrO6oJY0ql+D7lQGZcIwj/bs2bf3t95CU3NZFLrrZoJrKxVeyp5mCPo5iNopsp+wkksrjI7FI/Q==",
       "dev": true,
       "requires": {}
     },

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "devDependencies": {
     "@babel/core": "^7.25.2",
     "@babel/eslint-parser": "^7.25.1",
+    "@csstools/stylelint-formatter-github": "^1.0.0",
     "ava": "^6.1.3",
     "cheerio": "^1.0.0-rc.12",
     "cross-spawn": "^7.0.3",


### PR DESCRIPTION
Stylelint's GitHub formatter was deprecated in [v16.8.0](https://github.com/stylelint/stylelint/blob/main/CHANGELOG.md#1680). Running [`npx stylelint "**/*.css" -f github`](https://github.com/w3c/aria-practices/blob/b0c04c4bf4bae3d2de4b1fed893d250ec27f5de8/.github/workflows/lint-css.yml#L40) from the workflow now gives the following error and is being thrown in #2991:

```sh
[stylelint:004] DeprecationWarning: "github" formatter is deprecated
Please use "stylelint-actions-formatters" instead.
```

This PR uses [`--custom-formatter @csstools/stylelint-formatter-github`](https://github.com/csstools/postcss-plugins/tree/main/plugins-stylelint/formatter-github#csstoolsstylelint-formatter-github), which should be a drop in replacement for `-f github`
