### PR TITLE
Modal Dialog Example: Change dialog title heading elements from H2 to H1

### DIFF
--- a/content/patterns/dialog-modal/examples/dialog.html
+++ b/content/patterns/dialog-modal/examples/dialog.html
@@ -52,7 +52,7 @@
           <button type="button" onclick="openDialog('dialog1', this)">Add Delivery Address</button>
           <div id="dialog_layer" class="dialogs">
             <div role="dialog" id="dialog1" aria-labelledby="dialog1_label" aria-modal="true" class="hidden">
-              <h2 id="dialog1_label" class="dialog_label">Add Delivery Address</h2>
+              <h1 id="dialog1_label" class="dialog_label">Add Delivery Address</h1>
               <div class="dialog_form">
                 <div class="dialog_form_item">
                   <label>
@@ -96,7 +96,7 @@
 
             <!--  Second modal to open on top of the first modal  -->
             <div id="dialog2" role="dialog" aria-labelledby="dialog2_label" aria-describedby="dialog2_desc" aria-modal="true" class="hidden">
-              <h2 id="dialog2_label" class="dialog_label">Verification Result</h2>
+              <h1 id="dialog2_label" class="dialog_label">Verification Result</h1>
               <div id="dialog2_desc" class="dialog_desc">
                 <p tabindex="-1" id="dialog2_para1">
                   This is just a demonstration.
@@ -148,7 +148,7 @@
 
             <!--  Dialog that replaces dialog 1.  -->
             <div id="dialog3" role="dialog" aria-labelledby="dialog3_label" aria-describedby="dialog3_desc" aria-modal="true" class="hidden">
-              <h2 id="dialog3_label" class="dialog_label">Address Added</h2>
+              <h1 id="dialog3_label" class="dialog_label">Address Added</h1>
               <p id="dialog3_desc" class="dialog_desc">
                 The address you provided has been added to your list of delivery addresses.
                 It is ready for immediate use.
@@ -160,7 +160,7 @@
             </div>
 
             <div id="dialog4" role="dialog" aria-labelledby="dialog4_label" aria-describedby="dialog4_desc" class="hidden" aria-modal="true">
-              <h2 id="dialog4_label" class="dialog_label">End of the Road!</h2>
+              <h1 id="dialog4_label" class="dialog_label">End of the Road!</h1>
               <p id="dialog4_desc" class="dialog_desc">You activated a fake link or button that goes nowhere! The link or button is present for demonstration purposes only.</p>
               <div class="dialog_form_actions">
                 <button type="button" id="dialog4_close_btn" onclick="closeDialog(this)">Close</button>


### PR DESCRIPTION
Fixes #3395

See [Preview of modal dialog example](https://deploy-preview-451--aria-practices.netlify.app/aria/apg/patterns/dialog-modal/examples/dialog/) where these headings are no longer included in the ToC.

___
[WAI Preview Link](https://deploy-preview-451--aria-practices.netlify.app/ARIA/apg) _(Last built on Wed, 04 Feb 2026 19:23:58 GMT)._