### PR TITLE
Developing a Keyboard Interface: Add clarifying word to explanation of selection following focus

### DIFF
--- a/content/practices/keyboard-interface/keyboard-interface-practice.html
+++ b/content/practices/keyboard-interface/keyboard-interface-practice.html
@@ -201,7 +201,7 @@
           And, a screen reader user who perceives the labels on tabs by navigating through them may efficiently read through the complete list without any latency.
         </p>
         <p>
-          However, if displaying a new panel causes a network request and possibly a page refresh, the effect of having selection automatically focus can be devastating to the experience for keyboard and screen reader users.
+          However, if displaying a new panel causes a network request and possibly a page refresh, the effect of having selection automatically follow focus can be devastating to the experience for keyboard and screen reader users.
           In this case, displaying the fourth tab or reading through the list becomes a tedious and time-consuming task as the user experiences significant latency with each movement of focus.
           Further, if displaying a new tab refreshes the page, then the user not only has to wait for the new page to load but also return focus to the tab list.
         </p>


### PR DESCRIPTION
My proposed wording makes this paragraph match the heading of this section, which is "Selection Automatically Follow Focus" (not "Selection Automatically Focus").  It's only one word, but it completely changes the meaning (and is currently wrong, as far as I can see.)
___
[WAI Preview Link](https://deploy-preview-449--aria-practices.netlify.app/ARIA/apg) _(Last built on Wed, 21 Jan 2026 21:45:06 GMT)._