### PR TITLE
Infrastructure: Link checker patch

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -1,6 +1,10 @@
 name: Link Checker
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   link-checker:

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,6 @@
         "htmlparser2": "^10.0.0",
         "husky": "^9.1.7",
         "lint-staged": "^15.5.0",
-        "node-fetch": "^2.6.7",
         "prettier": "^3.6.2",
         "selenium-webdriver": "^4.34.0",
         "stylelint": "^16.22.0",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "htmlparser2": "^10.0.0",
     "husky": "^9.1.7",
     "lint-staged": "^15.5.0",
-    "node-fetch": "^2.6.7",
     "prettier": "^3.6.2",
     "selenium-webdriver": "^4.34.0",
     "stylelint": "^16.22.0",

--- a/scripts/link-checker.js
+++ b/scripts/link-checker.js
@@ -237,15 +237,18 @@ async function checkLinks() {
     console.info(`Checking ${loadedCount} of ${loadingCount} external pages`);
   }, 5000);
 
-  await Promise.all(
-    Object.entries(externalPageLoaders).map(
-      async ([externalPageLink, getPageData]) => {
-        let pageData = await getPageData();
+  const concurrencyLimit = 5;
+  const loaderEntries = Object.entries(externalPageLoaders);
+  for (let i = 0; i < loaderEntries.length; i += concurrencyLimit) {
+    const batch = loaderEntries.slice(i, i + concurrencyLimit);
+    await Promise.all(
+      batch.map(async ([externalPageLink, getPageData]) => {
+        const pageData = await getPageData();
         externalPageData[externalPageLink] = pageData;
         loadedCount += 1;
-      }
-    )
-  );
+      })
+    );
+  }
 
   clearInterval(intervalId);
   console.info(`Checked ${loadingCount} of ${loadingCount} external pages`);

--- a/scripts/link-checker.js
+++ b/scripts/link-checker.js
@@ -160,6 +160,10 @@ async function checkLinks() {
                   // Clearly identifies this as being a link checker, and links to the project repo for more info.
                   'User-Agent':
                     'W3C/aria-practices-link-checker (+https://github.com/w3c/aria-practices)',
+                  Accept:
+                    'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+                  'Accept-Language': 'en-US,en;q=0.5',
+                  'Accept-Encoding': 'gzip, deflate, br',
                 },
               });
 

