### PR TITLE
Accordion Pattern: Remove extraneous colon character from heading

### DIFF
--- a/content/patterns/accordion/accordion-pattern.html
+++ b/content/patterns/accordion/accordion-pattern.html
@@ -74,7 +74,7 @@
       </section>
 
       <section id="roles_states_properties">
-        <h2>WAI-ARIA Roles, States, and Properties:</h2>
+        <h2>WAI-ARIA Roles, States, and Properties</h2>
         <ul>
           <li>The title of each accordion header is contained in an element with role <a href="#button" class="role-reference">button</a>.</li>
           <li>


### PR DESCRIPTION
Resolves #3300 by removing the trailing colon (:) character at the end of the heading for roles, states, and properties.
___
[WAI Preview Link](https://deploy-preview-408--aria-practices.netlify.app/ARIA/apg) _(Last built on Tue, 01 Jul 2025 07:45:31 GMT)._