### PR TITLE
Accordion Pattern: Remove optional arrow, home, and end keys

### DIFF
--- a/content/patterns/accordion/accordion-pattern.html
+++ b/content/patterns/accordion/accordion-pattern.html
@@ -40,7 +40,7 @@
       <section id="examples">
         <img alt="" src="../../images/pattern-accordion.svg">
         <h2>Example</h2>
-        <p><a href="examples/accordion.html">Accordion Example</a>: demonstrates a form divided into three sections using an accordion to show one section at a time.</p>
+        <p><a href="examples/accordion.html">Accordion Example</a>: demonstrates using an accordion to divide a form into three expandable sections.</p>
       </section>
 
       <section id="keyboard_interaction">
@@ -61,16 +61,6 @@
           </li>
           <li><kbd>Tab</kbd>: Moves focus to the next focusable element; all focusable elements in the accordion are included in the page <kbd>Tab</kbd> sequence.</li>
           <li><kbd>Shift</kbd> + <kbd>Tab</kbd>: Moves focus to the previous focusable element; all focusable elements in the accordion are included in the page <kbd>Tab</kbd> sequence.</li>
-          <li>
-            <kbd>Down Arrow</kbd> (Optional): If focus is on an accordion header, moves focus to the next accordion header.
-            If focus is on the last accordion header, either does nothing or moves focus to the first accordion header.
-          </li>
-          <li>
-            <kbd>Up Arrow</kbd> (Optional): If focus is on an accordion header, moves focus to the previous accordion header.
-            If focus is on the first accordion header, either does nothing or moves focus to the last accordion header.
-          </li>
-          <li><kbd>Home</kbd> (Optional): When focus is on an accordion header, moves focus to the first accordion header.</li>
-          <li><kbd>End</kbd> (Optional): When focus is on an accordion header, moves focus to the last accordion header.</li>
         </ul>
       </section>
 


### PR DESCRIPTION
Resolves issue #3406 with the following changes to the keyboard section of the pattern:
1. Remove guidance for optionally implementing support for up and down arrow keys.
2. Remove guidance for optionally implementing support for Home and End arrow keys.

In addition, makes a minor editorial revision to the description of the example. When the example was originally implemented, it allowed only one section to be expanded at a time. Later it was changed to support expansion of multiple sections simultaneously, but the description of the example on the pattern page was not revised to reflect that change. This change aligns the description with the current behavior.
#### Preview

[Preview Accordion Pattern in compare branch](https://deploy-preview-458--aria-practices.netlify.app/aria/apg/patterns/accordion/)

___
[WAI Preview Link](https://deploy-preview-458--aria-practices.netlify.app/ARIA/apg) _(Last built on Wed, 15 Apr 2026 15:45:20 GMT)._