### PR TITLE
Search Landmark Example: Remove unnecessary `br` following `h3`

### DIFF
--- a/content/patterns/landmarks/examples/search.html
+++ b/content/patterns/landmarks/examples/search.html
@@ -63,7 +63,6 @@
                 <div id="tabpanel2" aria-labelledby="tab2" role="tabpanel" class="tab-pane active">
                   <p>Use the HTML <code>search</code> element to define a <code>search</code> landmark.</p>
                   <h3>HTML Example</h3>
-                  <br>
                   <search>
                     <input type="search" size="20" aria-label="search text"><input type="submit" value="Search">
                   </search>


### PR DESCRIPTION
Removes the `<br>` immediately following the HTML Example `<h3>` in the Search Landmark Example.

This should address a comment raised during latest publication PR review, https://github.com/w3c/wai-aria-practices/pull/413#discussion_r2200278013
___
[WAI Preview Link](https://deploy-preview-419--aria-practices.netlify.app/ARIA/apg) _(Last built on Mon, 14 Jul 2025 15:12:09 GMT)._