### PR TITLE
Infrastructure: Bump prettier to 3.6.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "husky": "^9.1.7",
         "lint-staged": "^15.5.0",
         "node-fetch": "^2.6.7",
-        "prettier": "^3.5.3",
+        "prettier": "^3.6.2",
         "selenium-webdriver": "^4.32.0",
         "stylelint": "^16.19.1",
         "stylelint-config-standard": "^36.0.1",
@@ -6787,9 +6787,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
-      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -12737,9 +12737,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
-      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true
     },
     "pretty-ms": {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "husky": "^9.1.7",
     "lint-staged": "^15.5.0",
     "node-fetch": "^2.6.7",
-    "prettier": "^3.5.3",
+    "prettier": "^3.6.2",
     "selenium-webdriver": "^4.32.0",
     "stylelint": "^16.19.1",
     "stylelint-config-standard": "^36.0.1",

--- a/scripts/coverage-report.js
+++ b/scripts/coverage-report.js
@@ -546,18 +546,19 @@ glob
       pointerUp: getNumberOfReferences(dataJS, 'pointerup', true),
     };
 
-    (example.documentationRoles = addExampleToRoles(getRoles(html), example)),
-      console.log(
-        '  [Documentation Roles]: ' + example.documentationRoles.length
-      );
-    (example.documentationAttributes = addExampleToPropertiesAndStates(
+    example.documentationRoles = addExampleToRoles(getRoles(html), example);
+    console.log(
+      '  [Documentation Roles]: ' + example.documentationRoles.length
+    );
+
+    example.documentationAttributes = addExampleToPropertiesAndStates(
       getPropertiesAndStates(html),
       example
-    )),
-      console.log(
-        '  [Documentation aria-* Attributes]: ' +
-          example.documentationAttributes.length
-      );
+    );
+    console.log(
+      '  [Documentation aria-* Attributes]: ' +
+        example.documentationAttributes.length
+    );
 
     indexOfExamples.push(example);
   });


### PR DESCRIPTION
#3303 is failing because it requires a formatting update for `prettier` which [forces additional parentheses](https://prettier.io/blog/2025/06/23/3.6.0#change-17085) around [these `coverage-report.js` comma expressions](https://github.com/w3c/aria-practices/blob/d16d25dd176638c1a04d779bdfebd87ff00ff793/scripts/coverage-report.js#L549:L560) like so:

```diff
-   (example.documentationRoles = addExampleToRoles(getRoles(html), example)),
+   ((example.documentationRoles = addExampleToRoles(getRoles(html), example)),
      console.log(
        '  [Documentation Roles]: ' + example.documentationRoles.length
-     );
-   (example.documentationAttributes = addExampleToPropertiesAndStates(
+     ));
+   ((example.documentationAttributes = addExampleToPropertiesAndStates(
      getPropertiesAndStates(html),
      example
    )),
      console.log(
        '  [Documentation aria-* Attributes]: ' +
        example.documentationAttributes.length
-    );
+    ));
```

Readability suffers a bit here so this PR bumps prettier and moves away from using the comma expressions.
___
[WAI Preview Link](https://deploy-preview-420--aria-practices.netlify.app/ARIA/apg) _(Last built on Tue, 22 Jul 2025 13:52:02 GMT)._

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210860369565488