### PR TITLE
Developing a Keyboard Interface Practice: Clarify guidance for “Focusability of disabled controls”

### DIFF
--- a/content/practices/keyboard-interface/keyboard-interface-practice.html
+++ b/content/practices/keyboard-interface/keyboard-interface-practice.html
@@ -391,9 +391,8 @@
       <section id="kbd_disabled_controls">
         <h2>Focusability of disabled controls</h2>
         <p>
-          By default, disabled HTML input elements are removed from the tab sequence.
-          In most contexts, the normal expectation is that disabled interactive elements are not focusable.
-          However, there are some contexts where it is common for disabled elements to be focusable, especially inside of composite widgets.
+          By default, HTML input elements with the <code>disabled</code> attribute are removed from the tab sequence.
+          However, there are some contexts where it is useful for an element to convey a disabled state while remaining focusable, especially inside of composite widgets.
           For example, as demonstrated in the
           <a href="../../patterns/menubar/menu-and-menubar-pattern.html">menu and menubar pattern</a>,
           disabled items are focusable when navigating through a menu with the arrow keys.
@@ -406,12 +405,12 @@
         </p>
 
         <p>
-          Authors are encouraged to adopt a consistent set of conventions for the focusability of disabled elements.
+          Authors are encouraged to adopt a consistent set of pattern-specific conventions for the focusability of disabled elements.
           The examples in this guide adopt the following conventions, which both reflect common practice and attempt to balance competing concerns.
         </p>
 
         <ol>
-          <li>For elements that are in the tab sequence when enabled, remove them from the tab sequence when disabled.</li>
+          <li>For disabled elements that don’t need to remain discoverable, remove them from the tab sequence.</li>
 
           <li>
             For the following composite widget elements, keep them focusable when disabled:

--- a/content/practices/keyboard-interface/keyboard-interface-practice.html
+++ b/content/practices/keyboard-interface/keyboard-interface-practice.html
@@ -402,7 +402,7 @@
         <p>
           Removing focusability from disabled elements can offer users both advantages and disadvantages.
           Allowing keyboard users to skip disabled elements usually reduces the number of key presses required to complete a task.
-          However, preventing focus from moving to disabled elements can hide their presence from screen reader users who "see" by moving the focus.
+          However, screen reader users are far less likely to discover disabled elements that are not focusable because moving focus is one of their primary methods of discovery.
         </p>
 
         <p>

--- a/content/practices/keyboard-interface/keyboard-interface-practice.html
+++ b/content/practices/keyboard-interface/keyboard-interface-practice.html
@@ -412,7 +412,7 @@ Authors are encouraged to adopt consistent pattern-based conventions for the foc
         <ol>
           <li>
             When users can reasonably infer the presence of a disabled element from nearby
-            focusable elements, it can be removed from the keyboard focus order
+            focusable elements, it is removed from the keyboard focus order
             using the HTML <code>disabled</code> attribute. For example:
             <ul>
               <li>

--- a/content/practices/keyboard-interface/keyboard-interface-practice.html
+++ b/content/practices/keyboard-interface/keyboard-interface-practice.html
@@ -411,18 +411,23 @@ Authors are encouraged to adopt consistent pattern-based conventions for the foc
         </p>
         <ol>
           <li>
-            When a disabled element <em>does not</em> need to remain discoverable, the native <code>disabled</code> attribute is applied so that it will no longer be focusable.
-            For example:
-              <ul>
-                <li>
-                  The “Previous” and “Next” buttons in the <a href="../../patterns/grid/examples/layout-grids.html#ex3_label">“Scrollable Search Results”</a> example of a <a href="../../patterns/grid/grid-pattern.html">Grid</a>, each of which will become respectively disabled when the user has navigated to the start or end of the grid.
-                </li>
-                <li>
-                  A toolbar with buttons for moving, removing, and adding items in a list includes buttons for &quot;Up&quot;, &quot;Down&quot;, &quot;Add&quot;, and &quot;Remove&quot;.
-                  The &quot;Up&quot; button is disabled and its focusability is removed when the first item in the list is selected.
-                  Given the presence of the &quot;Down&quot; button, discoverability of the &quot;Up&quot; button is not a concern.
-                </li>
-              </ul>
+            When users can reasonably infer a disabled element from nearby
+            focusable elements, it can be removed from the keyboard focus order
+            using the HTML <code>disabled</code> attribute. For example:
+            <ul>
+              <li>
+                In the <a
+                href="../../patterns/grid/examples/layout-grids.html#ex3_label">“Scrollable
+                Search Results” grid example</a>, when the grid is showing the
+                first page and the “Next” button receives focus, users can infer
+                that the “Previous” button is disabled.
+              </li>
+              <li>
+                A toolbar with buttons for moving, removing, and adding items in a list includes buttons for &quot;Up&quot;, &quot;Down&quot;, &quot;Add&quot;, and &quot;Remove&quot;.
+                The &quot;Up&quot; button is disabled and its focusability is removed when the first item in the list is selected.
+                Given the presence of the &quot;Down&quot; button, discoverability of the &quot;Up&quot; button is not a concern.
+              </li>
+            </ul>
           </li>
 
           <li>

