### PR TITLE
[Draft] Update workflows

### DIFF
--- a/.github/workflows/wai-trigger-cleanup.yml
+++ b/.github/workflows/wai-trigger-cleanup.yml
@@ -8,15 +8,18 @@ on:
     types:
       - closed
 
+permissions:
+  contents: read
+
 jobs:
   cleanup-branch-wai:
     if: ${{ github.event_name == 'delete' && github.event.ref_type == 'branch' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7.0.1
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 #v7.0.0
         with:
           cache: npm
 
@@ -36,10 +39,10 @@ jobs:
     if: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_target' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7.0.1
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 #v7.0.0
         with:
           cache: npm
 

--- a/.github/workflows/wai-trigger-deploy.yml
+++ b/.github/workflows/wai-trigger-deploy.yml
@@ -10,6 +10,9 @@ on:
       - "content/**"
       - "README.md"
 
+permissions:
+  contents: read
+
 jobs:
   deploy-wai:
     runs-on: ubuntu-latest
@@ -17,7 +20,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Trigger wai-aria-practices update
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b #v7.1.0
         with:
           github-token: ${{ secrets.W3CGRUNTBOT_TOKEN }}
           script: |

--- a/.github/workflows/wai-trigger-pr.yml
+++ b/.github/workflows/wai-trigger-pr.yml
@@ -15,17 +15,18 @@ on:
       - "!content/landmarks/examples/**"
       - "!common/**"
 
+permissions:
+  contents: read
+
 jobs:
   create-pr-wai:
     runs-on: ubuntu-latest
+    # Only run on pull requests within the same repository, and not from forks.
+    if: github.event.pull_request.head.repo.full_name == github.repository
 
     steps:
-      - uses: actions/checkout@v5
-        with:
-          ref: refs/pull/${{ github.event.pull_request.number }}/head
-
       - name: Trigger wai-aria-practices PR update
-        uses: actions/github-script@v7
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd #v8.0.0
         env:
           APG_BRANCH: ${{ github.head_ref }}
           APG_SHA: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
This PR:
- pins actions to a full-length commit SHA, following GitHub's recommendations
- bumps `checkout` from v6 to v7.0.1
- bumps `setup-node` from v4 to v7.0.0
- sets more specific permissions
- do not trigger `create-pr-wai` for forks

The workflow was tested successfully in forks.
___
[WAI Preview Link](https://deploy-preview-485--aria-practices.netlify.app/ARIA/apg) _(Last built on Fri, 14 Aug 2026 17:51:14 GMT)._