### PR TITLE
Three Combobox Examples: Expand on click and improve filter behavior

### DIFF
--- a/content/patterns/combobox/combobox-pattern.html
+++ b/content/patterns/combobox/combobox-pattern.html
@@ -37,6 +37,8 @@
           For example, in some browsers, an HTML <code>select</code> element with <code>size="1"</code> is presented to assistive technologies as a combobox.
           Alternatively, if a combobox supports text input, it is referred to as editable.
           An editable combobox may either allow users to input any arbitrary value, or it may restrict its value to a discrete set of allowed values, in which case typing input serves to filter suggestions presented in the popup.
+          When filtering is applied, the popup displays only options that match the typed string.
+          However, if the typed string is empty or exactly matches one of the available options, all options are displayed without filtering.
         </p>
         <p>
           The popup is hidden by default, i.e., the default state is collapsed.
@@ -48,7 +50,8 @@
             It is displayed when the <kbd>Down Arrow</kbd> key is pressed or the <q>Open</q> button is activated.
             Optionally, if the combobox is editable and contains a string that does not match an allowed value, expansion does not occur.
           </li>
-          <li>It is displayed when the combobox receives focus even if the combobox is editable and empty.</li>
+          <li>It is displayed when the user clicks the combobox input. Clicking the input only opens the popup and does not toggle it closed.</li>
+          <li>If a chevron or toggle button is present adjacent to the combobox, activating it toggles the popup open or closed.</li>
           <li>If the combobox is editable, the popup is displayed only if a certain number of characters are typed in the combobox and those characters match some portion of one of the suggested values.</li>
         </ul>
         <p>Combobox widgets are useful for acquiring user input in either of two scenarios:</p>

--- a/content/patterns/combobox/examples/combobox-autocomplete-both.html
+++ b/content/patterns/combobox/examples/combobox-autocomplete-both.html
@@ -226,6 +226,15 @@
                 </ul>
               </td>
             </tr>
+            <tr data-test-id="textbox-filter">
+              <th>Printable Characters</th>
+              <td>
+                <ul>
+                  <li>Filters the options in the listbox to those that start with the typed string.</li>
+                  <li>If the trimmed textbox value is empty or exactly matches one of the available options, all options are displayed without filtering.</li>
+                </ul>
+              </td>
+            </tr>
           </tbody>
         </table>
         <h3 id="kbd_label_listbox">Listbox Popup</h3>
@@ -312,6 +321,44 @@
         </table>
         <h3 id="kbd_label_button">Button</h3>
         <p>The button has been removed from the tab sequence of the page, but is still important to assistive technologies for mobile devices that use touch events to open the list of options.</p>
+      </section>
+
+      <section>
+        <h2 id="ptr_label">Pointer Interaction</h2>
+        <h3 id="ptr_label_textbox">Textbox</h3>
+        <table aria-labelledby="ptr_label_textbox ptr_label" class="def">
+          <thead>
+            <tr>
+              <th>Action</th>
+              <th>Function</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr data-test-id="textbox-click">
+              <th>Click</th>
+              <td>Opens the listbox popup if it is not already visible. Clicking the textbox again does not close the popup.</td>
+            </tr>
+            <tr data-test-id="textbox-focus">
+              <th>Focus (without click)</th>
+              <td>Does not open the listbox popup. The popup only opens when the user clicks the textbox, presses a key, or activates the button.</td>
+            </tr>
+          </tbody>
+        </table>
+        <h3 id="ptr_label_button">Button</h3>
+        <table aria-labelledby="ptr_label_button ptr_label" class="def">
+          <thead>
+            <tr>
+              <th>Action</th>
+              <th>Function</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr data-test-id="button-click">
+              <th>Click</th>
+              <td>Toggles the listbox popup open or closed.</td>
+            </tr>
+          </tbody>
+        </table>
       </section>
 
       <section>

--- a/content/patterns/combobox/examples/combobox-autocomplete-list.html
+++ b/content/patterns/combobox/examples/combobox-autocomplete-list.html
@@ -220,6 +220,15 @@
                 </ul>
               </td>
             </tr>
+            <tr data-test-id="textbox-filter">
+              <th>Printable Characters</th>
+              <td>
+                <ul>
+                  <li>Filters the options in the listbox to those that start with the typed string.</li>
+                  <li>If the trimmed textbox value is empty or exactly matches one of the available options, all options are displayed without filtering.</li>
+                </ul>
+              </td>
+            </tr>
           </tbody>
         </table>
         <h3 id="kbd_label_listbox">Listbox Popup</h3>
