### PR TITLE
Infrastructure: Update `vnu-jar` to 24.10.17; ignore warnings

### DIFF
--- a/.vnurc
+++ b/.vnurc
@@ -27,3 +27,6 @@ Bad value “presentation” for attribute “role” on element “svg”.
 Element “input” is missing required attribute “aria-checked”.
 # https://github.com/w3c/aria-practices/issues/3070
 Attribute “aria-actions” not allowed on element “button” at this point.
+# https://github.com/validator/validator/issues/1364
+The “role” attribute must not be used on a “td” element which has a “table” ancestor with no “role” attribute, or with a “role” attribute whose value is “table”, “grid”, or “treegrid”.
+The “role” attribute must not be used on a “tr” element which has a “table” ancestor with no “role” attribute, or with a “role” attribute whose value is “table”, “grid”, or “treegrid”.

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "selenium-webdriver": "^4.29.0",
         "stylelint": "^16.16.0",
         "stylelint-config-standard": "^36.0.1",
-        "vnu-jar": "^21.2.5"
+        "vnu-jar": "^24.10.17"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -7902,10 +7902,11 @@
       "dev": true
     },
     "node_modules/vnu-jar": {
-      "version": "21.2.5",
-      "resolved": "https://registry.npmjs.org/vnu-jar/-/vnu-jar-21.2.5.tgz",
-      "integrity": "sha512-mVBXRui9jAkZwXyiqofprrDIAB91F5S0xRic49elb5sutx/L3JFICVut4rMlOoX5Jwqv7lAMHGnl7RMOFdSkVA==",
+      "version": "24.10.17",
+      "resolved": "https://registry.npmjs.org/vnu-jar/-/vnu-jar-24.10.17.tgz",
+      "integrity": "sha512-YT7gNrRY5PiJrI1GavlWRHWIwqq2o52COc6J9QeXPfoldKRiZ9BeGP4shNLLaVfi0naA+/LMksdYWkKCr4pnVg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10"
       }
@@ -13591,9 +13592,9 @@
       "dev": true
     },
     "vnu-jar": {
-      "version": "21.2.5",
-      "resolved": "https://registry.npmjs.org/vnu-jar/-/vnu-jar-21.2.5.tgz",
-      "integrity": "sha512-mVBXRui9jAkZwXyiqofprrDIAB91F5S0xRic49elb5sutx/L3JFICVut4rMlOoX5Jwqv7lAMHGnl7RMOFdSkVA==",
+      "version": "24.10.17",
+      "resolved": "https://registry.npmjs.org/vnu-jar/-/vnu-jar-24.10.17.tgz",
+      "integrity": "sha512-YT7gNrRY5PiJrI1GavlWRHWIwqq2o52COc6J9QeXPfoldKRiZ9BeGP4shNLLaVfi0naA+/LMksdYWkKCr4pnVg==",
       "dev": true
     },
     "vscode-languageserver-textdocument": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "selenium-webdriver": "^4.29.0",
     "stylelint": "^16.16.0",
     "stylelint-config-standard": "^36.0.1",
