### PR TITLE
Pattern Pages: Show link to "Read This First" just after the H1 on each pattern page

### DIFF
--- a/content/patterns/accordion/accordion-pattern.html
+++ b/content/patterns/accordion/accordion-pattern.html
@@ -11,6 +11,7 @@
     <script src="../../shared/js/highlight.pack.js"></script>
     <script src="../../shared/js/app.js"></script>
     <script data-skipto="colorTheme:aria; displayOption:popup; containerElement:div" src="../../shared/js/skipto.js"></script>
+    <script data-read-this-first="showImage:false" src="../../shared/js/read-this-first.js"></script>
   </head>
   <body>
     <main>

--- a/content/patterns/alert/alert-pattern.html
+++ b/content/patterns/alert/alert-pattern.html
@@ -11,6 +11,7 @@
     <script src="../../shared/js/highlight.pack.js"></script>
     <script src="../../shared/js/app.js"></script>
     <script data-skipto="colorTheme:aria; displayOption:popup; containerElement:div" src="../../shared/js/skipto.js"></script>
+    <script data-read-this-first="showImage:false" src="../../shared/js/read-this-first.js"></script>
   </head>
   <body>
     <main>

--- a/content/patterns/alertdialog/alertdialog-pattern.html
+++ b/content/patterns/alertdialog/alertdialog-pattern.html
@@ -11,6 +11,7 @@
     <script src="../../shared/js/highlight.pack.js"></script>
     <script src="../../shared/js/app.js"></script>
     <script data-skipto="colorTheme:aria; displayOption:popup; containerElement:div" src="../../shared/js/skipto.js"></script>
+    <script data-read-this-first="showImage:false" src="../../shared/js/read-this-first.js"></script>
   </head>
   <body>
     <main>

--- a/content/patterns/breadcrumb/breadcrumb-pattern.html
+++ b/content/patterns/breadcrumb/breadcrumb-pattern.html
@@ -11,6 +11,7 @@
     <script src="../../shared/js/highlight.pack.js"></script>
     <script src="../../shared/js/app.js"></script>
     <script data-skipto="colorTheme:aria; displayOption:popup; containerElement:div" src="../../shared/js/skipto.js"></script>
+    <script data-read-this-first="showImage:false" src="../../shared/js/read-this-first.js"></script>
   </head>
   <body>
     <main>

--- a/content/patterns/button/button-pattern.html
+++ b/content/patterns/button/button-pattern.html
@@ -11,6 +11,7 @@
     <script src="../../shared/js/highlight.pack.js"></script>
     <script src="../../shared/js/app.js"></script>
     <script data-skipto="colorTheme:aria; displayOption:popup; containerElement:div" src="../../shared/js/skipto.js"></script>
+    <script data-read-this-first="showImage:false" src="../../shared/js/read-this-first.js"></script>
   </head>
   <body>
     <main>

--- a/content/patterns/carousel/carousel-pattern.html
+++ b/content/patterns/carousel/carousel-pattern.html
@@ -11,6 +11,7 @@
     <script src="../../shared/js/highlight.pack.js"></script>
     <script src="../../shared/js/app.js"></script>
     <script data-skipto="colorTheme:aria; displayOption:popup; containerElement:div" src="../../shared/js/skipto.js"></script>
+    <script data-read-this-first="showImage:false" src="../../shared/js/read-this-first.js"></script>
   </head>
   <body>
     <main>

--- a/content/patterns/checkbox/checkbox-pattern.html
+++ b/content/patterns/checkbox/checkbox-pattern.html
@@ -11,6 +11,7 @@
     <script src="../../shared/js/highlight.pack.js"></script>
     <script src="../../shared/js/app.js"></script>
     <script data-skipto="colorTheme:aria; displayOption:popup; containerElement:div" src="../../shared/js/skipto.js"></script>
+    <script data-read-this-first="showImage:false" src="../../shared/js/read-this-first.js"></script>
   </head>
   <body>
     <main>

--- a/content/patterns/combobox/combobox-pattern.html
+++ b/content/patterns/combobox/combobox-pattern.html
@@ -11,6 +11,7 @@
     <script src="../../shared/js/highlight.pack.js"></script>
     <script src="../../shared/js/app.js"></script>
     <script data-skipto="colorTheme:aria; displayOption:popup; containerElement:div" src="../../shared/js/skipto.js"></script>
