### PR TITLE
Grid Pattern: Correct error in description of left/right arrow behavior when navigating inside a cell

### DIFF
--- a/content/patterns/grid/grid-pattern.html
+++ b/content/patterns/grid/grid-pattern.html
@@ -346,7 +346,7 @@
               Otherwise, passes the key event to the focused widget.
             </li>
             <li>
-              <kbd>Left Arrow</kbd> or <kbd>Up Arrow</kbd>: If the cell contains multiple widgets, moves focus to the previous widget inside the cell, optionally wrapping to the first widget if focus is on the last widget.
+              <kbd>Left Arrow</kbd> or <kbd>Up Arrow</kbd>: If the cell contains multiple widgets, moves focus to the previous widget inside the cell, optionally wrapping to the last widget if focus is on the first widget.
               Otherwise, passes the key event to the focused widget.
             </li>
             <li>


### PR DESCRIPTION
When grid navigation is off, pressing the Left Arrow or Up Arrow key moves focus between widgets. The description seemed to have the wrap-around behavior reversed, so I corrected it.

[Preview of Grid (Interactive Tabular Data and Layout Containers) Pattern](https://deploy-preview-432--aria-practices.netlify.app/aria/apg/patterns/grid/#keyboardinteraction-settingfocusandnavigatinginsidecells)

___
[WAI Preview Link](https://deploy-preview-432--aria-practices.netlify.app/ARIA/apg) _(Last built on Mon, 01 Sep 2025 07:59:24 GMT)._