### PR TITLE
Link Example 3: Fix iframe source for AT support table

### DIFF
--- a/content/patterns/link/examples/link.html
+++ b/content/patterns/link/examples/link.html
@@ -168,8 +168,8 @@
         </iframe>
         <h3>Example 3: Link on a <code>span</code> Element with CSS <code>:before</code> Content Property</h3>
         <iframe
-          class="support-levels-link-span-css"
-          src="https://aria-at.w3.org/embed/reports/apg/link-span-css"
+          class="support-levels-link-css"
+          src="https://aria-at.w3.org/embed/reports/apg/link-css"
           height="100"
           allow="clipboard-write"
           style="border-style: none; width: 100%;">


### PR DESCRIPTION
Fixes the source URL and CSS class for the link example 3 AT support table.

This problem was identified by @remibetin  in [a review comment](https://github.com/w3c/wai-aria-practices/pull/452#pullrequestreview-3855030272) on w3c/wai-aria-practices#452, blocking current publication.
___
[WAI Preview Link](https://deploy-preview-453--aria-practices.netlify.app/ARIA/apg) _(Last built on Wed, 04 Mar 2026 18:23:34 GMT)._