+    <script data-read-this-first="showImage:false" src="../../shared/js/read-this-first.js"></script>
   </head>
   <body>
     <main>

--- a/content/patterns/dialog-modal/dialog-modal-pattern.html
+++ b/content/patterns/dialog-modal/dialog-modal-pattern.html
@@ -11,6 +11,7 @@
     <script src="../../shared/js/highlight.pack.js"></script>
     <script src="../../shared/js/app.js"></script>
     <script data-skipto="colorTheme:aria; displayOption:popup; containerElement:div" src="../../shared/js/skipto.js"></script>
+    <script data-read-this-first="showImage:false" src="../../shared/js/read-this-first.js"></script>
   </head>
   <body>
     <main>

--- a/content/patterns/disclosure/disclosure-pattern.html
+++ b/content/patterns/disclosure/disclosure-pattern.html
@@ -11,6 +11,7 @@
     <script src="../../shared/js/highlight.pack.js"></script>
     <script src="../../shared/js/app.js"></script>
     <script data-skipto="colorTheme:aria; displayOption:popup; containerElement:div" src="../../shared/js/skipto.js"></script>
+    <script data-read-this-first="showImage:false" src="../../shared/js/read-this-first.js"></script>
   </head>
   <body>
     <main>

--- a/content/patterns/feed/feed-pattern.html
+++ b/content/patterns/feed/feed-pattern.html
@@ -11,6 +11,7 @@
     <script src="../../shared/js/highlight.pack.js"></script>
     <script src="../../shared/js/app.js"></script>
     <script data-skipto="colorTheme:aria; displayOption:popup; containerElement:div" src="../../shared/js/skipto.js"></script>
+    <script data-read-this-first="showImage:false" src="../../shared/js/read-this-first.js"></script>
   </head>
   <body>
     <main>

--- a/content/patterns/grid/grid-pattern.html
+++ b/content/patterns/grid/grid-pattern.html
@@ -11,6 +11,7 @@
     <script src="../../shared/js/highlight.pack.js"></script>
     <script src="../../shared/js/app.js"></script>
     <script data-skipto="colorTheme:aria; displayOption:popup; containerElement:div" src="../../shared/js/skipto.js"></script>
+    <script data-read-this-first="showImage:false" src="../../shared/js/read-this-first.js"></script>
   </head>
   <body>
     <main>

--- a/content/patterns/landmarks/landmarks-pattern.html
+++ b/content/patterns/landmarks/landmarks-pattern.html
@@ -11,6 +11,7 @@
     <script src="../../shared/js/highlight.pack.js"></script>
     <script src="../../shared/js/app.js"></script>
     <script data-skipto="colorTheme:aria; displayOption:popup; containerElement:div" src="../../shared/js/skipto.js"></script>
+    <script data-read-this-first="showImage:false" src="../../shared/js/read-this-first.js"></script>
   </head>
   <body>
     <main>

--- a/content/patterns/link/link-pattern.html
+++ b/content/patterns/link/link-pattern.html
@@ -11,6 +11,7 @@
     <script src="../../shared/js/highlight.pack.js"></script>
     <script src="../../shared/js/app.js"></script>
     <script data-skipto="colorTheme:aria; displayOption:popup; containerElement:div" src="../../shared/js/skipto.js"></script>
+    <script data-read-this-first="showImage:false" src="../../shared/js/read-this-first.js"></script>
   </head>
   <body>
     <main>

--- a/content/patterns/listbox/listbox-pattern.html
+++ b/content/patterns/listbox/listbox-pattern.html
@@ -11,6 +11,7 @@
     <script src="../../shared/js/highlight.pack.js"></script>
     <script src="../../shared/js/app.js"></script>
     <script data-skipto="colorTheme:aria; displayOption:popup; containerElement:div" src="../../shared/js/skipto.js"></script>
+    <script data-read-this-first="showImage:false" src="../../shared/js/read-this-first.js"></script>
   </head>
   <body>
     <main>

--- a/content/patterns/menu-button/menu-button-pattern.html
+++ b/content/patterns/menu-button/menu-button-pattern.html
@@ -11,6 +11,7 @@
     <script src="../../shared/js/highlight.pack.js"></script>
     <script src="../../shared/js/app.js"></script>
     <script data-skipto="colorTheme:aria; displayOption:popup; containerElement:div" src="../../shared/js/skipto.js"></script>
