### PR TITLE
Editable Combobox With Both List and Inline Autocomplete Example: Editorial correction to accessibility features documentation

### DIFF
--- a/content/patterns/combobox/examples/combobox-autocomplete-list.html
+++ b/content/patterns/combobox/examples/combobox-autocomplete-list.html
@@ -147,7 +147,7 @@
                 Note: Because transparent borders are visible on some systems with operating system high contrast settings enabled, transparency cannot be used to create a visual difference between the element that is focused and other elements.
                 Instead of using transparency, the focused element has a thicker border and less padding.
                 When an element receives focus, its border changes from zero to two pixels and padding is reduced by two pixels.
-                When an element loses focus, its border changes from two pixels to two and padding is increased by two pixels.
+                When an element loses focus, its border changes from two pixels to zero and padding is increased by two pixels.
               </li>
             </ul>
           </li>


### PR DESCRIPTION
Under the **Accessibility Features** heading, 2nd bullet point, last sub-bullet point, the sentence reads:

"When an element loses focus, its border changes from two pixels to two and padding is increased by two pixels."

This update changes the second occurrence of "two" in the sentence to "zero", following the preceding sentence's logic.
___
[WAI Preview Link](https://deploy-preview-393--aria-practices.netlify.app/ARIA/apg) _(Last built on Tue, 18 Mar 2025 22:52:38 GMT)._