### PR TITLE
AlertDialog Pattern: Add guidance about use of `aria-modal` attribute

### DIFF
--- a/content/patterns/alertdialog/alertdialog-pattern.html
+++ b/content/patterns/alertdialog/alertdialog-pattern.html
@@ -43,6 +43,7 @@
           <li>
             The element that contains all elements of the dialog, including the alert message and any dialog buttons, has role <a class="role-reference" href="#alertdialog">alertdialog</a>.
           </li>
+          <li>The dialog container element has <a href="#aria-modal" class="property-reference">aria-modal</a> set to <code>true</code>.</li>
           <li>
             The element with role <code>alertdialog</code> has either:
             <ul>
@@ -58,6 +59,27 @@
             The element with role <code>alertdialog</code> has a value set for <a href="#aria-describedby" class="property-reference">aria-describedby</a> that refers to the element containing the alert message.
           </li>
         </ul>
+        <div class="note">
+          <h3>Note</h3>
+          <ul>
+            <li>
+              Because marking a dialog modal by setting <a href="#aria-modal" class="property-reference">aria-modal</a> to <code>true</code> can prevent users of some assistive technologies from perceiving content outside the dialog, users of those technologies will experience severe negative ramifications if a dialog is marked modal but does not behave as a modal for other users.
+              So, mark a dialog modal <strong>only when both:</strong>
+              <ol>
+                <li>Application code prevents all users from interacting in any way with content outside of it.</li>
+                <li>Visual styling obscures the content outside of it.</li>
+              </ol>
+            </li>
+            <li>
+              The <code>aria-modal</code> property introduced by ARIA 1.1 replaces <a href="#aria-hidden" class="state-reference">aria-hidden</a> for informing assistive technologies that content outside a dialog is inert.
+              However, in legacy dialog implementations where <code>aria-hidden</code> is used to make content outside a dialog inert for assistive technology users, it is important that:
+              <ol>
+                <li><code>aria-hidden</code> is set to <code>true</code> on each element containing a portion of the inert layer.</li>
+                <li>The dialog element is not a descendant of any element that has <code>aria-hidden</code> set to <code>true</code>.</li>
+              </ol>
+            </li>
+          </ul>
+        </div>
       </section>
     </main>
   </body>


### PR DESCRIPTION
I added a description of the `aria-modal` attribute to the “WAI-ARIA Roles, States, and Properties” section of the alertdialog pattern, as it was missing.

___

#### Preview
[Direct link to preview of new pattern page](https://deploy-preview-455--aria-practices.netlify.app/aria/apg/patterns/alertdialog/#wai-ariaroles,states,andproperties)

#### Draft Commit Description

Adds guidance about use of the `aria-modal` attribute to the “WAI-ARIA Roles, States, and Properties” section of the alertdialog pattern, making its state and property guidance consistent with the modal dialog pattern.

___
[WAI Preview Link](https://deploy-preview-455--aria-practices.netlify.app/ARIA/apg) _(Last built on Tue, 24 Mar 2026 10:50:38 GMT)._