+    <script data-read-this-first="showImage:false" src="../../shared/js/read-this-first.js"></script>
   </head>
   <body>
     <main>

--- a/content/patterns/menubar/menu-and-menubar-pattern.html
+++ b/content/patterns/menubar/menu-and-menubar-pattern.html
@@ -11,6 +11,7 @@
     <script src="../../shared/js/highlight.pack.js"></script>
     <script src="../../shared/js/app.js"></script>
     <script data-skipto="colorTheme:aria; displayOption:popup; containerElement:div" src="../../shared/js/skipto.js"></script>
+    <script data-read-this-first="showImage:false" src="../../shared/js/read-this-first.js"></script>
   </head>
   <body>
     <main>

--- a/content/patterns/meter/meter-pattern.html
+++ b/content/patterns/meter/meter-pattern.html
@@ -11,6 +11,7 @@
     <script src="../../shared/js/highlight.pack.js"></script>
     <script src="../../shared/js/app.js"></script>
     <script data-skipto="colorTheme:aria; displayOption:popup; containerElement:div" src="../../shared/js/skipto.js"></script>
+    <script data-read-this-first="showImage:false" src="../../shared/js/read-this-first.js"></script>
   </head>
   <body>
     <main>

--- a/content/patterns/patterns.html
+++ b/content/patterns/patterns.html
@@ -13,6 +13,7 @@
     <script src="../shared/js/app.js"></script>
     <script src="../shared/js/filterBySearch.js"></script>
     <script data-skipto="colorTheme:aria; displayOption:popup; containerElement:div" src="../shared/js/skipto.js"></script>
+    <script data-read-this-first="showImage:true" src="../shared/js/read-this-first.js"></script>
   </head>
   <body>
     <h1>Patterns</h1>

--- a/content/patterns/radio/radio-group-pattern.html
+++ b/content/patterns/radio/radio-group-pattern.html
@@ -11,6 +11,7 @@
     <script src="../../shared/js/highlight.pack.js"></script>
     <script src="../../shared/js/app.js"></script>
     <script data-skipto="colorTheme:aria; displayOption:popup; containerElement:div" src="../../shared/js/skipto.js"></script>
+    <script data-read-this-first="showImage:false" src="../../shared/js/read-this-first.js"></script>
   </head>
   <body>
     <main>

--- a/content/patterns/slider-multithumb/slider-multithumb-pattern.html
+++ b/content/patterns/slider-multithumb/slider-multithumb-pattern.html
@@ -11,6 +11,7 @@
     <script src="../../shared/js/highlight.pack.js"></script>
     <script src="../../shared/js/app.js"></script>
     <script data-skipto="colorTheme:aria; displayOption:popup; containerElement:div" src="../../shared/js/skipto.js"></script>
+    <script data-read-this-first="showImage:false" src="../../shared/js/read-this-first.js"></script>
   </head>
   <body>
     <main>

--- a/content/patterns/slider/slider-pattern.html
+++ b/content/patterns/slider/slider-pattern.html
@@ -11,6 +11,7 @@
     <script src="../../shared/js/highlight.pack.js"></script>
     <script src="../../shared/js/app.js"></script>
     <script data-skipto="colorTheme:aria; displayOption:popup; containerElement:div" src="../../shared/js/skipto.js"></script>
+    <script data-read-this-first="showImage:false" src="../../shared/js/read-this-first.js"></script>
   </head>
   <body>
     <main>

--- a/content/patterns/spinbutton/spinbutton-pattern.html
+++ b/content/patterns/spinbutton/spinbutton-pattern.html
@@ -11,6 +11,7 @@
     <script src="../../shared/js/highlight.pack.js"></script>
     <script src="../../shared/js/app.js"></script>
     <script data-skipto="colorTheme:aria; displayOption:popup; containerElement:div" src="../../shared/js/skipto.js"></script>
+    <script data-read-this-first="showImage:false" src="../../shared/js/read-this-first.js"></script>
   </head>
   <body>
     <main>