@@ -306,6 +315,44 @@
         </table>
         <h3 id="kbd_label_button">Button</h3>
         <p>The button has been removed from the tab sequence of the page, but is still important to assistive technologies for mobile devices that use touch events to open the list of options.</p>
+      </section>
+
+      <section>
+        <h2 id="ptr_label">Pointer Interaction</h2>
+        <h3 id="ptr_label_textbox">Textbox</h3>
+        <table aria-labelledby="ptr_label_textbox ptr_label" class="def">
+          <thead>
+            <tr>
+              <th>Action</th>
+              <th>Function</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr data-test-id="textbox-click">
+              <th>Click</th>
+              <td>Opens the listbox popup if it is not already visible. Clicking the textbox again does not close the popup.</td>
+            </tr>
+            <tr data-test-id="textbox-focus">
+              <th>Focus (without click)</th>
+              <td>Does not open the listbox popup. The popup only opens when the user clicks the textbox, presses a key, or activates the button.</td>
+            </tr>
+          </tbody>
+        </table>
+        <h3 id="ptr_label_button">Button</h3>
+        <table aria-labelledby="ptr_label_button ptr_label" class="def">
+          <thead>
+            <tr>
+              <th>Action</th>
+              <th>Function</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr data-test-id="button-click">
+              <th>Click</th>
+              <td>Toggles the listbox popup open or closed.</td>
+            </tr>
+          </tbody>
+        </table>
       </section>
 
       <section>

--- a/content/patterns/combobox/examples/combobox-autocomplete-none.html
+++ b/content/patterns/combobox/examples/combobox-autocomplete-none.html
@@ -252,6 +252,44 @@
       </section>
 
       <section>
+        <h2 id="ptr_label">Pointer Interaction</h2>
+        <h3 id="ptr_label_textbox">Textbox</h3>
+        <table aria-labelledby="ptr_label_textbox ptr_label" class="def">
+          <thead>
+            <tr>
+              <th>Action</th>
+              <th>Function</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr data-test-id="textbox-click">
+              <th>Click</th>
+              <td>Opens the listbox popup if it is not already visible. Clicking the textbox again does not close the popup.</td>
+            </tr>
+            <tr data-test-id="textbox-focus">
+              <th>Focus (without click)</th>
+              <td>Does not open the listbox popup. The popup only opens when the user clicks the textbox, presses a key, or activates the button.</td>
+            </tr>
+          </tbody>
+        </table>
+        <h3 id="ptr_label_button">Button</h3>
+        <table aria-labelledby="ptr_label_button ptr_label" class="def">
+          <thead>
+            <tr>
+              <th>Action</th>
+              <th>Function</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr data-test-id="button-click">
+              <th>Click</th>
+              <td>Toggles the listbox popup open or closed.</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+
+      <section>
         <h2 id="rps_label">Role, Property, State, and Tabindex Attributes</h2>
         <p>
           The example combobox on this page implements the following ARIA roles, states, and properties.