-    "vnu-jar": "^21.2.5"
+    "vnu-jar": "^24.10.17"
   },
   "lint-staged": {
     "*": "prettier --ignore-unknown --write",


### PR DESCRIPTION
Ignores the following errors when running `npm run lint:html`:

* The “role” attribute must not be used on a “tr” element which has a “table” ancestor with no “role” attribute, or with a “role” attribute whose value is “table”, “grid”, or “treegrid”.
* The “role” attribute must not be used on a “td” element which has a “table” ancestor with no “role” attribute, or with a “role” attribute whose value is “table”, “grid”, or “treegrid”.

This is already being tracked at https://github.com/validator/validator/issues/1364 and #2082 (but was closed as out of scope). Additional details are in thread at #2082.

<details>

<summary>Detailed failing output:</summary>

```sh
"file:/Users/Projects/aria/aria-practices/content/patterns/treegrid/examples/treegrid-1.html":114.20-115.100: error: The “role” attribute must not be used on a “tr” element which has a “table” ancestor with no “role” attribute, or with a “role” attribute whose value is “table”, “grid”, or “treegrid”.
"file:/Users/Projects/aria/aria-practices/content/patterns/treegrid/examples/treegrid-1.html":115.101-116.36: error: The “role” attribute must not be used on a “td” element which has a “table” ancestor with no “role” attribute, or with a “role” attribute whose value is “table”, “grid”, or “treegrid”.
"file:/Users/Projects/aria/aria-practices/content/patterns/treegrid/examples/treegrid-1.html":116.63-117.36: error: The “role” attribute must not be used on a “td” element which has a “table” ancestor with no “role” attribute, or with a “role” attribute whose value is “table”, “grid”, or “treegrid”.
"file:/Users/Projects/aria/aria-practices/content/patterns/treegrid/examples/treegrid-1.html":117.72-118.36: error: The “role” attribute must not be used on a “td” element which has a “table” ancestor with no “role” attribute, or with a “role” attribute whose value is “table”, “grid”, or “treegrid”.
"file:/Users/Projects/aria/aria-practices/content/patterns/treegrid/examples/treegrid-1.html":119.20-120.79: error: The “role” attribute must not be used on a “tr” element which has a “table” ancestor with no “role” attribute, or with a “role” attribute whose value is “table”, “grid”, or “treegrid”.
"file:/Users/Projects/aria/aria-practices/content/patterns/treegrid/examples/treegrid-1.html":120.80-121.36: error: The “role” attribute must not be used on a “td” element which has a “table” ancestor with no “role” attribute, or with a “role” attribute whose value is “table”, “grid”, or “treegrid”.
"file:/Users/Projects/aria/aria-practices/content/patterns/treegrid/examples/treegrid-1.html":121.67-122.36: error: The “role” attribute must not be used on a “td” element which has a “table” ancestor with no “role” attribute, or with a “role” attribute whose value is “table”, “grid”, or “treegrid”.
"file:/Users/Projects/aria/aria-practices/content/patterns/treegrid/examples/treegrid-1.html":122.80-123.36: error: The “role” attribute must not be used on a “td” element which has a “table” ancestor with no “role” attribute, or with a “role” attribute whose value is “table”, “grid”, or “treegrid”.
"file:/Users/Projects/aria/aria-practices/content/patterns/treegrid/examples/treegrid-1.html":124.20-125.101: error: The “role” attribute must not be used on a “tr” element which has a “table” ancestor with no “role” attribute, or with a “role” attribute whose value is “table”, “grid”, or “treegrid”.
"file:/Users/Projects/aria/aria-practices/content/patterns/treegrid/examples/treegrid-1.html":125.102-126.36: error: The “role” attribute must not be used on a “td” element which has a “table” ancestor with no “role” attribute, or with a “role” attribute whose value is “table”, “grid”, or “treegrid”.
"file:/Users/Projects/aria/aria-practices/content/patterns/treegrid/examples/treegrid-1.html":126.67-127.36: error: The “role” attribute must not be used on a “td” element which has a “table” ancestor with no “role” attribute, or with a “role” attribute whose value is “table”, “grid”, or “treegrid”.
"file:/Users/Projects/aria/aria-practices/content/patterns/treegrid/examples/treegrid-1.html":127.95-128.36: error: The “role” attribute must not be used on a “td” element which has a “table” ancestor with no “role” attribute, or with a “role” attribute whose value is “table”, “grid”, or “treegrid”.
"file:/Users/Projects/aria/aria-practices/content/patterns/treegrid/examples/treegrid-1.html":129.20-130.94: error: The “role” attribute must not be used on a “tr” element which has a “table” ancestor with no “role” attribute, or with a “role” attribute whose value is “table”, “grid”, or “treegrid”.
"file:/Users/Projects/aria/aria-practices/content/patterns/treegrid/examples/treegrid-1.html":130.95-131.36: error: The “role” attribute must not be used on a “td” element which has a “table” ancestor with no “role” attribute, or with a “role” attribute whose value is “table”, “grid”, or “treegrid”.
"file:/Users/Projects/aria/aria-practices/content/patterns/treegrid/examples/treegrid-1.html":131.67-132.36: error: The “role” attribute must not be used on a “td” element which has a “table” ancestor with no “role” attribute, or with a “role” attribute whose value is “table”, “grid”, or “treegrid”.
"file:/Users/Projects/aria/aria-practices/content/patterns/treegrid/examples/treegrid-1.html":132.95-133.36: error: The “role” attribute must not be used on a “td” element which has a “table” ancestor with no “role” attribute, or with a “role” attribute whose value is “table”, “grid”, or “treegrid”.
"file:/Users/Projects/aria/aria-practices/content/patterns/treegrid/examples/treegrid-1.html":134.20-135.101: error: The “role” attribute must not be used on a “tr” element which has a “table” ancestor with no “role” attribute, or with a “role” attribute whose value is “table”, “grid”, or “treegrid”.
"file:/Users/Projects/aria/aria-practices/content/patterns/treegrid/examples/treegrid-1.html":135.102-136.36: error: The “role” attribute must not be used on a “td” element which has a “table” ancestor with no “role” attribute, or with a “role” attribute whose value is “table”, “grid”, or “treegrid”.
"file:/Users/Projects/aria/aria-practices/content/patterns/treegrid/examples/treegrid-1.html":136.67-137.36: error: The “role” attribute must not be used on a “td” element which has a “table” ancestor with no “role” attribute, or with a “role” attribute whose value is “table”, “grid”, or “treegrid”.
"file:/Users/Projects/aria/aria-practices/content/patterns/treegrid/examples/treegrid-1.html":137.107-138.36: error: The “role” attribute must not be used on a “td” element which has a “table” ancestor with no “role” attribute, or with a “role” attribute whose value is “table”, “grid”, or “treegrid”.
"file:/Users/Projects/aria/aria-practices/content/patterns/treegrid/examples/treegrid-1.html":139.20-140.116: error: The “role” attribute must not be used on a “tr” element which has a “table” ancestor with no “role” attribute, or with a “role” attribute whose value is “table”, “grid”, or “treegrid”.
"file:/Users/Projects/aria/aria-practices/content/patterns/treegrid/examples/treegrid-1.html":140.117-141.36: error: The “role” attribute must not be used on a “td” element which has a “table” ancestor with no “role” attribute, or with a “role” attribute whose value is “table”, “grid”, or “treegrid”.
"file:/Users/Projects/aria/aria-practices/content/patterns/treegrid/examples/treegrid-1.html":141.67-142.36: error: The “role” attribute must not be used on a “td” element which has a “table” ancestor with no “role” attribute, or with a “role” attribute whose value is “table”, “grid”, or “treegrid”.
"file:/Users/Projects/aria/aria-practices/content/patterns/treegrid/examples/treegrid-1.html":142.104-143.36: error: The “role” attribute must not be used on a “td” element which has a “table” ancestor with no “role” attribute, or with a “role” attribute whose value is “table”, “grid”, or “treegrid”.
"file:/Users/Projects/aria/aria-practices/content/patterns/treegrid/examples/treegrid-1.html":144.20-145.94: error: The “role” attribute must not be used on a “tr” element which has a “table” ancestor with no “role” attribute, or with a “role” attribute whose value is “table”, “grid”, or “treegrid”.
"file:/Users/Projects/aria/aria-practices/content/patterns/treegrid/examples/treegrid-1.html":145.95-146.36: error: The “role” attribute must not be used on a “td” element which has a “table” ancestor with no “role” attribute, or with a “role” attribute whose value is “table”, “grid”, or “treegrid”.
"file:/Users/Projects/aria/aria-practices/content/patterns/treegrid/examples/treegrid-1.html":146.67-147.36: error: The “role” attribute must not be used on a “td” element which has a “table” ancestor with no “role” attribute, or with a “role” attribute whose value is “table”, “grid”, or “treegrid”.
"file:/Users/Projects/aria/aria-practices/content/patterns/treegrid/examples/treegrid-1.html":147.106-148.36: error: The “role” attribute must not be used on a “td” element which has a “table” ancestor with no “role” attribute, or with a “role” attribute whose value is “table”, “grid”, or “treegrid”.
"file:/Users/Projects/aria/aria-practices/content/patterns/treegrid/examples/treegrid-1.html":149.20-150.94: error: The “role” attribute must not be used on a “tr” element which has a “table” ancestor with no “role” attribute, or with a “role” attribute whose value is “table”, “grid”, or “treegrid”.
"file:/Users/Projects/aria/aria-practices/content/patterns/treegrid/examples/treegrid-1.html":150.95-151.36: error: The “role” attribute must not be used on a “td” element which has a “table” ancestor with no “role” attribute, or with a “role” attribute whose value is “table”, “grid”, or “treegrid”.
"file:/Users/Projects/aria/aria-practices/content/patterns/treegrid/examples/treegrid-1.html":151.67-152.36: error: The “role” attribute must not be used on a “td” element which has a “table” ancestor with no “role” attribute, or with a “role” attribute whose value is “table”, “grid”, or “treegrid”.
"file:/Users/Projects/aria/aria-practices/content/patterns/treegrid/examples/treegrid-1.html":152.86-153.36: error: The “role” attribute must not be used on a “td” element which has a “table” ancestor with no “role” attribute, or with a “role” attribute whose value is “table”, “grid”, or “treegrid”.
```

</details>