### PR TITLE
Carousel Pattern: Fix inconsistency in use of digits and number words

### DIFF
--- a/content/patterns/carousel/carousel-pattern.html
+++ b/content/patterns/carousel/carousel-pattern.html
@@ -28,7 +28,7 @@
         <p>
           Ensuring all users can easily control and are not adversely affected by slide rotation is an essential aspect of making carousels accessible.
           For instance, the screen reader experience can be confusing and disorienting if slides that are not visible on screen are incorrectly hidden, e.g., displayed off-screen.
-          Similarly, if slides rotate automatically and a screen reader user is not aware of the rotation, the user may read an element on slide one, execute the screen reader command for next element, and, instead of hearing the next element on slide one, hear an element from slide 2 without any knowledge that the element just announced is from an entirely new context.
+          Similarly, if slides rotate automatically and a screen reader user is not aware of the rotation, the user may read an element on slide 1, execute the screen reader command for next element, and, instead of hearing the next element on slide 1, hear an element from slide 2 without any knowledge that the element just announced is from an entirely new context.
         </p>
         <p>Features needed to provide sufficient rotation control include:</p>
         <ul>


### PR DESCRIPTION
In one place, found using slide one (word form), in another slide 2 (digit). 
Best to keep consistent (preferably digits in technical writing: slide 1, slide 2).
___
[WAI Preview Link](https://deploy-preview-435--aria-practices.netlify.app/ARIA/apg) _(Last built on Thu, 11 Sep 2025 08:34:14 GMT)._