--- a/content/patterns/switch/switch-pattern.html
+++ b/content/patterns/switch/switch-pattern.html
@@ -11,6 +11,7 @@
     <script src="../../shared/js/highlight.pack.js"></script>
     <script src="../../shared/js/app.js"></script>
     <script data-skipto="colorTheme:aria; displayOption:popup; containerElement:div" src="../../shared/js/skipto.js"></script>
+    <script data-read-this-first="showImage:false" src="../../shared/js/read-this-first.js"></script>
   </head>
   <body>
     <main>

--- a/content/patterns/table/table-pattern.html
+++ b/content/patterns/table/table-pattern.html
@@ -11,6 +11,7 @@
     <script src="../../shared/js/highlight.pack.js"></script>
     <script src="../../shared/js/app.js"></script>
     <script data-skipto="colorTheme:aria; displayOption:popup; containerElement:div" src="../../shared/js/skipto.js"></script>
+    <script data-read-this-first="showImage:false" src="../../shared/js/read-this-first.js"></script>
   </head>
   <body>
     <main>

--- a/content/patterns/tabs/tabs-pattern.html
+++ b/content/patterns/tabs/tabs-pattern.html
@@ -11,6 +11,7 @@
     <script src="../../shared/js/highlight.pack.js"></script>
     <script src="../../shared/js/app.js"></script>
     <script data-skipto="colorTheme:aria; displayOption:popup; containerElement:div" src="../../shared/js/skipto.js"></script>
+    <script data-read-this-first="showImage:false" src="../../shared/js/read-this-first.js"></script>
   </head>
   <body>
     <main>

--- a/content/patterns/toolbar/toolbar-pattern.html
+++ b/content/patterns/toolbar/toolbar-pattern.html
@@ -11,6 +11,7 @@
     <script src="../../shared/js/highlight.pack.js"></script>
     <script src="../../shared/js/app.js"></script>
     <script data-skipto="colorTheme:aria; displayOption:popup; containerElement:div" src="../../shared/js/skipto.js"></script>
+    <script data-read-this-first="showImage:false" src="../../shared/js/read-this-first.js"></script>
   </head>
   <body>
     <main>

--- a/content/patterns/tooltip/tooltip-pattern.html
+++ b/content/patterns/tooltip/tooltip-pattern.html
@@ -11,6 +11,7 @@
     <script src="../../shared/js/highlight.pack.js"></script>
     <script src="../../shared/js/app.js"></script>
     <script data-skipto="colorTheme:aria; displayOption:popup; containerElement:div" src="../../shared/js/skipto.js"></script>
+    <script data-read-this-first="showImage:false" src="../../shared/js/read-this-first.js"></script>
   </head>
   <body>
     <main>

--- a/content/patterns/treegrid/treegrid-pattern.html
+++ b/content/patterns/treegrid/treegrid-pattern.html
@@ -12,7 +12,6 @@
     <script src="../../shared/js/app.js"></script>
     <script data-skipto="colorTheme:aria; displayOption:popup; containerElement:div" src="../../shared/js/skipto.js"></script>
     <script data-read-this-first="showImage:false" src="../../shared/js/read-this-first.js"></script>
-    <script data-read-this-first="showImage:false" src="../../shared/js/read-this-first.js"></script>
   </head>
   <body>
     <main>

--- a/content/patterns/treegrid/treegrid-pattern.html
+++ b/content/patterns/treegrid/treegrid-pattern.html
@@ -11,6 +11,8 @@
     <script src="../../shared/js/highlight.pack.js"></script>
     <script src="../../shared/js/app.js"></script>
     <script data-skipto="colorTheme:aria; displayOption:popup; containerElement:div" src="../../shared/js/skipto.js"></script>
+    <script data-read-this-first="showImage:false" src="../../shared/js/read-this-first.js"></script>
+    <script data-read-this-first="showImage:false" src="../../shared/js/read-this-first.js"></script>
   </head>
   <body>
     <main>

--- a/content/patterns/treeview/treeview-pattern.html
+++ b/content/patterns/treeview/treeview-pattern.html
@@ -11,6 +11,7 @@
     <script src="../../shared/js/highlight.pack.js"></script>
     <script src="../../shared/js/app.js"></script>
     <script data-skipto="colorTheme:aria; displayOption:popup; containerElement:div" src="../../shared/js/skipto.js"></script>
