### PR TITLE
Infrastructure: Temp fix to regression test - Fix `toolbar_toolbar.js` by resetting menu button state

### DIFF
--- a/test/tests/toolbar_toolbar.js
+++ b/test/tests/toolbar_toolbar.js
@@ -370,6 +370,10 @@ ariaTest(
     let menu = await t.context.session.findElement(By.css(ex.menuSelector));
 
     for (let i = 0; i < menuItems.length; i++) {
+      // Reset expanded state if necessary
+      if ((await menuButton.getAttribute('aria-expanded')) === 'true') {
+        await menuButton.click();
+      }
       await menuButton.click();
       await t.context.session.wait(
         async function () {

--- a/test/tests/toolbar_toolbar.js
+++ b/test/tests/toolbar_toolbar.js
@@ -371,10 +371,9 @@ ariaTest(
 
     for (let i = 0; i < menuItems.length; i++) {
       // Reset expanded state if necessary
-      // Note: This is a workaround and shouldn't be necessary. In the test
-      // environment, the menu button's aria-expanded state isn't
-      // being set back to false on a menu option click which requires this
-      // workaround.
+      // Note: This is a workaround. In the test environment, the menu button's
+      // aria-expanded state isn't being set back to false on a menu option
+      // click which requires this workaround.
       // Issue tracked at https://github.com/w3c/aria-practices/issues/3331
       // TODO: Remove once fixed
       if ((await menuButton.getAttribute('aria-expanded')) === 'true') {

--- a/test/tests/toolbar_toolbar.js
+++ b/test/tests/toolbar_toolbar.js
@@ -371,6 +371,12 @@ ariaTest(
 
     for (let i = 0; i < menuItems.length; i++) {
       // Reset expanded state if necessary
+      // Note: This is a workaround and shouldn't be necessary. In the test
+      // environment, the menu button's aria-expanded state isn't
+      // being set back to false on a menu option click which requires this
+      // workaround.
+      // Issue tracked at https://github.com/w3c/aria-practices/issues/3331
+      // TODO: Remove once fixed
       if ((await menuButton.getAttribute('aria-expanded')) === 'true') {
         await menuButton.click();
       }


### PR DESCRIPTION
Fix #3331

The [`menuitemradio elements have aria-checked set`](https://github.com/w3c/aria-practices/actions/runs/17052897813/job/48344540282?pr=3354#step:5:61) test now successfully passes in the CI and locally
___
[WAI Preview Link](https://deploy-preview-431--aria-practices.netlify.app/ARIA/apg) _(Last built on Tue, 19 Aug 2025 18:30:58 GMT)._