### PR TITLE
Vertical Temperature Slider Example: Eliminate redundant AX tree rendering of value

### DIFF
--- a/content/patterns/landmarks/examples/resources.html
+++ b/content/patterns/landmarks/examples/resources.html
@@ -53,8 +53,8 @@
                             <li><a href="https://www.w3.org/TR/WCAG20-TECHS/aria#ARIA11">ARIA11: Using ARIA landmarks to identify regions of a page</a> (WCAG 2.0 Technique)</li>
                             <li><a href="https://www.w3.org/TR/WCAG20-TECHS/aria#ARIA20">ARIA20: Using the region role to identify a region of the page</a> (WCAG 2.0 Technique)</li>
                             <li><a href="https://alistapart.com/column/wai-finding-with-aria-landmark-roles">WAI-finding with ARIA Landmark Roles</a> (A List Apart)</li>
-                            <li><a href="https://www.tpgi.com/using-wai-aria-landmarks-2013/">Using WAI-ARIA Landmarks – 2013</a> (Paciello Group)</li>
-                            <li><a href="https://www.tpgi.com/blog/2015/01/basic-screen-reader-commands-for-accessibility-testing/">Basic screen reader commands for accessibility testing</a>  (Paciello Group)</li>
+                            <li><a href="https://www.paciellogroup.com/blog/2013/02/using-wai-aria-landmarks-2013/">Using WAI-ARIA Landmarks – 2013</a> (Paciello Group)</li>
+                            <li><a href="https://www.paciellogroup.com/blog/2015/01/basic-screen-reader-commands-for-accessibility-testing/">Basic screen reader commands for accessibility testing</a>  (Paciello Group)</li>
                             <li><a href="http://webaim.org/projects/screenreadersurvey9/#landmarks">Screen Reader User Survey #9 Results: Landmarks/Regions</a> (WebAIM)</li>
                           </ul>
                         </section>

--- a/content/patterns/landmarks/examples/resources.html
+++ b/content/patterns/landmarks/examples/resources.html
@@ -53,8 +53,8 @@
                             <li><a href="https://www.w3.org/TR/WCAG20-TECHS/aria#ARIA11">ARIA11: Using ARIA landmarks to identify regions of a page</a> (WCAG 2.0 Technique)</li>
                             <li><a href="https://www.w3.org/TR/WCAG20-TECHS/aria#ARIA20">ARIA20: Using the region role to identify a region of the page</a> (WCAG 2.0 Technique)</li>
                             <li><a href="https://alistapart.com/column/wai-finding-with-aria-landmark-roles">WAI-finding with ARIA Landmark Roles</a> (A List Apart)</li>
-                            <li><a href="https://www.paciellogroup.com/blog/2013/02/using-wai-aria-landmarks-2013/">Using WAI-ARIA Landmarks – 2013</a> (Paciello Group)</li>
-                            <li><a href="https://www.paciellogroup.com/blog/2015/01/basic-screen-reader-commands-for-accessibility-testing/">Basic screen reader commands for accessibility testing</a>  (Paciello Group)</li>
+                            <li><a href="https://www.tpgi.com/using-wai-aria-landmarks-2013/">Using WAI-ARIA Landmarks – 2013</a> (Paciello Group)</li>
+                            <li><a href="https://www.tpgi.com/blog/2015/01/basic-screen-reader-commands-for-accessibility-testing/">Basic screen reader commands for accessibility testing</a>  (Paciello Group)</li>
                             <li><a href="http://webaim.org/projects/screenreadersurvey9/#landmarks">Screen Reader User Survey #9 Results: Landmarks/Regions</a> (WebAIM)</li>
                           </ul>
                         </section>

--- a/content/patterns/slider/examples/slider-temperature.html
+++ b/content/patterns/slider/examples/slider-temperature.html
@@ -62,9 +62,9 @@
             <div id="id-temp-label" class="label">Temperature</div>
 
             <svg role="none" class="slider-group" width="145" height="360">
-              <text class="temp-value" x="28" y="35">25°C</text>
-              <rect class="rail" x="60" y="47" width="8" height="300" rx="5" aria-hidden="true" />
               <g role="slider" id="id-temp-slider" aria-orientation="vertical" tabindex="0" aria-valuemin="10.0" aria-valuenow="25.0" aria-valuetext="25.0 degrees Celsius" aria-valuemax="38.0" aria-labelledby="id-temp-label">
+                <text class="temp-value" x="28" y="35">25°C</text>
+                <rect class="rail" x="60" y="47" width="8" height="300" rx="5" aria-hidden="true" />
                 <text class="value" x="94" y="150">25°C</text>
                 <rect class="focus-ring" x="35" y="170" width="105" height="24" rx="12" />
                 <rect class="thumb" x="35" y="145" width="48" height="14" rx="5" />


### PR DESCRIPTION
Resolves #3257 

Changes the vertical temperature slider to eliminate redundant announcement of the slider value by screen readers. This change makes the value displayed visually above the slider a child of the slider so its content becomes presentational.

[Vertical Slider Preview](https://deploy-preview-400--aria-practices.netlify.app/aria/apg/patterns/slider/examples/slider-temperature/)

___
[WAI Preview Link](https://deploy-preview-400--aria-practices.netlify.app/ARIA/apg) _(Last built on Mon, 26 May 2025 02:02:22 GMT)._