+    <script data-read-this-first="showImage:false" src="../../shared/js/read-this-first.js"></script>
   </head>
   <body>
     <main>

--- a/content/patterns/windowsplitter/windowsplitter-pattern.html
+++ b/content/patterns/windowsplitter/windowsplitter-pattern.html
@@ -11,6 +11,7 @@
     <script src="../../shared/js/highlight.pack.js"></script>
     <script src="../../shared/js/app.js"></script>
     <script data-skipto="colorTheme:aria; displayOption:popup; containerElement:div" src="../../shared/js/skipto.js"></script>
+    <script data-read-this-first="showImage:false" src="../../shared/js/read-this-first.js"></script>
   </head>
   <body>
     <main>

--- a/content/practices/practices.html
+++ b/content/practices/practices.html
@@ -12,6 +12,7 @@
     <script src="../shared/js/highlight.pack.js"></script>
     <script src="../shared/js/app.js"></script>
     <script data-skipto="colorTheme:aria; displayOption:popup; containerElement:div" src="../shared/js/skipto.js"></script>
+    <script data-read-this-first="showImage:true" src="../shared/js/read-this-first.js"></script>
   </head>
   <body>
     <h1>Practices</h1>

--- a/content/shared/js/read-this-first.js
+++ b/content/shared/js/read-this-first.js
@@ -1,0 +1,170 @@
+'use strict';
+
+/**
+ * Read This First Banner
+ *
+ * Inserts the "Read This First" banner from /content/shared/templates/read-this-first.html into
+ * pages after the h1 element when the DOM is loaded. The banner is configured using data
+ * attributes on the script element.
+ *
+ * USAGE:
+ * Add this script to your HTML page with the appropriate data attributes:
+ *
+ * <script data-read-this-first="showImage:true" src="../../shared/js/read-this-first.js"></script>
+ *
+ * CONFIGURATION OPTIONS:
+ * - showImage: boolean (default: true) - Controls whether the illustration image is displayed
+ *
+ * REQUIREMENTS:
+ * - Page must have an <h1> element (banner is inserted after it)
+ * - Script automatically adjusts paths based on where it's called from
+ * - Works with both template file fetch and fallback banner
+ *
+ * BEHAVIOR:
+ * - Banner is inserted after the h1 element when DOM is loaded
+ * - If template file can't be fetched (e.g., CORS issues with file:// protocol), uses fallback
+ * - Paths are automatically adjusted based on script location
+ * - Image can be conditionally removed based on showImage setting
+ */
+(function () {
+  const defaultConfig = {
+    showImage: true,
+  };
+
+  // NOTE: If read-this-first.html is ever changed, update this fallback banner to match
+  // MUST HAVE `div class="read-this-first"`
+  const fallbackBanner = `
+    <div class="read-this-first">
+      <div class="text">
+        <img
+          src="../../images/read-this-first.svg"
+          width="178"
+          alt="Illustration of a brown-skinned woman with a slight smile gesturing towards the right with her hand"
+        >
+        <h2>Read This First</h2>
+        <p>
+          No ARIA is better than Bad ARIA. Before using any ARIA, <a href="../../practices/read-me-first/read-me-first-practice.html" aria-label="Read this to understand why no ARIA is better than bad ARIA">read this to understand why</a>.
+        </p>
+      </div>
+    </div>
+  `;
+
+  function getScriptBasePath() {
+    const scriptElement = document.querySelector(
+      'script[src*="read-this-first.js"]'
+    );
+    if (!scriptElement) {
+      return '../../'; // Default fallback
+    }
+
+    const scriptSrc = scriptElement.getAttribute('src');
+    // Extract the directory path from the script src
+    // e.g., "../../shared/js/read-this-first.js" gives "../../"
+    const match = scriptSrc.match(/^(.*\/)shared\/js\/read-this-first\.js$/);
+    return match ? match[1] : '../../';
+  }
+
+  function adjustPaths(html, basePath) {
+    return html
+      .replace(/src="\.\.\/\.\.\//g, `src="${basePath}`)
+      .replace(/href="\.\.\/\.\.\//g, `href="${basePath}`);
+  }
+
+  function parseConfigFromDataAttribute() {
+    const config = { ...defaultConfig };
+    const configElem = document.querySelector('[data-read-this-first]');
+
+    if (configElem) {
+      const dataValue = configElem.getAttribute('data-read-this-first');
+      if (dataValue) {
+        const values = dataValue.split(';');
+        values.forEach((v) => {
+          let [prop, value] = v.split(':');
+          if (prop) {
+            prop = prop.trim();
+          }
+          if (value) {
+            value = value.trim();
+          }
+          if (prop && value) {
+            // Convert string values to appropriate types
+            if (value === 'true' || value === 'false') {
+              config[prop] = value === 'true';
+            } else {
+              config[prop] = value;
+            }
+          }
+        });
+      }
+    }
+
+    return config;
+  }
+
+  function removeImageIfNeeded(bannerElement, config) {
+    if (!config.showImage) {
+      const img = bannerElement.querySelector('img');
+      if (img) {
+        img.remove();
+      }
+    }
+  }
+
+  async function insertBanner(config) {
+    // Find the h1 element
+    const h1 = document.querySelector('h1');
+    if (!h1) {
+      return;
+    }
+
+    // Get the base path for relative URLs
+    const basePath = getScriptBasePath();
+
+    try {
+      // Fetch the banner HTML from the template file
+      const response = await fetch(
+        `${basePath}shared/templates/read-this-first.html`
+      );
+      const html = await response.text();
+
+      // Parse the HTML and extract the read-this-first div
+      const parser = new DOMParser();
+      const doc = parser.parseFromString(html, 'text/html');
+      const bannerDiv = doc.querySelector('.read-this-first');
+
+      if (!bannerDiv) {
+        return;
+      }
+
+      const bannerElement = bannerDiv.cloneNode(true);
+      removeImageIfNeeded(bannerElement, config);
+
+      // Insert the banner after h1
+      h1.parentNode.insertBefore(bannerElement, h1.nextSibling);
+    } catch (error) {
+      // Fallback to static banner if fetch fails (CORS will fail with file:// protocol)
+      const temp = document.createElement('div');
+      // Adjust paths in the fallback banner based on script location
+      const adjustedFallbackBanner = adjustPaths(fallbackBanner, basePath);
+      temp.innerHTML = adjustedFallbackBanner;
+      const fallbackBannerElement = temp.firstElementChild;
+      removeImageIfNeeded(fallbackBannerElement, config);
+
+      // Insert the banner after h1
+      h1.parentNode.insertBefore(fallbackBannerElement, h1.nextSibling);
+    }
+  }
+
+  async function init() {
+    const config = parseConfigFromDataAttribute();
+    await insertBanner(config);
+  }
+
+  // Initialize on DOMContentLoaded
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    // DOM is already loaded
+    init();
+  }
+})();

