### PR TITLE
Navigation Treeview Example: Explain aria-current without selection

### DIFF
--- a/content/patterns/treeview/examples/treeview-navigation.html
+++ b/content/patterns/treeview/examples/treeview-navigation.html
@@ -341,6 +341,10 @@
             <ul>
               <li>The <code>aria-current="page"</code> attribute is applied to the item in the tree associated with the currently displayed page.</li>
               <li>
+                This example does not use <code>aria-selected</code> because it does not support selecting tree items independently of navigating to a page.
+                <code>aria-current</code> identifies the item associated with the currently displayed page rather than a selected item.
+              </li>
+              <li>
                 The tree item with <code>aria-current</code> is also the only item with <code>tabindex="0"</code>.
                 That is, when tabbing into the tree, focus always lands on the item representing the current page.
               </li>
@@ -608,6 +612,7 @@
               <td>
                 <ul>
                   <li>Applied to the <code>treeitem</code> that is the link to the currently displayed page.</li>
+                  <li>This example does not use <code>aria-selected</code> because the tree does not support selection independently of page navigation.</li>
                   <li>The visual indication of the <code>treeitem</code> with <code>aria-current</code> is a vertical bar to the left of the treeitem label.</li>
                 </ul>
               </td>


### PR DESCRIPTION
## Summary

- explain why the navigation tree example uses `aria-current` without `aria-selected`
- clarify that the example identifies the displayed page and does not offer an independent selection operation
- add the clarification both to the accessibility features guidance and the `aria-current` characteristics row

## Why

The tree view pattern supports selection states, but this navigation-only example does not implement selection separately from navigating to a page. Without an explanation, readers can interpret the absence of `aria-selected` as an omission.

This follows the direction discussed by the APG task force in #3371 and does not change the example's behavior.

## Validation

- Prettier
- HTMLHint
- CSpell across 417 files
- ESLint and CSS lint
- rendered the updated page in headless Chrome and confirmed both clarifications are present

## Environment limitations

- Nu HTML Checker was not run because Java is unavailable locally.
- The Firefox regression suite could not start because Firefox is unavailable locally. No example behavior or test identifiers changed.

AI assistance disclosure: Codex assisted with investigation, drafting, and validation. I reviewed and verified the wording and changes.

#### Preview Example

[Preview Navigation Treeview Example in compare branch](https://deploy-preview-479--aria-practices.netlify.app/aria/apg/patterns/treeview/examples/treeview-navigation/)

___
[WAI Preview Link](https://deploy-preview-479--aria-practices.netlify.app/ARIA/apg) _(Last built on Wed, 15 Jul 2026 14:43:27 GMT)._