### PR TITLE
Landmark Examples Resource Page: Fix broken links to tools pages

### DIFF
--- a/content/patterns/landmarks/examples/resources.html
+++ b/content/patterns/landmarks/examples/resources.html
@@ -63,9 +63,9 @@
                           <h2>Tools</h2>
 
                           <ul>
-                            <li><a href="https://opena11y.github.io/h2l-side-panel/">Headings, Landmarks and Links Browser Extensions</a></li>
-                            <li><a href="https://skipto-landmarks-headings.github.io/page-script-5/extensions.html">SkipTo.js Browser Extensions</a></li>
-                            <li><a href="https://skipto-landmarks-headings.github.io/page-script-5/page-script.html">SkipTo.js Page Script (used on this page)</a></li>
+                            <li><a href="https://opena11y.github.io/h2l-side-panel/">Headings, Landmarks and Links Browser Extensions</a> (H2L)</li>
+                            <li><a href="https://skipto-landmarks-headings.github.io/page-script-5/extensions.html">SkipTo.js: Browser Extensions</a></li>
+                            <li><a href="https://skipto-landmarks-headings.github.io/page-script-5/page-script.html">SkipTo.js: Page Script</a> (used on this page)</li>
                             <li><a href="http://matatk.agrip.org.uk/landmarks/">Landmarks Browser Extension</a></li>
                             <li><a href="https://accessibility-bookmarklets.org/">Accessibility Bookmarklets: Landmark Bookmarklet</a></li>
                             <li><a href="https://whatsock.github.io/visual-aria/github-bookmarklet/visual-aria.htm">The Visual ARIA Bookmarklet</a></li>

--- a/content/patterns/landmarks/examples/resources.html
+++ b/content/patterns/landmarks/examples/resources.html
@@ -55,7 +55,7 @@
                             <li><a href="https://alistapart.com/column/wai-finding-with-aria-landmark-roles">WAI-finding with ARIA Landmark Roles</a> (A List Apart)</li>
                             <li><a href="https://vispero.com/resources/using-wai-aria-landmark-roles/">Using WAI-ARIA Landmarks – updated</a> (Vispero)</li>
                             <li><a href="https://vispero.com/resources/basic-screen-reader-commands-for-accessibility-testing/">Basic screen reader commands for accessibility testing</a>  (Vispero)</li>
-                            <li><a href="http://webaim.org/projects/screenreadersurvey9/#landmarks">Screen Reader User Survey #9 Results: Landmarks/Regions</a> (WebAIM)</li>
+                            <li><a href="https://webaim.org/projects/screenreadersurvey10/#landmarks">Screen Reader User Survey #10 Results: Landmarks/Regions</a> (WebAIM)</li>
                           </ul>
                         </section>
 
@@ -63,12 +63,13 @@
                           <h2>Tools</h2>
 
                           <ul>
-                            <li><a href="https://skipto-landmarks-headings.github.io">SkipTo Landmarks &amp; Headings: Browser Extension</a></li>
-                            <li><a href="https://github.com/skipto-landmarks-headings/page-script-5">SkipTo Landmarks &amp; Headings: Page Script (used on this page)</a></li>
+                            <li><a href="https://opena11y.github.io/h2l-side-panel/">Headings, Landmarks and Links Browser Extensions</a></li>
+                            <li><a href="https://skipto-landmarks-headings.github.io/page-script-5/extensions.html">SkipTo.js Browser Extensions</a></li>
+                            <li><a href="https://skipto-landmarks-headings.github.io/page-script-5/page-script.html">SkipTo.js Page Script (used on this page)</a></li>
                             <li><a href="http://matatk.agrip.org.uk/landmarks/">Landmarks Browser Extension</a></li>
                             <li><a href="https://accessibility-bookmarklets.org/">Accessibility Bookmarklets: Landmark Bookmarklet</a></li>
                             <li><a href="https://whatsock.github.io/visual-aria/github-bookmarklet/visual-aria.htm">The Visual ARIA Bookmarklet</a></li>
-                            <li><a href="https://ainspector.disability.illinois.edu">AInspector for Firefox</a> (Landmark Rule Category)</li>
+                            <li><a href="https://opena11y.github.io/ainspector/">Accessibility Inspector for WCAG Evaluation</a> (Landmark Rule Category)</li>
                           </ul>
 
                         </section>


### PR DESCRIPTION
Updated links in the tool section and the WebAIM Survey result link to lastest survey.

[Preview fixed Landmark Resources Page](https://deploy-preview-459--aria-practices.netlify.app/aria/apg/patterns/landmarks/examples/resources)
___
[WAI Preview Link](https://deploy-preview-459--aria-practices.netlify.app/ARIA/apg) _(Last built on Thu, 16 Apr 2026 20:36:24 GMT)._