### PR TITLE
Developing a Keyboard Interface Practice: Editorial revision to note about pointer considerations

### DIFF
--- a/content/practices/keyboard-interface/keyboard-interface-practice.html
+++ b/content/practices/keyboard-interface/keyboard-interface-practice.html
@@ -379,7 +379,7 @@
 
           <div class="note">
             <h4>Note</h4>
-            <p>This guidance focuses specifically on keyboard interaction. However, authors must of course also consider pointer interactions, such as mouse clicks
+            <p>This guidance focuses specifically on keyboard interaction. However, authors also need to consider pointer interactions, such as mouse clicks
               and touchscreen taps. When a component is clicked/tapped,
               authors should take the same steps to set the correct <code>tabindex</code> or <code>aria-activedescendant</code> for the element,
               in the same way that they would for keyboard navigation. Otherwise, this could lead to a confusing experience for users that switch between pointer


### PR DESCRIPTION
Makes two minor editorial improvements to the note about pointer considerations when managing focus:

* Change `must` to `need to` to avoid use of normative sounding language.
* Remove `of course` to avoid superfluous language.

___
[WAI Preview Link](https://deploy-preview-437--aria-practices.netlify.app/ARIA/apg) _(Last built on Tue, 23 Sep 2025 17:31:39 GMT)._