### PR TITLE
All Pages: Change 'Javascript' to 'JavaScript'

### DIFF
--- a/content-templates/Depricated-MultipleImplementationExample-Template.html
+++ b/content-templates/Depricated-MultipleImplementationExample-Template.html
@@ -243,7 +243,7 @@
   </section>
 
   <section>
-    <h2>Javascript and CSS Source Code</h2>
+    <h2>JavaScript and CSS Source Code</h2>
     <!--  After the js and css files are named with the name of this example, change the href and text of the following 2 links to refer to the appropriate js and css files.  -->
     <ul>
       <li>
@@ -251,7 +251,7 @@
         <a href="css/example_name.css" type="tex/css">example_name.css</a>
       </li>
       <li>
-        Javascript:
+        JavaScript:
         <a href="js/example_name.js" type="text/javascript">example_name.js</a>
       </li>
     </ul>

--- a/content-templates/Example-Template.html
+++ b/content-templates/Example-Template.html
@@ -86,7 +86,7 @@
             <script type="text/javascript">
               /* eslint-disable */
 
-              //  Javascript relevant to example
+              //  JavaScript relevant to example
               var i;
               var str = 'text';
               for (i = 0; i < str.length; i++) {
@@ -196,7 +196,7 @@
       </section>
 
       <section>
-        <h2>Javascript and CSS Source Code</h2>
+        <h2>JavaScript and CSS Source Code</h2>
         <!--  After the js and css files are named with the name of this example, change the href and text of the following 2 links to refer to the appropriate js and css files.  -->
         <ul id="css_js_files">
           <li>
@@ -204,7 +204,7 @@
             <a href="css/example_name.css" type="text/css">example_name.css</a>
           </li>
           <li>
-            Javascript:
+            JavaScript:
             <a href="js/example_name.js" type="text/javascript">example_name.js</a>
           </li>
         </ul>

--- a/content/about/change-history/change-history.html
+++ b/content/about/change-history/change-history.html
@@ -43,7 +43,7 @@
           <li>Improved support for high contrast settings and added detailed documentation of high contrast support in many examples.</li>
           <li>Improved support for touch-based screen readers in several examples, most notably in sliders.</li>
           <li>Due to change in ARIA 1.2, removed Math role from list of roles that have presentational children.</li>
-          <li>Developed a <a href="https://github.com/w3c/aria-practices/wiki/Code-Guide#apg-coding-standards">comprehensive set of coding standards for HTML, CSS, and Javascript</a> for the APG and updated a significant portion of content to conform with the standards.</li>
+          <li>Developed a <a href="https://github.com/w3c/aria-practices/wiki/Code-Guide#apg-coding-standards">comprehensive set of coding standards for HTML, CSS, and JavaScript</a> for the APG and updated a significant portion of content to conform with the standards.</li>
           <li>In response to feedback, fixed many documentation errors and functional bugs in examples.</li>
       </ul>
       <p>Comprehensive lists of closed issues included in APG 1.2 release 1 are tracked in the following GitHub milestones.</p>

--- a/content/about/coverage-and-quality/coverage-and-quality-report.html
+++ b/content/about/coverage-and-quality/coverage-and-quality-report.html
@@ -1339,9 +1339,9 @@
             <th>Uses <code>event.which</code></th>
             <th>High Contrast Documentation</th>
             <th>Example Code ID</th>
-            <th>Roles in Javascript and HTML</th>
+            <th>Roles in JavaScript and HTML</th>
             <th>Roles in Documentation</th>
-            <th>aria-* Attributes in Javascript and HTML</th>
+            <th>aria-* Attributes in JavaScript and HTML</th>
             <th>aria-* Attributes in Documentation</th>
             <th>Differences between the documentation and the source code.</th>
           </tr>

--- a/content/patterns/alert/examples/alert.html
+++ b/content/patterns/alert/examples/alert.html
@@ -140,7 +140,7 @@
             <a href="css/alert.css" type="tex/css">alert.css</a>
           </li>
           <li>
-            Javascript:
+            JavaScript:
             <a href="js/alert.js" type="text/javascript">alert.js</a>
           </li>
         </ul>

--- a/content/patterns/alertdialog/examples/alertdialog.html
+++ b/content/patterns/alertdialog/examples/alertdialog.html
@@ -226,10 +226,10 @@
       </section>
 
       <section>
-        <h2 id="src_label">Javascript and CSS Source Code</h2>
+        <h2 id="src_label">JavaScript and CSS Source Code</h2>
         <ul id="css_js_files">
           <li>CSS: <a href="css/alertdialog.css" type="text/css">alertdialog.css</a></li>
-          <li>Javascript: <a href="js/alertdialog.js" type="text/javascript">alertdialog.js</a>, <a href="../../../shared/js/utils.js">utils.js</a></li>
+          <li>JavaScript: <a href="js/alertdialog.js" type="text/javascript">alertdialog.js</a>, <a href="../../../shared/js/utils.js">utils.js</a></li>
         </ul>
       </section>
 

--- a/content/patterns/button/examples/button.html
+++ b/content/patterns/button/examples/button.html
@@ -202,7 +202,7 @@
             <a href="css/button.css" type="text/css">button.css</a>
           </li>
           <li>
-            Javascript:
+            JavaScript:
             <a href="js/button.js" type="text/javascript">button.js</a>
           </li>
         </ul>

--- a/content/patterns/button/examples/button_idl.html
+++ b/content/patterns/button/examples/button_idl.html
@@ -193,7 +193,7 @@
             <a href="css/button.css" type="text/css">button.css</a>
           </li>
           <li>
-            Javascript:
+            JavaScript:
             <a href="js/button_idl.js" type="text/javascript">button_idl.js</a>
           </li>
         </ul>

--- a/content/patterns/carousel/examples/carousel-1-prev-next.html
+++ b/content/patterns/carousel/examples/carousel-1-prev-next.html
@@ -520,7 +520,7 @@
         <h2>JavaScript and CSS Source Code</h2>
         <ul id="css_js_files">
           <li>CSS: <a href="css/carousel-prev-next.css" type="text/css">carousel-prev-next.css</a></li>
-          <li>Javascript: <a href="js/carousel-prev-next.js" type="text/javascript">carousel-prev-next.js</a></li>
+          <li>JavaScript: <a href="js/carousel-prev-next.js" type="text/javascript">carousel-prev-next.js</a></li>
         </ul>
       </section>
 

--- a/content/patterns/carousel/examples/carousel-2-tablist.html
+++ b/content/patterns/carousel/examples/carousel-2-tablist.html
@@ -706,7 +706,7 @@
         <h2>JavaScript and CSS Source Code</h2>
         <ul id="css_js_files">
           <li>CSS: <a href="css/carousel-tablist.css" type="text/css">carousel-tablist.css</a></li>
-          <li>Javascript: <a href="js/carousel-tablist.js" type="text/javascript">carousel-tablist.js</a></li>
+          <li>JavaScript: <a href="js/carousel-tablist.js" type="text/javascript">carousel-tablist.js</a></li>
         </ul>
       </section>
 

--- a/content/patterns/checkbox/examples/checkbox-mixed.html
+++ b/content/patterns/checkbox/examples/checkbox-mixed.html
@@ -204,7 +204,7 @@
         <h2>JavaScript and CSS Source Code</h2>
         <ul id="css_js_files">
           <li>CSS: <a href="css/checkbox-mixed.css" type="text/css">checkbox-mixed.css</a></li>
-          <li>Javascript: <a href="js/checkbox-mixed.js" type="text/javascript">checkbox-mixed.js</a></li>
+          <li>JavaScript: <a href="js/checkbox-mixed.js" type="text/javascript">checkbox-mixed.js</a></li>
         </ul>
       </section>
 

--- a/content/patterns/checkbox/examples/checkbox.html
+++ b/content/patterns/checkbox/examples/checkbox.html
@@ -191,7 +191,7 @@
         <h2>JavaScript and CSS Source Code</h2>
         <ul id="css_js_files">
           <li>CSS: <a href="css/checkbox.css" type="text/css">checkbox.css</a></li>
-          <li>Javascript: <a href="js/checkbox.js" type="text/javascript">checkbox.js</a></li>
+          <li>JavaScript: <a href="js/checkbox.js" type="text/javascript">checkbox.js</a></li>
         </ul>
       </section>
 

--- a/content/patterns/combobox/examples/combobox-autocomplete-both.html
+++ b/content/patterns/combobox/examples/combobox-autocomplete-both.html
@@ -525,7 +525,7 @@
             <a href="css/combobox-autocomplete.css" type="text/css">combobox-autocomplete.css</a>
           </li>
           <li>
-            Javascript:
+            JavaScript:
             <a href="js/combobox-autocomplete.js" type="text/javascript">combobox-autocomplete.js</a>
           </li>
         </ul>

--- a/content/patterns/combobox/examples/combobox-autocomplete-list.html
+++ b/content/patterns/combobox/examples/combobox-autocomplete-list.html
@@ -519,7 +519,7 @@
             <a href="css/combobox-autocomplete.css" type="text/css">combobox-autocomplete.css</a>
           </li>
           <li>
-            Javascript:
+            JavaScript:
             <a href="js/combobox-autocomplete.js" type="text/javascript">combobox-autocomplete.js</a>
           </li>
         </ul>

--- a/content/patterns/combobox/examples/combobox-autocomplete-none.html
+++ b/content/patterns/combobox/examples/combobox-autocomplete-none.html
@@ -461,7 +461,7 @@
             <a href="css/combobox-autocomplete.css" type="text/css">combobox-autocomplete.css</a>
           </li>
           <li>
-            Javascript:
+            JavaScript:
             <a href="js/combobox-autocomplete.js" type="text/javascript">combobox-autocomplete.js</a>
           </li>
         </ul>

--- a/content/patterns/combobox/examples/combobox-datepicker.html
+++ b/content/patterns/combobox/examples/combobox-datepicker.html
@@ -704,7 +704,7 @@ Moves focus to the day of the month that has the same number.
             <a href="css/combobox-datepicker.css" type="text/css">combobox-datepicker.css</a>
           </li>
           <li>
-            Javascript:
+            JavaScript:
             <a href="js/combobox-datepicker.js" type="text/javascript">combobox-datepicker.js</a>
           </li>
         </ul>

--- a/content/patterns/combobox/examples/combobox-select-only.html
+++ b/content/patterns/combobox/examples/combobox-select-only.html
@@ -401,7 +401,7 @@
             <a href="css/select-only.css" type="text/css">select-only.css</a>
           </li>
           <li>
-            Javascript:
+            JavaScript:
             <a href="js/select-only.js" type="text/javascript">select-only.js</a>
           </li>
         </ul>

--- a/content/patterns/combobox/examples/grid-combo.html
+++ b/content/patterns/combobox/examples/grid-combo.html
@@ -382,7 +382,7 @@
         <h2>JavaScript and CSS Source Code</h2>
         <ul id="css_js_files">
           <li>CSS: <a href="css/grid-combo.css" type="tex/css">grid-combo.css</a></li>
-          <li>Javascript: <a href="js/grid-combo.js">grid-combo.js</a>, <a href="js/grid-combo-example.js">grid-combo-example.js</a>, <a href="../../../shared/js/utils.js">utils.js</a></li>
+          <li>JavaScript: <a href="js/grid-combo.js">grid-combo.js</a>, <a href="js/grid-combo-example.js">grid-combo-example.js</a>, <a href="../../../shared/js/utils.js">utils.js</a></li>
         </ul>
       </section>
 

--- a/content/patterns/dialog-modal/examples/datepicker-dialog.html
+++ b/content/patterns/dialog-modal/examples/datepicker-dialog.html
@@ -638,7 +638,7 @@
             <a href="css/datepicker-dialog.css" type="text/css">datepicker-dialog.css</a>
           </li>
           <li>
-            Javascript:
+            JavaScript:
             <a href="js/datepicker-dialog.js" type="text/javascript">datepicker-dialog.js</a>
           </li>
         </ul>

--- a/content/patterns/dialog-modal/examples/dialog.html
+++ b/content/patterns/dialog-modal/examples/dialog.html
@@ -349,7 +349,7 @@
             <a href="css/dialog.css" type="text/css">dialog.css</a>
           </li>
           <li>
-            Javascript:
+            JavaScript:
             <a href="js/dialog.js" type="text/javascript">dialog.js</a>,
             <a href="../../../shared/js/utils.js">utils.js</a>
           </li>

--- a/content/patterns/disclosure/examples/disclosure-faq.html
+++ b/content/patterns/disclosure/examples/disclosure-faq.html
@@ -208,7 +208,7 @@
             <a href="css/disclosure-faq.css" type="tex/css">disclosure-faq.css</a>
           </li>
           <li>
-            Javascript:
+            JavaScript:
             <a href="js/disclosure-button.js" type="text/javascript">disclosureButton.js</a>
           </li>
         </ul>

--- a/content/patterns/disclosure/examples/disclosure-image-description.html
+++ b/content/patterns/disclosure/examples/disclosure-image-description.html
@@ -360,7 +360,7 @@
             <a href="css/disclosure-image-description.css" type="tex/css">disclosure-img-long-description.css</a>
           </li>
           <li>
-            Javascript:
+            JavaScript:
             <a href="js/disclosure-button.js" type="text/javascript">disclosureButton.js</a>
           </li>
         </ul>

--- a/content/patterns/disclosure/examples/disclosure-navigation-hybrid.html
+++ b/content/patterns/disclosure/examples/disclosure-navigation-hybrid.html
@@ -360,7 +360,7 @@
             <a href="css/disclosure-navigation.css" type="tex/css">disclosure-navigation.css</a>
           </li>
           <li>
-            Javascript:
+            JavaScript:
             <a href="js/disclosureMenu.js" type="text/javascript">disclosureMenu.js</a>
           </li>
         </ul>

--- a/content/patterns/disclosure/examples/disclosure-navigation.html
+++ b/content/patterns/disclosure/examples/disclosure-navigation.html
@@ -355,7 +355,7 @@
             <a href="css/disclosure-navigation.css">disclosure-navigation.css</a>
           </li>
           <li>
-            Javascript:
+            JavaScript:
             <a href="js/disclosureMenu.js">disclosureMenu.js</a>
           </li>
         </ul>

--- a/content/patterns/feed/examples/feed.html
+++ b/content/patterns/feed/examples/feed.html
@@ -204,10 +204,10 @@
 
       <section>
         <h2>JavaScript and CSS Source Code</h2>
-        <p>The following Javascript and CSS is used by the feed-display.html page:</p>
+        <p>The following JavaScript and CSS is used by the feed-display.html page:</p>
         <ul id="css_js_files">
           <li>CSS: <a href="css/feedDisplay.css" type="tex/css">feedDisplay.css</a></li>
-          <li>Javascript: <a href="js/feed.js" type="text/javascript">feed.js</a>, <a href="js/feedDisplay.js" type="text/javascript">feedDisplay.js</a>, <a href="js/main.js" type="text/javascript">main.js</a>, <a href="../../../shared/js/utils.js">utils.js</a></li>
+          <li>JavaScript: <a href="js/feed.js" type="text/javascript">feed.js</a>, <a href="js/feedDisplay.js" type="text/javascript">feedDisplay.js</a>, <a href="js/main.js" type="text/javascript">main.js</a>, <a href="../../../shared/js/utils.js">utils.js</a></li>
         </ul>
       </section>
 

--- a/content/patterns/grid/examples/advanced-data-grid.html
+++ b/content/patterns/grid/examples/advanced-data-grid.html
@@ -135,7 +135,7 @@
             <!--a href="css/example_name.css" type="tex/css">example_name.css</a-->
           </li>
           <li>
-            Javascript:
+            JavaScript:
             <!--a href="js/example_name.js" type="text/javascript">example_name.js</a-->
           </li>
         </ul>

--- a/content/patterns/link/examples/link.html
+++ b/content/patterns/link/examples/link.html
@@ -167,7 +167,7 @@
             <a href="css/link.css" type="tex/css">link.css</a>
           </li>
           <li>
-            Javascript:
+            JavaScript:
             <a href="js/link.js" type="text/javascript">link.js</a>
           </li>
         </ul>

--- a/content/patterns/listbox/examples/listbox-collapsible.html
+++ b/content/patterns/listbox/examples/listbox-collapsible.html
@@ -313,7 +313,7 @@
             <a href="css/listbox.css" type="tex/css">listbox.css</a>
           </li>
           <li>
-            Javascript:
+            JavaScript:
             <a href="js/listbox.js" type="text/javascript">listbox.js</a>, <a href="js/listbox-collapsible.js" type="text/javascript">listbox-collapsible.js</a>
           </li>
         </ul>

--- a/content/patterns/listbox/examples/listbox-grouped.html
+++ b/content/patterns/listbox/examples/listbox-grouped.html
@@ -286,7 +286,7 @@
             <a href="css/listbox.css" type="tex/css">listbox.css</a>
           </li>
           <li>
-            Javascript:
+            JavaScript:
             <a href="js/listbox.js" type="text/javascript">listbox.js</a>, <a href="js/listbox-scrollable.js" type="text/javascript">listbox-scrollable.js</a>
           </li>
         </ul>

--- a/content/patterns/listbox/examples/listbox-rearrangeable.html
+++ b/content/patterns/listbox/examples/listbox-rearrangeable.html
@@ -519,7 +519,7 @@
             <a href="css/listbox.css" type="tex/css">listbox.css</a>
           </li>
           <li>
-            Javascript:
+            JavaScript:
             <a href="js/listbox.js" type="text/javascript">listbox.js</a>, <a href="js/toolbar.js" type="text/javascript">toolbar.js</a>, <a href="js/listbox-rearrangeable.js" type="text/javascript">listbox-rearrangeable.js</a>
           </li>
         </ul>

--- a/content/patterns/listbox/examples/listbox-scrollable.html
+++ b/content/patterns/listbox/examples/listbox-scrollable.html
@@ -326,7 +326,7 @@
             <a href="css/listbox.css" type="tex/css">listbox.css</a>
           </li>
           <li>
-            Javascript:
+            JavaScript:
             <a href="js/listbox.js" type="text/javascript">listbox.js</a>, <a href="js/listbox-scrollable.js" type="text/javascript">listbox-scrollable.js</a>
           </li>
         </ul>

--- a/content/patterns/menu-button/examples/menu-button-actions-active-descendant.html
+++ b/content/patterns/menu-button/examples/menu-button-actions-active-descendant.html
@@ -334,7 +334,7 @@
 
         <ul id="css_js_files">
           <li>CSS: <a href="css/menu-button-actions.css" type="text/css">menu-button-actions.css</a></li>
-          <li>Javascript: <a href="js/menu-button-actions-active-descendant.js" type="text/javascript">menu-button-actions-active-descendant.js</a></li>
+          <li>JavaScript: <a href="js/menu-button-actions-active-descendant.js" type="text/javascript">menu-button-actions-active-descendant.js</a></li>
         </ul>
       </section>
 

--- a/content/patterns/menu-button/examples/menu-button-actions.html
+++ b/content/patterns/menu-button/examples/menu-button-actions.html
@@ -313,7 +313,7 @@
 
         <ul id="css_js_files">
           <li>CSS: <a href="css/menu-button-actions.css" type="text/css">menu-button-actions.css</a></li>
-          <li>Javascript: <a href="js/menu-button-actions.js" type="text/javascript">menu-button-actions.js</a></li>
+          <li>JavaScript: <a href="js/menu-button-actions.js" type="text/javascript">menu-button-actions.js</a></li>
         </ul>
       </section>
 

--- a/content/patterns/menu-button/examples/menu-button-links.html
+++ b/content/patterns/menu-button/examples/menu-button-links.html
@@ -349,7 +349,7 @@
 
         <ul id="css_js_files">
           <li>CSS: <a href="css/menu-button-links.css" type="text/css">menu-button-links.css</a></li>
-          <li>Javascript: <a href="js/menu-button-links.js" type="text/javascript">menu-button-links.js</a></li>
+          <li>JavaScript: <a href="js/menu-button-links.js" type="text/javascript">menu-button-links.js</a></li>
         </ul>
       </section>
 

--- a/content/patterns/menubar/examples/menubar-editor.html
+++ b/content/patterns/menubar/examples/menubar-editor.html
@@ -775,8 +775,8 @@
             CSS:
             <a href="css/menubar-editor.css" type="tex/css">menubar-editor.css</a>
           </li>
-          <li>Javascript: <a href="js/menubar-editor.js" type="text/javascript">menubar-editor.js</a></li>
-          <li>Javascript: <a href="js/style-manager.js" type="text/javascript">style-manager.js</a></li>
+          <li>JavaScript: <a href="js/menubar-editor.js" type="text/javascript">menubar-editor.js</a></li>
+          <li>JavaScript: <a href="js/style-manager.js" type="text/javascript">style-manager.js</a></li>
         </ul>
       </section>
 

--- a/content/patterns/menubar/examples/menubar-navigation.html
+++ b/content/patterns/menubar/examples/menubar-navigation.html
@@ -810,7 +810,7 @@
         <h2>JavaScript and CSS Source Code</h2>
         <ul id="css_js_files">
           <li>CSS: <a href="css/menubar-navigation.css" type="tex/css">menubar-navigation.css</a></li>
-          <li>Javascript: <a href="js/menubar-navigation.js" type="text/javascript">menubar-navigation.js</a></li>
+          <li>JavaScript: <a href="js/menubar-navigation.js" type="text/javascript">menubar-navigation.js</a></li>
         </ul>
       </section>
 

--- a/content/patterns/meter/examples/meter.html
+++ b/content/patterns/meter/examples/meter.html
@@ -124,7 +124,7 @@
             <a href="css/meter.css" type="text/css">meter.css</a>
           </li>
           <li>
-            Javascript:
+            JavaScript:
             <a href="js/meter.js" type="text/javascript">meter.js</a>
           </li>
         </ul>

--- a/content/patterns/radio/examples/radio-activedescendant.html
+++ b/content/patterns/radio/examples/radio-activedescendant.html
@@ -261,7 +261,7 @@
         <h2>JavaScript and CSS Source Code</h2>
         <ul id="css_js_files">
           <li>CSS: <a href="css/radio.css" type="tex/css">radio.css</a></li>
-          <li>Javascript: <a href="js/radio-activedescendant.js" type="text/javascript">radio-activedescendant.js</a></li>
+          <li>JavaScript: <a href="js/radio-activedescendant.js" type="text/javascript">radio-activedescendant.js</a></li>
         </ul>
       </section>
 

--- a/content/patterns/radio/examples/radio-rating.html
+++ b/content/patterns/radio/examples/radio-rating.html
@@ -279,7 +279,7 @@
         <h2>JavaScript and CSS Source Code</h2>
         <ul id="css_js_files">
           <li>CSS: <a href="css/radio-rating.css" type="text/css">radio-rating.css</a></li>
-          <li>Javascript: <a href="js/radio-rating.js" type="text/javascript">radio-rating.js</a></li>
+          <li>JavaScript: <a href="js/radio-rating.js" type="text/javascript">radio-rating.js</a></li>
         </ul>
       </section>
 

--- a/content/patterns/radio/examples/radio.html
+++ b/content/patterns/radio/examples/radio.html
@@ -250,7 +250,7 @@
         <h2>JavaScript and CSS Source Code</h2>
         <ul id="css_js_files">
           <li>CSS: <a href="css/radio.css">radio.css</a></li>
-          <li>Javascript: <a href="js/radio.js">radio.js</a></li>
+          <li>JavaScript: <a href="js/radio.js">radio.js</a></li>
         </ul>
       </section>
 

--- a/content/patterns/slider-multithumb/examples/slider-multithumb.html
+++ b/content/patterns/slider-multithumb/examples/slider-multithumb.html
@@ -256,7 +256,7 @@
         <h2>JavaScript and CSS Source Code</h2>
         <ul id="css_js_files">
           <li>CSS: <a href="css/slider-multithumb.css" type="tex/css">slider-multithumb.css</a></li>
-          <li>Javascript: <a href="js/slider-multithumb.js" type="text/javascript">slider-multithumb.js</a></li>
+          <li>JavaScript: <a href="js/slider-multithumb.js" type="text/javascript">slider-multithumb.js</a></li>
         </ul>
       </section>
 

--- a/content/patterns/slider/examples/slider-color-viewer.html
+++ b/content/patterns/slider/examples/slider-color-viewer.html
@@ -64,7 +64,7 @@
 
             <div id="id-red" class="color-slider-label">Red</div>
             <div class="color-slider red" role="slider" tabindex="0" aria-valuemin="0" aria-valuenow="128" aria-valuemax="255" aria-labelledby="id-red">
-              <!-- SVG position and dimension values added through Javascript -->
+              <!-- SVG position and dimension values added through JavaScript -->
 
               <svg width="0" height="0" aria-hidden="true">
                 <text class="value" x="0" y="0">128</text>
@@ -77,7 +77,7 @@
 
             <div id="id-green" class="color-slider-label">Green</div>
             <div class="color-slider green" role="slider" tabindex="0" aria-valuemin="0" aria-valuenow="128" aria-valuemax="255" aria-labelledby="id-green">
-              <!-- SVG position and dimension values added through Javascript -->
+              <!-- SVG position and dimension values added through JavaScript -->
 
               <svg width="0" height="0" aria-hidden="true">
                 <text class="value" x="0" y="0">128</text>
@@ -90,7 +90,7 @@
 
             <div id="id-blue" class="color-slider-label">Blue</div>
             <div class="color-slider blue" role="slider" tabindex="0" aria-valuemin="0" aria-valuenow="128" aria-valuemax="255" aria-labelledby="id-blue">
-              <!-- SVG position and dimension values added through Javascript -->
+              <!-- SVG position and dimension values added through JavaScript -->
 
               <svg width="0" height="0" aria-hidden="true">
                 <text class="value" x="0" y="0">128</text>
@@ -307,7 +307,7 @@
         <h2>JavaScript and CSS Source Code</h2>
         <ul id="css_js_files">
           <li>CSS: <a href="css/slider-color-viewer.css" type="text/css">slider-color-viewer.css</a></li>
-          <li>Javascript: <a href="js/slider-color-viewer.js" type="text/javascript">slider-color-viewer.js</a></li>
+          <li>JavaScript: <a href="js/slider-color-viewer.js" type="text/javascript">slider-color-viewer.js</a></li>
         </ul>
       </section>
 

--- a/content/patterns/slider/examples/slider-rating.html
+++ b/content/patterns/slider/examples/slider-rating.html
@@ -78,7 +78,7 @@
                aria-valuemax="10"
                aria-valuetext="Choose a rating from 1 to 10 where 10 is extremely satisfied"
               aria-labelledby="id-rating-label">
-            <!-- SVG position and dimension values added through Javascript -->
+            <!-- SVG position and dimension values added through JavaScript -->
 
             <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="800" height="110">
               <rect class="focus-ring" x="23" y="2" width="54" height="90" rx="5" />
@@ -309,7 +309,7 @@
         <h2>JavaScript and CSS Source Code</h2>
         <ul id="css_js_files">
           <li>CSS: <a href="css/slider-rating.css" type="text/css">slider-rating.css</a></li>
-          <li>Javascript: <a href="js/slider-rating.js" type="text/javascript">slider-rating.js</a></li>
+          <li>JavaScript: <a href="js/slider-rating.js" type="text/javascript">slider-rating.js</a></li>
         </ul>
       </section>
 

--- a/content/patterns/slider/examples/slider-seek.html
+++ b/content/patterns/slider/examples/slider-seek.html
@@ -71,7 +71,7 @@
                 <rect class="focus-ring" x="0" y="0" width="28" height="60" rx="12" />
                 <rect class="thumb" x="0" y="0" width="14" height="48" rx="5" />
               </g>
-              <!-- Button positions set by Javascript calculations  -->
+              <!-- Button positions set by JavaScript calculations  -->
               <g class="value-label" data-value="0">
                 <text x="0" y="0">0:00</text>
               </g>
@@ -302,7 +302,7 @@
         <h2>JavaScript and CSS Source Code</h2>
         <ul id="css_js_files">
           <li>CSS: <a href="css/slider-seek.css" type="text/css">slider-seek.css</a></li>
-          <li>Javascript: <a href="js/slider-seek.js" type="text/javascript">slider-seek.js</a></li>
+          <li>JavaScript: <a href="js/slider-seek.js" type="text/javascript">slider-seek.js</a></li>
         </ul>
       </section>
 

--- a/content/patterns/slider/examples/slider-temperature.html
+++ b/content/patterns/slider/examples/slider-temperature.html
@@ -283,7 +283,7 @@
         <h2>JavaScript and CSS Source Code</h2>
         <ul id="css_js_files">
           <li>CSS: <a href="css/slider-temperature.css" type="text/css">slider-temperature.css</a></li>
-          <li>Javascript: <a href="js/slider-temperature.js" type="text/javascript">slider-temperature.js</a></li>
+          <li>JavaScript: <a href="js/slider-temperature.js" type="text/javascript">slider-temperature.js</a></li>
         </ul>
       </section>
 

--- a/content/patterns/spinbutton/examples/datepicker-spinbuttons.html
+++ b/content/patterns/spinbutton/examples/datepicker-spinbuttons.html
@@ -314,7 +314,7 @@
             <a href="css/datepicker-spinbuttons.css" type="text/css">datepicker-spinbuttons.css</a>
           </li>
           <li>
-            Javascript:
+            JavaScript:
             <ul>
               <li><a href="js/datepicker-spinbuttons.js" type="text/javascript">datepicker-spinbuttons.js</a></li>
               <li><a href="js/spinbutton-date.js" type="text/javascript">spinbutton-date.js</a></li>

--- a/content/patterns/switch/examples/switch-button.html
+++ b/content/patterns/switch/examples/switch-button.html
@@ -220,7 +220,7 @@
             <a href="css/switch-button.css" type="text/css">switch-button.css</a>
           </li>
           <li>
-            Javascript:
+            JavaScript:
             <a href="js/switch-button.js" type="text/javascript">switch-button.js</a>
           </li>
         </ul>

--- a/content/patterns/switch/examples/switch-checkbox.html
+++ b/content/patterns/switch/examples/switch-checkbox.html
@@ -178,7 +178,7 @@
             <a href="css/switch-checkbox.css" type="tex/css">switch-checkbox.css</a>
           </li>
           <li>
-            Javascript:
+            JavaScript:
             <a href="js/switch-checkbox.js" type="text/javascript">switch-checkbox.js</a>
           </li>
         </ul>

--- a/content/patterns/switch/examples/switch.html
+++ b/content/patterns/switch/examples/switch.html
@@ -186,7 +186,7 @@
         <h2>JavaScript and CSS Source Code</h2>
         <ul id="css_js_files">
           <li>CSS: <a href="css/switch.css" type="tex/css">switch.css</a></li>
-          <li>Javascript: <a href="js/switch.js" type="text/javascript">switch.js</a></li>
+          <li>JavaScript: <a href="js/switch.js" type="text/javascript">switch.js</a></li>
         </ul>
       </section>
 

--- a/content/patterns/table/examples/sortable-table.html
+++ b/content/patterns/table/examples/sortable-table.html
@@ -201,7 +201,7 @@
             <a href="css/sortable-table.css" type="text/css">sortable-table.css</a>
           </li>
           <li>
-            Javascript:
+            JavaScript:
             <a href="js/sortable-table.js" type="text/javascript">sortable-table.js</a>
           </li>
         </ul>

--- a/content/patterns/table/examples/table.html
+++ b/content/patterns/table/examples/table.html
@@ -167,7 +167,7 @@
             CSS:
             <a href="css/table.css" type="tex/css">table.css</a>
           </li>
-          <li>Javascript: Not applicable.</li>
+          <li>JavaScript: Not applicable.</li>
         </ul>
       </section>
 

--- a/content/patterns/tabs/examples/tabs-actions.html
+++ b/content/patterns/tabs/examples/tabs-actions.html
@@ -491,8 +491,8 @@
         <h2>JavaScript and CSS Source Code</h2>
         <ul id="css_js_files">
           <li>CSS: <a href="css/tabs-actions.css" type="tex/css">tabs-actions.css</a></li>
-          <li>Javascript: <a href="js/tabs-actions.js" type="text/javascript">tabs-actions.js</a></li>
-          <li>Javascript: <a href="../../menu-button/examples/js/menu-button-actions.js" type="text/javascript">menu-button-actions.js</a></li>
+          <li>JavaScript: <a href="js/tabs-actions.js" type="text/javascript">tabs-actions.js</a></li>
+          <li>JavaScript: <a href="../../menu-button/examples/js/menu-button-actions.js" type="text/javascript">menu-button-actions.js</a></li>
         </ul>
       </section>
 

--- a/content/patterns/tabs/examples/tabs-automatic.html
+++ b/content/patterns/tabs/examples/tabs-automatic.html
@@ -343,7 +343,7 @@
         <h2>JavaScript and CSS Source Code</h2>
         <ul id="css_js_files">
           <li>CSS: <a href="css/tabs.css" type="tex/css">tabs.css</a></li>
-          <li>Javascript: <a href="js/tabs-automatic.js" type="text/javascript">tabs-automatic.js</a></li>
+          <li>JavaScript: <a href="js/tabs-automatic.js" type="text/javascript">tabs-automatic.js</a></li>
         </ul>
       </section>
 

--- a/content/patterns/tabs/examples/tabs-manual.html
+++ b/content/patterns/tabs/examples/tabs-manual.html
@@ -337,7 +337,7 @@
         <h2>JavaScript and CSS Source Code</h2>
         <ul id="css_js_files">
           <li>CSS: <a href="css/tabs.css" type="tex/css">tabs.css</a></li>
-          <li>Javascript: <a href="js/tabs-manual.js" type="text/javascript">tabs-manual.js</a></li>
+          <li>JavaScript: <a href="js/tabs-manual.js" type="text/javascript">tabs-manual.js</a></li>
         </ul>
       </section>
 

--- a/content/patterns/toolbar/examples/toolbar.html
+++ b/content/patterns/toolbar/examples/toolbar.html
@@ -942,12 +942,12 @@ But, in a larger sense, we can not dedicate, we can not consecrate, we can not h
         <ul id="css_js_files">
           <li>CSS: <a href="css/toolbar.css" type="text/css">toolbar.css</a></li>
           <li>CSS: <a href="css/menuButton.css" type="text/css">menuButton.css</a></li>
-          <li>Javascript: <a href="js/FormatToolbar.js" type="text/javascript">FormatToolbar.js</a></li>
-          <li>Javascript: <a href="js/FormatToolbarItem.js" type="text/javascript">FormatToolbarItem.js</a></li>
-          <li>Javascript: <a href="js/FontMenuButton.js" type="text/javascript">FontMenuButton.js</a></li>
-          <li>Javascript: <a href="js/FontMenu.js" type="text/javascript">FontMenu.js</a></li>
-          <li>Javascript: <a href="js/FontMenuItem.js" type="text/javascript">FontMenuItem.js</a></li>
-          <li>Javascript: <a href="js/SpinButton.js" type="text/javascript">SpinButton.js</a></li>
+          <li>JavaScript: <a href="js/FormatToolbar.js" type="text/javascript">FormatToolbar.js</a></li>
+          <li>JavaScript: <a href="js/FormatToolbarItem.js" type="text/javascript">FormatToolbarItem.js</a></li>
+          <li>JavaScript: <a href="js/FontMenuButton.js" type="text/javascript">FontMenuButton.js</a></li>
+          <li>JavaScript: <a href="js/FontMenu.js" type="text/javascript">FontMenu.js</a></li>
+          <li>JavaScript: <a href="js/FontMenuItem.js" type="text/javascript">FontMenuItem.js</a></li>
+          <li>JavaScript: <a href="js/SpinButton.js" type="text/javascript">SpinButton.js</a></li>
         </ul>
       </section>
 

--- a/content/patterns/treegrid/examples/treegrid-1.html
+++ b/content/patterns/treegrid/examples/treegrid-1.html
@@ -449,7 +449,7 @@
             <a href="css/treegrid-1.css" type="text/css">treegrid-1.css</a>
           </li>
           <li>
-            Javascript:
+            JavaScript:
             <a href="js/treegrid-1.js" type="text/javascript">treegrid-1.js</a>
           </li>
         </ul>

--- a/content/patterns/treeview/examples/treeview-1a.html
+++ b/content/patterns/treeview/examples/treeview-1a.html
@@ -403,15 +403,15 @@
             <a href="css/tree.css" type="text/css">tree.css</a>
           </li>
           <li>
-            Javascript:
+            JavaScript:
             <a href="js/tree.js" type="text/javascript">tree.js</a>
           </li>
           <li>
-            Javascript:
+            JavaScript:
             <a href="js/treeitem.js" type="text/javascript">treeitem.js</a>
           </li>
           <li>
-            Javascript:
+            JavaScript:
             <a href="js/treeitemClick.js" type="text/javascript">treeitemClick.js</a>
           </li>
         </ul>

--- a/content/patterns/treeview/examples/treeview-1b.html
+++ b/content/patterns/treeview/examples/treeview-1b.html
@@ -429,15 +429,15 @@
             <a href="css/tree.css" type="text/css">tree.css</a>
           </li>
           <li>
-            Javascript:
+            JavaScript:
             <a href="js/tree.js" type="text/javascript">tree.js</a>
           </li>
           <li>
-            Javascript:
+            JavaScript:
             <a href="js/treeitem.js" type="text/javascript">treeitem.js</a>
           </li>
           <li>
-            Javascript:
+            JavaScript:
             <a href="js/treeitemClick.js" type="text/javascript">treeitemClick.js</a>
           </li>
         </ul>

--- a/content/patterns/treeview/examples/treeview-navigation.html
+++ b/content/patterns/treeview/examples/treeview-navigation.html
@@ -682,7 +682,7 @@
             <a href="css/treeview-navigation.css" type="text/css">treeview-navigation.css</a>
           </li>
           <li>
-            Javascript:
+            JavaScript:
             <a href="js/treeview-navigation.js" type="text/javascript">treeview-navigation.js</a>
           </li>
         </ul>

--- a/content/shared/js/skipto.js
+++ b/content/shared/js/skipto.js
@@ -405,7 +405,7 @@ $skipToId [role="menuitem"].hover .label {
    *
    *   @desc Returns
    *
-   *   @param  {Object}  colorThemes  -  Javascript object with keyed color themes
+   *   @param  {Object}  colorThemes  -  JavaScript object with keyed color themes
    *   @param  {String}  colorTheme   -  A string identifying a color theme  
    *
    *   @returns {Object}  see @desc
@@ -2828,8 +2828,8 @@ $skipToId [role="menuitem"].hover .label {
        * @desc Get configuration information from author configuration to change
        *       default settings 
        *
-       * @param  {object}  config       - Javascript object with default configuration information
-       * @param  {object}  globalConfig - Javascript object with configuration information oin a global variable
+       * @param  {object}  config       - JavaScript object with default configuration information
+       * @param  {object}  globalConfig - JavaScript object with configuration information oin a global variable
        */
       setupConfigFromGlobal: function(config, globalConfig) {
         let authorConfig = {};
@@ -2869,7 +2869,7 @@ $skipToId [role="menuitem"].hover .label {
        * @desc Get configuration information from author configuration to change
        *       default settings
        *
-       * @param  {object}  config - Javascript object with default configuration information
+       * @param  {object}  config - JavaScript object with default configuration information
        */
       setupConfigFromDataAttribute: function(config) {
         let dataConfig = {};

--- a/content/shared/js/skipto.js
+++ b/content/shared/js/skipto.js
@@ -405,7 +405,7 @@ $skipToId [role="menuitem"].hover .label {
    *
    *   @desc Returns
    *
-   *   @param  {Object}  colorThemes  -  JavaScript object with keyed color themes
+   *   @param  {Object}  colorThemes  -  Javascript object with keyed color themes
    *   @param  {String}  colorTheme   -  A string identifying a color theme  
    *
    *   @returns {Object}  see @desc
@@ -2828,8 +2828,8 @@ $skipToId [role="menuitem"].hover .label {
        * @desc Get configuration information from author configuration to change
        *       default settings 
        *
-       * @param  {object}  config       - JavaScript object with default configuration information
-       * @param  {object}  globalConfig - JavaScript object with configuration information oin a global variable
+       * @param  {object}  config       - Javascript object with default configuration information
+       * @param  {object}  globalConfig - Javascript object with configuration information oin a global variable
        */
       setupConfigFromGlobal: function(config, globalConfig) {
         let authorConfig = {};
@@ -2869,7 +2869,7 @@ $skipToId [role="menuitem"].hover .label {
        * @desc Get configuration information from author configuration to change
        *       default settings
        *
-       * @param  {object}  config - JavaScript object with default configuration information
+       * @param  {object}  config - Javascript object with default configuration information
        */
       setupConfigFromDataAttribute: function(config) {
         let dataConfig = {};

--- a/scripts/coverage-report.js
+++ b/scripts/coverage-report.js
@@ -324,7 +324,7 @@ function getUniqueRolesInExample(html, dataJS) {
           if (items.length) {
             roles.push(role);
           } else {
-            // Check Javascript
+            // Check JavaScript
 
             const hasRole1 = RegExp(".role = '" + role, 'g');
             const hasRole2 = RegExp('.role = "' + role, 'g');

--- a/scripts/coverage-report.template
+++ b/scripts/coverage-report.template
@@ -218,9 +218,9 @@
             <th>Uses <code>event.which</code></th>
             <th>High Contrast Documentation</th>
             <th>Example Code ID</th>
-            <th>Roles in Javascript and HTML</th>
+            <th>Roles in JavaScript and HTML</th>
             <th>Roles in Documentation</th>
-            <th>aria-* Attributes in Javascript and HTML</th>
+            <th>aria-* Attributes in JavaScript and HTML</th>
             <th>aria-* Attributes in Documentation</th>
             <th>Differences between the documentation and the source code.</th>
           </tr>


### PR DESCRIPTION
This PR fixes inconsistent casing of "JavaScript" across the project.

Changes include:
- Replacing all instances of "Javascript" with "JavaScript" in `content/` and `content-templates/`
- Updating related comments for consistency
- Resolving the issue that caused the coverage report to fail in the previous PR

(description copied from #3317)
___
[WAI Preview Link](https://deploy-preview-410--aria-practices.netlify.app/ARIA/apg) _(Last built on Wed, 06 Aug 2025 16:21:39 GMT)._