--- a/content/practices/keyboard-interface/keyboard-interface-practice.html
+++ b/content/practices/keyboard-interface/keyboard-interface-practice.html
@@ -391,7 +391,7 @@
       <section id="kbd_disabled_controls">
         <h2>Focusability of disabled controls</h2>
         <p>
-          By default, HTML input elements with the <code>disabled</code> attribute are removed from the tab sequence.
+          Browsers remove HTML input elements with the <code>disabled</code> attribute from the tab sequence.
           However, there are some contexts where it is useful for an element to convey a disabled state while remaining focusable, especially inside of composite widgets.
           For example, as demonstrated in the
           <a href="../../patterns/menubar/menu-and-menubar-pattern.html">menu and menubar pattern</a>,

--- a/content/practices/keyboard-interface/keyboard-interface-practice.html
+++ b/content/practices/keyboard-interface/keyboard-interface-practice.html
@@ -393,6 +393,7 @@
         <p>
           Browsers remove HTML input elements with the <code>disabled</code> attribute from the tab sequence.
           However, there are some contexts where it is useful for an element to convey a disabled state while remaining focusable, especially inside of composite widgets.
+          This can be accomplished by applying the state <code>aria-disabled="true"</code>.
           For example, as demonstrated in the
           <a href="../../patterns/menubar/menu-and-menubar-pattern.html">menu and menubar pattern</a>,
           disabled items are focusable when navigating through a menu with the arrow keys.

--- a/content/practices/keyboard-interface/keyboard-interface-practice.html
+++ b/content/practices/keyboard-interface/keyboard-interface-practice.html
@@ -411,7 +411,7 @@ Authors are encouraged to adopt consistent pattern-based conventions for the foc
         </p>
         <ol>
           <li>
-            When users can reasonably infer a disabled element from nearby
+            When users can reasonably infer the presence of a disabled element from nearby
             focusable elements, it can be removed from the keyboard focus order
             using the HTML <code>disabled</code> attribute. For example:
             <ul>

--- a/content/practices/keyboard-interface/keyboard-interface-practice.html
+++ b/content/practices/keyboard-interface/keyboard-interface-practice.html
@@ -411,7 +411,7 @@ Authors are encouraged to adopt consistent pattern-based conventions for the foc
         </p>
         <ol>
           <li>
-            When a disabled element <em>does not</em> need to remain discoverable, we apply the native <code>disabled</code> attribute so that it will no longer be focusable.
+            When a disabled element <em>does not</em> need to remain discoverable, the native <code>disabled</code> attribute is applied so that it will no longer be focusable.
             For example:
               <ul>
                 <li>
@@ -426,7 +426,7 @@ Authors are encouraged to adopt consistent pattern-based conventions for the foc
           </li>
 
           <li>
-            When a disabled element <em>does</em> need to remain discoverable, we apply <code>aria-disabled="true"</code> so that it remains focusable. For example:
+            When a disabled element <em>does</em> need to remain discoverable, <code>aria-disabled="true"</code> is applied so that it will remain focusable. For example:
             <ul>
               <li>
                 The “Copy”, “Cut”, and “Paste” buttons in the <a href="../../patterns/toolbar/examples/toolbar.html">Toolbar</a>.

--- a/content/practices/keyboard-interface/keyboard-interface-practice.html
+++ b/content/practices/keyboard-interface/keyboard-interface-practice.html
@@ -406,7 +406,7 @@
         </p>
 
         <p>
-          Authors are encouraged to adopt a consistent set of pattern-specific conventions for the focusability of disabled elements.
+Authors are encouraged to adopt consistent pattern-based conventions for the focusability of disabled elements.
           The examples in this guide adopt the following conventions, which both reflect common practice and attempt to balance competing concerns.
         </p>
         <ol>