--- a/content/shared/templates/read-this-first.html
+++ b/content/shared/templates/read-this-first.html
@@ -3,6 +3,7 @@
   <meta charset="utf-8">
   <title>Read This First (Template)</title>
   <body>
+    <!-- NOTE: Copy below div to read-this-first.js fallbackBanner variable if changing -->
     <div class="read-this-first">
       <div class="text">
         <img


### PR DESCRIPTION
Closes #3293 

Additionally, this PR ensures the pages that `/content/shared/templates/read-this-first.html` appears on is controlled from this repository with the new `/shared/js/read-this-first.js` script. That was being done from `w3c/wai-aria-practices` by _manually_ adding the template into the patterns and practices index pages. This was discussed in [Jul 22, 2025 TF meeting](https://www.w3.org/2025/07/22-aria-apg-minutes.html#8314).

The script is doing the same by inserting the template content after the first `h1` found on the page.

This PR means the insertion from `w3c/wai-aria-practices` should be removed. Note that this should be reviewed and merged before https://github.com/w3c/wai-aria-practices/pull/422 is merged.

* [Updated patterns page with "Read This First" banner (should be no change)](https://deploy-preview-422--aria-practices.netlify.app/aria/apg/patterns/)
* [Updated accordion pattern page with the "Read This First" banner (should not have illustration)](https://deploy-preview-422--aria-practices.netlify.app/aria/apg/patterns/accordion/)
___
[WAI Preview Link](https://deploy-preview-423--aria-practices.netlify.app/ARIA/apg) _(Last built on Tue, 19 Aug 2025 16:56:44 GMT)._