--- a/scripts/link-checker.js
+++ b/scripts/link-checker.js
@@ -238,16 +238,21 @@ async function checkLinks() {
 
   let externalPageData = {};
 
-  for (const [externalPageLink, getPageData] of Object.entries(
-    externalPageLoaders
-  )) {
-    const start = Date.now();
-    const pageData = await getPageData();
-    const elapsed = ((Date.now() - start) / 1000).toFixed(2);
-    externalPageData[externalPageLink] = pageData;
-    loadedCount += 1;
-    console.info(
-      `[${loadedCount}/${loadingCount}] ${externalPageLink} (${elapsed}s)`
+  const concurrencyLimit = 5;
+  const loaderEntries = Object.entries(externalPageLoaders);
+  for (let i = 0; i < loaderEntries.length; i += concurrencyLimit) {
+    const batch = loaderEntries.slice(i, i + concurrencyLimit);
+    await Promise.all(
+      batch.map(async ([externalPageLink, getPageData]) => {
+        const start = Date.now();
+        const pageData = await getPageData();
+        const elapsed = ((Date.now() - start) / 1000).toFixed(2);
+        externalPageData[externalPageLink] = pageData;
+        loadedCount += 1;
+        console.info(
+          `[${loadedCount}/${loadingCount}] ${externalPageLink} (${elapsed}s)`
+        );
+      })
     );
   }
 

--- a/scripts/link-checker.js
+++ b/scripts/link-checker.js
@@ -150,11 +150,10 @@ async function checkLinks() {
 
         const getPageData = async () => {
           const domain = new URL(externalPageLink).hostname;
-          let retryCount = 0;
           const maxRetries = 3;
           const baseDelay = 15;
 
-          while (retryCount < maxRetries) {
+          for (let attempt = 0; attempt < maxRetries; attempt++) {
             try {
               const response = await nFetch(externalPageLink, {
                 headers: {
@@ -194,16 +193,15 @@ async function checkLinks() {
                 reactPartial,
               };
             } catch (error) {
-              if (retryCount < maxRetries) {
+              if (attempt < maxRetries - 1) {
                 // Found the retry-after unit returned from response headers too
                 // variable to use here, but ~15 seconds seems like a safe
                 // initial default
-                const delay = baseDelay * 1000 * Math.pow(2, retryCount);
+                const delay = baseDelay * 1000 * Math.pow(2, attempt);
                 console.info(
                   `Error fetching ${externalPageLink}: ${error.message}, retrying in ${delay}ms`
                 );
                 await new Promise((resolve) => setTimeout(resolve, delay));
-                retryCount++;
                 continue;
               }
               return {

--- a/scripts/link-checker.js
+++ b/scripts/link-checker.js
@@ -3,7 +3,6 @@ const path = require('path');
 const fs = require('fs/promises');
 const glob = require('glob');
 const HTMLParser = require('node-html-parser');
-const nFetch = require('node-fetch');
 const options = require('../.link-checker');
 
 async function checkLinks() {
@@ -154,8 +153,9 @@ async function checkLinks() {
           const baseDelay = 15;
 
           for (let attempt = 0; attempt < maxRetries; attempt++) {
+            let step = 'fetch';
             try {
-              const response = await nFetch(externalPageLink, {
+              const response = await fetch(externalPageLink, {
                 headers: {
                   // Clearly identifies this as being a link checker, and links to the project repo for more info.
                   'User-Agent':
@@ -181,14 +181,18 @@ async function checkLinks() {
                 );
               }
 
+              step = 'read body';
               const text = await response.text();
+              step = 'parse HTML';
               const html = HTMLParser.parse(text);
+              step = 'extract ids';
               const ids = html
                 .querySelectorAll('[id]')
                 .map((idElement) => idElement.getAttribute('id'));
 
               // Handle GitHub README links.
               // These links are stored within a react-partial element
+              step = 'getReactPartial';
               const reactPartial = getReactPartial(hrefOrSrc, html);
               return {
                 ok: response.ok,
@@ -203,7 +207,7 @@ async function checkLinks() {
                 // initial default
                 const delay = baseDelay * 1000 * Math.pow(2, attempt);
                 console.info(
-                  `Error fetching ${externalPageLink}: ${error.message}, retrying in ${delay}ms`
+                  `Error at step "${step}" for ${externalPageLink}: ${error.message}, retrying in ${delay}ms`
                 );
                 await new Promise((resolve) => setTimeout(resolve, delay));
                 continue;

--- a/scripts/link-checker.js
+++ b/scripts/link-checker.js
@@ -230,25 +230,19 @@ async function checkLinks() {
 
   let externalPageData = {};
 
-  // Limit number of logs for readability
-  const intervalId = setInterval(() => {
-    console.info(`Checking ${loadedCount} of ${loadingCount} external pages`);
-  }, 5000);
-
-  const concurrencyLimit = 5;
-  const loaderEntries = Object.entries(externalPageLoaders);
-  for (let i = 0; i < loaderEntries.length; i += concurrencyLimit) {
-    const batch = loaderEntries.slice(i, i + concurrencyLimit);
-    await Promise.all(
-      batch.map(async ([externalPageLink, getPageData]) => {
-        const pageData = await getPageData();
-        externalPageData[externalPageLink] = pageData;
-        loadedCount += 1;
-      })
+  for (const [externalPageLink, getPageData] of Object.entries(
+    externalPageLoaders
+  )) {
+    const start = Date.now();
+    const pageData = await getPageData();
+    const elapsed = ((Date.now() - start) / 1000).toFixed(2);
+    externalPageData[externalPageLink] = pageData;
+    loadedCount += 1;
+    console.info(
+      `[${loadedCount}/${loadingCount}] ${externalPageLink} (${elapsed}s)`
     );
   }
 
-  clearInterval(intervalId);
   console.info(`Checked ${loadingCount} of ${loadingCount} external pages`);
 
   for (const [htmlPath, { links }] of Object.entries(allLinkData)) {


### PR DESCRIPTION
That PR:
- replaces `node-fetch` with the native fetch API, and added browser-like request headers (Accept, Accept-Language, Accept-Encoding) to reduce connection resets from Cloudflare-protected sites
- fixes a retry logic bug: the while loop with a broken guard condition was replaced by a for loop, ensuring failed requests are correctly reported after all retries are exhausted
- adds a step variable to retry log messages to identify whether the failure occurred during the fetch, body read, HTML parsing, or id extraction
- fetches external pages in batches of 5 concurrent requests (instead of all at once) to avoid overwhelming servers
- adds per-page timing logs: each completed page prints its index, URL, and elapsed time
- updates the workflow `.github/workflows/link-checker.yml` so it no longer triggers twice for pull requests: push is now scoped to the main branch only, while pull_request continues to run on all PRs
___
[WAI Preview Link](https://deploy-preview-477--aria-practices.netlify.app/ARIA/apg) _(Last built on Tue, 30 Jun 2026 09:48:19 GMT)._