--- a/content/practices/keyboard-interface/keyboard-interface-practice.html
+++ b/content/practices/keyboard-interface/keyboard-interface-practice.html
@@ -409,14 +409,30 @@
           Authors are encouraged to adopt a consistent set of pattern-specific conventions for the focusability of disabled elements.
           The examples in this guide adopt the following conventions, which both reflect common practice and attempt to balance competing concerns.
         </p>
-
         <ol>
-          <li>For disabled elements that don’t need to remain discoverable, remove them from the tab sequence.</li>
+          <li>
+            When a disabled element <em>does not</em> need to remain discoverable, we apply the native <code>disabled</code> attribute so that it will no longer be focusable.
+            For example:
+              <ul>
+                <li>
+                  The “Previous” and “Next” buttons in the <a href="../../patterns/grid/examples/layout-grids.html#ex3_label">“Scrollable Search Results”</a> example of a <a href="../../patterns/grid/grid-pattern.html">Grid</a>, each of which will become respectively disabled when the user has navigated to the start or end of the grid.
+                </li>
+                <li>
+                  A toolbar with buttons for moving, removing, and adding items in a list includes buttons for &quot;Up&quot;, &quot;Down&quot;, &quot;Add&quot;, and &quot;Remove&quot;.
+                  The &quot;Up&quot; button is disabled and its focusability is removed when the first item in the list is selected.
+                  Given the presence of the &quot;Down&quot; button, discoverability of the &quot;Up&quot; button is not a concern.
+                </li>
+              </ul>
+          </li>
 
           <li>
-            For the following composite widget elements, keep them focusable when disabled:
-
+            When a disabled element <em>does</em> need to remain discoverable, we apply <code>aria-disabled="true"</code> so that it remains focusable. For example:
             <ul>
+              <li>
+                The “Copy”, “Cut”, and “Paste” buttons in the <a href="../../patterns/toolbar/examples/toolbar.html">Toolbar</a>.
+                The discoverability of these features relies on their focusability even when they are not immediately applicable
+                (i.e., when no text is selected in the editor and/or when the clipboard is empty).
+              </li>
               <li>Options in a <a href="../../patterns/listbox/listbox-pattern.html">Listbox</a></li>
               <li>Menu items in a <a href="../../patterns/menubar/menu-and-menubar-pattern.html">Menu or menu bar</a></li>
               <li>Tab elements in a set of <a href="../../patterns/tabs/tabs-pattern.html">Tabs</a></li>
@@ -424,23 +440,6 @@
             </ul>
           </li>
 
-          <li>
-            For elements contained in a toolbar, make them focusable if discoverability is a concern.
-            Here are two examples to aid with this judgment.
-
-            <ol>
-              <li>
-                A toolbar with buttons for moving, removing, and adding items in a list includes buttons for &quot;Up&quot;, &quot;Down&quot;, &quot;Add&quot;, and &quot;Remove&quot;.
-                The &quot;Up&quot; button is disabled and its focusability is removed when the first item in the list is selected.
-                Given the presence of the &quot;Down&quot; button, discoverability of the &quot;Up&quot; button is not a concern.
-              </li>
-
-              <li>
-                A toolbar in an editor contains a set of special smart paste functions that are disabled when the clipboard is empty or when the function is not applicable to the current content of the clipboard.
-                It could be helpful to keep the disabled buttons focusable if the ability to discover their functionality is primarily via their presence on the toolbar.
-              </li>
-            </ol>
-          </li>
         </ol>
 
         <p>One design technique for mitigating the impact of including disabled elements in the path of keyboard focus is employing appropriate keyboard shortcuts as described in <a href="#kbd_shortcuts">Keyboard Shortcuts</a>.</p>


### PR DESCRIPTION
Makes small clarifications in the “[Focusability of disabled controls](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#focusabilityofdisabledcontrols)” section.

Closes #2318.

#### Preview

[Preview the revised keyboard practice page in the compare branch](https://deploy-preview-444--aria-practices.netlify.app/aria/apg/practices/keyboard-interface/#focusabilityofdisabledcontrols)



___
[WAI Preview Link](https://deploy-preview-444--aria-practices.netlify.app/ARIA/apg) _(Last built on Wed, 15 Apr 2026 14:41:50 GMT)._