--- a/content/patterns/combobox/examples/js/combobox-autocomplete.js
+++ b/content/patterns/combobox/examples/js/combobox-autocomplete.js
@@ -523,9 +523,8 @@ class ComboboxAutocomplete {
   }
 
   onComboboxClick() {
-    if (this.isOpen()) {
-      this.close(true);
-    } else {
+    // Do not toggle open state. Only open the listbox if it is closed.
+    if (!this.isOpen()) {
       this.open();
     }
   }

--- a/content/patterns/combobox/examples/js/combobox-autocomplete.js
+++ b/content/patterns/combobox/examples/js/combobox-autocomplete.js
@@ -200,7 +200,7 @@ class ComboboxAutocomplete {
     // 2. The filter is empty.
     // 3. The filter exactly matches the content of an option (case-insensitive).
     var optionsFilter =
-      this.none || normalizedFilter === '' || hasExactMatch
+      this.isNone || normalizedFilter === '' || hasExactMatch
         ? ''
         : normalizedFilter;
 
@@ -431,14 +431,19 @@ class ComboboxAutocomplete {
   onComboboxKeyUp(event) {
     var flag = false,
       option = null,
-      char = event.key;
+      char = event.key,
+      isTextEditKey =
+        this.isPrintableCharacter(char) ||
+        event.key === 'Backspace' ||
+        event.key === 'Delete';
 
     if (this.isPrintableCharacter(char)) {
       this.filter += char;
     }
 
     // this is for the case when a selection in the textbox has been deleted
-    if (this.comboboxNode.value.length < this.filter.length) {
+    // updated to only check for text edit keys, since the filter should not be updated on navigation keys
+    if (isTextEditKey && this.comboboxNode.value.length < this.filter.length) {
       this.filter = this.comboboxNode.value;
       this.option = null;
       this.filterOptions();

--- a/content/patterns/combobox/examples/js/combobox-autocomplete.js
+++ b/content/patterns/combobox/examples/js/combobox-autocomplete.js
@@ -189,14 +189,23 @@ class ComboboxAutocomplete {
   // ComboboxAutocomplete Events
 
   filterOptions() {
-    // do not filter any options if autocomplete is none
-    if (this.isNone) {
-      this.filter = '';
-    }
+    var normalizedFilter = this.filter.trim().toLowerCase();
+    var hasExactMatch =
+      normalizedFilter !== '' &&
+      this.allOptions.some(
+        (opt) => this.getLowercaseContent(opt).trim() === normalizedFilter
+      );
+    // Do not filter options when:
+    // 1. The autocomplete value is "none".
+    // 2. The filter is empty.
+    // 3. The filter exactly matches the content of an option (case-insensitive).
+    var optionsFilter =
+      this.none || normalizedFilter === '' || hasExactMatch
+        ? ''
+        : normalizedFilter;
 
     var option = null;
     var currentOption = this.option;
-    var filter = this.filter.toLowerCase();
 
     this.filteredOptions = [];
     this.listboxNode.innerHTML = '';
@@ -204,8 +213,8 @@ class ComboboxAutocomplete {
     for (var i = 0; i < this.allOptions.length; i++) {
       option = this.allOptions[i];
       if (
-        filter.length === 0 ||
-        this.getLowercaseContent(option).indexOf(filter) === 0
+        optionsFilter.length === 0 ||
+        this.getLowercaseContent(option).indexOf(optionsFilter) === 0
       ) {
         this.filteredOptions.push(option);
         this.listboxNode.appendChild(option);

--- a/test/tests/combobox_autocomplete-both.js
+++ b/test/tests/combobox_autocomplete-both.js
@@ -1207,3 +1207,42 @@ ariaTest(
     );
   }
 );
+
+ariaTest(
+  'Test arrow key navigation after an exact option match',
+  exampleFile,
+  'textbox-filter',
+  async (t) => {
+    const textbox = await t.context.session.findElement(
+      By.css(ex.textboxSelector)
+    );
+
+    await textbox.sendKeys('California', Key.ARROW_DOWN);
+
+    t.is(
+      await textbox.getAttribute('value'),
+      'Colorado',
+      'The first ARROW_DOWN should move from California to Colorado'
+    );
+    await assertAriaSelectedAndActivedescendant(
+      t,
+      ex.textboxSelector,
+      ex.optionsSelector,
+      6
+    );
+
+    await textbox.sendKeys(Key.ARROW_DOWN);
+
+    t.is(
+      await textbox.getAttribute('value'),
+      'Connecticut',
+      'The second ARROW_DOWN should move from Colorado to Connecticut'
+    );
+    await assertAriaSelectedAndActivedescendant(
+      t,
+      ex.textboxSelector,
+      ex.optionsSelector,
+      7
+    );
+  }
+);

--- a/test/tests/combobox_autocomplete-both.js
+++ b/test/tests/combobox_autocomplete-both.js
@@ -15,6 +15,7 @@ const ex = {
   optionsSelector: '#ex1 [role="option"]',
   buttonSelector: '#ex1 button',
   numAOptions: 5,
+  numOptions: 56,
   secondAOption: 'Alaska',
 };
 
@@ -1041,6 +1042,168 @@ ariaTest(
       (await t.context.queryElements(t, ex.optionsSelector)).length,
       ex.numAOptions,
       'Sending standard editing keys should filter results'
+    );
+  }
+);
+
+ariaTest(
+  'Test clicking textbox opens popup but does not close it on second click',
+  exampleFile,
+  'textbox-click',
+  async (t) => {
+    const textbox = await t.context.session.findElement(
+      By.css(ex.textboxSelector)
+    );
+
+    // First click - popup should open
+    await textbox.click();
+    t.true(
+      await t.context.session
+        .findElement(By.css(ex.listboxSelector))
+        .isDisplayed(),
+      'Listbox should be displayed after clicking the textbox'
+    );
+
+    // Second click - popup should remain open
+    await textbox.click();
+    t.true(
+      await t.context.session
+        .findElement(By.css(ex.listboxSelector))
+        .isDisplayed(),
+      'Listbox should remain displayed after clicking the textbox a second time'
+    );
+  }
+);
+
+ariaTest(
+  'Test focusing textbox without click does not open popup',
+  exampleFile,
+  'textbox-focus',
+  async (t) => {
+    // Focus the textbox via JavaScript without triggering a click
+    await t.context.session.executeScript(function () {
+      document.querySelector(arguments[0]).focus();
+    }, ex.textboxSelector);
+
+    t.false(
+      await t.context.session
+        .findElement(By.css(ex.listboxSelector))
+        .isDisplayed(),
+      'Listbox should not be displayed after focusing the textbox without clicking'
+    );
+  }
+);
+
+ariaTest(
+  'Test filter behavior: all options are shown when value is empty',
+  exampleFile,
+  'textbox-filter',
+  async (t) => {
+    const textbox = await t.context.session.findElement(
+      By.css(ex.textboxSelector)
+    );
+
+    await textbox.click();
+
+    t.is(
+      (await t.context.queryElements(t, ex.optionsSelector)).length,
+      ex.numOptions,
+      'All options should be shown when the textbox is empty'
+    );
+  }
+);
+
+ariaTest(
+  'Test filter behavior: all options are shown when value exactly matches an option',
+  exampleFile,
+  'textbox-filter',
+  async (t) => {
+    const textbox = await t.context.session.findElement(
+      By.css(ex.textboxSelector)
+    );
+
+    await textbox.sendKeys('Alabama');
+
+    t.is(
+      (await t.context.queryElements(t, ex.optionsSelector)).length,
+      ex.numOptions,
+      'All options should be shown when the textbox value exactly matches an option'
+    );
+  }
+);
+
+ariaTest(
+  'Test filter behavior: exact option matches are case-insensitive',
+  exampleFile,
+  'textbox-filter',
+  async (t) => {
+    const textbox = await t.context.session.findElement(
+      By.css(ex.textboxSelector)
+    );
+
+    await textbox.sendKeys('alabama');
+
+    t.is(
+      (await t.context.queryElements(t, ex.optionsSelector)).length,
+      ex.numOptions,
+      'All options should be shown when the textbox value exactly matches an option ignoring case'
+    );
+  }
+);
+
+ariaTest(
+  'Test filter behavior: trimmed exact option matches show all options',
+  exampleFile,
+  'textbox-filter',
+  async (t) => {
+    await t.context.session.executeScript(function () {
+      document.querySelector(arguments[0]).value = 'Alabama ';
+    }, ex.textboxSelector);
+
+    await t.context.session.findElement(By.css(ex.textboxSelector)).click();
+
+    t.is(
+      (await t.context.queryElements(t, ex.optionsSelector)).length,
+      ex.numOptions,
+      'All options should be shown when the trimmed textbox value exactly matches an option'
+    );
+  }
+);
+
+ariaTest(
+  'Test filter behavior: all options are shown when trimmed value is empty',
+  exampleFile,
+  'textbox-filter',
+  async (t) => {
+    const textbox = await t.context.session.findElement(
+      By.css(ex.textboxSelector)
+    );
+
+    await textbox.sendKeys('  ');
+
+    t.is(
+      (await t.context.queryElements(t, ex.optionsSelector)).length,
+      ex.numOptions,
+      'All options should be shown when the textbox contains only whitespace'
+    );
+  }
+);
+
+ariaTest(
+  'Test filter behavior: partial values filter options',
+  exampleFile,
+  'textbox-filter',
+  async (t) => {
+    const textbox = await t.context.session.findElement(
+      By.css(ex.textboxSelector)
+    );
+
+    await textbox.sendKeys('al');
+
+    t.is(
+      (await t.context.queryElements(t, ex.optionsSelector)).length,
+      2,
+      'Only Alabama and Alaska should be shown when typing "al"'
     );
   }
 );

--- a/test/tests/combobox_autocomplete-list.js
+++ b/test/tests/combobox_autocomplete-list.js
@@ -15,6 +15,7 @@ const ex = {
   optionsSelector: '#ex1 [role="option"]',
   buttonSelector: '#ex1 button',
   numAOptions: 5,
+  numOptions: 56,
   exampleHeadingSelector: '.example-header',
 };
 
@@ -1094,6 +1095,167 @@ ariaTest(
       (await t.context.queryElements(t, ex.optionsSelector)).length,
       ex.numAOptions,
       'Sending standard editing keys should filter results'
+    );
+  }
+);
+
+ariaTest(
+  'Test clicking textbox opens popup but does not close it on second click',
+  exampleFile,
+  'textbox-click',
+  async (t) => {
+    const textbox = await t.context.session.findElement(
+      By.css(ex.textboxSelector)
+    );
+
+    // First click - popup should open
+    await textbox.click();
+    t.true(
+      await t.context.session
+        .findElement(By.css(ex.listboxSelector))
+        .isDisplayed(),
+      'Listbox should be displayed after clicking the textbox'
+    );
+
+    // Second click - popup should remain open
+    await textbox.click();
+    t.true(
+      await t.context.session
+        .findElement(By.css(ex.listboxSelector))
+        .isDisplayed(),
+      'Listbox should remain displayed after clicking the textbox a second time'
+    );
+  }
+);
+
+ariaTest(
+  'Test focusing textbox without click does not open popup',
+  exampleFile,
+  'textbox-focus',
+  async (t) => {
+    await t.context.session.executeScript(function () {
+      document.querySelector(arguments[0]).focus();
+    }, ex.textboxSelector);
+
+    t.false(
+      await t.context.session
+        .findElement(By.css(ex.listboxSelector))
+        .isDisplayed(),
+      'Listbox should not be displayed after focusing the textbox without clicking'
+    );
+  }
+);
+
+ariaTest(
+  'Test filter behavior: all options are shown when value is empty',
+  exampleFile,
+  'textbox-filter',
+  async (t) => {
+    const textbox = await t.context.session.findElement(
+      By.css(ex.textboxSelector)
+    );
+
+    await textbox.click();
+
+    t.is(
+      (await t.context.queryElements(t, ex.optionsSelector)).length,
+      ex.numOptions,
+      'All options should be shown when the textbox is empty'
+    );
+  }
+);
+
+ariaTest(
+  'Test filter behavior: all options are shown when value exactly matches an option',
+  exampleFile,
+  'textbox-filter',
+  async (t) => {
+    const textbox = await t.context.session.findElement(
+      By.css(ex.textboxSelector)
+    );
+
+    await textbox.sendKeys('Alabama');
+
+    t.is(
+      (await t.context.queryElements(t, ex.optionsSelector)).length,
+      ex.numOptions,
+      'All options should be shown when the textbox value exactly matches an option'
+    );
+  }
+);
+
+ariaTest(
+  'Test filter behavior: exact option matches are case-insensitive',
+  exampleFile,
+  'textbox-filter',
+  async (t) => {
+    const textbox = await t.context.session.findElement(
+      By.css(ex.textboxSelector)
+    );
+
+    await textbox.sendKeys('alabama');
+
+    t.is(
+      (await t.context.queryElements(t, ex.optionsSelector)).length,
+      ex.numOptions,
+      'All options should be shown when the textbox value exactly matches an option ignoring case'
+    );
+  }
+);
+
+ariaTest(
+  'Test filter behavior: trimmed exact option matches show all options',
+  exampleFile,
+  'textbox-filter',
+  async (t) => {
+    await t.context.session.executeScript(function () {
+      document.querySelector(arguments[0]).value = 'Alabama ';
+    }, ex.textboxSelector);
+
+    await t.context.session.findElement(By.css(ex.textboxSelector)).click();
+
+    t.is(
+      (await t.context.queryElements(t, ex.optionsSelector)).length,
+      ex.numOptions,
+      'All options should be shown when the trimmed textbox value exactly matches an option'
+    );
+  }
+);
+
+ariaTest(
+  'Test filter behavior: all options are shown when trimmed value is empty',
+  exampleFile,
+  'textbox-filter',
+  async (t) => {
+    const textbox = await t.context.session.findElement(
+      By.css(ex.textboxSelector)
+    );
+
+    await textbox.sendKeys('  ');
+
+    t.is(
+      (await t.context.queryElements(t, ex.optionsSelector)).length,
+      ex.numOptions,
+      'All options should be shown when the textbox contains only whitespace'
+    );
+  }
+);
+
+ariaTest(
+  'Test filter behavior: partial values filter options',
+  exampleFile,
+  'textbox-filter',
+  async (t) => {
+    const textbox = await t.context.session.findElement(
+      By.css(ex.textboxSelector)
+    );
+
+    await textbox.sendKeys('al');
+
+    t.is(
+      (await t.context.queryElements(t, ex.optionsSelector)).length,
+      2,
+      'Only Alabama and Alaska should be shown when typing "al"'
     );
   }
 );

--- a/test/tests/combobox_autocomplete-none.js
+++ b/test/tests/combobox_autocomplete-none.js
@@ -815,3 +815,50 @@ ariaTest(
     );
   }
 );
+
+ariaTest(
+  'Test clicking textbox opens popup but does not close it on second click',
+  exampleFile,
+  'textbox-click',
+  async (t) => {
+    const textbox = await t.context.session.findElement(
+      By.css(ex.textboxSelector)
+    );
+
+    // First click - popup should open
+    await textbox.click();
+    t.true(
+      await t.context.session
+        .findElement(By.css(ex.listboxSelector))
+        .isDisplayed(),
+      'Listbox should be displayed after clicking the textbox'
+    );
+
+    // Second click - popup should remain open
+    await textbox.click();
+    t.true(
+      await t.context.session
+        .findElement(By.css(ex.listboxSelector))
+        .isDisplayed(),
+      'Listbox should remain displayed after clicking the textbox a second time'
+    );
+  }
+);
+
+ariaTest(
+  'Test focusing textbox without click does not open popup',
+  exampleFile,
+  'textbox-focus',
+  async (t) => {
+    await t.context.session.executeScript(function () {
+      document.querySelector(arguments[0]).focus();
+    }, ex.textboxSelector);
+
+    t.false(
+      await t.context.session
+        .findElement(By.css(ex.listboxSelector))
+        .isDisplayed(),
+      'Listbox should not be displayed after focusing the textbox without clicking'
+    );
+  }
+);


### PR DESCRIPTION
Closes https://github.com/w3c/aria-practices/issues/3442.

Implements what we discussed in this [comment](https://github.com/w3c/aria-practices/issues/3442#issuecomment-4672847815).

## Improve combobox click, focus, and filter guidance

### Changes

**Behavior (`combobox-autocomplete.js`)**
- Show all options when the trimmed input value is empty or exactly matches an option (case-insensitive); filter otherwise.
- Remove the menu toggle behavior on input click. Now, clicking the input only opens the menu, if it's closed.
- Fix an issue when `this.option` because `null` inside `onComboboxKeyUp` when `this.comboboxNode.value.length < this.filter.length`. Augmented the condition to only happen on text edit keys.
> The issue became visible with the new all options showing whenever filter is one of the options. After selecting an option, in autocomplete="both", and then navigating with arrow down, whenever then highlighted option had fewer characters than the selected, this.option became null, and the next arrow down was reset to the first option. With the fix, navigation works as expected after selection.

**Pattern documentation (`combobox-pattern.html`)**
- Replace "focus opens popup" with "click opens popup but does not toggle it closed".
- Add bullet for the chevron/toggle button, which toggles the popup open or closed.
- Extend filtering description to clarify trimmed-value and exact-match behavior.

**Example pages (`combobox-autocomplete-{both,list,none}.html`)**
- Add `textbox-filter` row to the keyboard table (list/both examples) documenting filter and show-all conditions.
- Add new **Pointer Interaction** section with separate Textbox and Button subsections covering click, focus, and toggle behaviors.

**Regression tests (`combobox_autocomplete-{both,list,none}.js`)**
- `textbox-click`: clicking the input opens the popup and a second click does not close it.
- `textbox-focus`: focusing the input without clicking does not open the popup.
- `textbox-filter` (list/both): verifies all options shown for empty input, exact match, case-insensitive exact match, and whitespace-only input; verifies filtered count (2) for partial string `"al"`.


#### Preview Links

* [Preview Editable Combobox With Both List and Inline Autocomplete Example | APG | WAI | W3C](https://deploy-preview-467--aria-practices.netlify.app/aria/apg/patterns/combobox/examples/combobox-autocomplete-both/)
* [Preview Editable Combobox With List Autocomplete Example | APG | WAI | W3C](https://deploy-preview-467--aria-practices.netlify.app/aria/apg/patterns/combobox/examples/combobox-autocomplete-list/)
* [Preview Editable Combobox without Autocomplete Example | APG | WAI | W3C](https://deploy-preview-467--aria-practices.netlify.app/aria/apg/patterns/combobox/examples/combobox-autocomplete-none/)
* 
___
[WAI Preview Link](https://deploy-preview-467--aria-practices.netlify.app/ARIA/apg) _(Last built on Thu, 09 Jul 2026 09:29:14 GMT)._